### PR TITLE
Implement mix group tier pricing

### DIFF
--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -115,7 +115,10 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   };
 
   const getTotal = () => {
-    return cartItems.reduce((total, item) => total + (item.product.price * item.quantity), 0);
+    return cartItems.reduce((total, item) => {
+      const price = item.unitPrice ?? item.product.price;
+      return total + price * item.quantity;
+    }, 0);
   };
 
   const getTotalItems = () => {
@@ -308,7 +311,11 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           {item.product.name}
         </Text>
         
-        <Text style={[styles.productPrice, { color: colors.gold }]}>{currencySymbol}{item.product.price.toFixed(2)}</Text>
+        <Text style={[styles.productPrice, { color: colors.gold }]}>{currencySymbol}{(item.unitPrice ?? item.product.price).toFixed(2)}</Text>
+        {item.tierName && (
+          <Text style={[styles.tierInfo, { color: colors.text.secondary }]}>\n            {item.tierName} • EQ {item.effectiveQty}
+          </Text>
+        )}
       </View>
 
       <View style={styles.quantityControls}>
@@ -592,7 +599,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           {cartItems.map(item => (
             <View key={item.id} style={styles.summaryItem}>
               <Text style={[styles.summaryItemName, { color: colors.text.primary }]}>{item.product.name} x{item.quantity}</Text>
-              <Text style={[styles.summaryItemPrice, { color: colors.gold }]}>{currencySymbol}{(item.product.price * item.quantity).toFixed(2)}</Text>
+              <Text style={[styles.summaryItemPrice, { color: colors.gold }]}>{currencySymbol}{((item.unitPrice ?? item.product.price) * item.quantity).toFixed(2)}</Text>
             </View>
           ))}
           <View style={styles.summaryRow}>
@@ -688,7 +695,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           {cartItems.map(item => (
             <View key={item.id} style={styles.summaryItem}>
               <Text style={[styles.summaryItemName, { color: colors.text.primary }]}>{item.product.name} x{item.quantity}</Text>
-              <Text style={[styles.summaryItemPrice, { color: colors.gold }]}>{currencySymbol}{(item.product.price * item.quantity).toFixed(2)}</Text>
+              <Text style={[styles.summaryItemPrice, { color: colors.gold }]}>{currencySymbol}{((item.unitPrice ?? item.product.price) * item.quantity).toFixed(2)}</Text>
             </View>
           ))}
           <View style={styles.summaryRow}>
@@ -951,6 +958,10 @@ const styles = StyleSheet.create({
   productPrice: {
     fontSize: 16,
     fontWeight: 'bold',
+    textAlign: 'right',
+  },
+  tierInfo: {
+    fontSize: 12,
     textAlign: 'right',
   },
   quantityControls: {

--- a/components/FloatingCartWidget.tsx
+++ b/components/FloatingCartWidget.tsx
@@ -79,7 +79,10 @@ export default function FloatingCartWidget() {
   };
 
   const getTotal = () => {
-    return cartItems.reduce((total, item) => total + (item.product.price * item.quantity), 0);
+    return cartItems.reduce((total, item) => {
+      const price = item.unitPrice ?? item.product.price;
+      return total + price * item.quantity;
+    }, 0);
   };
 
   const getTotalItems = () => {
@@ -192,8 +195,12 @@ export default function FloatingCartWidget() {
                     {item.product.name}
                   </Text>
                   <Text style={[styles.itemPrice, { color: colors.gold }]}>
-                    {currencySymbol}{item.product.price.toFixed(2)}
+                    {currencySymbol}{(item.unitPrice ?? item.product.price).toFixed(2)}
                   </Text>
+                  {item.tierName && (
+                    <Text style={[styles.tierInfo, { color: colors.text.secondary }]}>\n                      {item.tierName} • EQ {item.effectiveQty}
+                    </Text>
+                  )}
                 </View>
 
                 <View style={styles.quantityControls}>
@@ -364,6 +371,10 @@ const styles = StyleSheet.create({
   itemPrice: {
     fontSize: 12,
     fontWeight: '600',
+    textAlign: 'right',
+  },
+  tierInfo: {
+    fontSize: 10,
     textAlign: 'right',
   },
   quantityControls: {

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -237,7 +237,7 @@ ${order.shippingAddress.phone}
 ${order.shippingAddress.notes ? `הערות: ${order.shippingAddress.notes}` : ''}
 
 פריטים:
-${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currencySymbol}${(item.product.price * item.quantity).toFixed(2)}`).join('\n')}
+${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currencySymbol}${((item.unitPrice ?? item.product.price) * item.quantity).toFixed(2)}`).join('\n')}
       `.trim();
 
       await Clipboard.setStringAsync(formattedDetails);
@@ -459,7 +459,7 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
                 <View style={styles.itemInfo}>
                   <Text style={[styles.itemName, { color: colors.text.primary }]}>{item.product.name}</Text>
                   <Text style={[styles.itemDetails, { color: colors.text.secondary }]}>
-                    כמות: {item.quantity} | מחיר: {currencySymbol}{item.product.price.toFixed(2)}
+                    כמות: {item.quantity} | מחיר: {currencySymbol}{(item.unitPrice ?? item.product.price).toFixed(2)}
                   </Text>
                   {item.selectedColor && (
                     <View style={styles.itemColor}>
@@ -472,7 +472,7 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
                   )}
                 </View>
                 <Text style={[styles.itemTotal, { color: colors.gold }]}>
-                  {currencySymbol}{(item.product.price * item.quantity).toFixed(2)}
+                  {currencySymbol}{((item.unitPrice ?? item.product.price) * item.quantity).toFixed(2)}
                 </Text>
               </View>
             ))}

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { CartItem, WishlistItem, Product } from '../types';
+import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
+import DatabaseService from './database';
 
 const CART_STORAGE_KEY = 'cart_items';
 const WISHLIST_STORAGE_KEY = 'wishlist_items';
@@ -9,6 +10,8 @@ class CartService {
   private cartItems: CartItem[] = [];
   private wishlistItems: WishlistItem[] = [];
   private listeners: (() => void)[] = [];
+  private tierCache: Record<string, PricingTier> = {};
+  private groupCache: Record<string, MixGroup> = {};
 
   public static getInstance(): CartService {
     if (!CartService.instance) {
@@ -34,7 +37,8 @@ class CartService {
       if (wishlistData) {
         this.wishlistItems = JSON.parse(wishlistData);
       }
-      
+
+      await this.recalcPricing();
       this.notifyListeners();
     } catch (error) {
       console.error('Error loading cart/wishlist from storage:', error);
@@ -64,6 +68,72 @@ class CartService {
     this.listeners = this.listeners.filter(l => l !== listener);
   }
 
+  private async getPricingTier(id: string): Promise<PricingTier | null> {
+    if (!id) return null;
+    if (!this.tierCache[id]) {
+      const db = DatabaseService.getInstance();
+      const tier = await db.getPricingTier(id);
+      if (tier) this.tierCache[id] = tier;
+    }
+    return this.tierCache[id] || null;
+  }
+
+  private async getMixGroup(id: string): Promise<MixGroup | null> {
+    if (!id) return null;
+    if (!this.groupCache[id]) {
+      const db = DatabaseService.getInstance();
+      const group = await db.getMixGroup(id);
+      if (group) this.groupCache[id] = group;
+    }
+    return this.groupCache[id] || null;
+  }
+
+  private async recalcPricing(): Promise<void> {
+    const combos: Record<string, CartItem[]> = {};
+
+    for (const item of this.cartItems) {
+      const key = `${item.product.mixGroupId || 'none'}|${item.product.pricingTier || 'none'}`;
+      if (!combos[key]) combos[key] = [];
+      combos[key].push(item);
+    }
+
+    for (const key of Object.keys(combos)) {
+      const items = combos[key];
+      if (items.length === 0) continue;
+      const mixGroupId = items[0].product.mixGroupId || '';
+      const tierId = items[0].product.pricingTier || '';
+
+      const group = await this.getMixGroup(mixGroupId);
+      const tier = await this.getPricingTier(tierId);
+
+      const conversionFactor = group?.conversionFactor ?? 1;
+      const effectiveQty = items.reduce((sum, it) => sum + it.quantity * conversionFactor, 0);
+
+      let rule: PricingTierRule | undefined;
+      if (tier?.rules && tier.rules.length > 0) {
+        rule = tier.rules.find(r => effectiveQty >= r.minQty && effectiveQty <= r.maxQty);
+        if (!rule) {
+          rule = tier.rules
+            .filter(r => effectiveQty >= r.minQty)
+            .sort((a, b) => b.minQty - a.minQty)[0];
+        }
+      }
+
+      for (const it of items) {
+        it.effectiveQty = effectiveQty;
+        it.tierName = rule ? tier?.name : undefined;
+
+        if (rule?.pricePerUnit !== undefined && rule.pricePerUnit !== null) {
+          it.unitPrice = rule.pricePerUnit * conversionFactor;
+        } else if (rule?.discountPct !== undefined && rule.discountPct !== null) {
+          it.unitPrice = it.product.price * (1 - rule.discountPct / 100);
+        } else {
+          it.unitPrice = it.product.price;
+        }
+      }
+    }
+  }
+
   // Cart methods
   public async addToCart(product: Product, quantity: number = 1): Promise<void> {
     const existingItemIndex = this.cartItems.findIndex(
@@ -83,12 +153,14 @@ class CartService {
       this.cartItems.push(cartItem);
     }
 
+    await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();
   }
 
   public async removeFromCart(itemId: string): Promise<void> {
     this.cartItems = this.cartItems.filter(item => item.id !== itemId);
+    await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();
   }
@@ -100,6 +172,7 @@ class CartService {
         await this.removeFromCart(itemId);
       } else {
         this.cartItems[itemIndex].quantity = quantity;
+        await this.recalcPricing();
         await this.saveToStorage();
         this.notifyListeners();
       }
@@ -108,6 +181,7 @@ class CartService {
 
   public async clearCart(): Promise<void> {
     this.cartItems = [];
+    await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();
   }
@@ -118,7 +192,8 @@ class CartService {
 
   public getCartTotal(): number {
     return this.cartItems.reduce((total, item) => {
-      return total + (item.product.price * item.quantity);
+      const price = item.unitPrice ?? item.product.price;
+      return total + price * item.quantity;
     }, 0);
   }
 

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -114,7 +114,10 @@ class OrderService {
     items: CartItem[],
     shippingAddress: ShippingAddress
   ): Promise<Order> {
-    const total = items.reduce((sum, item) => sum + (item.product.price * item.quantity), 0);
+    const total = items.reduce((sum, item) => {
+      const price = item.unitPrice ?? item.product.price;
+      return sum + price * item.quantity;
+    }, 0);
     
     const order: Order = {
       id: `order_${Date.now()}`,

--- a/types/index.ts
+++ b/types/index.ts
@@ -168,6 +168,9 @@ export interface CartItem {
   product: Product;
   quantity: number;
   addedAt: string;
+  unitPrice?: number;
+  tierName?: string;
+  effectiveQty?: number;
 }
 
 export interface WishlistItem {


### PR DESCRIPTION
## Summary
- track unit price, effective quantity and tier on cart items
- compute pricing tiers by mix group in cart service
- display tiered price info in cart, floating cart and order tracking
- include tier pricing in order totals

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b1049cb88326a658422787a8defd