### PR TITLE
Add fallback user search via database

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -115,6 +115,15 @@ export default function ChatWidget() {
         const results = await matrixService.searchUsers(searchQuery.trim());
         const mapped = await Promise.all(
           results.map(async (r: any) => {
+            if (r.matrix_user_id) {
+              return {
+                id: r.matrix_user_id,
+                displayName:
+                  r.display_name || r.app_username || r.matrix_user_id,
+                isAppUser: true,
+              };
+            }
+
             const profile = await db.findUserProfileByMatrixId(r.user_id);
             return {
               id: r.user_id,

--- a/services/database.ts
+++ b/services/database.ts
@@ -604,6 +604,30 @@ class DatabaseService {
     }
   }
 
+  async searchUserProfiles(
+    term: string
+  ): Promise<{ matrix_user_id: string; display_name: string; app_username: string }[]> {
+    try {
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('matrix_user_id, display_name, app_username')
+        .or(
+          `display_name.ilike.%${term}%,app_username.ilike.%${term}%`
+        )
+        .limit(10);
+
+      if (error) {
+        console.error('Error searching user profiles:', error);
+        return [];
+      }
+
+      return data || [];
+    } catch (error) {
+      console.error('Error in searchUserProfiles:', error);
+      return [];
+    }
+  }
+
   async updateUserRole(userId: string, role: 'user' | 'admin'): Promise<void> {
     try {
       const { error } = await supabase

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -19,6 +19,7 @@ import * as olm from '@matrix-org/olm';
 import olmWasm from '@matrix-org/olm/olm.wasm';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from './supabase';
+import DatabaseService from './database';
 import { ChatMessage, User } from '../types';
 import { Platform } from 'react-native';
 import { debugLog } from '../utils/logger';
@@ -608,17 +609,29 @@ export class MatrixService {
 
   async searchUsers(
     term: string
-  ): Promise<{ user_id: string; display_name?: string }[]> {
+  ): Promise<{ user_id: string; display_name?: string; app_username?: string }[]> {
     try {
-      if (!this.matrixClient) {
-        return [];
+      let results: { user_id: string; display_name?: string; app_username?: string }[] = [];
+
+      if (this.matrixClient) {
+        const searchRes = await (this.matrixClient as any).searchUserDirectory({
+          term,
+          limit: 10,
+        });
+        results = searchRes?.results || [];
       }
 
-      const result = await (this.matrixClient as any).searchUserDirectory({
-        term,
-        limit: 10,
-      });
-      return result?.results || [];
+      if (!this.matrixClient || results.length === 0) {
+        const db = DatabaseService.getInstance();
+        const dbResults = await db.searchUserProfiles(term);
+        results = dbResults.map(r => ({
+          user_id: r.matrix_user_id,
+          display_name: r.display_name,
+          app_username: r.app_username,
+        }));
+      }
+
+      return results;
     } catch (error) {
       console.error('Error searching user directory:', error);
       return [];


### PR DESCRIPTION
## Summary
- allow user profile searches directly through Supabase
- fallback to DB search when Matrix search yields no results
- support ChatWidget results from Matrix or DB searches

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865489ba0a08326b7f75267eb2abd13