### PR TITLE
Remove email from auth flow

### DIFF
--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -21,7 +21,7 @@ import InfoModal from '../../components/InfoModal';
 
 
 export default function AuthLoginScreen() {
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [infoModal, setInfoModal] = useState({
@@ -35,7 +35,7 @@ export default function AuthLoginScreen() {
   const { t } = useLanguage();
 
   const handleLogin = async () => {
-    if (!email || !password) {
+    if (!username || !password) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -47,7 +47,7 @@ export default function AuthLoginScreen() {
 
     setLoading(true);
     try {
-      const success = await login(email, password);
+      const success = await login(username, password);
       
       if (success) {
         router.replace('/');
@@ -108,22 +108,22 @@ export default function AuthLoginScreen() {
           </View>
 
           <View style={styles.form}>
-            <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>אימייל</Text>
-              <TextInput
-                style={[styles.input, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary
-                }]}
-                value={email}
-                onChangeText={setEmail}
-                placeholder="הכנס אימייל"
-                autoCapitalize="none"
-                autoCorrect={false}
-                textAlign="right"
-                placeholderTextColor={colors.text.tertiary}
-              />
+          <View style={styles.inputGroup}>
+            <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
+            <TextInput
+              style={[styles.input, {
+                borderColor: colors.border.primary,
+                backgroundColor: colors.surface.primary,
+                color: colors.text.primary
+              }]}
+              value={username}
+              onChangeText={setUsername}
+              placeholder="הכנס שם משתמש"
+              autoCapitalize="none"
+              autoCorrect={false}
+              textAlign="right"
+              placeholderTextColor={colors.text.tertiary}
+            />
             </View>
 
             <View style={styles.inputGroup}>

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -21,7 +21,6 @@ import InfoModal from '../../components/InfoModal';
 
 
 export default function AuthSignupScreen() {
-  const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [password, setPassword] = useState('');
@@ -37,7 +36,7 @@ export default function AuthSignupScreen() {
   const { signup } = useAuth();
 
   const handleSignup = async () => {
-    if (!email || !username || !password || !confirmPassword) {
+    if (!username || !password || !confirmPassword) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -59,7 +58,7 @@ export default function AuthSignupScreen() {
 
     setLoading(true);
     try {
-      const success = await signup(email, password, username, displayName || username);
+      const success = await signup(username, password, displayName || username);
 
       if (success) {
         setInfoModal({
@@ -115,23 +114,7 @@ export default function AuthSignupScreen() {
           </Text>
 
           <View style={styles.form}>
-            <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>אימייל</Text>
-              <TextInput
-                style={[styles.input, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary
-                }]}
-                value={email}
-                onChangeText={setEmail}
-                placeholder="הכנס אימייל"
-                autoCapitalize="none"
-                autoCorrect={false}
-                textAlign="right"
-                placeholderTextColor={colors.text.tertiary}
-              />
-            </View>
+
 
             <View style={styles.inputGroup}>
               <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -7,8 +7,8 @@ interface AuthContextType {
   isDriver: boolean;
   user: any | null;
   loading: boolean;
-  login: (email: string, password: string) => Promise<boolean>;
-  signup: (email: string, password: string, username: string, displayName: string) => Promise<boolean>;
+  login: (username: string, password: string) => Promise<boolean>;
+  signup: (username: string, password: string, displayName: string) => Promise<boolean>;
   logout: () => Promise<void>;
   checkAuthState: () => Promise<void>;
 }
@@ -67,8 +67,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
-  const login = async (email: string, password: string): Promise<boolean> => {
+  const login = async (username: string, password: string): Promise<boolean> => {
     setLoading(true);
+    const email = `${username}@user.local`;
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
     if (error || !data.session) {
       setLoading(false);
@@ -79,8 +80,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return true;
   };
 
-  const signup = async (email: string, password: string, username: string, displayName: string): Promise<boolean> => {
+  const signup = async (username: string, password: string, displayName: string): Promise<boolean> => {
     setLoading(true);
+    const email = `${username}@user.local`;
     const { data, error } = await supabase.auth.signUp({ email, password });
     if (error || !data.user) {
       setLoading(false);

--- a/components/AuthTabsModal.tsx
+++ b/components/AuthTabsModal.tsx
@@ -32,7 +32,6 @@ export default function AuthTabsModal({
   initialTab = 'login'
 }: AuthTabsModalProps) {
   const [activeTab, setActiveTab] = useState<'login' | 'signup'>(initialTab);
-  const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [password, setPassword] = useState('');
@@ -49,7 +48,6 @@ export default function AuthTabsModal({
   const { colors } = useTheme();
 
   const resetForm = () => {
-    setEmail('');
     setUsername('');
     setDisplayName('');
     setPassword('');
@@ -62,7 +60,7 @@ export default function AuthTabsModal({
   };
 
   const handleLogin = async () => {
-    if (!email || !password) {
+    if (!username || !password) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -74,7 +72,7 @@ export default function AuthTabsModal({
 
     setLoading(true);
     try {
-      const success = await login(email, password);
+      const success = await login(username, password);
       
       if (success) {
         onClose();
@@ -101,7 +99,7 @@ export default function AuthTabsModal({
   };
 
   const handleSignup = async () => {
-    if (!email || !username || !password || !confirmPassword) {
+    if (!username || !password || !confirmPassword) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -123,7 +121,7 @@ export default function AuthTabsModal({
 
     setLoading(true);
     try {
-      const success = await signup(email, password, username, displayName || username);
+      const success = await signup(username, password, displayName || username);
 
       if (success) {
         setInfoModal({
@@ -165,16 +163,16 @@ export default function AuthTabsModal({
       
       <View style={styles.form}>
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>אימייל</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
           <TextInput
             style={[styles.input, {
               borderColor: colors.border.primary,
               backgroundColor: colors.surface.primary,
               color: colors.text.primary
             }]}
-            value={email}
-            onChangeText={setEmail}
-            placeholder="הכנס אימייל"
+            value={username}
+            onChangeText={setUsername}
+            placeholder="הכנס שם משתמש"
             autoCapitalize="none"
             autoCorrect={false}
             textAlign="right"
@@ -245,23 +243,6 @@ export default function AuthTabsModal({
       </Text>
       
       <View style={styles.form}>
-        <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>אימייל</Text>
-          <TextInput
-            style={[styles.input, {
-              borderColor: colors.border.primary,
-              backgroundColor: colors.surface.primary,
-              color: colors.text.primary
-            }]}
-            value={email}
-            onChangeText={setEmail}
-            placeholder="הכנס אימייל"
-            autoCapitalize="none"
-            autoCorrect={false}
-            textAlign="right"
-            placeholderTextColor={colors.text.tertiary}
-          />
-        </View>
 
         <View style={styles.inputGroup}>
           <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>


### PR DESCRIPTION
## Summary
- drop email fields from login/signup screens and modal
- use username to authenticate with Supabase, generating a dummy email internally

## Testing
- `yarn lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition)*

------
https://chatgpt.com/codex/tasks/task_e_686e70e7d1dc8326a1ae4a744d302d14