### PR TITLE
Implement driver role logic

### DIFF
--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -41,7 +41,7 @@ export default function AdminDashboardScreen() {
     totalUsers: 0
   });
   const { showNotification } = useNotifications();
-  const { isAdmin } = useAuth();
+  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
 
   // Modal states
@@ -54,13 +54,13 @@ export default function AdminDashboardScreen() {
 
   useEffect(() => {
     // Check if user is logged in as admin
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       router.replace('/auth/login');
       return;
     }
 
     loadData();
-  }, [isAdmin]);
+  }, [isAdmin, isDriver]);
 
   const loadData = async () => {
     try {

--- a/app/admin/kyc-approvals.tsx
+++ b/app/admin/kyc-approvals.tsx
@@ -25,11 +25,11 @@ I18nManager.forceRTL(true);
 export default function KycApprovalsScreen() {
   const [pendingRequests, setPendingRequests] = useState<UserType[]>([]);
   const [loading, setLoading] = useState(true);
-  const { isAdmin, user } = useAuth();
+  const { isAdmin, isDriver, user } = useAuth();
   const { colors } = useTheme();
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
         { text: 'אישור', onPress: () => router.replace('/') }
       ]);
@@ -37,7 +37,7 @@ export default function KycApprovalsScreen() {
     }
 
     loadPendingRequests();
-  }, [isAdmin]);
+  }, [isAdmin, isDriver]);
 
   const loadPendingRequests = async () => {
     setLoading(true);

--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -38,7 +38,7 @@ export default function PricingTiersScreen() {
       { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any
     ]
   });
-  const { isAdmin } = useAuth();
+  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
@@ -66,13 +66,13 @@ export default function PricingTiersScreen() {
   });
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       router.replace('/');
       return;
     }
     
     loadPricingTiers();
-  }, [isAdmin]);
+  }, [isAdmin, isDriver]);
 
   const loadPricingTiers = async () => {
     setLoading(true);

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -28,7 +28,7 @@ export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const { isAdmin } = useAuth();
+  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { t } = useLanguage();
@@ -42,13 +42,13 @@ export default function SettingsScreen() {
   });
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       router.replace('/');
       return;
     }
     
     loadSettings();
-  }, [isAdmin]);
+  }, [isAdmin, isDriver]);
 
   useEffect(() => {
     // Update local state when context changes

--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -40,12 +40,12 @@ export default function UserManagementScreen() {
   const [filterKyc, setFilterKyc] = useState<string | null>(null);
   const [showFilterModal, setShowFilterModal] = useState(false);
   
-  const { isAdmin, user } = useAuth();
+  const { isAdmin, isDriver, user } = useAuth();
   const { colors } = useTheme();
   const { showNotification } = useNotifications();
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
         { text: 'אישור', onPress: () => router.replace('/') }
       ]);
@@ -53,7 +53,7 @@ export default function UserManagementScreen() {
     }
 
     loadUsers();
-  }, [isAdmin]);
+  }, [isAdmin, isDriver]);
 
   useEffect(() => {
     applyFilters();

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -26,17 +26,17 @@ export default function UserProfileScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const { isAdmin } = useAuth();
+  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isAdmin && !isDriver) {
       router.back();
       return;
     }
-    
+
     loadUserProfile();
-  }, [id, isAdmin]);
+  }, [id, isAdmin, isDriver]);
 
   const loadUserProfile = async () => {
     if (!id) return;
@@ -67,6 +67,8 @@ export default function UserProfileScreen() {
     switch (role) {
       case 'admin':
         return colors.gold;
+      case 'driver':
+        return colors.status.warning;
       case 'user':
         return colors.interactive.primary;
       default:
@@ -78,6 +80,8 @@ export default function UserProfileScreen() {
     switch (role) {
       case 'admin':
         return 'מנהל';
+      case 'driver':
+        return 'נהג';
       case 'user':
         return 'משתמש';
       default:
@@ -103,7 +107,7 @@ export default function UserProfileScreen() {
     }
   };
 
-  if (!isAdmin) {
+  if (!isAdmin && !isDriver) {
     return null;
   }
 

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -46,7 +46,7 @@ export default function ChatWidget() {
   const [playingAudio, setPlayingAudio] = useState<{ [key: string]: Audio.Sound }>({});
   const [showReactions, setShowReactions] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<{ id: string; displayName: string; isAppUser: boolean }[]>([]);
-  const { isAdmin, isLoggedIn, user } = useAuth();
+  const { isAdmin, isDriver, isLoggedIn, user } = useAuth();
   const { colors } = useTheme();
   const { t } = useLanguage();
   const recordingTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -65,13 +65,13 @@ export default function ChatWidget() {
 
   useEffect(() => {
     if (isOpen && isLoggedIn) {
-      if (isAdmin) {
+      if (isAdmin || isDriver) {
         loadChatRooms();
       } else {
         loadOrCreateDefaultRoom();
       }
     }
-  }, [isOpen, isAdmin, isLoggedIn]);
+  }, [isOpen, isAdmin, isDriver, isLoggedIn]);
 
   useEffect(() => {
     return () => {
@@ -88,7 +88,7 @@ export default function ChatWidget() {
   useEffect(() => {
     // Listen for chat trigger events
     const handleChatTrigger = (userId: string) => {
-      if (isAdmin) {
+      if (isAdmin || isDriver) {
         // Find or create a room for this user
         const room = chatRooms.find(r => r.userId === userId);
         if (room) {
@@ -108,11 +108,11 @@ export default function ChatWidget() {
     return () => {
       matrixService.removeChatTriggerListener(handleChatTrigger);
     };
-  }, [chatRooms, isAdmin]);
+  }, [chatRooms, isAdmin, isDriver]);
 
   useEffect(() => {
     const fetchResults = async () => {
-      if (isAdmin && searchQuery.trim()) {
+      if ((isAdmin || isDriver) && searchQuery.trim()) {
         try {
           const db = DatabaseService.getInstance();
           const results = await matrixService.searchUsers(searchQuery.trim());
@@ -151,7 +151,7 @@ export default function ChatWidget() {
     };
 
     fetchResults();
-  }, [searchQuery, isAdmin]);
+  }, [searchQuery, isAdmin, isDriver]);
 
   const loadChatRooms = async () => {
     try {
@@ -262,14 +262,14 @@ export default function ChatWidget() {
       const success = await matrixService.sendMessage(roomId, newMessage.trim());
       
       // Add message to local state
-      const message: ChatMessage = {
-        id: Date.now().toString(),
-        senderId: isAdmin ? (process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin') : (user?.id || 'user_guest'),
-        senderName: isAdmin ? 'מנהל' : (user?.displayName || 'משתמש אורח'),
-        message: newMessage.trim(),
-        timestamp: Date.now(),
-        isAdmin: isAdmin,
-      };
+    const message: ChatMessage = {
+      id: Date.now().toString(),
+      senderId: (isAdmin || isDriver) ? (process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin') : (user?.id || 'user_guest'),
+      senderName: isAdmin || isDriver ? 'מנהל' : (user?.displayName || 'משתמש אורח'),
+      message: newMessage.trim(),
+      timestamp: Date.now(),
+      isAdmin: isAdmin || isDriver,
+    };
 
       setMessages(prev => [...prev, message]);
       setNewMessage('');
@@ -280,7 +280,7 @@ export default function ChatWidget() {
       }, 100);
 
       // If not admin, simulate admin response after a delay
-      if (!isAdmin) {
+      if (!isAdmin && !isDriver) {
         setTimeout(() => {
           const adminResponse: ChatMessage = {
             id: (Date.now() + 1).toString(),
@@ -382,11 +382,11 @@ export default function ChatWidget() {
         const roomId = selectedRoom ? selectedRoom.id : await matrixService.getOrCreateAdminRoom();
         const voiceMessage: ChatMessage = {
           id: Date.now().toString(),
-          senderId: isAdmin ? (process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin') : (user?.id || 'user_guest'),
-          senderName: isAdmin ? 'מנהל' : (user?.displayName || 'משתמש אורח'),
+          senderId: (isAdmin || isDriver) ? (process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin') : (user?.id || 'user_guest'),
+          senderName: isAdmin || isDriver ? 'מנהל' : (user?.displayName || 'משתמש אורח'),
           message: '',
           timestamp: Date.now(),
-          isAdmin: isAdmin,
+          isAdmin: isAdmin || isDriver,
           audioUri: uploadedUrl,
           audioDuration: recordingDuration
         };
@@ -488,7 +488,7 @@ export default function ChatWidget() {
   };
 
   const navigateToUserProfile = async (userId: string) => {
-    if (!isAdmin) return;
+    if (!isAdmin && !isDriver) return;
 
     try {
       setIsOpen(false);
@@ -524,13 +524,13 @@ export default function ChatWidget() {
       onLongPress={() => setShowReactions(item.id)}
     >
       <View style={styles.messageHeader}>
-        <TouchableOpacity 
+        <TouchableOpacity
           onPress={() => navigateToUserProfile(item.senderId)}
-          disabled={!isAdmin}
+          disabled={!(isAdmin || isDriver)}
         >
           <Text style={[
             styles.senderName,
-            isAdmin && styles.clickableSender
+            (isAdmin || isDriver) && styles.clickableSender
           ]}>
             {item.senderName}
           </Text>
@@ -712,7 +712,7 @@ export default function ChatWidget() {
             borderBottomColor: colors.border.primary,
             backgroundColor: colors.gold 
           }]}>
-            {isAdmin && selectedRoom && (
+            {(isAdmin || isDriver) && selectedRoom && (
               <TouchableOpacity 
                 style={styles.backButton}
                 onPress={backToRoomList}
@@ -722,12 +722,12 @@ export default function ChatWidget() {
             )}
             <View style={styles.headerContent}>
               <Text style={[styles.chatTitle, { color: colors.text.inverse }]}>
-                {isAdmin
+                {isAdmin || isDriver
                   ? (selectedRoom ? selectedRoom.userName : t('chat.adminChat'))
                   : t('chat.customerSupport')}
               </Text>
               <Text style={styles.chatSubtitle}>
-                {isAdmin
+                {(isAdmin || isDriver)
                   ? (selectedRoom ? t('chat.customerSupportChat') : t('chat.selectChatToStart'))
                   : t('chat.chatWithTeam')}
               </Text>
@@ -757,7 +757,7 @@ export default function ChatWidget() {
               style={styles.chatContent}
               behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             >
-              {isAdmin && !selectedRoom ? (
+              {(isAdmin || isDriver) && !selectedRoom ? (
                 // Admin Chat List View
                 <>
                   {/* Search */}

--- a/translations/en.json
+++ b/translations/en.json
@@ -211,6 +211,7 @@
     "guest": "Guest",
     "guestBrowsing": "Guest browsing",
     "admin": "Admin",
+    "driver": "Driver",
     "customer": "Customer",
     "orders": "Orders",
     "favorites": "Favorites",

--- a/translations/he.json
+++ b/translations/he.json
@@ -211,6 +211,7 @@
     "guest": "אורח",
     "guestBrowsing": "גלישה כאורח",
     "admin": "מנהל",
+    "driver": "נהג",
     "customer": "לקוח",
     "orders": "ההזמנות שלי",
     "favorites": "המועדפים שלי",


### PR DESCRIPTION
## Summary
- add driver label to translations
- show driver role color/text on user profile
- grant drivers access to admin screens
- enable drivers in chat logic

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6869220083088326889e9be823c61ea9