### PR TITLE
Add UserProfileModal and integrate with ChatWidget

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -21,8 +21,8 @@ import DatabaseService from '../services/database';
 import { ChatMessage, ChatRoom, User } from '../types';
 import { useAuth } from './AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { router } from 'expo-router';
 import InfoModal from './InfoModal';
+import UserProfileModal from './UserProfileModal';
 
 // Enable RTL for Hebrew
 I18nManager.allowRTL(true);
@@ -57,6 +57,8 @@ export default function ChatWidget() {
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning'
   });
+  const [profileModalVisible, setProfileModalVisible] = useState(false);
+  const [profileUserId, setProfileUserId] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen && isLoggedIn) {
@@ -464,12 +466,13 @@ export default function ChatWidget() {
 
   const navigateToUserProfile = async (userId: string) => {
     if (!isAdmin) return;
-    
+
     try {
       setIsOpen(false);
-      router.push(`/user/${encodeURIComponent(userId)}`);
+      setProfileUserId(userId);
+      setProfileModalVisible(true);
     } catch (error) {
-      console.error('Error navigating to user profile:', error);
+      console.error('Error opening user profile modal:', error);
     }
   };
 
@@ -874,6 +877,15 @@ export default function ChatWidget() {
           onPress={() => setShowReactions(null)}
         />
       )}
+
+      <UserProfileModal
+        visible={profileModalVisible}
+        userId={profileUserId || ''}
+        onClose={() => {
+          setProfileModalVisible(false);
+          setProfileUserId(null);
+        }}
+      />
 
       {/* Info Modal */}
       <InfoModal

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
+import { X } from 'lucide-react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { MatrixService } from '../services/matrix';
+import DatabaseService from '../services/database';
+
+interface UserProfileModalProps {
+  visible: boolean;
+  userId: string;
+  onClose: () => void;
+}
+
+export default function UserProfileModal({ visible, userId, onClose }: UserProfileModalProps) {
+  const { colors } = useTheme();
+  const [loading, setLoading] = useState(false);
+  const [profile, setProfile] = useState<{ username: string; displayName: string; exists: boolean } | null>(null);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      if (!visible || !userId) return;
+      setLoading(true);
+      const db = DatabaseService.getInstance();
+      let user = await db.getUserProfile(userId);
+      const exists = !!user;
+
+      if (!user) {
+        const matrixProfile = await MatrixService.getInstance().getProfileInfo(userId);
+        if (matrixProfile) {
+          user = {
+            id: userId,
+            username: userId.replace(/^@/, '').split(':')[0],
+            displayName: matrixProfile.displayname || userId,
+            isAdmin: false,
+          } as any;
+        }
+      }
+
+      if (user) {
+        setProfile({
+          username: user.username || userId,
+          displayName: user.displayName || user.username || userId,
+          exists,
+        });
+      } else {
+        setProfile(null);
+      }
+      setLoading(false);
+    };
+
+    fetchProfile();
+  }, [visible, userId]);
+
+  if (!visible) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.overlay}>
+          <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
+            <View style={[styles.modalContainer, { backgroundColor: colors.surface.elevated }]}>
+              <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+                <X size={20} color={colors.text.secondary} />
+              </TouchableOpacity>
+              {loading ? (
+                <ActivityIndicator size="large" color={colors.gold} style={{ margin: 20 }} />
+              ) : profile ? (
+                <>
+                  <Text style={[styles.username, { color: colors.text.primary }]}>@{profile.username}</Text>
+                  <Text style={[styles.displayName, { color: colors.text.secondary }]}>{profile.displayName}</Text>
+                  <View
+                    style={[
+                      styles.tag,
+                      { backgroundColor: profile.exists ? colors.status.success : colors.status.error },
+                    ]}
+                  >
+                    <Text style={[styles.tagText, { color: colors.text.inverse }]}> 
+                      {profile.exists ? 'Exists in Supabase' : 'Matrix only'}
+                    </Text>
+                  </View>
+                </>
+              ) : (
+                <Text style={[styles.displayName, { color: colors.text.primary }]}>User not found</Text>
+              )}
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  modalContainer: {
+    width: '100%',
+    maxWidth: 340,
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+      },
+      android: {
+        elevation: 5,
+      },
+      web: {
+        boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.15)',
+      },
+    }),
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    padding: 4,
+    zIndex: 1,
+  },
+  username: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  displayName: {
+    fontSize: 16,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  tag: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+  },
+  tagText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -556,6 +556,20 @@ export class MatrixService {
     }
   }
 
+  async getProfileInfo(userId: string): Promise<{ displayname?: string; avatar_url?: string } | null> {
+    try {
+      if (!this.matrixClient) {
+        return null;
+      }
+
+      const info = await this.matrixClient.getProfileInfo(userId);
+      return info as any;
+    } catch (error) {
+      console.error('Error fetching profile info:', error);
+      return null;
+    }
+  }
+
   async getOrCreateAdminRoom(): Promise<string> {
     try {
       if (!this.isAuthenticated) {


### PR DESCRIPTION
## Summary
- add a reusable `UserProfileModal` component
- expose `getProfileInfo` on MatrixService for profile lookup
- open `UserProfileModal` from ChatWidget instead of routing to a page

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d57d16f88326aadc4871f8e6edc9