### PR TITLE
Fix confirmation modal timing

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -325,7 +325,10 @@ export default function ProductDetailScreen() {
   const confirmDeleteProduct = () => {
     // Close the edit modal so the confirmation modal is visible on web
     setShowEditModal(false);
-    setConfirmDeleteModal(true);
+    // Wait for the modal to close before showing the confirmation dialog
+    setTimeout(() => {
+      setConfirmDeleteModal(true);
+    }, 300);
   };
 
   const deleteProduct = async () => {

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -315,7 +315,10 @@ export default function SubcategoryScreen() {
     if (!editingProduct) return;
     // Close the edit modal so the confirmation modal is visible on web
     setShowProductModal(false);
-    setConfirmDeleteVisible(true);
+    // Wait for the modal to close before showing the confirmation dialog
+    setTimeout(() => {
+      setConfirmDeleteVisible(true);
+    }, 300);
   };
 
   const deleteProduct = async (productId: string) => {


### PR DESCRIPTION
## Summary
- delay showing confirmation modal until edit modal is closed

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ad8a2edc8326aaa5507691352155