### PR TITLE
Fix logout when matrix server unreachable

### DIFF
--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -115,13 +115,12 @@ export class MatrixService {
           console.error('Matrix sync error:', data);
 
           // If it's an authentication error during sync, handle it
-          if (
-            data &&
-            data.error &&
-            (data.error.httpStatus === 401 || data.error.httpStatus === 503)
-          ) {
+          if (data && data.error && data.error.httpStatus === 401) {
             console.warn('Matrix sync authentication error, logging out...');
             this.handleAuthenticationError();
+          } else if (data && data.error && data.error.httpStatus === 503) {
+            console.warn('Matrix sync server unavailable, will retry soon');
+            // Do not log out on server unavailability; allow retry
           }
         } else if (state === 'PREPARED') {
           debugLog('Matrix client sync prepared');


### PR DESCRIPTION
## Summary
- avoid logout during Matrix client sync errors unless authentication fails

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651282b1908326988f5134879b6b88