### PR TITLE
Centralize RTL control

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  I18nManager,
   Modal,
   TextInput,
 } from 'react-native';
@@ -20,9 +19,7 @@ import GlobalHeader from '../../components/GlobalHeader';
 import InfoModal from '../../components/InfoModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function CategoriesScreen() {
   const [categories, setCategories] = useState<Category[]>([]);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,7 +9,6 @@ import {
   FlatList,
   Dimensions,
   Modal,
-  I18nManager,
   TextInput,
   RefreshControl,
   useWindowDimensions,
@@ -37,9 +36,7 @@ import BannerFormModal from '../../components/BannerFormModal';
 import CartModal from '../../components/CartModal';
 import ProductFormModal from '../../components/ProductFormModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 const { width } = Dimensions.get('window');
 

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Bell, Package, Tag, MessageCircle, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info } from 'lucide-react-native';
@@ -20,9 +19,7 @@ import GlobalHeader from '../../components/GlobalHeader';
 import InfoModal from '../../components/InfoModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function NotificationsScreen() {
   const [notifications, setNotifications] = useState<Notification[]>([]);

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -19,9 +18,7 @@ import OrderTrackingModal from '../../components/OrderTrackingModal';
 import InfoModal from '../../components/InfoModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function OrdersScreen() {
   const [orders, setOrders] = useState<Order[]>([]);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  I18nManager,
   ScrollView,
   Switch,
 } from 'react-native';
@@ -30,9 +29,7 @@ import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 // Storage keys for settings
 const NOTIFICATIONS_STORAGE_KEY = 'settings_notifications';

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -20,9 +19,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import InfoModal from '../../components/InfoModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function AdminDashboardScreen() {
   const [products, setProducts] = useState<Product[]>([]);

--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -7,7 +7,6 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
-  I18nManager,
   Image,
   Linking,
   Platform,
@@ -21,9 +20,6 @@ import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
 import { MatrixService } from '../../services/matrix';
 import { DeliveryJob, User } from '../../types';
-
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
 
 export default function AdminDeliveriesScreen() {
   const { isAdmin } = useAuth();

--- a/app/admin/kyc-approvals.tsx
+++ b/app/admin/kyc-approvals.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   ScrollView,
   Alert,
-  I18nManager,
   Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -18,9 +17,7 @@ import DatabaseService from '../../services/database';
 import { User as UserType } from '../../types';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function KycApprovalsScreen() {
   const [pendingRequests, setPendingRequests] = useState<UserType[]>([]);

--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -7,7 +7,6 @@ import {
   ScrollView,
   TextInput,
   Modal,
-  I18nManager,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -21,9 +20,7 @@ import { PricingTier } from '../../types';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function PricingTiersScreen() {
   const [pricingTiers, setPricingTiers] = useState<PricingTier[]>([]);

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   ScrollView,
   TextInput,
-  I18nManager,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -20,9 +19,7 @@ import DatabaseService from '../../services/database';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');

--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -8,7 +8,6 @@ import {
   TextInput,
   Modal,
   Alert,
-  I18nManager,
   ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -19,10 +18,6 @@ import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
 import { User as UserType, CustomerTier } from '../../types';
 import { useNotifications } from '../../components/NotificationContext';
-
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
 
 export default function UserManagementScreen() {
   const [users, setUsers] = useState<UserType[]>([]);

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
-  I18nManager,
   ActivityIndicator,
   ScrollView,
   KeyboardAvoidingView,
@@ -19,9 +18,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import InfoModal from '../../components/InfoModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function AuthLoginScreen() {
   const [username, setUsername] = useState('');

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
-  I18nManager,
   ActivityIndicator,
   ScrollView,
   KeyboardAvoidingView,
@@ -19,9 +18,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import InfoModal from '../../components/InfoModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function AuthSignupScreen() {
   const [username, setUsername] = useState('');

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  I18nManager,
   Modal,
   TextInput,
 } from 'react-native';
@@ -19,9 +18,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import InfoModal from '../../components/InfoModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function CategoryScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -8,7 +8,6 @@ import {
   ScrollView,
   TouchableOpacity,
   Alert,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -25,8 +24,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import DatabaseService from '../services/database';
 import { DeliveryJob } from '../types';
 
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function DriverDashboardScreen() {
   const { user, isDriver, isAdmin } = useAuth();

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -7,7 +7,6 @@ import {
   ScrollView,
   TextInput,
   Linking,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -20,9 +19,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 const TELEGRAM_LINK = 'https://t.me/+fTyw0RbT2Kk5NTI0';
 

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -10,7 +10,6 @@ import {
   Dimensions,
   Modal,
   TextInput,
-  I18nManager,
   Platform,
   ActivityIndicator,
 } from 'react-native';
@@ -39,9 +38,7 @@ import InfoModal from '../../components/InfoModal';
 import ProductFormModal from '../../components/ProductFormModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 interface MediaItem {
   id: string;

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -9,7 +9,6 @@ import {
   TextInput,
   Modal,
   Alert,
-  I18nManager,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -24,9 +23,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function ReviewsScreen() {
   const [reviews, setReviews] = useState<Review[]>([]);

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -8,7 +8,6 @@ import {
   Image,
   Modal,
   TextInput,
-  I18nManager,
   Platform,
   ActivityIndicator,
 } from 'react-native';
@@ -25,9 +24,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 interface MediaItem {
   id: string;

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   TouchableOpacity,
   Image,
-  I18nManager,
   Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -18,9 +17,7 @@ import { User } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 export default function UserProfileScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();

--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -6,16 +6,11 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  I18nManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../contexts/ThemeContext';
-
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
 
 const AGE_VERIFICATION_KEY = 'age_verified';
 

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -10,7 +10,6 @@ import {
   KeyboardAvoidingView,
   Platform,
   Image,
-  I18nManager,
   Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -25,10 +24,6 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import InfoModal from './InfoModal';
 import UserProfileModal from './UserProfileModal';
-
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
 
 const EMOJI_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '😡'];
 

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -9,7 +9,6 @@ import {
   Image,
   Animated,
   Easing,
-  I18nManager,
   Alert,
 } from 'react-native';
 import { X, CircleCheck as CheckCircle, Circle, Package, Truck, MapPin, Star, Phone, MessageCircle, Copy } from 'lucide-react-native';
@@ -23,9 +22,7 @@ import * as Clipboard from 'expo-clipboard';
 import { useAuth } from './AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 
-// Enable RTL for Hebrew
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+
 
 interface OrderTrackingModalProps {
   visible: boolean;

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
-import { I18nManager } from 'react-native';
+import { configureRTL } from '../utils/rtl';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // Import translation files
@@ -40,6 +40,10 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     loadStoredLanguage();
   }, []);
 
+  useEffect(() => {
+    configureRTL(isRTL);
+  }, [isRTL]);
+
   const loadStoredLanguage = async () => {
     try {
       const storedLanguage = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -59,14 +63,11 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       if (language === 'en') {
         setTranslations(enTranslations);
         setIsRTL(false);
-        I18nManager.allowRTL(false);
-        I18nManager.forceRTL(false);
       } else {
         setTranslations(heTranslations);
         setIsRTL(true);
-        I18nManager.allowRTL(true);
-        I18nManager.forceRTL(true);
       }
+      configureRTL(language === 'he');
 
       // Store language preference
       await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, language);

--- a/utils/rtl.ts
+++ b/utils/rtl.ts
@@ -1,0 +1,8 @@
+import { I18nManager } from 'react-native';
+
+export function configureRTL(enable: boolean): void {
+  if (I18nManager.isRTL !== enable) {
+    I18nManager.allowRTL(enable);
+    I18nManager.forceRTL(enable);
+  }
+}


### PR DESCRIPTION
## Summary
- add a helper to manage RTL switching
- call helper from `LanguageContext`
- remove inline `I18nManager` calls from screens and components

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bab8704c8326b9f88604fe329bc7