### PR TITLE
Add customizable branding settings

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -25,6 +25,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import GlobalHeader from '../../components/GlobalHeader';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { useAppInfo } from '../../contexts/AppInfoContext';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
@@ -38,6 +39,7 @@ export default function ProfileScreen() {
   const { isLoggedIn, isAdmin, isDriver, user, logout } = useAuth();
   const { t, currentLanguage, setLanguage } = useLanguage();
   const { theme, toggleTheme, colors } = useTheme();
+  const { platformName } = useAppInfo();
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [showOrderTracking, setShowOrderTracking] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState(null);
@@ -428,12 +430,8 @@ export default function ProfileScreen() {
 
         {/* App Info */}
         <View style={styles.appInfo}>
-          <Text style={[styles.appVersion, { color: colors.text.tertiary }]}>
-            גרסה 1.0.0
-          </Text>
-          <Text style={[styles.appCopyright, { color: colors.text.tertiary }]}>
-            © 2024 הקונגרס הציוני
-          </Text>
+          <Text style={[styles.appVersion, { color: colors.text.tertiary }]}>{t('profile.version')}</Text>
+          <Text style={[styles.appCopyright, { color: colors.text.tertiary }]}>© 2024 {platformName || t('ageVerification.platformName')}</Text>
         </View>
       </ScrollView>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { AuthProvider, useAuth } from '../components/AuthContext';
 import { LanguageProvider } from '../contexts/LanguageContext';
 import { ThemeProvider, useTheme } from '../contexts/ThemeContext';
 import { CurrencyProvider } from '../contexts/CurrencyContext';
+import { AppInfoProvider } from '../contexts/AppInfoContext';
 import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import { View, ActivityIndicator } from 'react-native';
@@ -79,11 +80,13 @@ export default function RootLayout() {
     <ThemeProvider>
       <LanguageProvider>
         <AuthProvider>
-          <CurrencyProvider>
-            <NotificationProvider>
-              <AppContent />
-            </NotificationProvider>
-          </CurrencyProvider>
+          <AppInfoProvider>
+            <CurrencyProvider>
+              <NotificationProvider>
+                <AppContent />
+              </NotificationProvider>
+            </CurrencyProvider>
+          </AppInfoProvider>
         </AuthProvider>
       </LanguageProvider>
     </ThemeProvider>

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -10,25 +10,29 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import { ArrowLeft, Save, Settings as SettingsIcon, DollarSign, Globe, Bell } from 'lucide-react-native';
+import { ArrowLeft, Save, Settings as SettingsIcon, DollarSign, Globe, Bell, Image as ImageIcon } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
 import { useLanguage } from '../../contexts/LanguageContext';
-import DatabaseService from '../../services/database';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
+import MediaUploader from '../../components/MediaUploader';
+import { useAppInfo } from '../../contexts/AppInfoContext';
 
 
 
 export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
+  const [platformName, setPlatformNameState] = useState('');
+  const [platformLogoMedia, setPlatformLogoMedia] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { t, currentLanguage } = useLanguage();
+  const { platformName: contextPlatformName, platformLogo: contextPlatformLogo, setPlatformName, setPlatformLogo } = useAppInfo();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -50,13 +54,25 @@ export default function SettingsScreen() {
   useEffect(() => {
     // Update local state when context changes
     setCurrencySymbolState(contextCurrencySymbol);
-  }, [contextCurrencySymbol]);
+    setPlatformNameState(contextPlatformName);
+    setPlatformLogoMedia(
+      contextPlatformLogo
+        ? [{ id: '1', uri: contextPlatformLogo, type: 'image' }]
+        : []
+    );
+  }, [contextCurrencySymbol, contextPlatformName, contextPlatformLogo]);
 
   const loadSettings = async () => {
     setLoading(true);
     try {
       // Currency symbol is already loaded from context
       setCurrencySymbolState(contextCurrencySymbol);
+      setPlatformNameState(contextPlatformName);
+      setPlatformLogoMedia(
+        contextPlatformLogo
+          ? [{ id: '1', uri: contextPlatformLogo, type: 'image' }]
+          : []
+      );
     } catch (error) {
       console.error('Error loading settings:', error);
       setInfoModal({
@@ -75,6 +91,8 @@ export default function SettingsScreen() {
     try {
       // Update currency symbol in context (which will update database)
       await setCurrencySymbol(currencySymbol);
+      await setPlatformName(platformName);
+      await setPlatformLogo(platformLogoMedia[0]?.uri || '');
       
       setInfoModal({
         visible: true,
@@ -128,6 +146,53 @@ export default function SettingsScreen() {
         <View style={styles.sectionHeader}>
           <SettingsIcon size={24} color={colors.gold} />
           <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>הגדרות כלליות</Text>
+        </View>
+
+        {/* Branding Settings */}
+        <View style={[styles.settingCard, {
+          backgroundColor: colors.surface.primary,
+          borderColor: colors.border.primary,
+          ...Platform.select({
+            ios: {
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.1,
+              shadowRadius: 4,
+            },
+            android: { elevation: 2 },
+            web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
+          }),
+        }]}>
+          <View style={styles.settingHeader}>
+            <ImageIcon size={20} color={colors.gold} />
+            <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות מיתוג</Text>
+          </View>
+
+          <View style={styles.settingContent}>
+            <Text style={[styles.settingDescription, { color: colors.text.secondary }]}>נהל את שם המערכת והלוגו המוצג באפליקציה</Text>
+
+            <View style={styles.inputContainer}>
+              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>שם המערכת</Text>
+              <TextInput
+                style={[styles.input, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.secondary,
+                  color: colors.text.primary
+                }]}
+                value={platformName}
+                onChangeText={setPlatformNameState}
+                placeholder="הקונגרס הציוני"
+                textAlign="right"
+              />
+            </View>
+
+            <MediaUploader
+              media={platformLogoMedia}
+              onMediaChange={setPlatformLogoMedia}
+              maxFiles={1}
+              allowVideos={false}
+            />
+          </View>
         </View>
 
         {/* Currency Settings */}

--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -9,8 +9,11 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
+import { Image } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAppInfo } from '../contexts/AppInfoContext';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const AGE_VERIFICATION_KEY = 'age_verified';
 
@@ -18,6 +21,8 @@ export default function AgeVerificationModal() {
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(true);
   const { colors } = useTheme();
+  const { platformName, platformLogo } = useAppInfo();
+  const { t } = useLanguage();
 
   useEffect(() => {
     checkAgeVerification();
@@ -68,14 +73,18 @@ export default function AgeVerificationModal() {
           <View style={styles.content}>
             {/* Logo Section */}
             <View style={styles.logoSection}>
-              <View style={[styles.logoContainer, { 
+            <View style={[styles.logoContainer, {
                 backgroundColor: colors.interactive.secondary,
-                borderColor: colors.gold 
+                borderColor: colors.gold
               }]}>
-                <Shield size={60} color={colors.gold} />
+                {platformLogo ? (
+                  <Image source={{ uri: platformLogo }} style={{ width: 60, height: 60 }} resizeMode="contain" />
+                ) : (
+                  <Shield size={60} color={colors.gold} />
+                )}
               </View>
-              <Text style={[styles.platformName, { color: colors.gold }]}>הקונגרס הציוני</Text>
-              <Text style={[styles.platformSubtitle, { color: colors.text.secondary }]}>פלטפורמה דיגיטלית מתקדמת</Text>
+              <Text style={[styles.platformName, { color: colors.gold }]}>{platformName || t('ageVerification.platformName')}</Text>
+              <Text style={[styles.platformSubtitle, { color: colors.text.secondary }]}>{t('ageVerification.platformSubtitle')}</Text>
             </View>
 
             {/* Age Verification Section */}
@@ -87,9 +96,9 @@ export default function AgeVerificationModal() {
                 <Calendar size={48} color={colors.gold} />
               </View>
               
-              <Text style={[styles.title, { color: colors.text.primary }]}>אישור גיל</Text>
+              <Text style={[styles.title, { color: colors.text.primary }]}>{t('ageVerification.ageVerification')}</Text>
               <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-                כדי להמשיך, עליך לאשר שאתה בן 18 ומעלה
+                {t('ageVerification.verificationRequired')}
               </Text>
               
               <View style={[styles.warningBox, { 
@@ -97,15 +106,15 @@ export default function AgeVerificationModal() {
                 borderColor: colors.status.warning 
               }]}>
                 <Text style={[styles.warningText, { color: colors.status.warning }]}>
-                  ⚠️ תוכן זה מיועד לבוגרים בלבד
+                  {t('ageVerification.adultContentWarning')}
                 </Text>
                 <Text style={[styles.warningSubtext, { color: colors.text.secondary }]}>
-                  הפלטפורמה מכילה תוכן המיועד לבני 18 ומעלה בהתאם לחוקי המדינה
+                  {t('ageVerification.adultContentDescription')}
                 </Text>
               </View>
 
               <Text style={[styles.question, { color: colors.text.primary }]}>
-                האם אתה בן 18 ומעלה?
+                {t('ageVerification.ageQuestion')}
               </Text>
             </View>
 
@@ -115,21 +124,23 @@ export default function AgeVerificationModal() {
                 style={[styles.confirmButton, { backgroundColor: colors.gold }]}
                 onPress={handleConfirm}
               >
-                <Text style={[styles.confirmButtonText, { color: colors.text.inverse }]}>כן, אני בן 18 ומעלה</Text>
+                <Text style={[styles.confirmButtonText, { color: colors.text.inverse }]}>
+                  {t('ageVerification.yes18Plus')}
+                </Text>
               </TouchableOpacity>
               
               <TouchableOpacity
                 style={[styles.denyButton, { borderColor: colors.interactive.disabled }]}
                 onPress={handleDeny}
               >
-                <Text style={[styles.denyButtonText, { color: colors.text.primary }]}>לא, אני מתחת לגיל 18</Text>
+                <Text style={[styles.denyButtonText, { color: colors.text.primary }]}>{t('ageVerification.noUnder18')}</Text>
               </TouchableOpacity>
             </View>
 
             {/* Footer */}
             <View style={[styles.footer, { borderTopColor: colors.border.secondary }]}>
               <Text style={[styles.footerText, { color: colors.text.tertiary }]}>
-                על ידי המשך השימוש, אתה מאשר שקראת והסכמת לתנאי השימוש
+                {t('ageVerification.termsAgreement')}
               </Text>
             </View>
           </View>

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -5,11 +5,13 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
+  Image,
 } from 'react-native';
 import { Heart, Search, Star } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAppInfo } from '../contexts/AppInfoContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from './WishlistModal';
 import CartService from '../services/cart';
@@ -27,6 +29,7 @@ export default function GlobalHeader({
 }: GlobalHeaderProps) {
   const { t } = useLanguage();
   const { colors } = useTheme();
+  const { platformName, platformLogo } = useAppInfo();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
 
@@ -52,8 +55,12 @@ export default function GlobalHeader({
       <View style={[styles.header, { backgroundColor: colors.background }]}>
         <View style={styles.headerTop}>
           <View style={styles.logo}>
-            <View style={[styles.logoIcon, { backgroundColor: colors.gold }]} />
-            <Text style={[styles.logoText, { color: colors.gold }]}>{t('ageVerification.platformName')}</Text>
+            {platformLogo ? (
+              <Image source={{ uri: platformLogo }} style={styles.logoIcon} />
+            ) : (
+              <View style={[styles.logoIcon, { backgroundColor: colors.gold }]} />
+            )}
+            <Text style={[styles.logoText, { color: colors.gold }]}> {platformName || t('ageVerification.platformName')}</Text>
           </View>
           <View style={styles.headerIcons}>
             <TouchableOpacity 

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -1,0 +1,93 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import DatabaseService from '../services/database';
+
+interface AppInfoContextType {
+  platformName: string;
+  platformLogo: string;
+  setPlatformName: (name: string) => Promise<void>;
+  setPlatformLogo: (logo: string) => Promise<void>;
+}
+
+const AppInfoContext = createContext<AppInfoContextType>({
+  platformName: '',
+  platformLogo: '',
+  setPlatformName: async () => {},
+  setPlatformLogo: async () => {},
+});
+
+export const useAppInfo = () => useContext(AppInfoContext);
+
+interface AppInfoProviderProps {
+  children: ReactNode;
+}
+
+const NAME_STORAGE_KEY = 'app_platform_name';
+const LOGO_STORAGE_KEY = 'app_platform_logo';
+
+export function AppInfoProvider({ children }: AppInfoProviderProps) {
+  const [platformName, setPlatformNameState] = useState('');
+  const [platformLogo, setPlatformLogoState] = useState('');
+
+  useEffect(() => {
+    loadAppInfo();
+  }, []);
+
+  const loadAppInfo = async () => {
+    try {
+      const storedName = await AsyncStorage.getItem(NAME_STORAGE_KEY);
+      const storedLogo = await AsyncStorage.getItem(LOGO_STORAGE_KEY);
+      if (storedName) setPlatformNameState(storedName);
+      if (storedLogo) setPlatformLogoState(storedLogo);
+
+      const db = DatabaseService.getInstance();
+      const name = await db.getSetting('platform_name');
+      if (name) {
+        setPlatformNameState(name);
+        await AsyncStorage.setItem(NAME_STORAGE_KEY, name);
+      }
+      const logo = await db.getSetting('platform_logo');
+      if (logo) {
+        setPlatformLogoState(logo);
+        await AsyncStorage.setItem(LOGO_STORAGE_KEY, logo);
+      }
+    } catch (error) {
+      console.error('Error loading app info:', error);
+    }
+  };
+
+  const setPlatformName = async (name: string) => {
+    try {
+      setPlatformNameState(name);
+      await AsyncStorage.setItem(NAME_STORAGE_KEY, name);
+      const db = DatabaseService.getInstance();
+      await db.updateSetting('platform_name', name);
+    } catch (error) {
+      console.error('Error setting platform name:', error);
+    }
+  };
+
+  const setPlatformLogo = async (logo: string) => {
+    try {
+      setPlatformLogoState(logo);
+      await AsyncStorage.setItem(LOGO_STORAGE_KEY, logo);
+      const db = DatabaseService.getInstance();
+      await db.updateSetting('platform_logo', logo);
+    } catch (error) {
+      console.error('Error setting platform logo:', error);
+    }
+  };
+
+  return (
+    <AppInfoContext.Provider
+      value={{
+        platformName,
+        platformLogo,
+        setPlatformName,
+        setPlatformLogo,
+      }}
+    >
+      {children}
+    </AppInfoContext.Provider>
+  );
+}

--- a/supabase/migrations/20250704000000_platform_info.sql
+++ b/supabase/migrations/20250704000000_platform_info.sql
@@ -1,0 +1,13 @@
+/*
+  # Add Platform Info Settings
+
+  1. New Settings
+    - platform_name: Name of the platform displayed across the app
+    - platform_logo: URL for the platform logo
+*/
+
+INSERT INTO settings (key, value, type, description)
+VALUES
+  ('platform_name', 'Zionist Congress', 'string', 'Name of the platform'),
+  ('platform_logo', '', 'string', 'URL of the platform logo')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- add migration for platform name and logo settings
- create `AppInfoContext` for branding info
- wrap application with `AppInfoProvider`
- allow admins to change platform name and logo in settings
- display branding from context across the UI

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d1f672088326aa29c7a2589b202c