### PR TITLE
Implement admin pricing tier rule management

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -35,12 +35,28 @@ export default function PricingTiersScreen() {
     name: '',
     description: '',
     rules: [
-      { minQty: 1, maxQty: 1, pricePerUnit: undefined, discountPct: undefined } as any
+      { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any
     ]
   });
   const { isAdmin } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+
+  const validateRules = (rules: { minQty: number; maxQty: number; pricePerBaseUnit?: number; discountPct?: number; }[]): string | null => {
+    const sorted = [...rules].sort((a, b) => a.minQty - b.minQty);
+    for (let i = 0; i < sorted.length; i++) {
+      const r = sorted[i];
+      if (r.minQty < 1) return 'כמות מינימלית חייבת להיות מספר גדול מ-0';
+      if (r.maxQty < r.minQty) return 'ערך מקסימום חייב להיות גדול או שווה למינימום';
+      if (r.pricePerBaseUnit == null && r.discountPct == null) return 'יש להזין מחיר או הנחה לכל כלל';
+      if (i === 0 && r.minQty !== 1) return 'הטווח הראשון חייב להתחיל ב-1';
+      if (i > 0) {
+        const prev = sorted[i - 1];
+        if (r.minQty !== prev.maxQty + 1) return 'טווחי הכמויות חופפים או מכילים חוסרים';
+      }
+    }
+    return null;
+  };
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -85,7 +101,7 @@ export default function PricingTiersScreen() {
       name: '',
       description: '',
       rules: [
-        { minQty: 1, maxQty: 1, pricePerUnit: undefined, discountPct: undefined } as any
+        { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any
       ]
     });
     setShowTierModal(true);
@@ -108,14 +124,12 @@ export default function PricingTiersScreen() {
       return;
     }
 
-    if (newTier.rules && newTier.rules.some(r => r.minQty < 1)) {
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'כמות מינימלית חייבת להיות מספר גדול מ-0',
-        type: 'error'
-      });
-      return;
+    if (newTier.rules) {
+      const errorMsg = validateRules(newTier.rules);
+      if (errorMsg) {
+        setInfoModal({ visible: true, title: 'שגיאה', message: errorMsg, type: 'error' });
+        return;
+      }
     }
 
     setLoading(true);
@@ -207,7 +221,7 @@ export default function PricingTiersScreen() {
           backgroundColor: colors.interactive.secondary,
           borderColor: colors.gold
         }]}>
-          {typeof (tier.rules?.[0]?.pricePerUnit) === 'number' ? (
+          {typeof (tier.rules?.[0]?.pricePerBaseUnit) === 'number' ? (
             <DollarSign size={24} color={colors.gold} />
           ) : (
             <Percent size={24} color={colors.gold} />
@@ -216,8 +230,8 @@ export default function PricingTiersScreen() {
         <View style={styles.tierInfo}>
           <Text style={[styles.tierName, { color: colors.text.primary }]}>{tier.name}</Text>
           <Text style={[styles.tierDiscount, { color: colors.gold }]}>
-            {typeof (tier.rules?.[0]?.pricePerUnit) === 'number'
-              ? `${currencySymbol}${tier.rules![0].pricePerUnit!.toFixed(2)} ליחידה`
+            {typeof (tier.rules?.[0]?.pricePerBaseUnit) === 'number'
+              ? `${currencySymbol}${tier.rules![0].pricePerBaseUnit!.toFixed(2)} ליחידה`
               : 'מחיר רגיל'}
           </Text>
         </View>
@@ -407,10 +421,10 @@ export default function PricingTiersScreen() {
                       backgroundColor: colors.surface.primary,
                       color: colors.text.primary
                     }]}
-                    value={rule.pricePerUnit?.toString() || ''}
+                    value={rule.pricePerBaseUnit?.toString() || ''}
                     onChangeText={(text) => {
                       const updated = [...(newTier.rules || [])];
-                      updated[idx].pricePerUnit = text ? parseFloat(text) : undefined;
+                      updated[idx].pricePerBaseUnit = text ? parseFloat(text) : undefined;
                       setNewTier({...newTier, rules: updated});
                     }}
                     keyboardType="numeric"
@@ -444,7 +458,7 @@ export default function PricingTiersScreen() {
                 </TouchableOpacity>
               </View>
             ))}
-            <TouchableOpacity onPress={() => setNewTier({...newTier, rules: [...(newTier.rules||[]), {minQty:1, maxQty:1, pricePerUnit: undefined, discountPct: undefined}]})} style={{marginBottom:10}}>
+            <TouchableOpacity onPress={() => setNewTier({...newTier, rules: [...(newTier.rules||[]), {minQty:1, maxQty:1, pricePerBaseUnit: undefined, discountPct: undefined}]})} style={{marginBottom:10}}>
               <Text style={{color: colors.gold}}>הוסף כלל</Text>
             </TouchableOpacity>
 

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -123,8 +123,8 @@ class CartService {
         it.effectiveQty = effectiveQty;
         it.tierName = rule ? tier?.name : undefined;
 
-        if (rule?.pricePerUnit !== undefined && rule.pricePerUnit !== null) {
-          it.unitPrice = rule.pricePerUnit * conversionFactor;
+        if (rule?.pricePerBaseUnit !== undefined && rule.pricePerBaseUnit !== null) {
+          it.unitPrice = rule.pricePerBaseUnit * conversionFactor;
         } else if (rule?.discountPct !== undefined && rule.discountPct !== null) {
           it.unitPrice = it.product.price * (1 - rule.discountPct / 100);
         } else {

--- a/services/database.ts
+++ b/services/database.ts
@@ -727,7 +727,7 @@ class DatabaseService {
             tierId: r.tier_id,
             minQty: r.min_qty,
             maxQty: r.max_qty,
-            pricePerUnit: r.price_per_unit,
+            pricePerBaseUnit: r.price_per_unit,
             discountPct: r.discount_pct,
             createdAt: r.created_at,
             updatedAt: r.updated_at
@@ -780,7 +780,7 @@ class DatabaseService {
           tierId: r.tier_id,
           minQty: r.min_qty,
           maxQty: r.max_qty,
-          pricePerUnit: r.price_per_unit,
+          pricePerBaseUnit: r.price_per_unit,
           discountPct: r.discount_pct,
           createdAt: r.created_at,
           updatedAt: r.updated_at
@@ -818,7 +818,7 @@ class DatabaseService {
           tier_id: tier.id,
           min_qty: r.minQty,
           max_qty: r.maxQty,
-          price_per_unit: r.pricePerUnit,
+          price_per_unit: r.pricePerBaseUnit,
           discount_pct: r.discountPct
         }));
         const { error: ruleError } = await supabase
@@ -867,7 +867,7 @@ class DatabaseService {
             tier_id: id,
             min_qty: r.minQty,
             max_qty: r.maxQty,
-            price_per_unit: r.pricePerUnit,
+            price_per_unit: r.pricePerBaseUnit,
             discount_pct: r.discountPct
           }));
           const { error: ruleError } = await supabase

--- a/types/index.ts
+++ b/types/index.ts
@@ -62,7 +62,7 @@ export interface PricingTierRule {
   tierId: string;
   minQty: number;
   maxQty: number;
-  pricePerUnit?: number;
+  pricePerBaseUnit?: number;
   discountPct?: number;
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary
- allow adding and removing pricing tier rule rows
- validate ranges and missing price/discount values
- rename rule property to `pricePerBaseUnit`
- support the new field in cart calculations and database service

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b2e225c88326a0e15f8606c947f7