### PR TITLE
Fix randombytes init error

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,6 @@
-import 'react-native-crypto';
+// Ensure the getRandomValues polyfill is loaded before the crypto shim
 import 'react-native-get-random-values';
+import 'react-native-crypto';
 import 'react-native-url-polyfill/auto';
 import { useEffect, useState } from 'react';
 import { Stack } from 'expo-router';


### PR DESCRIPTION
## Summary
- ensure random values polyfill loads before the crypto shim

## Testing
- `pnpm lint` *(fails: expo not found; node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68656b805bd8832699a8e132b4bbd36c