### PR TITLE
Fix Buffer global setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the polyfill in `app/_layout.tsx`. Buffer must be defined before importing
 ```ts
 import { Buffer } from 'buffer';
 if (typeof global.Buffer === 'undefined') {
-  (global as any).Buffer = Buffer;
+  global.Buffer = Buffer;
 }
 import 'react-native-get-random-values';
 import 'react-native-crypto';

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@
 import { Buffer } from 'buffer';
 // Expose Buffer globally for dependencies that rely on the Node.js API
 if (typeof global.Buffer === 'undefined') {
-  (global as any).Buffer = Buffer;
+  global.Buffer = Buffer;
 }
 import 'react-native-get-random-values';
 import 'react-native-crypto';

--- a/patches/react-native-crypto.patch
+++ b/patches/react-native-crypto.patch
@@ -9,7 +9,7 @@ index f644543d689793341fff087b9e30ce84d11cf6e6..2531da525a404b1099ab14a1054375e4
 +import 'react-native-get-random-values'
 +import { Buffer } from 'buffer'
 +if (typeof global.Buffer === 'undefined') {
-+  (global as any).Buffer = Buffer
++  global.Buffer = Buffer
 +}
 +
 +function randomBytes(size) {


### PR DESCRIPTION
## Summary
- use a plain JavaScript statement to expose `Buffer`
- update the README snippet
- regenerate the `react-native-crypto` patch with the same fix

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e5aede0483268fd190cbe4b6c1c2