### PR TITLE
Add webpack config for production source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,11 @@
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+
+module.exports = async function (env, argv) {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+
+  if (config.mode === 'production') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};


### PR DESCRIPTION
## Summary
- add `webpack.config.js` that uses `@expo/webpack-config`
- enable source maps when the build mode is `production`

## Testing
- `yarn install --frozen-lockfile` *(fails: incompatible node version)*
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc06486008326a868c6827e339e1a