### PR TITLE
Fix require undefined error in web build

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -2,8 +2,18 @@ import 'expo-standard-web-crypto';
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
 import { Buffer } from 'buffer';
+import * as SafeAreaContext from 'react-native-safe-area-context';
 
 if (typeof global.Buffer === 'undefined') {
   global.Buffer = Buffer;
+}
+
+if (typeof global.require === 'undefined') {
+  global.require = (moduleName) => {
+    if (moduleName === 'react-native-safe-area-context') {
+      return SafeAreaContext;
+    }
+    throw new Error(`Cannot find module '${moduleName}'`);
+  };
 }
 


### PR DESCRIPTION
## Summary
- add a small require polyfill for `react-native-safe-area-context`

## Testing
- `yarn lint`
- `EXPO_ROUTER_APP_ROOT=src/app yarn build:web`


------
https://chatgpt.com/codex/tasks/task_e_6870e05dae348326b8ffb7b893bfd4ba