### PR TITLE
Fix minor TS errors

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -43,6 +43,13 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 I18nManager.allowRTL(true);
 I18nManager.forceRTL(true);
 
+interface MediaItem {
+  id: string;
+  uri: string;
+  type: 'image' | 'video';
+  name?: string;
+}
+
 const { width } = Dimensions.get('window');
 
 export default function ProductDetailScreen() {
@@ -243,7 +250,7 @@ export default function ProductDetailScreen() {
     await addToCart();
     // Navigate to cart or checkout
     router.push({
-      pathname: '/(tabs)/',
+      pathname: '/(tabs)',
       params: { showCart: 'true' },
     });
   };

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -41,7 +41,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
   const { t } = useLanguage();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
-  const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
 
   useEffect(() => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -171,6 +171,7 @@ export interface CartItem {
   unitPrice?: number;
   tierName?: string;
   effectiveQty?: number;
+  selectedColor?: string;
 }
 
 export interface WishlistItem {


### PR DESCRIPTION
## Summary
- define `MediaItem` interface for product screen
- fix route path string
- adjust copy timeout type
- include `selectedColor` in `CartItem` interface

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650b6dc58483268919ddcb31ddc02a