### PR TITLE
Add mix group feature

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,7 +20,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { Heart, Plus, Pencil, X, Save, Trash2, Filter, ArrowUpDown } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import PinataService from '../../services/pinata';
-import { Product, Category, HeroBanner, Subcategory } from '../../types';
+import { Product, Category, HeroBanner, Subcategory, MixGroup } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -51,6 +51,7 @@ export default function HomeScreen() {
   const [filteredProducts, setFilteredProducts] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [subcategories, setSubcategories] = useState<Subcategory[]>([]);
+  const [mixGroups, setMixGroups] = useState<MixGroup[]>([]);
   const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [currentBannerIndex, setCurrentBannerIndex] = useState(0);
@@ -73,6 +74,7 @@ export default function HomeScreen() {
   const [showProductModal, setShowProductModal] = useState(false);
   const [showCategorySelector, setShowCategorySelector] = useState(false);
   const [showSubcategorySelector, setShowSubcategorySelector] = useState(false);
+  const [showMixGroupSelector, setShowMixGroupSelector] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [newProduct, setNewProduct] = useState<Partial<Product>>({
     name: '',
@@ -80,6 +82,7 @@ export default function HomeScreen() {
     description: '',
     category: '',
     subcategory: '',
+    mixGroupId: '',
     images: [],
     videos: [],
     stock: 0,
@@ -131,10 +134,11 @@ export default function HomeScreen() {
     try {
       setLoading(true);
       const db = DatabaseService.getInstance();
-      const [productsData, categoriesData, bannersData] = await Promise.all([
+      const [productsData, categoriesData, bannersData, mixGroupsData] = await Promise.all([
         db.getProducts(),
         db.getCategories(),
-        db.getHeroBanners()
+        db.getHeroBanners(),
+        db.getMixGroups()
       ]);
       setProducts(productsData);
       setCategories(categoriesData);
@@ -149,6 +153,7 @@ export default function HomeScreen() {
       setSubcategories(allSubcategories);
       
       setHeroBanners(bannersData);
+      setMixGroups(mixGroupsData);
     } catch (error) {
       console.error('Error loading data:', error);
     } finally {
@@ -307,6 +312,7 @@ export default function HomeScreen() {
       description: '',
       category: '',
       subcategory: '',
+      mixGroupId: '',
       images: [],
       videos: [],
       stock: 0,
@@ -435,6 +441,13 @@ export default function HomeScreen() {
       setNewProduct({...newProduct, subcategory});
     }
     setShowSubcategorySelector(false);
+  };
+
+  const selectMixGroup = (groupId: string) => {
+    if (showProductModal) {
+      setNewProduct({ ...newProduct, mixGroupId: groupId });
+    }
+    setShowMixGroupSelector(false);
   };
 
   const getFilteredSubcategories = () => {
@@ -984,6 +997,26 @@ export default function HomeScreen() {
             </View>
 
             <View style={styles.formGroup}>
+              <Text style={[styles.formLabel, { color: colors.text.primary }]}>קבוצת מיקס (אופציונלי)</Text>
+              <TouchableOpacity
+                style={[styles.categorySelector, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.primary
+                }]}
+                onPress={() => setShowMixGroupSelector(true)}
+              >
+                <Text style={[
+                  styles.categorySelectorText,
+                  { color: newProduct.mixGroupId ? colors.text.primary : colors.text.tertiary }
+                ]}>
+                  {newProduct.mixGroupId ?
+                    mixGroups.find(g => g.id === newProduct.mixGroupId)?.name || newProduct.mixGroupId
+                    : "בחר קבוצת מיקס"}
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.formGroup}>
               <Text style={[styles.formLabel, { color: colors.text.primary }]}>מלאי *</Text>
               <TextInput
                 style={[styles.formInput, { 
@@ -1165,6 +1198,43 @@ export default function HomeScreen() {
                   <Text style={[styles.categorySelectorItemText, { color: colors.gold }]}>הוסף תת-קטגוריה חדשה</Text>
                 </View>
               </TouchableOpacity>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Mix Group Selector Modal */}
+      <Modal
+        visible={showMixGroupSelector}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={() => setShowMixGroupSelector(false)}
+      >
+        <View style={[styles.categorySelectorOverlay, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>
+          <View style={[styles.categorySelectorContent, {
+            backgroundColor: colors.surface.elevated,
+            borderColor: colors.border.primary
+          }]}>
+            <View style={styles.categorySelectorHeader}>
+              <Text style={[styles.categorySelectorTitle, { color: colors.text.primary }]}>בחר קבוצת מיקס</Text>
+              <TouchableOpacity onPress={() => setShowMixGroupSelector(false)}>
+                <X size={24} color={colors.text.primary} />
+              </TouchableOpacity>
+            </View>
+
+            <ScrollView style={styles.categorySelectorList}>
+              {mixGroups.map(group => (
+                <TouchableOpacity
+                  key={group.id}
+                  style={[styles.categorySelectorItem, { borderBottomColor: colors.border.secondary }]}
+                  onPress={() => selectMixGroup(group.id)}
+                >
+                  <View style={styles.categorySelectorItemContent}>
+                    <Text style={[styles.categorySelectorItemText, { color: colors.text.primary }]}>{group.name}</Text>
+                  </View>
+                  <Text style={[styles.categorySelectorItemId, { color: colors.text.tertiary }]}>{group.id}</Text>
+                </TouchableOpacity>
+              ))}
             </ScrollView>
           </View>
         </View>

--- a/services/database.ts
+++ b/services/database.ts
@@ -8,8 +8,9 @@ import {
   User, 
   Notification, 
   Review, 
-  HeroBanner, 
-  PricingTier 
+  HeroBanner,
+  PricingTier,
+  MixGroup
 } from '../types';
 
 class DatabaseService {
@@ -822,6 +823,117 @@ class DatabaseService {
       }
     } catch (error) {
       console.error('Error in deletePricingTier:', error);
+      throw error;
+    }
+  }
+
+  // Mix Groups
+  async getMixGroups(): Promise<MixGroup[]> {
+    try {
+      const { data, error } = await supabase
+        .from('mix_groups')
+        .select('*')
+        .order('name');
+
+      if (error) {
+        console.error('Error fetching mix groups:', error);
+        return [];
+      }
+
+      return (data || []).map(group => ({
+        id: group.id,
+        name: group.name,
+        conversionFactor: group.conversion_factor,
+        createdAt: group.created_at
+      }));
+    } catch (error) {
+      console.error('Error in getMixGroups:', error);
+      return [];
+    }
+  }
+
+  async getMixGroup(id: string): Promise<MixGroup | null> {
+    try {
+      const { data, error } = await supabase
+        .from('mix_groups')
+        .select('*')
+        .eq('id', id)
+        .single();
+
+      if (error) {
+        console.error('Error fetching mix group:', error);
+        return null;
+      }
+
+      if (!data) return null;
+
+      return {
+        id: data.id,
+        name: data.name,
+        conversionFactor: data.conversion_factor,
+        createdAt: data.created_at
+      };
+    } catch (error) {
+      console.error('Error in getMixGroup:', error);
+      return null;
+    }
+  }
+
+  async addMixGroup(group: MixGroup): Promise<void> {
+    try {
+      const { error } = await supabase
+        .from('mix_groups')
+        .insert([{ id: group.id, name: group.name, conversion_factor: group.conversionFactor }]);
+
+      if (error) {
+        console.error('Error adding mix group:', error);
+        throw new Error('Failed to add mix group');
+      }
+    } catch (error) {
+      console.error('Error in addMixGroup:', error);
+      throw error;
+    }
+  }
+
+  async updateMixGroup(id: string, group: Partial<MixGroup>): Promise<void> {
+    try {
+      const { error } = await supabase
+        .from('mix_groups')
+        .update({
+          name: group.name,
+          conversion_factor: group.conversionFactor
+        })
+        .eq('id', id);
+
+      if (error) {
+        console.error('Error updating mix group:', error);
+        throw new Error('Failed to update mix group');
+      }
+    } catch (error) {
+      console.error('Error in updateMixGroup:', error);
+      throw error;
+    }
+  }
+
+  async deleteMixGroup(id: string): Promise<void> {
+    try {
+      // Remove reference from products first
+      await supabase
+        .from('products')
+        .update({ mix_group_id: null })
+        .eq('mix_group_id', id);
+
+      const { error } = await supabase
+        .from('mix_groups')
+        .delete()
+        .eq('id', id);
+
+      if (error) {
+        console.error('Error deleting mix group:', error);
+        throw new Error('Failed to delete mix group');
+      }
+    } catch (error) {
+      console.error('Error in deleteMixGroup:', error);
       throw error;
     }
   }

--- a/supabase/migrations/20250702010000_crimson_mix.sql
+++ b/supabase/migrations/20250702010000_crimson_mix.sql
@@ -1,0 +1,49 @@
+/*
+  # Add Mix Groups Table
+
+  1. New Tables
+    - mix_groups: store mix group name and conversion factor
+
+  2. Table Changes
+    - products: add mix_group_id column referencing mix_groups
+
+  3. Security
+    - Enable RLS and public policies similar to other tables
+*/
+
+-- Create mix_groups table
+CREATE TABLE IF NOT EXISTS mix_groups (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  conversion_factor numeric NOT NULL CHECK (conversion_factor > 0),
+  created_at timestamptz DEFAULT now()
+);
+
+-- Add mix_group_id column to products
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS mix_group_id text REFERENCES mix_groups(id);
+
+-- Enable row level security for mix_groups
+ALTER TABLE mix_groups ENABLE ROW LEVEL SECURITY;
+
+-- Public read access
+CREATE POLICY "Public read access for mix_groups"
+  ON mix_groups FOR SELECT
+  TO public
+  USING (true);
+
+-- Admin CRUD policies
+CREATE POLICY "Admin insert access for mix_groups"
+  ON mix_groups FOR INSERT
+  TO public
+  WITH CHECK (true);
+
+CREATE POLICY "Admin update access for mix_groups"
+  ON mix_groups FOR UPDATE
+  TO public
+  USING (true);
+
+CREATE POLICY "Admin delete access for mix_groups"
+  ON mix_groups FOR DELETE
+  TO public
+  USING (true);

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,6 +17,7 @@ export interface Product {
   reviews: number;
   badges?: string[];
   pricingTier?: string;
+  mixGroupId?: string;
   stock: number;
   createdAt?: string;
   updatedAt?: string;
@@ -52,6 +53,13 @@ export interface PricingTier {
   description: string;
   description_en?: string;
   description_he?: string;
+  createdAt?: string;
+}
+
+export interface MixGroup {
+  id: string;
+  name: string;
+  conversionFactor: number;
   createdAt?: string;
 }
 


### PR DESCRIPTION
## Summary
- add `mix_groups` table and reference from products
- support mix groups in TypeScript models and database service
- allow admins to assign a mix group when creating products

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864af0358fc8326a3878fe9ebc013b7