### PR TITLE
Fix admin dashboard notifications

### DIFF
--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -38,7 +38,7 @@ export default function AdminDashboardScreen() {
     totalUsers: 0
   });
   const { showNotification } = useNotifications();
-  const { isAdmin, isDriver } = useAuth();
+  const { isAdmin, isDriver, user } = useAuth();
   const { colors } = useTheme();
 
   // Modal states
@@ -68,7 +68,7 @@ export default function AdminDashboardScreen() {
       const [productsData, chatRoomsData, notificationsData, reviewsData, pendingKycRequests, allUsers] = await Promise.all([
         db.getProducts(),
         db.getChatRooms(),
-        notificationService.getNotifications(),
+        notificationService.getNotifications(user?.id),
         db.getReviews(),
         db.getPendingKycRequests(),
         db.getAllUserProfiles()


### PR DESCRIPTION
## Summary
- pass user ID to `notificationService.getNotifications` when loading the admin dashboard
- grab `user` from `useAuth` to fetch user-specific notifications

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6f7c7b9483268c54d527358ea6bf