### PR TITLE
Store wishlist in Supabase

### DIFF
--- a/services/cart.ts
+++ b/services/cart.ts
@@ -1,6 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
 import DatabaseService from './database';
+import { MatrixService } from './matrix';
+import { isSupabaseConfigured } from './supabase';
 
 const CART_STORAGE_KEY = 'cart_items';
 const WISHLIST_STORAGE_KEY = 'wishlist_items';
@@ -26,16 +28,20 @@ class CartService {
 
   private async loadFromStorage() {
     try {
-      const [cartData, wishlistData] = await Promise.all([
-        AsyncStorage.getItem(CART_STORAGE_KEY),
-        AsyncStorage.getItem(WISHLIST_STORAGE_KEY)
-      ]);
-
+      const cartData = await AsyncStorage.getItem(CART_STORAGE_KEY);
       if (cartData) {
         this.cartItems = JSON.parse(cartData);
       }
-      if (wishlistData) {
-        this.wishlistItems = JSON.parse(wishlistData);
+
+      const user = MatrixService.getInstance().getCurrentUser();
+      if (isSupabaseConfigured() && user?.id) {
+        const db = DatabaseService.getInstance();
+        this.wishlistItems = await db.getWishlistItems(user.id);
+      } else {
+        const wishlistData = await AsyncStorage.getItem(WISHLIST_STORAGE_KEY);
+        if (wishlistData) {
+          this.wishlistItems = JSON.parse(wishlistData);
+        }
       }
 
       await this.recalcPricing();
@@ -47,10 +53,15 @@ class CartService {
 
   private async saveToStorage() {
     try {
-      await Promise.all([
-        AsyncStorage.setItem(CART_STORAGE_KEY, JSON.stringify(this.cartItems)),
-        AsyncStorage.setItem(WISHLIST_STORAGE_KEY, JSON.stringify(this.wishlistItems))
-      ]);
+      await AsyncStorage.setItem(CART_STORAGE_KEY, JSON.stringify(this.cartItems));
+
+      const user = MatrixService.getInstance().getCurrentUser();
+      if (!(isSupabaseConfigured() && user?.id)) {
+        await AsyncStorage.setItem(
+          WISHLIST_STORAGE_KEY,
+          JSON.stringify(this.wishlistItems)
+        );
+      }
     } catch (error) {
       console.error('Error saving cart/wishlist to storage:', error);
     }
@@ -214,12 +225,34 @@ class CartService {
     };
 
     this.wishlistItems.push(wishlistItem);
+
+    const user = MatrixService.getInstance().getCurrentUser();
+    if (isSupabaseConfigured() && user?.id) {
+      const db = DatabaseService.getInstance();
+      try {
+        await db.addWishlistItem(user.id, product.id);
+      } catch (err) {
+        console.error('Error saving wishlist item to Supabase:', err);
+      }
+    }
+
     await this.saveToStorage();
     this.notifyListeners();
   }
 
   public async removeFromWishlist(productId: string): Promise<void> {
     this.wishlistItems = this.wishlistItems.filter(item => item.productId !== productId);
+
+    const user = MatrixService.getInstance().getCurrentUser();
+    if (isSupabaseConfigured() && user?.id) {
+      const db = DatabaseService.getInstance();
+      try {
+        await db.removeWishlistItem(user.id, productId);
+      } catch (err) {
+        console.error('Error removing wishlist item from Supabase:', err);
+      }
+    }
+
     await this.saveToStorage();
     this.notifyListeners();
   }

--- a/services/database.ts
+++ b/services/database.ts
@@ -6,11 +6,12 @@ import {
   ChatMessage, 
   ChatRoom, 
   User, 
-  Notification, 
-  Review, 
+  Notification,
+  Review,
   HeroBanner,
   PricingTier,
-  MixGroup
+  MixGroup,
+  WishlistItem
 } from '../types';
 
 class DatabaseService {
@@ -1169,6 +1170,91 @@ class DatabaseService {
       }
     } catch (error) {
       console.error('Error in deleteMixGroup:', error);
+      throw error;
+    }
+  }
+
+  // Wishlist
+  async getWishlistItems(userId: string): Promise<WishlistItem[]> {
+    try {
+      const { data, error } = await supabase
+        .from('wishlist_items')
+        .select(
+          'id, product_id, added_at, products(*)'
+        )
+        .eq('user_id', userId)
+        .order('added_at', { ascending: false });
+
+      if (error) {
+        console.error('Error fetching wishlist items:', error);
+        return [];
+      }
+
+      return (data || []).map((item: any) => ({
+        id: item.id,
+        productId: item.product_id,
+        product: {
+          id: item.products.id,
+          name: item.products.name,
+          name_en: item.products.name_en,
+          name_he: item.products.name_he,
+          price: item.products.price,
+          originalPrice: item.products.original_price ?? undefined,
+          description: item.products.description,
+          description_en: item.products.description_en,
+          description_he: item.products.description_he,
+          category: item.products.category,
+          subcategory: item.products.subcategory,
+          images: item.products.images,
+          videos: item.products.videos ?? undefined,
+          colors: item.products.colors ?? undefined,
+          rating: item.products.rating,
+          reviews: item.products.reviews,
+          badges: item.products.badges ?? undefined,
+          pricingTier: item.products.pricing_tier ?? undefined,
+          mixGroupId: item.products.mix_group_id ?? undefined,
+          stock: item.products.stock,
+          createdAt: item.products.created_at,
+          updatedAt: item.products.updated_at,
+        },
+        addedAt: item.added_at,
+      }));
+    } catch (error) {
+      console.error('Error in getWishlistItems:', error);
+      return [];
+    }
+  }
+
+  async addWishlistItem(userId: string, productId: string): Promise<void> {
+    try {
+      const { error } = await supabase
+        .from('wishlist_items')
+        .insert([{ user_id: userId, product_id: productId }]);
+
+      if (error) {
+        console.error('Error adding wishlist item:', error);
+        throw new Error('Failed to add wishlist item');
+      }
+    } catch (error) {
+      console.error('Error in addWishlistItem:', error);
+      throw error;
+    }
+  }
+
+  async removeWishlistItem(userId: string, productId: string): Promise<void> {
+    try {
+      const { error } = await supabase
+        .from('wishlist_items')
+        .delete()
+        .eq('user_id', userId)
+        .eq('product_id', productId);
+
+      if (error) {
+        console.error('Error removing wishlist item:', error);
+        throw new Error('Failed to remove wishlist item');
+      }
+    } catch (error) {
+      console.error('Error in removeWishlistItem:', error);
       throw error;
     }
   }

--- a/supabase/migrations/20250702130000_wishlist_items.sql
+++ b/supabase/migrations/20250702130000_wishlist_items.sql
@@ -1,0 +1,56 @@
+/*
+  # Add Wishlist Items Table
+
+  1. New Table
+    - wishlist_items: store user wishlist products
+
+  2. Security
+    - Enable RLS with user scoped policies and admin override
+*/
+
+-- Create wishlist_items table
+CREATE TABLE IF NOT EXISTS wishlist_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id text NOT NULL,
+  product_id uuid REFERENCES products(id) ON DELETE CASCADE,
+  added_at timestamptz DEFAULT now(),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE wishlist_items ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Users can view their wishlist"
+  ON wishlist_items FOR SELECT TO public
+  USING (
+    auth.uid() IS NOT NULL AND
+    user_id = auth.uid()::text
+  );
+
+CREATE POLICY "Users can add to wishlist"
+  ON wishlist_items FOR INSERT TO public
+  WITH CHECK (
+    auth.uid() IS NOT NULL AND
+    user_id = auth.uid()::text
+  );
+
+CREATE POLICY "Users can remove from wishlist"
+  ON wishlist_items FOR DELETE TO public
+  USING (
+    auth.uid() IS NOT NULL AND
+    user_id = auth.uid()::text
+  );
+
+CREATE POLICY "Admin manage wishlist"
+  ON wishlist_items FOR ALL TO public
+  USING (is_admin());
+
+CREATE INDEX idx_wishlist_items_user_id ON wishlist_items(user_id);
+CREATE INDEX idx_wishlist_items_product_id ON wishlist_items(product_id);
+
+-- Trigger to update updated_at
+CREATE TRIGGER update_wishlist_items_updated_at
+  BEFORE UPDATE ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- create `wishlist_items` table in Supabase
- add DB helpers for wishlist
- persist wishlist to Supabase when available

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fc0cadb8832695dfe406881ae3a6