### PR TITLE
Fix undefined variable error in getPricingTier

### DIFF
--- a/services/database.ts
+++ b/services/database.ts
@@ -900,6 +900,9 @@ class DatabaseService {
         }
       }
 
+      const effectiveRules =
+        rulesError && rulesError.code === '42P01' ? [] : (rulesData || []);
+
       return {
         id: data.id,
         name: data.name,


### PR DESCRIPTION
## Summary
- handle missing `price_tier_rules` gracefully when fetching a single tier

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864fc9591c48326b39abc22b3c5baf6