### PR TITLE
Add driver role support

### DIFF
--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -31,7 +31,7 @@ export default function UserManagementScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserType | null>(null);
-  const [editedRole, setEditedRole] = useState<'user' | 'admin'>('user');
+  const [editedRole, setEditedRole] = useState<'user' | 'driver' | 'admin'>('user');
   const [editedTier, setEditedTier] = useState<CustomerTier>('new');
   const [showRoleDropdown, setShowRoleDropdown] = useState(false);
   const [showTierDropdown, setShowTierDropdown] = useState(false);
@@ -106,7 +106,7 @@ export default function UserManagementScreen() {
 
   const openEditModal = (user: UserType) => {
     setSelectedUser(user);
-    setEditedRole(user.role as 'user' | 'admin' || 'user');
+    setEditedRole(user.role as 'user' | 'driver' | 'admin' || 'user');
     setEditedTier(user.customerTier || 'new');
     setShowEditModal(true);
   };
@@ -129,9 +129,9 @@ export default function UserManagementScreen() {
       }
       
       // Update local state
-      setUsers(prev => prev.map(u => 
-        u.id === selectedUser.id 
-          ? { ...u, role: editedRole, isAdmin: editedRole === 'admin', customerTier: editedTier }
+      setUsers(prev => prev.map(u =>
+        u.id === selectedUser.id
+          ? { ...u, role: editedRole, isAdmin: editedRole === 'admin', isDriver: editedRole === 'driver', customerTier: editedTier }
           : u
       ));
       
@@ -226,6 +226,11 @@ export default function UserManagementScreen() {
           {user.role === 'admin' && (
             <View style={[styles.roleBadge, { backgroundColor: colors.gold }]}>
               <Text style={[styles.roleBadgeText, { color: colors.text.inverse }]}>מנהל</Text>
+            </View>
+          )}
+          {user.role === 'driver' && (
+            <View style={[styles.roleBadge, { backgroundColor: colors.status.info }]}>
+              <Text style={[styles.roleBadgeText, { color: colors.text.inverse }]}>נהג</Text>
             </View>
           )}
           
@@ -323,7 +328,7 @@ export default function UserManagementScreen() {
             {filterRole && (
               <View style={[styles.activeFilterChip, { backgroundColor: colors.interactive.secondary }]}>
                 <Text style={[styles.activeFilterText, { color: colors.text.primary }]}>
-                  תפקיד: {filterRole === 'admin' ? 'מנהל' : 'משתמש'}
+                  תפקיד: {filterRole === 'admin' ? 'מנהל' : filterRole === 'driver' ? 'נהג' : 'משתמש'}
                 </Text>
                 <TouchableOpacity onPress={() => setFilterRole(null)}>
                   <X size={14} color={colors.text.primary} />
@@ -382,8 +387,17 @@ export default function UserManagementScreen() {
             </Text>
             <Text style={[styles.statLabel, { color: colors.text.secondary }]}>מנהלים</Text>
           </View>
-          
-          <View style={[styles.statCard, { 
+          <View style={[styles.statCard, {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.border.primary
+          }]}>
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}>
+              {users.filter(u => u.role === 'driver').length}
+            </Text>
+            <Text style={[styles.statLabel, { color: colors.text.secondary }]}>נהגים</Text>
+          </View>
+
+          <View style={[styles.statCard, {
             backgroundColor: colors.surface.primary,
             borderColor: colors.border.primary 
           }]}>
@@ -471,7 +485,7 @@ export default function UserManagementScreen() {
                     onPress={() => setShowRoleDropdown(!showRoleDropdown)}
                   >
                     <Text style={[styles.dropdownText, { color: colors.text.primary }]}>
-                      {editedRole === 'admin' ? 'מנהל' : 'משתמש רגיל'}
+                      {editedRole === 'admin' ? 'מנהל' : editedRole === 'driver' ? 'נהג' : 'משתמש רגיל'}
                     </Text>
                     <ChevronDown size={20} color={colors.text.secondary} />
                   </TouchableOpacity>
@@ -481,7 +495,7 @@ export default function UserManagementScreen() {
                       backgroundColor: colors.surface.primary,
                       borderColor: colors.border.primary 
                     }]}>
-                      <TouchableOpacity 
+                      <TouchableOpacity
                         style={[
                           styles.dropdownItem,
                           editedRole === 'user' && { backgroundColor: colors.interactive.secondary }
@@ -493,7 +507,19 @@ export default function UserManagementScreen() {
                       >
                         <Text style={[styles.dropdownItemText, { color: colors.text.primary }]}>משתמש רגיל</Text>
                       </TouchableOpacity>
-                      <TouchableOpacity 
+                      <TouchableOpacity
+                        style={[
+                          styles.dropdownItem,
+                          editedRole === 'driver' && { backgroundColor: colors.interactive.secondary }
+                        ]}
+                        onPress={() => {
+                          setEditedRole('driver');
+                          setShowRoleDropdown(false);
+                        }}
+                      >
+                        <Text style={[styles.dropdownItemText, { color: colors.text.primary }]}>נהג</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
                         style={[
                           styles.dropdownItem,
                           editedRole === 'admin' && { backgroundColor: colors.interactive.secondary }
@@ -636,7 +662,7 @@ export default function UserManagementScreen() {
                   <Text style={[styles.filterOptionText, { color: colors.text.primary }]}>הכל</Text>
                   {filterRole === null && <View style={[styles.filterSelectedDot, { backgroundColor: colors.gold }]} />}
                 </TouchableOpacity>
-                <TouchableOpacity 
+                <TouchableOpacity
                   style={[
                     styles.filterOption,
                     { borderBottomColor: colors.border.secondary },
@@ -647,7 +673,18 @@ export default function UserManagementScreen() {
                   <Text style={[styles.filterOptionText, { color: colors.text.primary }]}>משתמשים רגילים</Text>
                   {filterRole === 'user' && <View style={[styles.filterSelectedDot, { backgroundColor: colors.gold }]} />}
                 </TouchableOpacity>
-                <TouchableOpacity 
+                <TouchableOpacity
+                  style={[
+                    styles.filterOption,
+                    { borderBottomColor: colors.border.secondary },
+                    filterRole === 'driver' && { backgroundColor: colors.interactive.secondary }
+                  ]}
+                  onPress={() => setFilterRole('driver')}
+                >
+                  <Text style={[styles.filterOptionText, { color: colors.text.primary }]}>נהגים</Text>
+                  {filterRole === 'driver' && <View style={[styles.filterSelectedDot, { backgroundColor: colors.gold }]} />}
+                </TouchableOpacity>
+                <TouchableOpacity
                   style={[
                     styles.filterOption,
                     { borderBottomColor: colors.border.secondary },

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -8,6 +8,7 @@ import InfoModal from './InfoModal';
 interface AuthContextType {
   isLoggedIn: boolean;
   isAdmin: boolean;
+  isDriver: boolean;
   user: any | null;
   loading: boolean;
   login: (username: string, password: string) => Promise<boolean>;
@@ -19,6 +20,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType>({
   isLoggedIn: false,
   isAdmin: false,
+  isDriver: false,
   user: null,
   loading: true,
   login: async () => false,
@@ -36,6 +38,7 @@ interface AuthProviderProps {
 export function AuthProvider({ children }: AuthProviderProps) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isDriver, setIsDriver] = useState(false);
   const [user, setUser] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
   const [showMatrixUserModal, setShowMatrixUserModal] = useState(false);
@@ -61,6 +64,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (mounted.current) {
         setIsLoggedIn(loggedIn);
         setIsAdmin(currentUser?.isAdmin || false);
+        setIsDriver(currentUser?.isDriver || false);
         setUser(currentUser);
         setLoading(false);
       }
@@ -92,6 +96,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (mounted.current) {
           setIsLoggedIn(loggedIn);
           setIsAdmin(matrixService.isAdmin());
+          setIsDriver(matrixService.isDriver());
           setUser(currentUser);
           setLoading(false);
         }
@@ -113,6 +118,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
               setUser(prev => ({
                 ...prev,
                 displayName: userProfile.display_name,
+                isDriver: userProfile.role === 'driver',
                 role: userProfile.role,
                 kycStatus: userProfile.kyc_status,
                 customerTier: userProfile.customer_tier
@@ -129,6 +135,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (mounted.current) {
           setIsLoggedIn(false);
           setIsAdmin(false);
+          setIsDriver(false);
           setUser(null);
           setLoading(false);
         }
@@ -138,6 +145,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (mounted.current) {
         setIsLoggedIn(false);
         setIsAdmin(false);
+        setIsDriver(false);
         setUser(null);
         setLoading(false);
       }
@@ -179,6 +187,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           if (mounted.current) {
             setIsLoggedIn(true);
             setIsAdmin(matrixService.isAdmin() || existingProfile.role === 'admin');
+            setIsDriver(existingProfile.role === 'driver');
             setUser({
               ...currentUser,
               displayName: existingProfile.display_name,
@@ -243,6 +252,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (mounted.current) {
         setIsLoggedIn(true);
         setIsAdmin(matrixService.isAdmin());
+        setIsDriver(false);
         setUser({
           ...currentUser,
           displayName: displayName
@@ -331,10 +341,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   return (
     <AuthContext.Provider 
-      value={{ 
-        isLoggedIn, 
-        isAdmin, 
-        user, 
+      value={{
+        isLoggedIn,
+        isAdmin,
+        isDriver,
+        user,
         loading,
         login, 
         signup,

--- a/services/database.ts
+++ b/services/database.ts
@@ -517,6 +517,7 @@ class DatabaseService {
         displayName: data.display_name,
         email: data.email,
         isAdmin: data.role === 'admin',
+        isDriver: data.role === 'driver',
         role: data.role,
         createdAt: data.created_at,
         updatedAt: data.updated_at,
@@ -551,6 +552,7 @@ class DatabaseService {
         displayName: profile.display_name,
         email: profile.email,
         isAdmin: profile.role === 'admin',
+        isDriver: profile.role === 'driver',
         role: profile.role,
         createdAt: profile.created_at,
         updatedAt: profile.updated_at,
@@ -588,6 +590,7 @@ class DatabaseService {
         displayName: data.display_name,
         email: data.email,
         isAdmin: data.role === 'admin',
+        isDriver: data.role === 'driver',
         role: data.role,
         createdAt: data.created_at,
         updatedAt: data.updated_at,
@@ -628,7 +631,7 @@ class DatabaseService {
     }
   }
 
-  async updateUserRole(userId: string, role: 'user' | 'admin'): Promise<void> {
+  async updateUserRole(userId: string, role: 'user' | 'driver' | 'admin'): Promise<void> {
     try {
       const { error } = await supabase
         .from('user_profiles')
@@ -721,6 +724,7 @@ class DatabaseService {
         displayName: profile.display_name,
         email: profile.email,
         isAdmin: profile.role === 'admin',
+        isDriver: profile.role === 'driver',
         role: profile.role,
         createdAt: profile.created_at,
         updatedAt: profile.updated_at,

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -337,7 +337,7 @@ export class MatrixService {
 
         if (existingProfile) {
           // User exists in database, check if they're admin
-          if (existingProfile.role !== 'admin') {
+          if (existingProfile.role !== 'admin' && existingProfile.role !== 'driver') {
             // If not admin in database and not the admin username, logout
             if (matrixLoginSuccess && this.matrixClient) {
               await this.matrixClient.logout();
@@ -353,6 +353,7 @@ export class MatrixService {
             id: userId,
             username,
             isAdmin: isAdmin || existingProfile.role === 'admin',
+            isDriver: existingProfile.role === 'driver',
             displayName: existingProfile.display_name,
             role: existingProfile.role,
           };
@@ -390,6 +391,7 @@ export class MatrixService {
               id: userId,
               username,
               isAdmin: true,
+              isDriver: false,
               displayName: username,
               role: 'admin',
             };
@@ -449,6 +451,10 @@ export class MatrixService {
 
   isAdmin(): boolean {
     return this.currentUser?.isAdmin || false;
+  }
+
+  isDriver(): boolean {
+    return this.currentUser?.isDriver || false;
   }
 
   addAuthStateListener(

--- a/supabase/migrations/20250703160000_allow_driver_role.sql
+++ b/supabase/migrations/20250703160000_allow_driver_role.sql
@@ -1,0 +1,23 @@
+/*
+  # Allow driver role in user_profiles
+
+  1. Changes
+    - Update role constraint to include 'driver'
+*/
+
+-- Update role constraint to include driver
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_column_usage
+    WHERE table_name = 'user_profiles'
+      AND column_name = 'role'
+      AND constraint_name = 'user_profiles_role_check'
+  ) THEN
+    ALTER TABLE user_profiles DROP CONSTRAINT user_profiles_role_check;
+  END IF;
+END $$;
+
+ALTER TABLE user_profiles
+  ADD CONSTRAINT user_profiles_role_check CHECK (role IN ('user', 'driver', 'admin'));

--- a/types/index.ts
+++ b/types/index.ts
@@ -103,6 +103,7 @@ export interface User {
   id: string;
   username: string;
   isAdmin: boolean;
+  isDriver?: boolean;
   displayName: string;
   avatar?: string;
   email?: string;


### PR DESCRIPTION
## Summary
- allow `driver` role in user_profiles table
- expose driver info from DatabaseService
- handle driver role in MatrixService and AuthContext
- support driver role in admin UI

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686913c3d2c08326bb5f471cefdaa213