### PR TITLE
Implement Matrix signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ EXPO_PUBLIC_ADMIN_USERNAME=roymichaels
 
 # Matrix Configuration
 EXPO_PUBLIC_MATRIX_SERVER=https://matrix.org
+# Optional: token used when your Matrix server requires a registration token
+# EXPO_PUBLIC_MATRIX_REGISTRATION_TOKEN=your_token_here
 
 # App Configuration
 EXPO_PUBLIC_APP_NAME=QuickMart

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 thecongress
+
+### Matrix Signup
+
+This project communicates with a Matrix server for chat features. Public
+registration is disabled on many servers such as `matrix.org`. If your server
+uses token-based registration, set `EXPO_PUBLIC_MATRIX_REGISTRATION_TOKEN` in
+your environment to allow account creation.

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -167,9 +167,75 @@ export class MatrixService {
     }
   }
 
+  async signup(
+    username: string,
+    email: string,
+    displayName: string,
+    password: string
+  ): Promise<boolean> {
+    try {
+      // Determine the registration auth flow. Some servers require a token.
+      const registrationToken = process.env.EXPO_PUBLIC_MATRIX_REGISTRATION_TOKEN;
+      const auth = registrationToken
+        ? { type: 'm.login.registration_token', token: registrationToken }
+        : { type: 'm.login.dummy' };
+
+      // Register the user with the Matrix server
+      const registerResponse = await fetch(
+        `${MATRIX_SERVER_URL}/_matrix/client/v3/register`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username,
+            password,
+            auth
+          })
+        }
+      );
+
+      if (!registerResponse.ok) {
+        const errorText = await registerResponse.text();
+        console.error('Matrix signup failed:', errorText);
+        // Provide a clearer error when registration is disabled
+        if (registerResponse.status === 403) {
+          throw new Error('Matrix server does not allow public registration.');
+        }
+        return false;
+      }
+
+      const registerData = await registerResponse.json();
+      const userId = registerData.user_id;
+
+      // Create profile in Supabase
+      const { error } = await supabase.from('user_profiles').insert([
+        {
+          matrix_user_id: userId,
+          app_username: username,
+          email,
+          display_name: displayName,
+          role: 'user',
+          kyc_status: 'none',
+          customer_tier: 'new'
+        }
+      ]);
+
+      if (error) {
+        console.error('Error creating user profile:', error);
+        return false;
+      }
+
+      // Signup succeeded but we don't automatically log the user in
+      return true;
+    } catch (error) {
+      console.error('Matrix signup error:', error);
+      return false;
+    }
+  }
+
   async login(username: string, password: string): Promise<boolean> {
     try {
-      // Check if this is the admin user first
+      // Determine if this user should be treated as an admin
       const adminUsername = process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'roymichaels';
       const isAdmin = username === adminUsername;
 
@@ -222,18 +288,7 @@ export class MatrixService {
         const existingProfile = userProfiles && userProfiles.length > 0 ? userProfiles[0] : null;
         
         if (existingProfile) {
-          // User exists in database, check if they're admin
-          if (existingProfile.role !== 'admin') {
-            // If not admin in database and not the admin username, logout
-            if (matrixLoginSuccess && this.matrixClient) {
-              await this.matrixClient.logout();
-              this.matrixClient.stopClient();
-              this.matrixClient = null;
-            }
-            return false;
-          }
-          
-          // Set authentication state
+          // Set authentication state for existing users
           this.isAuthenticated = true;
           this.currentUser = {
             id: userId,

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -3,6 +3,7 @@ declare global {
     interface ProcessEnv {
       EXPO_PUBLIC_ADMIN_USERNAME: string;
       EXPO_PUBLIC_MATRIX_SERVER: string;
+      EXPO_PUBLIC_MATRIX_REGISTRATION_TOKEN?: string;
       EXPO_PUBLIC_APP_NAME: string;
     }
   }


### PR DESCRIPTION
## Summary
- add missing `signup` method in `MatrixService`
- adjust login to allow regular users
- support token-based Matrix registration

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686442ad6958832683b40872d5913a0b