### PR TITLE
Add proof upload for delivery jobs

### DIFF
--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -8,10 +8,14 @@ import {
   TextInput,
   Alert,
   I18nManager,
+  Image,
+  Linking,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Plus, Truck, ChevronDown } from 'lucide-react-native';
+import FullScreenMediaViewer from '../../components/FullScreenMediaViewer';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
@@ -29,6 +33,8 @@ export default function AdminDeliveriesScreen() {
   const [selectedDriver, setSelectedDriver] = useState<User | null>(null);
   const [showDriverDropdown, setShowDriverDropdown] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [proofMedia, setProofMedia] = useState<{ id: string; uri: string; type: 'image' | 'video' }[]>([]);
+  const [viewerVisible, setViewerVisible] = useState(false);
 
   useEffect(() => {
     if (!isAdmin) {
@@ -79,6 +85,19 @@ export default function AdminDeliveriesScreen() {
     } catch (error) {
       console.error('Error updating job:', error);
       Alert.alert('שגיאה', 'עדכון סטטוס נכשל');
+    }
+  };
+
+  const openProof = (uri: string) => {
+    if (uri.match(/\.(jpg|jpeg|png|gif|webp)$/i)) {
+      setProofMedia([{ id: '1', uri, type: 'image' }]);
+      setViewerVisible(true);
+    } else {
+      if (Platform.OS === 'web') {
+        window.open(uri, '_blank');
+      } else {
+        Linking.openURL(uri);
+      }
     }
   };
 
@@ -145,6 +164,11 @@ export default function AdminDeliveriesScreen() {
             <Text style={[styles.jobInfo, { color: colors.text.secondary }]}>סטטוס: {job.status}</Text>
             {job.pickupTime && <Text style={[styles.jobInfo, { color: colors.text.secondary }]}>איסוף: {formatDate(job.pickupTime)}</Text>}
             {job.dropoffTime && <Text style={[styles.jobInfo, { color: colors.text.secondary }]}>מסירה: {formatDate(job.dropoffTime)}</Text>}
+            {job.proofUri && (
+              <TouchableOpacity onPress={() => openProof(job.proofUri)}>
+                <Image source={{ uri: job.proofUri }} style={styles.proofImage} />
+              </TouchableOpacity>
+            )}
             <View style={styles.actionsRow}>
               {job.status !== 'in_progress' && job.status !== 'completed' && (
                 <TouchableOpacity
@@ -174,6 +198,12 @@ export default function AdminDeliveriesScreen() {
           </View>
         ))}
       </ScrollView>
+      <FullScreenMediaViewer
+        visible={viewerVisible}
+        media={proofMedia}
+        initialIndex={0}
+        onClose={() => setViewerVisible(false)}
+      />
     </SafeAreaView>
   );
 }
@@ -263,6 +293,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     marginLeft: 8,
+  },
+  proofImage: {
+    width: 80,
+    height: 80,
+    borderRadius: 8,
+    marginTop: 8,
   },
   actionText: { fontSize: 14 },
 });

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Truck, CheckCircle, Clock, XCircle } from 'lucide-react-native';
+import ProofUploader from '../components/ProofUploader';
 import { useAuth } from '../components/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import DatabaseService from '../services/database';
@@ -121,6 +122,9 @@ export default function DriverDashboardScreen() {
                 </TouchableOpacity>
               )}
             </View>
+            {job.status === 'completed' && (
+              <ProofUploader jobId={job.id} proofUri={job.proofUri} />
+            )}
           </View>
         ))}
         {!loading && jobs.length === 0 && (

--- a/components/ProofUploader.tsx
+++ b/components/ProofUploader.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+  Alert,
+  Platform
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import { Upload, Camera, File as FileIcon } from 'lucide-react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import MediaService from '../services/media';
+import DatabaseService from '../services/database';
+
+interface ProofUploaderProps {
+  jobId: string;
+  proofUri?: string;
+  onUploaded?: (uri: string) => void;
+}
+
+export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUploaderProps) {
+  const [uri, setUri] = useState(proofUri);
+  const [uploading, setUploading] = useState(false);
+  const { colors } = useTheme();
+
+  const requestMediaPermission = async () => {
+    if (Platform.OS !== 'web') {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert('Permission Required', 'אנא אפשר גישה למדיה במכשיר.');
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const pickDocument = async () => {
+    if (!(await requestMediaPermission())) return;
+    const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: false });
+    if (result.type === 'cancel') return;
+    await uploadFile(result.uri, result.name || `proof_${Date.now()}`);
+  };
+
+  const pickImage = async () => {
+    if (!(await requestMediaPermission())) return;
+    const result = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 0.8
+    });
+    if (result.canceled || result.assets.length === 0) return;
+    const asset = result.assets[0];
+    await uploadFile(asset.uri, asset.fileName || `proof_${Date.now()}`);
+  };
+
+  const takePhoto = async () => {
+    if (!(await requestMediaPermission())) return;
+    const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, quality: 0.8 });
+    if (result.canceled || result.assets.length === 0) return;
+    const asset = result.assets[0];
+    await uploadFile(asset.uri, asset.fileName || `proof_${Date.now()}`);
+  };
+
+  const uploadFile = async (fileUri: string, name: string) => {
+    try {
+      setUploading(true);
+      const mediaService = MediaService.getInstance();
+      const uploaded = await mediaService.uploadMedia(fileUri, name);
+      const db = DatabaseService.getInstance();
+      await db.updateDeliveryJobProof(jobId, uploaded);
+      setUri(uploaded);
+      onUploaded?.(uploaded);
+    } catch (error) {
+      console.error('Error uploading proof:', error);
+      Alert.alert('שגיאה', 'העלאת הקובץ נכשלה');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {uri ? (
+        uri.match(/\.(jpg|jpeg|png|gif|webp)$/i) ? (
+          <Image source={{ uri }} style={styles.preview} />
+        ) : (
+          <View style={[styles.filePreview, { borderColor: colors.border.primary }]}> 
+            <FileIcon size={24} color={colors.text.primary} />
+            <Text style={{ color: colors.text.primary, marginTop: 4 }}>File</Text>
+          </View>
+        )
+      ) : (
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.button, { borderColor: colors.gold }]}
+            onPress={pickImage}
+            disabled={uploading}
+          >
+            {uploading ? (
+              <ActivityIndicator size="small" color={colors.gold} />
+            ) : (
+              <>
+                <Upload size={20} color={colors.gold} />
+                <Text style={[styles.buttonText, { color: colors.gold }]}>Gallery</Text>
+              </>
+            )}
+          </TouchableOpacity>
+          {Platform.OS !== 'web' && (
+            <TouchableOpacity
+              style={[styles.button, { borderColor: colors.gold }]}
+              onPress={takePhoto}
+              disabled={uploading}
+            >
+              <Camera size={20} color={colors.gold} />
+              <Text style={[styles.buttonText, { color: colors.gold }]}>Camera</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity
+            style={[styles.button, { borderColor: colors.gold }]}
+            onPress={pickDocument}
+            disabled={uploading}
+          >
+            <FileIcon size={20} color={colors.gold} />
+            <Text style={[styles.buttonText, { color: colors.gold }]}>File</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+    alignItems: 'flex-start'
+  },
+  actions: {
+    flexDirection: 'row-reverse',
+    gap: 8
+  },
+  button: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    flexDirection: 'row-reverse',
+    alignItems: 'center',
+    gap: 4
+  },
+  buttonText: {
+    fontSize: 12,
+    fontWeight: '600'
+  },
+  preview: {
+    width: 100,
+    height: 100,
+    borderRadius: 8
+  },
+  filePreview: {
+    width: 100,
+    height: 100,
+    borderWidth: 1,
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-font": "~13.2.2",
     "expo-haptics": "~14.1.3",
     "expo-image-picker": "~16.1.0",
+    "expo-document-picker": "~15.0.0",
     "expo-linear-gradient": "~14.1.3",
     "expo-linking": "~7.1.3",
     "expo-router": "~5.0.2",

--- a/services/database.ts
+++ b/services/database.ts
@@ -1493,6 +1493,23 @@ class DatabaseService {
     }
   }
 
+  async updateDeliveryJobProof(jobId: string, proofUri: string): Promise<void> {
+    try {
+      const { error } = await supabase
+        .from('delivery_jobs')
+        .update({ proof_uri: proofUri })
+        .eq('id', jobId);
+
+      if (error) {
+        console.error('Error updating delivery job proof:', error);
+        throw new Error('Failed to update delivery job proof');
+      }
+    } catch (error) {
+      console.error('Error in updateDeliveryJobProof:', error);
+      throw error;
+    }
+  }
+
   // Settings
   async getSetting(key: string): Promise<string | null> {
     try {


### PR DESCRIPTION
## Summary
- allow drivers to upload proof files via new `ProofUploader` component
- store uploaded proof URI in `delivery_jobs.proof_uri`
- show proof images in admin deliveries view
- enable full-screen proof viewer
- include `expo-document-picker` dependency

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6869314c199c8326b448a30ac4039bfe