### PR TITLE
Allow branding and theme customization

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { AuthProvider, useAuth } from '../components/AuthContext';
 import { LanguageProvider } from '../contexts/LanguageContext';
 import { ThemeProvider, useTheme } from '../contexts/ThemeContext';
 import { CurrencyProvider } from '../contexts/CurrencyContext';
+import { AppInfoProvider } from '../contexts/AppInfoContext';
 import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import { View, ActivityIndicator } from 'react-native';
@@ -76,16 +77,18 @@ export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <ThemeProvider>
-      <LanguageProvider>
-        <AuthProvider>
-          <CurrencyProvider>
-            <NotificationProvider>
-              <AppContent />
-            </NotificationProvider>
-          </CurrencyProvider>
-        </AuthProvider>
-      </LanguageProvider>
-    </ThemeProvider>
+    <AppInfoProvider>
+      <ThemeProvider>
+        <LanguageProvider>
+          <AuthProvider>
+            <CurrencyProvider>
+              <NotificationProvider>
+                <AppContent />
+              </NotificationProvider>
+            </CurrencyProvider>
+          </AuthProvider>
+        </LanguageProvider>
+      </ThemeProvider>
+    </AppInfoProvider>
   );
 }

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -15,20 +15,25 @@ import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
 import { useLanguage } from '../../contexts/LanguageContext';
-import DatabaseService from '../../services/database';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
+import MediaUploader from '../../components/MediaUploader';
+import { useAppInfo } from '../../contexts/AppInfoContext';
 
 
 
 export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
+  const [name, setName] = useState('');
+  const [logoMedia, setLogoMedia] = useState<any[]>([]);
+  const [themeColor, setThemeColorState] = useState('#B99C5A');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { t, currentLanguage } = useLanguage();
+  const { platformName, platformLogo, themeColor: contextThemeColor, setPlatformName, setPlatformLogo, setThemeColor } = useAppInfo();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -50,13 +55,25 @@ export default function SettingsScreen() {
   useEffect(() => {
     // Update local state when context changes
     setCurrencySymbolState(contextCurrencySymbol);
-  }, [contextCurrencySymbol]);
+    setName(platformName);
+    setThemeColorState(contextThemeColor);
+    if (platformLogo) {
+      setLogoMedia([{ id: 'logo', uri: platformLogo, type: 'image' }]);
+    } else {
+      setLogoMedia([]);
+    }
+  }, [contextCurrencySymbol, platformName, platformLogo, contextThemeColor]);
 
   const loadSettings = async () => {
     setLoading(true);
     try {
       // Currency symbol is already loaded from context
       setCurrencySymbolState(contextCurrencySymbol);
+      setName(platformName);
+      setThemeColorState(contextThemeColor);
+      if (platformLogo) {
+        setLogoMedia([{ id: 'logo', uri: platformLogo, type: 'image' }]);
+      }
     } catch (error) {
       console.error('Error loading settings:', error);
       setInfoModal({
@@ -75,6 +92,10 @@ export default function SettingsScreen() {
     try {
       // Update currency symbol in context (which will update database)
       await setCurrencySymbol(currencySymbol);
+      await setPlatformName(name);
+      await setThemeColor(themeColor);
+      const logoUri = logoMedia[0]?.uri || '';
+      await setPlatformLogo(logoUri);
       
       setInfoModal({
         visible: true,
@@ -128,6 +149,90 @@ export default function SettingsScreen() {
         <View style={styles.sectionHeader}>
           <SettingsIcon size={24} color={colors.gold} />
           <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>הגדרות כלליות</Text>
+        </View>
+
+        {/* Branding Settings */}
+        <View style={[styles.settingCard, {
+          backgroundColor: colors.surface.primary,
+          borderColor: colors.border.primary,
+          ...Platform.select({
+            ios: {
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.1,
+              shadowRadius: 4,
+            },
+            android: {
+              elevation: 2,
+            },
+            web: {
+              boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)'
+            }
+          }),
+        }]}>
+          <View style={styles.settingHeader}>
+            <SettingsIcon size={20} color={colors.gold} />
+            <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות מיתוג</Text>
+          </View>
+
+          <View style={styles.settingContent}>
+            <View style={styles.inputContainer}>
+              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>שם הפלטפורמה</Text>
+              <TextInput
+                style={[styles.input, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.secondary,
+                  color: colors.text.primary
+                }]}
+                value={name}
+                onChangeText={setName}
+                placeholder={t('ageVerification.platformName')}
+                textAlign="right"
+                placeholderTextColor={colors.text.tertiary}
+              />
+            </View>
+
+            <View style={styles.inputContainer}>
+              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>לוגו</Text>
+              <MediaUploader
+                media={logoMedia}
+                onMediaChange={setLogoMedia}
+                maxFiles={1}
+                allowVideos={false}
+              />
+            </View>
+
+            <View style={styles.inputContainer}>
+              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>צבע נושא</Text>
+              {Platform.OS === 'web' ? (
+                <input
+                  type="color"
+                  value={themeColor}
+                  onChange={(e) => setThemeColorState(e.target.value)}
+                  style={{ width: 40, height: 40, borderWidth: 0, backgroundColor: 'transparent' }}
+                />
+              ) : (
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                  {['#B99C5A', '#FF0000', '#00FF00', '#0000FF', '#FF00FF', '#00FFFF'].map((c) => (
+                    <TouchableOpacity
+                      key={c}
+                      onPress={() => setThemeColorState(c)}
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 16,
+                        backgroundColor: c,
+                        marginRight: 8,
+                        marginBottom: 8,
+                        borderWidth: themeColor === c ? 3 : 1,
+                        borderColor: themeColor === c ? colors.gold : colors.border.primary,
+                      }}
+                    />
+                  ))}
+                </View>
+              )}
+            </View>
+          </View>
         </View>
 
         {/* Currency Settings */}

--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -6,11 +6,15 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
+  Image,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAppInfo } from '../contexts/AppInfoContext';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const AGE_VERIFICATION_KEY = 'age_verified';
 
@@ -18,6 +22,8 @@ export default function AgeVerificationModal() {
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(true);
   const { colors } = useTheme();
+  const { platformName, platformLogo } = useAppInfo();
+  const { t } = useLanguage();
 
   useEffect(() => {
     checkAgeVerification();
@@ -68,14 +74,28 @@ export default function AgeVerificationModal() {
           <View style={styles.content}>
             {/* Logo Section */}
             <View style={styles.logoSection}>
-              <View style={[styles.logoContainer, { 
-                backgroundColor: colors.interactive.secondary,
-                borderColor: colors.gold 
-              }]}>
-                <Shield size={60} color={colors.gold} />
+              <View
+                style={[styles.logoContainer, {
+                  backgroundColor: colors.interactive.secondary,
+                  borderColor: colors.gold
+                }]}
+              >
+                {platformLogo ? (
+                  <Image
+                    source={{ uri: platformLogo }}
+                    style={styles.logoImage}
+                    resizeMode="contain"
+                  />
+                ) : (
+                  <Shield size={60} color={colors.gold} />
+                )}
               </View>
-              <Text style={[styles.platformName, { color: colors.gold }]}>הקונגרס הציוני</Text>
-              <Text style={[styles.platformSubtitle, { color: colors.text.secondary }]}>פלטפורמה דיגיטלית מתקדמת</Text>
+              <Text style={[styles.platformName, { color: colors.gold }]}> 
+                {platformName || t('ageVerification.platformName')}
+              </Text>
+              <Text style={[styles.platformSubtitle, { color: colors.text.secondary }]}> 
+                {t('ageVerification.platformSubtitle')}
+              </Text>
             </View>
 
             {/* Age Verification Section */}
@@ -87,25 +107,27 @@ export default function AgeVerificationModal() {
                 <Calendar size={48} color={colors.gold} />
               </View>
               
-              <Text style={[styles.title, { color: colors.text.primary }]}>אישור גיל</Text>
-              <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-                כדי להמשיך, עליך לאשר שאתה בן 18 ומעלה
+              <Text style={[styles.title, { color: colors.text.primary }]}>\
+                {t('ageVerification.ageVerification')}
+              </Text>
+              <Text style={[styles.subtitle, { color: colors.text.secondary }]}>\
+                {t('ageVerification.verificationRequired')}
               </Text>
               
               <View style={[styles.warningBox, { 
                 backgroundColor: 'rgba(255, 193, 7, 0.1)',
                 borderColor: colors.status.warning 
               }]}>
-                <Text style={[styles.warningText, { color: colors.status.warning }]}>
-                  ⚠️ תוכן זה מיועד לבוגרים בלבד
+                <Text style={[styles.warningText, { color: colors.status.warning }]}>\
+                  {t('ageVerification.adultContentWarning')}
                 </Text>
-                <Text style={[styles.warningSubtext, { color: colors.text.secondary }]}>
-                  הפלטפורמה מכילה תוכן המיועד לבני 18 ומעלה בהתאם לחוקי המדינה
+                <Text style={[styles.warningSubtext, { color: colors.text.secondary }]}>\
+                  {t('ageVerification.adultContentDescription')}
                 </Text>
               </View>
 
-              <Text style={[styles.question, { color: colors.text.primary }]}>
-                האם אתה בן 18 ומעלה?
+              <Text style={[styles.question, { color: colors.text.primary }]}>\
+                {t('ageVerification.ageQuestion')}
               </Text>
             </View>
 
@@ -115,21 +137,25 @@ export default function AgeVerificationModal() {
                 style={[styles.confirmButton, { backgroundColor: colors.gold }]}
                 onPress={handleConfirm}
               >
-                <Text style={[styles.confirmButtonText, { color: colors.text.inverse }]}>כן, אני בן 18 ומעלה</Text>
+                <Text style={[styles.confirmButtonText, { color: colors.text.inverse }]}>\
+                  {t('ageVerification.yes18Plus')}
+                </Text>
               </TouchableOpacity>
               
               <TouchableOpacity
                 style={[styles.denyButton, { borderColor: colors.interactive.disabled }]}
                 onPress={handleDeny}
               >
-                <Text style={[styles.denyButtonText, { color: colors.text.primary }]}>לא, אני מתחת לגיל 18</Text>
+                <Text style={[styles.denyButtonText, { color: colors.text.primary }]}>\
+                  {t('ageVerification.noUnder18')}
+                </Text>
               </TouchableOpacity>
             </View>
 
             {/* Footer */}
             <View style={[styles.footer, { borderTopColor: colors.border.secondary }]}>
-              <Text style={[styles.footerText, { color: colors.text.tertiary }]}>
-                על ידי המשך השימוש, אתה מאשר שקראת והסכמת לתנאי השימוש
+              <Text style={[styles.footerText, { color: colors.text.tertiary }]}>\
+                {t('ageVerification.termsAgreement')}
               </Text>
             </View>
           </View>
@@ -163,6 +189,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 20,
     borderWidth: 2,
+  },
+  logoImage: {
+    width: 60,
+    height: 60,
+    borderRadius: Platform.OS === 'web' ? 8 : 30,
   },
   platformName: {
     fontSize: 24,

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -5,11 +5,13 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
+  Image,
 } from 'react-native';
 import { Heart, Search, Star } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAppInfo } from '../contexts/AppInfoContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from './WishlistModal';
 import CartService from '../services/cart';
@@ -27,6 +29,7 @@ export default function GlobalHeader({
 }: GlobalHeaderProps) {
   const { t } = useLanguage();
   const { colors } = useTheme();
+  const { platformName, platformLogo } = useAppInfo();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
 
@@ -52,8 +55,14 @@ export default function GlobalHeader({
       <View style={[styles.header, { backgroundColor: colors.background }]}>
         <View style={styles.headerTop}>
           <View style={styles.logo}>
-            <View style={[styles.logoIcon, { backgroundColor: colors.gold }]} />
-            <Text style={[styles.logoText, { color: colors.gold }]}>{t('ageVerification.platformName')}</Text>
+            {platformLogo ? (
+              <Image source={{ uri: platformLogo }} style={styles.logoImage} resizeMode="contain" />
+            ) : (
+              <View style={[styles.logoIcon, { backgroundColor: colors.gold }]} />
+            )}
+            <Text style={[styles.logoText, { color: colors.gold }]}>\
+              {platformName || t('ageVerification.platformName')}
+            </Text>
           </View>
           <View style={styles.headerIcons}>
             <TouchableOpacity 
@@ -121,6 +130,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   logoIcon: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    marginLeft: 8,
+  },
+  logoImage: {
     width: 24,
     height: 24,
     borderRadius: 12,

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -1,0 +1,119 @@
+import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import DatabaseService from '../services/database';
+
+interface AppInfoContextType {
+  platformName: string;
+  platformLogo: string;
+  themeColor: string;
+  setPlatformName: (name: string) => Promise<void>;
+  setPlatformLogo: (logo: string) => Promise<void>;
+  setThemeColor: (color: string) => Promise<void>;
+}
+
+const AppInfoContext = createContext<AppInfoContextType>({
+  platformName: '',
+  platformLogo: '',
+  themeColor: '#B99C5A',
+  setPlatformName: async () => {},
+  setPlatformLogo: async () => {},
+  setThemeColor: async () => {},
+});
+
+export const useAppInfo = () => useContext(AppInfoContext);
+
+interface AppInfoProviderProps {
+  children: ReactNode;
+}
+
+const NAME_KEY = 'app_platform_name';
+const LOGO_KEY = 'app_platform_logo';
+const COLOR_KEY = 'app_theme_color';
+
+export function AppInfoProvider({ children }: AppInfoProviderProps) {
+  const [platformName, setPlatformNameState] = useState('');
+  const [platformLogo, setPlatformLogoState] = useState('');
+  const [themeColor, setThemeColorState] = useState('#B99C5A');
+
+  useEffect(() => {
+    loadInfo();
+  }, []);
+
+  const loadInfo = async () => {
+    try {
+      const storedName = await AsyncStorage.getItem(NAME_KEY);
+      const storedLogo = await AsyncStorage.getItem(LOGO_KEY);
+      const storedColor = await AsyncStorage.getItem(COLOR_KEY);
+      if (storedName) setPlatformNameState(storedName);
+      if (storedLogo) setPlatformLogoState(storedLogo);
+      if (storedColor) setThemeColorState(storedColor);
+
+      const db = DatabaseService.getInstance();
+      const dbName = await db.getSetting('platform_name');
+      const dbLogo = await db.getSetting('platform_logo');
+      const dbColor = await db.getSetting('theme_color');
+      if (dbName) {
+        setPlatformNameState(dbName);
+        await AsyncStorage.setItem(NAME_KEY, dbName);
+      }
+      if (dbLogo) {
+        setPlatformLogoState(dbLogo);
+        await AsyncStorage.setItem(LOGO_KEY, dbLogo);
+      }
+      if (dbColor) {
+        setThemeColorState(dbColor);
+        await AsyncStorage.setItem(COLOR_KEY, dbColor);
+      }
+    } catch (e) {
+      console.error('Error loading app info:', e);
+    }
+  };
+
+  const setPlatformName = async (name: string) => {
+    try {
+      setPlatformNameState(name);
+      await AsyncStorage.setItem(NAME_KEY, name);
+      const db = DatabaseService.getInstance();
+      await db.updateSetting('platform_name', name);
+    } catch (e) {
+      console.error('Error setting platform name:', e);
+    }
+  };
+
+  const setPlatformLogo = async (logo: string) => {
+    try {
+      setPlatformLogoState(logo);
+      await AsyncStorage.setItem(LOGO_KEY, logo);
+      const db = DatabaseService.getInstance();
+      await db.updateSetting('platform_logo', logo);
+    } catch (e) {
+      console.error('Error setting platform logo:', e);
+    }
+  };
+
+  const setThemeColor = async (color: string) => {
+    try {
+      setThemeColorState(color);
+      await AsyncStorage.setItem(COLOR_KEY, color);
+      const db = DatabaseService.getInstance();
+      await db.updateSetting('theme_color', color);
+    } catch (e) {
+      console.error('Error setting theme color:', e);
+    }
+  };
+
+  return (
+    <AppInfoContext.Provider
+      value={{
+        platformName,
+        platformLogo,
+        themeColor,
+        setPlatformName,
+        setPlatformLogo,
+        setThemeColor,
+      }}
+    >
+      {children}
+    </AppInfoContext.Provider>
+  );
+}

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useContext, useEffect, ReactNode } from
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Colors as DarkColors } from '../constants/Colors';
 import { LightColors } from '../constants/LightColors';
+import { useAppInfo } from './AppInfoContext';
 
 const THEME_STORAGE_KEY = 'app_theme';
 
@@ -30,10 +31,15 @@ interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<ThemeMode>('dark');
   const [colors, setColors] = useState(DarkColors);
+  const { themeColor } = useAppInfo();
 
   useEffect(() => {
     loadStoredTheme();
   }, []);
+
+  useEffect(() => {
+    applyTheme(theme, themeColor);
+  }, [theme, themeColor]);
 
   const loadStoredTheme = async () => {
     try {
@@ -46,10 +52,25 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   };
 
+  const applyTheme = (mode: ThemeMode, color: string) => {
+    const base = mode === 'light' ? LightColors : DarkColors;
+    setColors({
+      ...base,
+      gold: color,
+      interactive: {
+        ...base.interactive,
+        primary: color,
+        primaryHover: color,
+      },
+      tabBar: { ...base.tabBar, active: color },
+      border: { ...base.border, focus: color },
+    });
+  };
+
   const setTheme = async (newTheme: ThemeMode) => {
     try {
       setThemeState(newTheme);
-      setColors(newTheme === 'light' ? LightColors : DarkColors);
+      applyTheme(newTheme, themeColor);
       await AsyncStorage.setItem(THEME_STORAGE_KEY, newTheme);
     } catch (error) {
       console.error('Error setting theme:', error);

--- a/supabase/migrations/20250704120000_branding_settings.sql
+++ b/supabase/migrations/20250704120000_branding_settings.sql
@@ -1,0 +1,16 @@
+/*
+  # Add branding settings
+  Insert default platform name, logo and theme color keys
+*/
+
+INSERT INTO settings (key, value, type, description) VALUES
+  ('platform_name', 'Zionist Congress', 'string', 'Name of the platform')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO settings (key, value, type, description) VALUES
+  ('platform_logo', '', 'string', 'URL of platform logo')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO settings (key, value, type, description) VALUES
+  ('theme_color', '#B99C5A', 'string', 'Primary theme color')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- add branding settings migration
- create AppInfo context for platform name, logo and theme color
- update Theme context to support runtime accent color
- show logo & name from settings in AgeVerificationModal and GlobalHeader
- extend admin Settings screen with logo, name and color picker fields
- register AppInfoProvider

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d0ce455c8326aeac918e67088997