### PR TITLE
Document Expo Router app root

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ npx expo install expo-file-system
 ```
 ## Building for Web
 
-Run the following command to generate the static web build:
+Run the following command to generate the static web build. The
+`EXPO_ROUTER_APP_ROOT` environment variable must point to your app directory
+(this project uses `app`):
 
 ```sh
-yarn build:web
+EXPO_ROUTER_APP_ROOT=app yarn build:web
 ```
 
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+process.env.EXPO_ROUTER_APP_ROOT = 'app';
+
 module.exports = function (api) {
   api.cache(true);
   return {


### PR DESCRIPTION
## Summary
- document `EXPO_ROUTER_APP_ROOT` usage in README
- set `EXPO_ROUTER_APP_ROOT` in `babel.config.js`

## Testing
- `yarn install`
- `EXPO_ROUTER_APP_ROOT=app yarn build:web` *(fails: Can't resolve '@/hooks/useFrameworkReady')*

------
https://chatgpt.com/codex/tasks/task_e_6870be423e3c8326affd2fd5db5f3cc2