### PR TITLE
Fix web build polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ defines it in `app/_layout.tsx` so libraries relying on Buffer continue to
 work:
 
 ```ts
+import 'react-native-get-random-values';
 import { Buffer } from 'buffer';
 if (typeof global.Buffer === 'undefined') {
   global.Buffer = Buffer;
@@ -72,9 +73,6 @@ if (typeof global.__filename === 'undefined') {
 }
 if (Platform.OS === 'web') {
   require('react-native-url-polyfill/auto');
-  if (typeof global.crypto === 'undefined') {
-    global.crypto = require('crypto').webcrypto;
-  }
 }
 ```
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ if (typeof global.__filename === 'undefined') {
   (global as any).__filename = '';
 }
 
+import 'react-native-get-random-values';
 import { Buffer } from 'buffer';
 import { Platform } from 'react-native';
 
@@ -12,9 +13,6 @@ if (typeof global.Buffer === 'undefined') {
 }
 if (Platform.OS === 'web') {
   require('react-native-url-polyfill/auto');
-  if (typeof global.crypto === 'undefined') {
-    global.crypto = require('crypto').webcrypto;
-  }
 }
 import { useEffect, useState } from 'react';
 import { Stack } from 'expo-router';

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-url-polyfill": "^2.0.0",
+    "react-native-get-random-values": "^1.11.0",
     "react-native-video": "^6.6.5",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "types": [],
+    "types": ["node"],
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8474,6 +8474,11 @@ react-native-url-polyfill@^2.0.0:
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
 
+react-native-get-random-values@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz"
+  integrity sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==
+
 react-native-video@^6.6.5:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/react-native-video/-/react-native-video-6.16.0.tgz#78ad0affc6f4a09c366d83532b36be562149d3f5"


### PR DESCRIPTION
## Summary
- add `react-native-get-random-values` polyfill
- remove Node `crypto` usage from `_layout`
- document updated initialization snippet in README
- expose Node typings in tsconfig

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9a6ad8708326ab914828ccff023e