### PR TITLE
Replace randombytes polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
   "pnpm": {
     "patchedDependencies": {
-      "@expo/metro-runtime": "patches/@expo__metro-runtime.patch"
+      "@expo/metro-runtime": "patches/@expo__metro-runtime.patch",
+      "react-native-crypto": "patches/react-native-crypto.patch"
     }
   }
 }

--- a/patches/react-native-crypto.patch
+++ b/patches/react-native-crypto.patch
@@ -1,0 +1,32 @@
+diff --git a/index.js b/index.js
+index f644543d689793341fff087b9e30ce84d11cf6e6..2531da525a404b1099ab14a1054375e42094e349 100644
+--- a/index.js
++++ b/index.js
+@@ -1,6 +1,13 @@
+ 'use strict'
+ 
+-import { randomBytes } from 'react-native-randombytes'
++import 'react-native-get-random-values'
++
++function randomBytes(size) {
++  const arr = new Uint8Array(size)
++  global.crypto.getRandomValues(arr)
++  return Buffer.from(arr)
++}
++
+ exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = randomBytes
+ 
+ // implement window.getRandomValues(), for packages that rely on it
+diff --git a/package.json b/package.json
+index 8d3bcb6b5cff71f03df931017ede10783f9aa696..b35e1040cca9bca4efcf50a8836a67a348097713 100644
+--- a/package.json
++++ b/package.json
+@@ -29,7 +29,7 @@
+     "randomfill": "^1.0.3"
+   },
+   "peerDependencies": {
+-    "react-native-randombytes": ">=2.0.0 <4.0.0"
++    "react-native-get-random-values": "*"
+   },
+   "devDependencies": {
+     "hash-test-vectors": "~1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@expo/metro-runtime':
     hash: 51bfaf975ab82bbe9df90e7bfd18a8ce624bfcb9182cd9c88b99b57ad05fbe29
     path: patches/@expo__metro-runtime.patch
+  react-native-crypto:
+    hash: ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779
+    path: patches/react-native-crypto.patch
 
 importers:
 
@@ -108,7 +111,7 @@ importers:
         version: 0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
       react-native-crypto:
         specifier: ^2.2.1
-        version: 2.2.1(react-native-randombytes@3.6.2)
+        version: 2.2.1(patch_hash=ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779)
       react-native-gesture-handler:
         specifier: ~2.24.0
         version: 2.24.0(react-native@0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -3841,7 +3844,7 @@ packages:
   react-native-crypto@2.2.1:
     resolution: {integrity: sha512-ltiPUK9zFoiSltwYVxGanmdZbrhzCTejK6/cmWBfPn8btyRRJqK21i5eraFP9rqJeU7KfeVNV8gA014wQLnQYg==}
     peerDependencies:
-      react-native-randombytes: '>=2.0.0 <4.0.0'
+      react-native-get-random-values: "*"
 
   react-native-edge-to-edge@1.6.0:
     resolution: {integrity: sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==}
@@ -3872,9 +3875,6 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-randombytes@3.6.2:
-    resolution: {integrity: sha512-28gK2ludbNN41MHtr0dVNHQbkunAbMZmgjPQqxPK68osCjG9VkdDGCM+Eqk0ZyZ7hwWd9MUCIgEpK7z2865hXQ==}
-    deprecated: use react-native-get-random-values instead
 
   react-native-reanimated@3.17.5:
     resolution: {integrity: sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==}
@@ -9498,7 +9498,7 @@ snapshots:
 
   react-is@19.1.0: {}
 
-  react-native-crypto@2.2.1(react-native-randombytes@3.6.2):
+  react-native-crypto@2.2.1(patch_hash=ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779):
     dependencies:
       browserify-cipher: 1.0.1
       browserify-sign: 4.2.3
@@ -9510,7 +9510,6 @@ snapshots:
       pbkdf2: 3.1.3
       public-encrypt: 4.0.3
       randomfill: 1.0.4
-      react-native-randombytes: 3.6.2
 
   react-native-edge-to-edge@1.6.0(react-native@0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -9540,10 +9539,6 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
 
-  react-native-randombytes@3.6.2:
-    dependencies:
-      buffer: 4.9.2
-      sjcl: 1.0.8
 
   react-native-reanimated@3.17.5(@babel/core@7.27.7)(react-native@0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
## Summary
- patch `react-native-crypto` to use `react-native-get-random-values`
- include patch in pnpm configuration
- clean lockfile of `react-native-randombytes`

## Testing
- `pnpm lint` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656ebac414832698c08d5a50540b22