### PR TITLE
Remove minQty starting at 1 requirement

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -49,7 +49,6 @@ export default function PricingTiersScreen() {
       if (r.minQty < 1) return 'כמות מינימלית חייבת להיות מספר גדול מ-0';
       if (r.maxQty < r.minQty) return 'ערך מקסימום חייב להיות גדול או שווה למינימום';
       if (r.pricePerBaseUnit == null && r.discountPct == null) return 'יש להזין מחיר או הנחה לכל כלל';
-      if (i === 0 && r.minQty !== 1) return 'הטווח הראשון חייב להתחיל ב-1';
       if (i > 0) {
         const prev = sorted[i - 1];
         if (r.minQty !== prev.maxQty + 1) return 'טווחי הכמויות חופפים או מכילים חוסרים';


### PR DESCRIPTION
## Summary
- allow pricing rules to start from any positive quantity

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d71108b08326a6134eb93a7163dc