### PR TITLE
Add admin DM room helper

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -123,18 +123,19 @@ export default function ChatWidget() {
 
   const loadOrCreateDefaultRoom = async () => {
     try {
-      // For non-admin users, always use a default room
+      const roomId = await matrixService.getOrCreateAdminRoom();
+
       const defaultRoom = {
-        id: 'default_room',
+        id: roomId,
         userId: user?.id || 'guest_user',
         userName: user?.displayName || 'Guest User',
         lastMessage: 'Welcome to our store!',
         lastMessageTime: Date.now() - 3600000, // 1 hour ago
         unreadCount: 0
       };
-      
+
       setSelectedRoom(defaultRoom);
-      await loadMessages(defaultRoom.id);
+      await loadMessages(roomId);
     } catch (error) {
       console.error('Error creating default room:', error);
       setInfoModal({
@@ -176,8 +177,8 @@ export default function ChatWidget() {
 
   const sendMessage = async () => {
     if (!newMessage.trim()) return;
-    
-    const roomId = selectedRoom ? selectedRoom.id : 'default_room';
+
+    const roomId = selectedRoom ? selectedRoom.id : await matrixService.getOrCreateAdminRoom();
     
     try {
       // Send message using Matrix service
@@ -300,7 +301,7 @@ export default function ChatWidget() {
         // In a real app, you would upload to Pinata here
         console.log('Voice message recorded:', uri);
         
-        const roomId = selectedRoom ? selectedRoom.id : 'default_room';
+        const roomId = selectedRoom ? selectedRoom.id : await matrixService.getOrCreateAdminRoom();
         const voiceMessage: ChatMessage = {
           id: Date.now().toString(),
           senderId: isAdmin ? (process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin') : (user?.id || 'user_guest'),
@@ -400,7 +401,7 @@ export default function ChatWidget() {
       setShowReactions(null);
       
       // Try to update in Matrix
-      const roomId = selectedRoom?.id || 'default_room';
+      const roomId = selectedRoom?.id || await matrixService.getOrCreateAdminRoom();
       await matrixService.updateChatMessageReactions(roomId, messageId, emoji);
     } catch (error) {
       console.error('Error adding reaction:', error);

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -542,6 +542,48 @@ export class MatrixService {
     }
   }
 
+  async getOrCreateAdminRoom(): Promise<string> {
+    try {
+      if (!this.isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+
+      const adminUsername = process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'roymichaels';
+      const domain = MATRIX_SERVER_URL.replace(/^https?:\/\//, '');
+      const adminUserId = `@${adminUsername}:${domain}`;
+
+      if (!this.matrixClient) {
+        return 'default_room';
+      }
+
+      const directData = this.matrixClient.getAccountData('m.direct')?.getContent() || {};
+      let roomId: string | undefined = directData[adminUserId]?.[0];
+
+      if (!roomId) {
+        const rooms = this.matrixClient.getRooms();
+        for (const room of rooms) {
+          const isDM = Object.values(directData).some((ids: any) => ids.includes(room.roomId));
+          if (isDM) {
+            const members = room.getJoinedMembers();
+            if (members.some(m => m.userId === adminUserId)) {
+              roomId = room.roomId;
+              break;
+            }
+          }
+        }
+      }
+
+      if (!roomId) {
+        roomId = await this.createRoom(adminUserId);
+      }
+
+      return roomId;
+    } catch (error) {
+      console.error('Error getting or creating admin room:', error);
+      return 'default_room';
+    }
+  }
+
   async getRooms(): Promise<any[]> {
     try {
       if (!this.isAuthenticated) {


### PR DESCRIPTION
## Summary
- create `getOrCreateAdminRoom` in MatrixService
- use admin DM room in ChatWidget

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d00a4a44832697b527c7c3839199