### PR TITLE
Add pricing tier rules

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -33,9 +33,10 @@ export default function PricingTiersScreen() {
   const [newTier, setNewTier] = useState<Partial<PricingTier>>({
     id: '',
     name: '',
-    pricePerUnit: undefined,
-    minQuantity: 1,
-    description: ''
+    description: '',
+    rules: [
+      { minQty: 1, maxQty: 1, pricePerUnit: undefined, discountPct: undefined } as any
+    ]
   });
   const { isAdmin } = useAuth();
   const { colors } = useTheme();
@@ -82,9 +83,10 @@ export default function PricingTiersScreen() {
     setNewTier({
       id: '',
       name: '',
-      pricePerUnit: undefined,
-      minQuantity: 1,
-      description: ''
+      description: '',
+      rules: [
+        { minQty: 1, maxQty: 1, pricePerUnit: undefined, discountPct: undefined } as any
+      ]
     });
     setShowTierModal(true);
   };
@@ -106,17 +108,7 @@ export default function PricingTiersScreen() {
       return;
     }
 
-    if (newTier.pricePerUnit !== undefined && (typeof newTier.pricePerUnit !== 'number' || newTier.pricePerUnit <= 0)) {
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'מחיר ליחידה חייב להיות מספר חיובי',
-        type: 'error'
-      });
-      return;
-    }
-
-    if (typeof newTier.minQuantity !== 'number' || newTier.minQuantity < 1) {
+    if (newTier.rules && newTier.rules.some(r => r.minQty < 1)) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -211,11 +203,11 @@ export default function PricingTiersScreen() {
       onPress={() => editTier(tier)}
     >
       <View style={styles.tierHeader}>
-        <View style={[styles.tierIcon, { 
+        <View style={[styles.tierIcon, {
           backgroundColor: colors.interactive.secondary,
-          borderColor: colors.gold 
+          borderColor: colors.gold
         }]}>
-          {typeof tier.pricePerUnit === 'number' ? (
+          {typeof (tier.rules?.[0]?.pricePerUnit) === 'number' ? (
             <DollarSign size={24} color={colors.gold} />
           ) : (
             <Percent size={24} color={colors.gold} />
@@ -224,8 +216,8 @@ export default function PricingTiersScreen() {
         <View style={styles.tierInfo}>
           <Text style={[styles.tierName, { color: colors.text.primary }]}>{tier.name}</Text>
           <Text style={[styles.tierDiscount, { color: colors.gold }]}>
-            {typeof tier.pricePerUnit === 'number' 
-              ? `${currencySymbol}${tier.pricePerUnit.toFixed(2)} ליחידה` 
+            {typeof (tier.rules?.[0]?.pricePerUnit) === 'number'
+              ? `${currencySymbol}${tier.rules![0].pricePerUnit!.toFixed(2)} ליחידה`
               : 'מחיר רגיל'}
           </Text>
         </View>
@@ -244,7 +236,7 @@ export default function PricingTiersScreen() {
         <View style={styles.tierDetailItem}>
           <Package size={16} color={colors.text.secondary} />
           <Text style={[styles.tierDetailText, { color: colors.text.secondary }]}>
-            מינימום {tier.minQuantity} יחידות
+            מינימום {tier.rules?.[0]?.minQty ?? 1} יחידות
           </Text>
         </View>
         <Text style={[styles.tierDescription, { color: colors.text.secondary }]}>
@@ -369,45 +361,92 @@ export default function PricingTiersScreen() {
               />
             </View>
 
-            <View style={styles.formRow}>
-              <View style={styles.formGroupHalf}>
-                <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר ליחידה</Text>
-                <TextInput
-                  style={[styles.formInput, { 
-                    borderColor: colors.border.primary,
-                    backgroundColor: colors.surface.primary,
-                    color: colors.text.primary 
-                  }]}
-                  value={newTier.pricePerUnit?.toString() || ''}
-                  onChangeText={(text) => {
-                    const price = text ? parseFloat(text) : undefined;
-                    setNewTier({...newTier, pricePerUnit: price});
-                  }}
-                  placeholder={`מחיר ליחידה (${currencySymbol})`}
-                  keyboardType="numeric"
-                  textAlign="right"
-                />
+            {newTier.rules?.map((rule, idx) => (
+              <View key={idx} style={styles.formRow}>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מינימום</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary
+                    }]}
+                    value={rule.minQty.toString()}
+                    onChangeText={(text) => {
+                      const updated = [...(newTier.rules || [])];
+                      updated[idx].minQty = parseInt(text) || 1;
+                      setNewTier({...newTier, rules: updated});
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מקסימום</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary
+                    }]}
+                    value={rule.maxQty.toString()}
+                    onChangeText={(text) => {
+                      const updated = [...(newTier.rules || [])];
+                      updated[idx].maxQty = parseInt(text) || 0;
+                      setNewTier({...newTier, rules: updated});
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר ליחידה</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary
+                    }]}
+                    value={rule.pricePerUnit?.toString() || ''}
+                    onChangeText={(text) => {
+                      const updated = [...(newTier.rules || [])];
+                      updated[idx].pricePerUnit = text ? parseFloat(text) : undefined;
+                      setNewTier({...newTier, rules: updated});
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>הנחה %</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary
+                    }]}
+                    value={rule.discountPct?.toString() || ''}
+                    onChangeText={(text) => {
+                      const updated = [...(newTier.rules || [])];
+                      updated[idx].discountPct = text ? parseFloat(text) : undefined;
+                      setNewTier({...newTier, rules: updated});
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <TouchableOpacity onPress={() => {
+                  const updated = [...(newTier.rules || [])];
+                  updated.splice(idx,1);
+                  setNewTier({...newTier, rules: updated});
+                }}>
+                  <Trash2 size={20} color={colors.status.error} />
+                </TouchableOpacity>
               </View>
-
-              <View style={styles.formGroupHalf}>
-                <Text style={[styles.formLabel, { color: colors.text.primary }]}>כמות מינימלית *</Text>
-                <TextInput
-                  style={[styles.formInput, { 
-                    borderColor: colors.border.primary,
-                    backgroundColor: colors.surface.primary,
-                    color: colors.text.primary 
-                  }]}
-                  value={newTier.minQuantity?.toString()}
-                  onChangeText={(text) => {
-                    const minQuantity = parseInt(text) || 1;
-                    setNewTier({...newTier, minQuantity: Math.max(1, minQuantity)});
-                  }}
-                  placeholder="מינימום 1"
-                  keyboardType="numeric"
-                  textAlign="right"
-                />
-              </View>
-            </View>
+            ))}
+            <TouchableOpacity onPress={() => setNewTier({...newTier, rules: [...(newTier.rules||[]), {minQty:1, maxQty:1, pricePerUnit: undefined, discountPct: undefined}]})} style={{marginBottom:10}}>
+              <Text style={{color: colors.gold}}>הוסף כלל</Text>
+            </TouchableOpacity>
 
             <View style={styles.formGroup}>
               <Text style={[styles.formLabel, { color: colors.text.primary }]}>תיאור *</Text>

--- a/services/database.ts
+++ b/services/database.ts
@@ -689,17 +689,25 @@ class DatabaseService {
   // Pricing Tiers
   async getPricingTiers(): Promise<PricingTier[]> {
     try {
-      const { data, error } = await supabase
+      const { data: tiersData, error: tiersError } = await supabase
         .from('pricing_tiers')
         .select('*')
-        .order('min_quantity', { ascending: true });
+        .order('created_at', { ascending: true });
 
-      if (error) {
-        console.error('Error fetching pricing tiers:', error);
+      if (tiersError) {
+        console.error('Error fetching pricing tiers:', tiersError);
         return [];
       }
 
-      return (data || []).map(tier => ({
+      const { data: rulesData, error: rulesError } = await supabase
+        .from('price_tier_rules')
+        .select('*');
+
+      if (rulesError) {
+        console.error('Error fetching pricing tier rules:', rulesError);
+      }
+
+      return (tiersData || []).map(tier => ({
         id: tier.id,
         name: tier.name,
         name_en: tier.name_en,
@@ -709,7 +717,20 @@ class DatabaseService {
         description: tier.description,
         description_en: tier.description_en,
         description_he: tier.description_he,
-        createdAt: tier.created_at
+        createdAt: tier.created_at,
+        rules: (rulesData || [])
+          .filter(r => r.tier_id === tier.id)
+          .sort((a, b) => a.min_qty - b.min_qty)
+          .map(r => ({
+            id: r.id,
+            tierId: r.tier_id,
+            minQty: r.min_qty,
+            maxQty: r.max_qty,
+            pricePerUnit: r.price_per_unit,
+            discountPct: r.discount_pct,
+            createdAt: r.created_at,
+            updatedAt: r.updated_at
+          }))
       }));
     } catch (error) {
       console.error('Error in getPricingTiers:', error);
@@ -732,6 +753,16 @@ class DatabaseService {
 
       if (!data) return null;
 
+      const { data: rulesData, error: rulesError } = await supabase
+        .from('price_tier_rules')
+        .select('*')
+        .eq('tier_id', id)
+        .order('min_qty', { ascending: true });
+
+      if (rulesError) {
+        console.error('Error fetching pricing tier rules:', rulesError);
+      }
+
       return {
         id: data.id,
         name: data.name,
@@ -742,7 +773,17 @@ class DatabaseService {
         description: data.description,
         description_en: data.description_en,
         description_he: data.description_he,
-        createdAt: data.created_at
+        createdAt: data.created_at,
+        rules: (rulesData || []).map(r => ({
+          id: r.id,
+          tierId: r.tier_id,
+          minQty: r.min_qty,
+          maxQty: r.max_qty,
+          pricePerUnit: r.price_per_unit,
+          discountPct: r.discount_pct,
+          createdAt: r.created_at,
+          updatedAt: r.updated_at
+        }))
       };
     } catch (error) {
       console.error('Error in getPricingTier:', error);
@@ -770,6 +811,23 @@ class DatabaseService {
         console.error('Error adding pricing tier:', error);
         throw new Error('Failed to add pricing tier');
       }
+
+      if (tier.rules && tier.rules.length > 0) {
+        const rulesToInsert = tier.rules.map(r => ({
+          tier_id: tier.id,
+          min_qty: r.minQty,
+          max_qty: r.maxQty,
+          price_per_unit: r.pricePerUnit,
+          discount_pct: r.discountPct
+        }));
+        const { error: ruleError } = await supabase
+          .from('price_tier_rules')
+          .insert(rulesToInsert);
+        if (ruleError) {
+          console.error('Error adding pricing tier rules:', ruleError);
+          throw new Error('Failed to add pricing tier rules');
+        }
+      }
     } catch (error) {
       console.error('Error in addPricingTier:', error);
       throw error;
@@ -795,6 +853,30 @@ class DatabaseService {
       if (error) {
         console.error('Error updating pricing tier:', error);
         throw new Error('Failed to update pricing tier');
+      }
+
+      if (tier.rules) {
+        await supabase
+          .from('price_tier_rules')
+          .delete()
+          .eq('tier_id', id);
+
+        if (tier.rules.length > 0) {
+          const rulesToInsert = tier.rules.map(r => ({
+            tier_id: id,
+            min_qty: r.minQty,
+            max_qty: r.maxQty,
+            price_per_unit: r.pricePerUnit,
+            discount_pct: r.discountPct
+          }));
+          const { error: ruleError } = await supabase
+            .from('price_tier_rules')
+            .insert(rulesToInsert);
+          if (ruleError) {
+            console.error('Error updating pricing tier rules:', ruleError);
+            throw new Error('Failed to update pricing tier rules');
+          }
+        }
       }
     } catch (error) {
       console.error('Error in updatePricingTier:', error);

--- a/supabase/migrations/20250701195900_price_tier_rules.sql
+++ b/supabase/migrations/20250701195900_price_tier_rules.sql
@@ -1,0 +1,25 @@
+-- Create price_tier_rules table
+CREATE TABLE price_tier_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tier_id text NOT NULL REFERENCES pricing_tiers(id) ON DELETE CASCADE,
+  min_qty integer NOT NULL CHECK (min_qty >= 0),
+  max_qty integer NOT NULL CHECK (max_qty >= min_qty),
+  price_per_unit numeric,
+  discount_pct numeric,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE price_tier_rules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read access for price_tier_rules"
+  ON price_tier_rules FOR SELECT TO public USING (true);
+
+CREATE POLICY "Admin write access for price_tier_rules"
+  ON price_tier_rules FOR ALL TO public USING (is_admin());
+
+CREATE INDEX idx_price_tier_rules_tier_id ON price_tier_rules(tier_id);
+
+CREATE TRIGGER update_price_tier_rules_updated_at
+  BEFORE UPDATE ON price_tier_rules
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/types/index.ts
+++ b/types/index.ts
@@ -53,6 +53,18 @@ export interface PricingTier {
   description_en?: string;
   description_he?: string;
   createdAt?: string;
+  rules?: PricingTierRule[];
+}
+
+export interface PricingTierRule {
+  id: string;
+  tierId: string;
+  minQty: number;
+  maxQty: number;
+  pricePerUnit?: number;
+  discountPct?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary
- add `price_tier_rules` table and RLS policies
- extend `PricingTier` with new `rules` property
- support CRUD of tier rules in `DatabaseService`
- allow admin to manage tier rules in UI

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ac6904f48326bd568d819867785f