### PR TITLE
Fix SafeAreaView import for web support

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   I18nManager,
   Modal,
   TextInput,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   TouchableOpacity,
   FlatList,
-  SafeAreaView,
   Dimensions,
   Modal,
   Alert,
@@ -16,6 +15,7 @@ import {
   RefreshControl,
   useWindowDimensions,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Heart, Plus, Pencil, X, Save, Trash2, Filter, ArrowUpDown } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -5,10 +5,10 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  SafeAreaView,
   ActivityIndicator,
   I18nManager,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Bell, Package, Tag, MessageCircle, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info } from 'lucide-react-native';
 import { MatrixService } from '../../services/matrix';
 import NotificationService from '../../services/notification';

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -3,11 +3,11 @@ import {
   View,
   Text,
   StyleSheet,
-  SafeAreaView,
   ScrollView,
   TouchableOpacity,
   I18nManager,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Package, ArrowLeft, ChevronLeft, ShoppingBag, Clock, Calendar, Truck } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { 
-  View, 
-  Text, 
-  StyleSheet, 
-  TouchableOpacity, 
-  SafeAreaView, 
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
   I18nManager,
   ScrollView,
   Switch
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Settings, User, Shield, Moon, Sun, Globe, Bell } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   I18nManager,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Package, MessageCircle, Users, Bell, Star, TrendingUp, ShoppingCart, Eye, Shield, Clock, DollarSign, Settings } from 'lucide-react-native';
 import { MatrixService } from '../../services/matrix';

--- a/app/admin/kyc-approvals.tsx
+++ b/app/admin/kyc-approvals.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   Alert,
   I18nManager,
   Image,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, CircleCheck as CheckCircle, Circle as XCircle, Clock, User, Mail, FileText, Calendar } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -4,13 +4,13 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   TextInput,
   Modal,
   I18nManager,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2, DollarSign, Percent, Package, Users } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   TextInput,
   I18nManager,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Save, Settings as SettingsIcon, DollarSign, Globe, Bell } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   TextInput,
   Modal,
@@ -12,6 +11,7 @@ import {
   I18nManager,
   ActivityIndicator,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Search, User, Mail, Calendar, Shield, UserCheck, UserX, Filter, X, Save, ChevronDown } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, StyleSheet, SafeAreaView } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { useTheme } from '../../contexts/ThemeContext';
 import AuthTabsModal from '../../components/AuthTabsModal';

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
 import {
-  View, 
-  Text, 
-  StyleSheet, 
-  TextInput, 
-  TouchableOpacity, 
-  SafeAreaView, 
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
   I18nManager,
   ActivityIndicator,
   ScrollView,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Lock, Shield } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
 import {
-  View, 
-  Text, 
-  StyleSheet, 
-  TextInput, 
-  TouchableOpacity, 
-  SafeAreaView, 
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
   I18nManager,
   ActivityIndicator,
   ScrollView,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, UserPlus } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   I18nManager,
   Modal,
   TextInput,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   TextInput,
   Linking,
   I18nManager,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Shield, CircleCheck as CheckCircle, TriangleAlert as AlertTriangle, Clock, ExternalLink } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -14,6 +14,7 @@ import {
   Platform,
   ActivityIndicator,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, Heart, Minus, Plus, ShoppingCart, Tag, Share2, Pencil, X, Save, Trash2, Image as ImageIcon } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  SafeAreaView,
   Image,
   TextInput,
   Modal,
@@ -13,6 +12,7 @@ import {
   I18nManager,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Star, Plus, X, Send, Filter, Search, ThumbsUp, ArrowLeft, Trash2 } from 'lucide-react-native';
 import { router } from 'expo-router';
 import DatabaseService from '../../services/database';

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  SafeAreaView,
   Image,
   Modal,
   TextInput,
@@ -13,6 +12,7 @@ import {
   Platform,
   ActivityIndicator,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2, Heart } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -3,13 +3,13 @@ import {
   View,
   Text,
   StyleSheet,
-  SafeAreaView,
   ScrollView,
   TouchableOpacity,
   Image,
   I18nManager,
   Alert,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, User as UserIcon, Mail, Calendar, Shield, MessageCircle } from 'lucide-react-native';
 import DatabaseService from '../../services/database';

--- a/components/AdminChatList.tsx
+++ b/components/AdminChatList.tsx
@@ -7,10 +7,10 @@ import {
   TouchableOpacity,
   TextInput,
   Modal,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Search, MessageCircle, Send, X } from 'lucide-react-native';
 import { ChatRoom, ChatMessage } from '../types';
 import DatabaseService from '../services/database';

--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -5,10 +5,10 @@ import {
   StyleSheet,
   Modal,
   TouchableOpacity,
-  SafeAreaView,
   ScrollView,
   I18nManager,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../contexts/ThemeContext';

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -7,13 +7,13 @@ import {
   Modal,
   TextInput,
   ScrollView,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   Image,
   I18nManager,
   Pressable,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { MessageCircle, Send, X, Minimize2, Search, ChevronLeft, Mic, MicOff, Play, Pause, Smile } from 'lucide-react-native';
 import { Audio } from 'expo-av';
 import { MatrixService } from '../services/matrix';

--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -5,13 +5,13 @@ import {
   Image,
   TouchableOpacity,
   Dimensions,
-  SafeAreaView,
   Modal,
   Text,
   StatusBar,
   Platform,
   Alert,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { X, ChevronLeft, ChevronRight, Share2, Download } from 'lucide-react-native';
 import { PanGestureHandler, PinchGestureHandler, State } from 'react-native-gesture-handler';
 import Animated, {

--- a/components/MediaViewer.tsx
+++ b/components/MediaViewer.tsx
@@ -5,8 +5,8 @@ import {
   Image,
   TouchableOpacity,
   Dimensions,
-  SafeAreaView,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { X } from 'lucide-react-native';
 import { PanGestureHandler, PinchGestureHandler, State } from 'react-native-gesture-handler';
 import Animated, {


### PR DESCRIPTION
## Summary
- import `SafeAreaView` from `react-native-safe-area-context` instead of `react-native`
- fix multiple screens and components so SafeAreaView works on web

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae6051a083269423a01c7e193cd3