### PR TITLE
Add patch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ This Expo project uses React Native with the Expo Router. It requires a polyfill
 
 ## Setup
 
-Install dependencies using `pnpm`:
+Run `pnpm install` to populate `node_modules`:
 
 ```sh
 pnpm install
+```
+
+To patch dependencies after installation, use:
+
+```sh
+pnpm patch <pkg>
+pnpm patch-commit
 ```
 
 ### Crypto polyfill


### PR DESCRIPTION
## Summary
- add instructions on using `pnpm patch` commands under **Setup**

## Testing
- `pnpm lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e5b46f98832695d5bda77f68bc44