### PR TITLE
Add Buffer/URL polyfills and clean webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If dependencies need patching, run `patch-package` after installation:
 yarn postinstall
 ```
 
+Some dependencies rely on Node.js globals like `Buffer` and `URL`. The project
+includes a `polyfills.js` file to provide these when running on React Native or
+the web. The polyfill is automatically imported from `index.ts`.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and fill in the required values:

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,3 @@
+import './polyfills';
+
 export { default } from 'expo-router/entry';

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,0 +1,8 @@
+import { Buffer } from 'buffer';
+import 'react-native-url-polyfill/auto';
+
+if (typeof global.Buffer === 'undefined') {
+  // @ts-ignore
+  global.Buffer = Buffer;
+}
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,15 +4,8 @@ const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
 
-  // disable all Node.js polyfills that are causing trouble
-  config.resolve.fallback = {
-    crypto: false,
-    buffer: false,
-    stream: false,
-    util: false,
-    url: false,
-    path: false,
-  };
+  // rely on Expo's default Node.js polyfills
+  // previously polyfills were disabled here but that caused issues with packages
 
   if (config.mode === 'production') {
     // remove Expo’s broken scope‐hoisting plugin in prod


### PR DESCRIPTION
## Summary
- recreate `polyfills.js` containing Buffer and URL polyfills
- import polyfills at the top of `index.ts`
- stop disabling Node polyfills in `webpack.config.js`
- mention polyfill setup in `README.md`

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn build:web` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9a9167348326bf917f8256a7f060