### PR TITLE
Update Buffer polyfill for react-native-crypto

### DIFF
--- a/patches/react-native-crypto.patch
+++ b/patches/react-native-crypto.patch
@@ -7,6 +7,10 @@ index f644543d689793341fff087b9e30ce84d11cf6e6..2531da525a404b1099ab14a1054375e4
  
 -import { randomBytes } from 'react-native-randombytes'
 +import 'react-native-get-random-values'
++import { Buffer } from 'buffer'
++if (typeof global.Buffer === 'undefined') {
++  (global as any).Buffer = Buffer
++}
 +
 +function randomBytes(size) {
 +  const arr = new Uint8Array(size)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 51bfaf975ab82bbe9df90e7bfd18a8ce624bfcb9182cd9c88b99b57ad05fbe29
     path: patches/@expo__metro-runtime.patch
   react-native-crypto:
-    hash: ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779
+    hash: 3ede8548054f67fe08146e8bdb2e3b3cda25760e6463e8368c1a80137e1367ff
     path: patches/react-native-crypto.patch
 
 importers:
@@ -114,7 +114,7 @@ importers:
         version: 6.0.3
       react-native-crypto:
         specifier: ^2.2.1
-        version: 2.2.1(patch_hash=ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779)
+        version: 2.2.1(patch_hash=3ede8548054f67fe08146e8bdb2e3b3cda25760e6463e8368c1a80137e1367ff)
       react-native-gesture-handler:
         specifier: ~2.24.0
         version: 2.24.0(react-native@0.79.1(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -9507,7 +9507,7 @@ snapshots:
 
   react-is@19.1.0: {}
 
-  react-native-crypto@2.2.1(patch_hash=ad338bdd860e7b0087ad02bc7e5c0002118bafbfdc814f94845f19fee21db779):
+  react-native-crypto@2.2.1(patch_hash=3ede8548054f67fe08146e8bdb2e3b3cda25760e6463e8368c1a80137e1367ff):
     dependencies:
       browserify-cipher: 1.0.1
       browserify-sign: 4.2.3


### PR DESCRIPTION
## Summary
- ensure Buffer polyfill is attached when react-native-crypto loads
- update pnpm lockfile for patched dependency

## Testing
- `pnpm patch react-native-crypto@2.2.1` *(fails: The modules directory is not ready for patching)*

------
https://chatgpt.com/codex/tasks/task_e_686587a3ced88326a09a176f1050c220