### PR TITLE
Fix Buffer polyfill ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ import 'react-native-crypto';
 
 React Native 0.79 no longer provides the Node.js `Buffer` global. Some
 dependencies (like `react-native-crypto`) expect it to exist. The project loads
-the polyfill in `app/_layout.tsx`:
+the polyfill in `app/_layout.tsx`. Buffer must be defined before importing
+`react-native-crypto`:
 
 ```ts
 import { Buffer } from 'buffer';
 if (typeof global.Buffer === 'undefined') {
   (global as any).Buffer = Buffer;
 }
+import 'react-native-get-random-values';
+import 'react-native-crypto';
 ```
 
 If you create a new entry file, make sure to include this snippet before other

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,11 @@
 // Ensure the getRandomValues polyfill is loaded before the crypto shim
-import 'react-native-get-random-values';
-import 'react-native-crypto';
 import { Buffer } from 'buffer';
-
 // Expose Buffer globally for dependencies that rely on the Node.js API
 if (typeof global.Buffer === 'undefined') {
   (global as any).Buffer = Buffer;
 }
+import 'react-native-get-random-values';
+import 'react-native-crypto';
 import 'react-native-url-polyfill/auto';
 import { useEffect, useState } from 'react';
 import { Stack } from 'expo-router';


### PR DESCRIPTION
## Summary
- load Buffer and assign global before importing react-native-crypto
- document ordering requirement in README

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865815771208326befc006818803fd0