### PR TITLE
Remove unused babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,9 +2,8 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      'babel-plugin-transform-import-meta',
-      'react-native-reanimated/plugin', // keep last
-    ],
+    // No extra plugins are needed currently. Keep reanimated last if more are
+    // added in the future.
+    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- clean up babel.config.js by dropping unused transform-import-meta plugin

## Testing
- `yarn lint`
- `yarn build:web`


------
https://chatgpt.com/codex/tasks/task_e_6870ff6a05c483269a7b9ee271ba69d4