### PR TITLE
Add custom HMRClient with polyfills

### DIFF
--- a/HMRClient.ts
+++ b/HMRClient.ts
@@ -1,0 +1,9 @@
+import 'react-native-get-random-values';
+import { Buffer } from 'buffer';
+// Ensure Buffer is available globally for any modules that expect it
+(global as any).Buffer = Buffer;
+import 'expo-standard-web-crypto';
+
+// Re-export Metro's HMRClient after applying the polyfills above
+export { default } from 'metro-runtime/src/modules/HMRClient';
+export * from 'metro-runtime/src/modules/HMRClient';


### PR DESCRIPTION
## Summary
- add `HMRClient.ts` that installs random-values/Buffer/web-crypto polyfills
- re-export Metro's HMRClient so hot reloading can work without crashes

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_687205cbbac4832696da79ed32bdf2ec