### PR TITLE
Refactor service logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ EXPO_PUBLIC_APP_NAME=QuickMart
 EXPO_PUBLIC_PINATA_API_KEY=your_pinata_api_key
 EXPO_PUBLIC_PINATA_SECRET_API_KEY=your_pinata_secret_key
 EXPO_PUBLIC_PINATA_JWT=your_pinata_jwt
+
+# Debug Configuration
+# Set to "true" to enable verbose debug logging
+EXPO_PUBLIC_DEBUG_LOGS=false

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from './supabase';
 import { ChatMessage, User } from '../types';
 import { Platform } from 'react-native';
+import { debugLog } from '../utils/logger';
 
 const AUTH_STORAGE_KEY = 'matrix_auth_state';
 const MATRIX_SERVER_URL = process.env.EXPO_PUBLIC_MATRIX_SERVER || 'https://matrix.org';
@@ -85,7 +86,7 @@ export class MatrixService {
       
       // Check if it's an authentication error (401)
       if (error && error.httpStatus === 401) {
-        console.log('Matrix token is invalid, logging out...');
+        console.warn('Matrix token is invalid, logging out...');
         this.handleAuthenticationError();
       }
     });
@@ -97,11 +98,11 @@ export class MatrixService {
         
         // If it's an authentication error during sync, handle it
         if (data && data.error && (data.error.httpStatus === 401 || data.error.httpStatus === 503)) {
-          console.log('Matrix sync authentication error, logging out...');
+          console.warn('Matrix sync authentication error, logging out...');
           this.handleAuthenticationError();
         }
       } else if (state === 'PREPARED') {
-        console.log('Matrix client sync prepared');
+        debugLog('Matrix client sync prepared');
       }
     });
 
@@ -122,7 +123,7 @@ export class MatrixService {
 
   private async handleAuthenticationError(): Promise<void> {
     try {
-      console.log('Handling authentication error - clearing auth state');
+      debugLog('Handling authentication error - clearing auth state');
       
       // Stop the Matrix client if it exists
       if (this.matrixClient) {
@@ -280,7 +281,7 @@ export class MatrixService {
         
         // If Matrix login fails but this is an admin user, we'll proceed with local auth
         if (isAdmin) {
-          console.log('Matrix login failed for admin user, proceeding with local authentication');
+          console.warn('Matrix login failed for admin user, proceeding with local authentication');
           // Generate a simulated Matrix user ID for consistency
           userId = `@${username}:${MATRIX_SERVER_URL.replace('https://', '')}`;
           matrixLoginSuccess = false; // We'll work without Matrix client
@@ -467,7 +468,7 @@ export class MatrixService {
         };
         
         // For demo purposes, we'll just return success
-        console.log('Simulated message sent:', simulatedMessage);
+        debugLog('Simulated message sent:', simulatedMessage);
         return true;
       }
 
@@ -494,7 +495,7 @@ export class MatrixService {
       if (!this.matrixClient) {
         // Create a simulated room ID
         const roomId = `room_${Date.now()}`;
-        console.log('Created simulated room:', roomId);
+        debugLog('Created simulated room:', roomId);
         return roomId;
       }
 

--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import FormData from 'form-data';
+import { debugLog } from '../utils/logger';
 
 // Pinata API configuration
 const PINATA_API_KEY = process.env.EXPO_PUBLIC_PINATA_API_KEY || 'YOUR_PINATA_API_KEY';
@@ -29,17 +30,17 @@ class PinataService {
     try {
       // Check if the URI is already an IPFS or HTTP URL
       if (uri.startsWith('http') || uri.startsWith('https') || uri.startsWith('ipfs://')) {
-        console.log('File is already a URL, skipping upload:', uri);
+        debugLog('File is already a URL, skipping upload:', uri);
         return uri;
       }
 
       // For web platform or when using remote images, just return the URI
       if (uri.startsWith('data:') || uri.includes('pexels.com') || uri.includes('gateway.pinata.cloud')) {
-        console.log('Using existing image URL:', uri);
+        debugLog('Using existing image URL:', uri);
         return uri;
       }
 
-      console.log('Uploading file to Pinata:', name);
+      debugLog('Uploading file to Pinata:', name);
 
       // Create form data for the file upload
       const formData = new FormData();
@@ -76,7 +77,7 @@ class PinataService {
       // Return the IPFS URL
       const ipfsHash = response.data.IpfsHash;
       const ipfsUrl = `${PINATA_GATEWAY_URL}${ipfsHash}`;
-      console.log('File uploaded to Pinata:', ipfsUrl);
+      debugLog('File uploaded to Pinata:', ipfsUrl);
       return ipfsUrl;
     } catch (error) {
       console.error('Error uploading to Pinata:', error);

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -4,6 +4,7 @@ declare global {
       EXPO_PUBLIC_ADMIN_USERNAME: string;
       EXPO_PUBLIC_MATRIX_SERVER: string;
       EXPO_PUBLIC_APP_NAME: string;
+      EXPO_PUBLIC_DEBUG_LOGS?: string;
     }
   }
 }

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,8 @@
+export const DEBUG_LOGS = process.env.EXPO_PUBLIC_DEBUG_LOGS === 'true';
+
+export function debugLog(...args: unknown[]): void {
+  if (DEBUG_LOGS) {
+    // eslint-disable-next-line no-console
+    console.debug(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce simple logger with optional debug flag
- use debug logger in Matrix and Pinata services
- document `EXPO_PUBLIC_DEBUG_LOGS` in environment template
- type the debug flag in env types

## Testing
- `npm run lint` *(fails: expo CLI missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864d92e477c8326904ab2e7414b652c