### PR TITLE
Fix hero banner upload auth

### DIFF
--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -78,14 +78,19 @@ class PinataService {
       );
 
       // Upload to Pinata
+      const headers: any = {};
+      if (PINATA_JWT) {
+        headers.Authorization = `Bearer ${PINATA_JWT}`;
+      } else {
+        headers.pinata_api_key = PINATA_API_KEY;
+        headers.pinata_secret_api_key = PINATA_SECRET_API_KEY;
+      }
+
       const response = await axios.post(
         'https://api.pinata.cloud/pinning/pinFileToIPFS',
         formData,
         {
-          headers: {
-            // Let axios set the correct multipart boundary automatically
-            Authorization: `Bearer ${PINATA_JWT}`,
-          },
+          headers,
         }
       );
 


### PR DESCRIPTION
## Summary
- update Pinata client to support API key + secret authentication

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653674b16083268f3a56b12e00fb35