### PR TITLE
Fix wishlist items retrieval without DB relation

### DIFF
--- a/services/database.ts
+++ b/services/database.ts
@@ -1285,9 +1285,7 @@ class DatabaseService {
     try {
       const { data, error } = await supabase
         .from('wishlist_items')
-        .select(
-          `id, product_id, added_at, product:products!wishlist_items_product_id_fkey(*)`
-        )
+        .select('id, product_id, added_at')
         .eq('user_id', userId)
         .order('added_at', { ascending: false });
 
@@ -1296,35 +1294,25 @@ class DatabaseService {
         return [];
       }
 
-      return (data || []).map((item: any) => ({
-        id: item.id,
-        productId: item.product_id,
-        product: {
-          id: item.product.id,
-          name: item.product.name,
-          name_en: item.product.name_en,
-          name_he: item.product.name_he,
-          price: item.product.price,
-          originalPrice: item.product.originalPrice ?? undefined,
-          description: item.product.description,
-          description_en: item.product.description_en,
-          description_he: item.product.description_he,
-          category: item.product.category,
-          subcategory: item.product.subcategory,
-          images: item.product.images,
-          videos: item.product.videos ?? undefined,
-          colors: item.product.colors ?? undefined,
-          rating: item.product.rating,
-          reviews: item.product.reviews,
-          badges: item.product.badges ?? undefined,
-          pricingTier: item.product.pricing_tier ?? undefined,
-          mixGroupId: item.product.mix_group_id ?? undefined,
-          stock: item.product.stock,
-          createdAt: item.product.created_at,
-          updatedAt: item.product.updated_at,
-        },
-        addedAt: item.added_at,
-      }));
+      const items = data || [];
+
+      const wishlistWithProducts = await Promise.all(
+        items.map(async (item: any) => {
+          const product = await this.getProduct(item.product_id);
+          if (!product) {
+            return null;
+          }
+
+          return {
+            id: item.id,
+            productId: item.product_id,
+            product,
+            addedAt: item.added_at,
+          } as WishlistItem;
+        })
+      );
+
+      return wishlistWithProducts.filter(Boolean) as WishlistItem[];
     } catch (error) {
       console.error('Error in getWishlistItems:', error);
       return [];


### PR DESCRIPTION
## Summary
- handle missing foreign key relationship when fetching wishlist items

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652baefae08326aeba4caaf5073804