### PR TITLE
Fix web bundler configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "supportsTablet": true
     },
     "web": {
-      "bundler": "metro",
+      "bundler": "webpack",
       "output": "single",
       "favicon": "./assets/images/favicon.png"
     },


### PR DESCRIPTION
## Summary
- fix bundler config for web build

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8ac324b08326983fcd9a96dc0e53