### PR TITLE
Add hero banner fallback

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -30,7 +30,7 @@ import {
 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import CartService from '../../services/cart';
-import { Product, Category, PricingTier } from '../../types';
+import { Product, Category, PricingTier, HeroBanner } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
@@ -59,6 +59,7 @@ export default function ProductDetailScreen() {
   const { isAdmin } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const [categoryBanner, setCategoryBanner] = useState<HeroBanner | null>(null);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -86,6 +87,22 @@ export default function ProductDetailScreen() {
       cartService.addListener(handleUpdate);
       return () => cartService.removeListener(handleUpdate);
     }
+  }, [product]);
+
+  useEffect(() => {
+    const fetchBanner = async () => {
+      if (!product) return;
+      try {
+        const db = DatabaseService.getInstance();
+        const banners = await db.getHeroBanners();
+        const matched = banners.find((b) => b.category === product.category);
+        setCategoryBanner(matched || null);
+      } catch (error) {
+        console.error('Error loading hero banner:', error);
+      }
+    };
+
+    fetchBanner();
   }, [product]);
 
   const loadProduct = async () => {
@@ -289,8 +306,9 @@ export default function ProductDetailScreen() {
   }
 
   const allMedia = getAllMedia();
+  const bannerImageUri = categoryBanner?.image || product.images?.[0];
   const currentPricingTier = pricingTiers.find(
-    (tier) => tier.id === product.pricingTier
+    (tier) => tier.id === product.pricingTier,
   );
   const effectivePrice = getEffectivePrice(product.price, quantity);
   const showTieredPricing =
@@ -354,6 +372,45 @@ export default function ProductDetailScreen() {
             )}
           </View>
         </View>
+
+        {(categoryBanner || (product.images && product.images.length > 0)) && (
+          <View style={styles.heroBanner}>
+            <Image
+              source={{ uri: bannerImageUri }}
+              style={styles.heroImage}
+            />
+            {categoryBanner && (
+              <View style={styles.heroOverlay}>
+                <View style={styles.heroContent}>
+                  <Text
+                    style={[
+                      styles.heroDiscount,
+                      {
+                        color: colors.text.inverse,
+                        backgroundColor: colors.gold,
+                      },
+                    ]}
+                  >
+                    {categoryBanner.discount} הנחה
+                  </Text>
+                  <Text
+                    style={[styles.heroTitle, { color: colors.text.inverse }]}
+                  >
+                    {categoryBanner.title}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.heroSubtitle,
+                      { color: colors.text.inverse },
+                    ]}
+                  >
+                    {categoryBanner.subtitle}
+                  </Text>
+                </View>
+              </View>
+            )}
+          </View>
+        )}
 
         {/* Main Cover Image */}
         <View
@@ -429,7 +486,7 @@ export default function ProductDetailScreen() {
                   {Math.round(
                     ((product.originalPrice - product.price) /
                       product.originalPrice) *
-                      100
+                      100,
                   )}
                   % הנחה
                 </Text>
@@ -476,7 +533,7 @@ export default function ProductDetailScreen() {
                 {currentPricingTier.name}
                 {typeof currentPricingTier.pricePerUnit === 'number' &&
                   ` - מחיר ליחידה: ${currencySymbol}${currentPricingTier.pricePerUnit.toFixed(
-                    2
+                    2,
                   )}`}
               </Text>
               {currentPricingTier.minQuantity > 1 && (
@@ -586,7 +643,7 @@ export default function ProductDetailScreen() {
                 ]}
               >
                 {`מחיר ליחידה: ${currencySymbol}${effectivePrice.toFixed(
-                  2
+                  2,
                 )} (במקום ${currencySymbol}${product.price.toFixed(2)})`}
               </Text>
               <Text style={[styles.tieredPricingTotal, { color: colors.gold }]}>
@@ -757,6 +814,51 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: 18,
     fontWeight: 'bold',
+  },
+  heroBanner: {
+    width: '100%',
+    height: 180,
+    marginBottom: 16,
+    borderRadius: 16,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  heroImage: {
+    width: '100%',
+    height: '100%',
+  },
+  heroOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(14, 13, 10, 0.4)',
+    justifyContent: 'center',
+  },
+  heroContent: {
+    paddingHorizontal: 20,
+    alignItems: 'flex-end',
+  },
+  heroDiscount: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+    alignSelf: 'flex-start',
+    marginBottom: 8,
+  },
+  heroTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 4,
+    textAlign: 'right',
+  },
+  heroSubtitle: {
+    fontSize: 16,
+    marginBottom: 16,
+    textAlign: 'right',
   },
   coverImageContainer: {
     width: '100%',

--- a/services/database.ts
+++ b/services/database.ts
@@ -798,14 +798,31 @@ class DatabaseService {
         .from('hero_banners')
         .select('*')
         .eq('is_active', true)
-        .order('order', { ascending: true });
+        .order('order_index', { ascending: true });
 
       if (error) {
         console.error('Error fetching hero banners:', error);
         return [];
       }
 
-      return data || [];
+      return (data || []).map((banner: any) => ({
+        id: banner.id,
+        title: banner.title,
+        title_en: banner.title_en,
+        title_he: banner.title_he,
+        subtitle: banner.subtitle,
+        subtitle_en: banner.subtitle_en,
+        subtitle_he: banner.subtitle_he,
+        image: banner.image,
+        discount: banner.discount,
+        discount_en: banner.discount_en,
+        discount_he: banner.discount_he,
+        category: banner.category,
+        isActive: banner.is_active,
+        order: banner.order_index,
+        createdAt: banner.created_at,
+        updatedAt: banner.updated_at,
+      }));
     } catch (error) {
       console.error('Error in getHeroBanners:', error);
       return [];


### PR DESCRIPTION
## Summary
- fallback hero image uses product's main preview when banner image missing

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f71f54b083269ee9549559334361