### PR TITLE
Fix delete confirmation modal visibility

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -323,6 +323,8 @@ export default function ProductDetailScreen() {
   };
 
   const confirmDeleteProduct = () => {
+    // Close the edit modal so the confirmation modal is visible on web
+    setShowEditModal(false);
     setConfirmDeleteModal(true);
   };
 
@@ -987,7 +989,11 @@ export default function ProductDetailScreen() {
           setConfirmDeleteModal(false);
           deleteProduct();
         }}
-        onCancel={() => setConfirmDeleteModal(false)}
+        onCancel={() => {
+          setConfirmDeleteModal(false);
+          // Reopen the edit modal if the user cancels deletion
+          setShowEditModal(true);
+        }}
         destructive={true}
       />
     </SafeAreaView>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -313,6 +313,8 @@ export default function SubcategoryScreen() {
 
   const confirmDeleteProduct = () => {
     if (!editingProduct) return;
+    // Close the edit modal so the confirmation modal is visible on web
+    setShowProductModal(false);
     setConfirmDeleteVisible(true);
   };
 
@@ -962,7 +964,11 @@ export default function SubcategoryScreen() {
             deleteProduct(editingProduct.id);
           }
         }}
-        onCancel={() => setConfirmDeleteVisible(false)}
+        onCancel={() => {
+          setConfirmDeleteVisible(false);
+          // Reopen the edit modal if the user cancels deletion
+          setShowProductModal(true);
+        }}
         destructive={true}
       />
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- ensure product edit modal closes before showing delete confirmation
- re-open edit modal if user cancels delete action

## Testing
- `npx expo --version`
- `npx expo lint` *(fails: Cannot determine the project's Expo SDK version because the module `expo` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a7fb386c8326a1f6003195487925