### PR TITLE
Fix Buffer import in entry

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import 'react-native-get-random-values';
-import Buffer from 'buffer';
+import { Buffer } from 'buffer';
 import { Platform } from 'react-native';
 
 if (typeof global.Buffer === 'undefined') {


### PR DESCRIPTION
## Summary
- correct Buffer import from `buffer` in `index.ts`

## Testing
- `yarn install` *(fails: matrix-js-sdk requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_686d09a364a8832699fb7dee087ec6b6