### PR TITLE
Add wasm support for Olm

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+const tsParser = require('@typescript-eslint/parser');
+module.exports = [
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+    rules: {},
+  },
+];

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,4 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+const config = getDefaultConfig(__dirname);
+config.resolver.assetExts.push('wasm');
+module.exports = config;

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -16,6 +16,7 @@ import {
   Visibility,
 } from 'matrix-js-sdk';
 import * as olm from '@matrix-org/olm';
+import olmWasm from '@matrix-org/olm/olm.wasm';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from './supabase';
 import { ChatMessage, User } from '../types';
@@ -82,7 +83,7 @@ export class MatrixService {
     try {
       // Load the Olm WASM module for end-to-end encryption support
       if (!this.olmInitialized) {
-        await olm.init();
+        await olm.init({ locateFile: () => olmWasm });
         this.olmInitialized = true;
       }
 
@@ -317,7 +318,7 @@ export class MatrixService {
       try {
         // Create a temporary client for login
         if (!this.olmInitialized) {
-          await olm.init();
+          await olm.init({ locateFile: () => olmWasm });
           this.olmInitialized = true;
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts",
-    "nativewind-env.d.ts"
+    "nativewind-env.d.ts",
+    "types/wasm.d.ts"
   ]
 }

--- a/types/wasm.d.ts
+++ b/types/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module '*.wasm' {
+  const wasmPath: string;
+  export default wasmPath;
+}


### PR DESCRIPTION
## Summary
- configure Metro to bundle wasm files
- setup ESLint to parse TS without rules
- declare module for wasm imports
- initialize `olm` with `olm.wasm`

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865206f04d0832695ce0d169126d1e8