### PR TITLE
Add job-specific chat rooms

### DIFF
--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft, Plus, Truck, ChevronDown } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
+import { MatrixService } from '../../services/matrix';
 import { DeliveryJob, User } from '../../types';
 
 I18nManager.allowRTL(true);
@@ -29,6 +30,7 @@ export default function AdminDeliveriesScreen() {
   const [selectedDriver, setSelectedDriver] = useState<User | null>(null);
   const [showDriverDropdown, setShowDriverDropdown] = useState(false);
   const [loading, setLoading] = useState(true);
+  const matrixService = MatrixService.getInstance();
 
   useEffect(() => {
     if (!isAdmin) {
@@ -75,11 +77,18 @@ export default function AdminDeliveriesScreen() {
     try {
       const db = DatabaseService.getInstance();
       await db.updateDeliveryJobStatus(jobId, status);
+      if (status === 'completed') {
+        matrixService.archiveJobRoom(jobId);
+      }
       loadData();
     } catch (error) {
       console.error('Error updating job:', error);
       Alert.alert('שגיאה', 'עדכון סטטוס נכשל');
     }
+  };
+
+  const openJobChat = (job: DeliveryJob) => {
+    matrixService.triggerJobChatOpen(job.id);
   };
 
   const formatDate = (date?: string) => {
@@ -136,7 +145,7 @@ export default function AdminDeliveriesScreen() {
         </View>
 
         {jobs.map(job => (
-          <View key={job.id} style={[styles.jobCard, { backgroundColor: colors.surface.primary, borderColor: colors.border.primary }]}>
+          <TouchableOpacity key={job.id} onPress={() => openJobChat(job)} style={[styles.jobCard, { backgroundColor: colors.surface.primary, borderColor: colors.border.primary }]}>
             <View style={styles.jobHeader}>
               <Truck size={24} color={colors.gold} />
               <Text style={[styles.jobTitle, { color: colors.text.primary }]}>הזמנה #{job.orderId.slice(-6)}</Text>
@@ -171,7 +180,7 @@ export default function AdminDeliveriesScreen() {
                 </TouchableOpacity>
               )}
             </View>
-          </View>
+          </TouchableOpacity>
         ))}
       </ScrollView>
     </SafeAreaView>

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, Truck, CheckCircle, Clock, XCircle } from 'lucide-react-nati
 import { useAuth } from '../components/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import DatabaseService from '../services/database';
+import { MatrixService } from '../services/matrix';
 import { DeliveryJob } from '../types';
 
 I18nManager.allowRTL(true);
@@ -24,6 +25,7 @@ export default function DriverDashboardScreen() {
   const { colors } = useTheme();
   const [jobs, setJobs] = useState<DeliveryJob[]>([]);
   const [loading, setLoading] = useState(true);
+  const matrixService = MatrixService.getInstance();
 
   useEffect(() => {
     if (!isDriver && !isAdmin) {
@@ -49,10 +51,17 @@ export default function DriverDashboardScreen() {
     }
   };
 
+  const openJobChat = (job: DeliveryJob) => {
+    matrixService.triggerJobChatOpen(job.id);
+  };
+
   const updateStatus = async (jobId: string, status: 'pending' | 'in_progress' | 'completed' | 'cancelled') => {
     try {
       const db = DatabaseService.getInstance();
       await db.updateDeliveryJobStatus(jobId, status);
+      if (status === 'completed') {
+        matrixService.archiveJobRoom(jobId);
+      }
       loadJobs();
     } catch (error) {
       console.error('Error updating status:', error);
@@ -77,7 +86,7 @@ export default function DriverDashboardScreen() {
 
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {jobs.map(job => (
-          <View key={job.id} style={[styles.jobCard, {
+          <TouchableOpacity key={job.id} onPress={() => openJobChat(job)} style={[styles.jobCard, {
             backgroundColor: colors.surface.primary,
             borderColor: colors.border.primary,
           }]}>
@@ -121,7 +130,7 @@ export default function DriverDashboardScreen() {
                 </TouchableOpacity>
               )}
             </View>
-          </View>
+          </TouchableOpacity>
         ))}
         {!loading && jobs.length === 0 && (
           <View style={styles.emptyContainer}>

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -111,6 +111,28 @@ export default function ChatWidget() {
   }, [chatRooms, isAdmin, isDriver]);
 
   useEffect(() => {
+    const handleJobChat = async (jobId: string) => {
+      const roomId = await matrixService.getOrCreateJobRoom(jobId);
+      const jobRoom: ChatRoom = {
+        id: roomId,
+        userId: jobId,
+        userName: `Job ${jobId}`,
+        lastMessage: '',
+        lastMessageTime: Date.now(),
+        unreadCount: 0,
+      };
+      setIsOpen(true);
+      setSelectedRoom(jobRoom);
+      await loadMessages(roomId);
+    };
+
+    matrixService.addJobChatTriggerListener(handleJobChat);
+    return () => {
+      matrixService.removeJobChatTriggerListener(handleJobChat);
+    };
+  }, []);
+
+  useEffect(() => {
     const fetchResults = async () => {
       if ((isAdmin || isDriver) && searchQuery.trim()) {
         try {

--- a/services/matrix.ts
+++ b/services/matrix.ts
@@ -32,6 +32,7 @@ export class MatrixService {
   private currentUser: any = null;
   private authStateListeners: ((isLoggedIn: boolean, user: any) => void)[] = [];
   private chatTriggerListeners: ((userId: string) => void)[] = [];
+  private jobChatTriggerListeners: ((jobId: string) => void)[] = [];
 
   public static getInstance(): MatrixService {
     if (!MatrixService.instance) {
@@ -494,6 +495,23 @@ export class MatrixService {
     }
   }
 
+  // Job chat trigger methods
+  addJobChatTriggerListener(listener: (jobId: string) => void): void {
+    this.jobChatTriggerListeners.push(listener);
+  }
+
+  removeJobChatTriggerListener(listener: (jobId: string) => void): void {
+    this.jobChatTriggerListeners = this.jobChatTriggerListeners.filter(
+      (l) => l !== listener
+    );
+  }
+
+  triggerJobChatOpen(jobId: string): void {
+    for (const listener of this.jobChatTriggerListeners) {
+      listener(jobId);
+    }
+  }
+
   async sendMessage(roomId: string, message: string): Promise<boolean> {
     try {
       if (!this.isAuthenticated) {
@@ -681,6 +699,54 @@ export class MatrixService {
     } catch (error) {
       console.error('Error getting or creating admin room:', error);
       return 'default_room';
+    }
+  }
+
+  async getOrCreateJobRoom(jobId: string): Promise<string> {
+    try {
+      if (!this.isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+
+      if (!this.matrixClient) {
+        return `job_${jobId}`;
+      }
+
+      const alias = `#job-${jobId}:${MATRIX_DOMAIN}`;
+
+      try {
+        const res = await this.matrixClient.getRoomIdForAlias(alias);
+        const roomId = res.room_id;
+        await this.matrixClient.joinRoom(roomId);
+        return roomId;
+      } catch {
+        const response = await this.matrixClient.createRoom({
+          room_alias_name: `job-${jobId}`,
+          name: `Job ${jobId}`,
+          preset: Preset.PrivateChat,
+          visibility: Visibility.Private,
+        });
+        return response.room_id;
+      }
+    } catch (error) {
+      console.error('Error getting or creating job room:', error);
+      return `job_${jobId}`;
+    }
+  }
+
+  async archiveJobRoom(jobId: string): Promise<void> {
+    if (!this.matrixClient) {
+      return;
+    }
+
+    const alias = `#job-${jobId}:${MATRIX_DOMAIN}`;
+    try {
+      const res = await this.matrixClient.getRoomIdForAlias(alias);
+      const roomId = res.room_id;
+      await this.matrixClient.leave(roomId);
+      await this.matrixClient.forget(roomId);
+    } catch (error) {
+      console.error('Error archiving job room:', error);
     }
   }
 


### PR DESCRIPTION
## Summary
- extend MatrixService with job chat helpers
- open a job's chat room when tapping a job card
- archive job chat rooms when completed
- load job chats in ChatWidget

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit --skipLibCheck` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_686931296bc48326bd66cd5f92707df3