### PR TITLE
Fix expo crypto bundler error

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -2,6 +2,7 @@ const { getDefaultConfig } = require('@expo/metro-config');
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push('wasm');
 config.resolver.extraNodeModules = {
-  crypto: require.resolve('react-native-crypto')
+  crypto: require.resolve('react-native-crypto'),
+  'react-native-randombytes': require.resolve('./polyfills/react-native-randombytes')
 };
 module.exports = config;

--- a/polyfills/react-native-randombytes.ts
+++ b/polyfills/react-native-randombytes.ts
@@ -1,0 +1,22 @@
+import { Buffer } from 'buffer';
+
+export function randomBytes(length: number, cb?: (err: Error | null, buf: Buffer) => void) {
+  const arr = new Uint8Array(length);
+  if (typeof global.crypto !== 'undefined' && global.crypto.getRandomValues) {
+    global.crypto.getRandomValues(arr);
+  } else {
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  const buf = Buffer.from(arr);
+  if (cb) {
+    cb(null, buf);
+    return;
+  }
+  return buf;
+}
+
+export const rng = randomBytes;
+export const pseudoRandomBytes = randomBytes;
+export const prng = randomBytes;


### PR DESCRIPTION
## Summary
- stub `react-native-randombytes` with a JS polyfill
- alias `react-native-randombytes` to local polyfill in Metro config

## Testing
- `npm run lint` *(fails: react-hooks/exhaustive-deps rule not found)*
- `npx tsc -p tsconfig.json` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6865fc94915c8326b7f182410b4723ac