### PR TITLE
Remove deprecated expo-router plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ the web. The polyfill is automatically imported from `index.ts`.
 The project also uses `expo-standard-web-crypto` to polyfill the Web Crypto API,
 so ensure it's installed as a dependency.
 
-When using the Expo Router, your `babel.config.js` must load `'expo-router/babel'`.
-An example plugin array looks like:
+When using the Expo Router with SDK 50 or later, `babel-preset-expo` already
+includes the router plugin. You no longer need to include `'expo-router/babel'`
+in your `plugins` array. A typical setup looks like:
 
 ```js
 plugins: [
-  'expo-router/babel',
   'babel-plugin-transform-import-meta',
   'react-native-reanimated/plugin', // keep last
 ]

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,6 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     plugins: [
       'babel-plugin-transform-import-meta',
-      'expo-router/babel',
       'react-native-reanimated/plugin', // keep last
     ],
   };


### PR DESCRIPTION
## Summary
- clarify Babel instructions in README
- remove `expo-router/babel` from `babel.config.js`

## Testing
- `yarn build:web` *(fails: expo not found)*
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b70a2bb483268fa54a9e095f24f0