### PR TITLE
Remove unused MATRIX_SERVER_URL

### DIFF
--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -25,8 +25,6 @@ import { debugLog } from '../utils/logger';
 import { getSanitizedMatrixUrl } from '../utils/matrix';
 
 const AUTH_STORAGE_KEY = 'matrix_auth_state';
-const MATRIX_SERVER_URL =
-  process.env.EXPO_PUBLIC_MATRIX_SERVER || 'https://matrix.org';
 const MATRIX_DOMAIN = getSanitizedMatrixUrl() || 'matrix.org';
 
 export class MatrixService {


### PR DESCRIPTION
## Summary
- remove unused `MATRIX_SERVER_URL` constant from the Matrix service

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686523f830f083268ef6cb444188bf9e