### PR TITLE
Fix unread badges in chat

### DIFF
--- a/components/AdminChatList.tsx
+++ b/components/AdminChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -24,14 +24,21 @@ export default function AdminChatList({ chatRooms }: Props) {
   const [selectedRoom, setSelectedRoom] = useState<ChatRoom | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [newMessage, setNewMessage] = useState('');
+  const [rooms, setRooms] = useState(chatRooms);
 
-  const filteredRooms = chatRooms.filter(room =>
+  useEffect(() => {
+    setRooms(chatRooms);
+  }, [chatRooms]);
+
+  const filteredRooms = rooms.filter(room =>
     room.userName && room.userName.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   const openChat = async (room: ChatRoom) => {
     setSelectedRoom(room);
     const db = DatabaseService.getInstance();
+    await db.markChatRoomRead(room.id);
+    setRooms(prev => prev.map(r => r.id === room.id ? { ...r, unreadCount: 0 } : r));
     const roomMessages = await db.getChatMessages(room.id);
     setMessages(roomMessages);
   };

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -193,6 +193,7 @@ export default function ChatWidget() {
       };
 
       setSelectedRoom(defaultRoom);
+      await db.markChatRoomRead(roomId);
       await loadMessages(roomId);
     } catch (error) {
       console.error('Error creating default room:', error);
@@ -237,6 +238,9 @@ export default function ChatWidget() {
 
   const openChat = async (room: ChatRoom) => {
     setSelectedRoom(room);
+    const db = DatabaseService.getInstance();
+    await db.markChatRoomRead(room.id);
+    setChatRooms(prev => prev.map(r => r.id === room.id ? { ...r, unreadCount: 0 } : r));
     await loadMessages(room.id);
   };
 
@@ -314,6 +318,9 @@ export default function ChatWidget() {
       }
 
       setSelectedRoom(room!);
+      const db = DatabaseService.getInstance();
+      await db.markChatRoomRead(roomId);
+      setChatRooms(prev => prev.map(r => r.id === roomId ? { ...r, unreadCount: 0 } : r));
       setSearchQuery('');
       setSearchResults([]);
       await loadMessages(roomId);

--- a/services/database.ts
+++ b/services/database.ts
@@ -505,6 +505,17 @@ class DatabaseService {
     }
   }
 
+  async markChatRoomRead(roomId: string): Promise<void> {
+    try {
+      await supabase
+        .from('chat_rooms')
+        .update({ unread_count: 0 })
+        .eq('id', roomId);
+    } catch (error) {
+      console.error('Error in markChatRoomRead:', error);
+    }
+  }
+
   async getOrCreateChatRoom(userId: string, userName: string): Promise<string> {
     try {
       const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- reset unread count in chat rooms when opened
- display updated unread badges for admin chat list

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type definition)*
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6e90bc088326903f9c12662128a5