### PR TITLE
Simplify Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,15 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo', 'module:metro-react-native-babel-preset'],
-    plugins: [
-      [
-        '@babel/plugin-transform-runtime',
-        {
-          helpers: true,
-          regenerator: true,
-          useESModules: true, // <-- keep it ES modules
-        },
-      ],
-    ],
   };
 };


### PR DESCRIPTION
## Summary
- remove unused `@babel/plugin-transform-runtime` settings

## Testing
- `yarn lint` *(fails: "lint" is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_e_687205ca85a88326a2c4962763618fea