### PR TITLE
Update web build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,13 @@ yarn dev
 
 `yarn start` works as an alias of `yarn dev`.
 
+## Building for Web
+
+Run the following command to generate the static web build:
+
+```sh
+yarn build:web
+```
+
 
 ***End of Document***

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "dev": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "lint": "expo lint",
-    "build:web": "expo export --platform web"
+    "build:web": "expo export:web"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",


### PR DESCRIPTION
## Summary
- change `build:web` npm script to use `expo export:web`
- document new build command in README

## Testing
- `yarn build:web` *(fails: ModuleNotFoundError from webpack)*

------
https://chatgpt.com/codex/tasks/task_e_686fa7d6c6a08326989e578e07ae243f