### PR TITLE
Use Pinata for media uploads

### DIFF
--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -63,28 +63,17 @@ export default function MediaUploader({
       const newMediaItems: MediaItem[] = [];
 
       for (const asset of pickerResult.assets) {
-        // For web, we need to handle File objects
-        if (Platform.OS === 'web') {
-          // In a real implementation, you would upload to Pinata here
-          // For now, we'll just use the local URI
-          const uri = asset.uri;
-          
-          newMediaItems.push({
-            id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
-            uri: uri,
-            type: asset.type === 'video' ? 'video' : 'image',
-            name: asset.fileName || `media_${Date.now()}`
-          });
-        } else {
-          // For native platforms, we need to upload the file to Pinata
-          // For now, we'll just use the local URI
-          newMediaItems.push({
-            id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
-            uri: asset.uri,
-            type: asset.type === 'video' ? 'video' : 'image',
-            name: asset.fileName || `media_${Date.now()}`
-          });
-        }
+        const uploadedUri = await mediaService.uploadMedia(
+          asset.uri,
+          asset.fileName || `media_${Date.now()}`
+        );
+
+        newMediaItems.push({
+          id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
+          uri: uploadedUri,
+          type: asset.type === 'video' ? 'video' : 'image',
+          name: asset.fileName || `media_${Date.now()}`
+        });
       }
 
       // Make sure we don't exceed maxFiles

--- a/services/media.ts
+++ b/services/media.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import FormData from 'form-data';
+import PinataService from './pinata';
 
 class MediaService {
   private static instance: MediaService;
@@ -14,24 +13,12 @@ class MediaService {
   }
 
   /**
-   * Upload media to a service
-   * In a real implementation, this would use Pinata or another IPFS service
-   * For now, we'll just return the original URI
+   * Upload media to Pinata IPFS
    */
   async uploadMedia(uri: string, name: string): Promise<string> {
     try {
-      // For demo purposes, we'll just return the original URI
-      // In a real implementation, you would upload to Pinata or another service
-      
-      // If the URI is already a URL, just return it
-      if (uri.startsWith('http') || uri.startsWith('https')) {
-        return uri;
-      }
-      
-      // For local files, we would upload them to a service
-      // But for now, we'll just return a placeholder URL
-      const randomId = Math.floor(Math.random() * 1000000);
-      return `https://images.pexels.com/photos/${randomId}/pexels-photo-${randomId}.jpeg`;
+      const pinataService = PinataService.getInstance();
+      return await pinataService.uploadFile(uri, name);
     } catch (error) {
       console.error('Error uploading media:', error);
       // Return the original URI as fallback


### PR DESCRIPTION
## Summary
- connect `MediaService` upload to `PinataService`
- use `MediaService` in `MediaUploader`
- clean up placeholder comments

## Testing
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651715f5c083268dd3eb162a91fd14