### PR TITLE
Fix duplicate __self error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo', 'module:metro-react-native-babel-preset'],
+    // 'babel-preset-expo' already includes the React Native preset, so
+    // including 'module:metro-react-native-babel-preset' causes plugins like
+    // 'transform-react-jsx-self' to run twice and inject duplicate props.
+    presets: ['babel-preset-expo'],
   };
 };


### PR DESCRIPTION
## Summary
- remove redundant preset from `babel.config.js`

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687205caa5988326929de7b1d0826570