### PR TITLE
Upload banners to Pinata

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -208,10 +208,20 @@ export default function HomeScreen() {
 
     try {
       setLoading(true);
+      const pinata = PinataService.getInstance();
+      const uploadedUrl = await pinata.uploadFile(bannerMedia[0].uri, 'banner');
+
+      if (!uploadedUrl ||
+          (uploadedUrl === bannerMedia[0].uri &&
+           !bannerMedia[0].uri.startsWith('http'))) {
+        Alert.alert('שגיאה', 'העלאת הבאנר נכשלה');
+        return;
+      }
+
       const db = DatabaseService.getInstance();
       const bannerData = {
         ...newBanner,
-        image: bannerMedia[0].uri
+        image: uploadedUrl
       };
       
       if (editingBanner) {


### PR DESCRIPTION
## Summary
- upload banner images to Pinata before saving banner data
- handle upload failures with a user alert

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865163080a88326abd2196c0ac617b7