### PR TITLE
Fix signup errors and language switch

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -29,7 +29,7 @@ const NOTIFICATIONS_STORAGE_KEY = 'settings_notifications';
 
 export default function ProfileScreen() {
   const { isLoggedIn, isAdmin, user, logout } = useAuth();
-  const { t } = useLanguage();
+  const { t, currentLanguage, setLanguage } = useLanguage();
   const { theme, toggleTheme, colors } = useTheme();
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [showOrderTracking, setShowOrderTracking] = useState(false);
@@ -105,8 +105,8 @@ export default function ProfileScreen() {
   };
 
   const handleLanguageSwitch = async () => {
-    const newLanguage = t.currentLanguage === 'en' ? 'he' : 'en';
-    await t.setLanguage(newLanguage);
+    const newLanguage = currentLanguage === 'en' ? 'he' : 'en';
+    await setLanguage(newLanguage);
   };
 
   return (
@@ -251,7 +251,9 @@ export default function ProfileScreen() {
               <Text style={[styles.menuText, { color: colors.text.primary }]}>שפה</Text>
             </View>
             <View style={styles.languageContainer}>
-              <Text style={[styles.languageText, { color: colors.text.secondary }]}>עברית</Text>
+              <Text style={[styles.languageText, { color: colors.text.secondary }]}>
+                {currentLanguage === 'en' ? t('profile.english') : t('profile.hebrew')}
+              </Text>
             </View>
           </TouchableOpacity>
         </View>

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -189,8 +189,14 @@ export class MatrixService {
       );
 
       if (!registerResponse.ok) {
-        console.error('Matrix signup failed:', await registerResponse.text());
-        return false;
+        const errorText = await registerResponse.text();
+        console.error('Matrix signup failed:', errorText);
+        try {
+          const err = JSON.parse(errorText);
+          throw new Error(err.error || 'Registration failed');
+        } catch {
+          throw new Error(errorText || 'Registration failed');
+        }
       }
 
       const registerData = await registerResponse.json();
@@ -235,7 +241,7 @@ export class MatrixService {
       return true;
     } catch (error) {
       console.error('Matrix signup error:', error);
-      return false;
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- handle Matrix signup HTTP errors more explicitly
- expose language context properly to profile screen
- fix language switcher to use context

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644c40bd34832681e65c56b030e313