### PR TITLE
Add expo-router plugin to Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     plugins: [
       'babel-plugin-transform-import-meta',
+      'expo-router/babel',
       'react-native-reanimated/plugin', // keep last
     ],
   };


### PR DESCRIPTION
## Summary
- add `expo-router/babel` plugin before `react-native-reanimated/plugin` in `babel.config.js`
- run `yarn install` and `npm run build:web`

## Testing
- `yarn install`
- `npm run build:web` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68709bdfacdc8326ba09021b72ea038a