### PR TITLE
Improve session recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ the web. The polyfill is automatically imported from `index.ts`.
 The project also uses `expo-standard-web-crypto` to polyfill the Web Crypto API,
 so ensure it's installed as a dependency.
 
+### Session Persistence
+
+User sessions are stored using `@react-native-async-storage/async-storage`. On
+native platforms this uses the native AsyncStorage implementation and falls back
+to `window.localStorage` when running on the web. This ensures Supabase auth
+state persists across reloads on every platform.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and fill in the required values:

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { supabase } from '../lib/supabase';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const ADMIN_USERNAME = process.env.EXPO_PUBLIC_ADMIN_USERNAME;
 
@@ -38,10 +39,38 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   useEffect(() => {
     const init = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setSession(session);
-      if (session) await loadProfile(session.user.id);
-      setLoading(false);
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (error) {
+          console.error('Error retrieving session', error);
+        }
+
+        let activeSession = data.session;
+
+        if (!activeSession) {
+          try {
+            const stored = await AsyncStorage.getItem(supabase.auth.storageKey);
+            if (stored) {
+              const parsed = JSON.parse(stored);
+              const { data: recovered, error: recoverError } = await supabase.auth.setSession(parsed);
+              if (recoverError) {
+                console.error('Failed to set session from storage', recoverError);
+              } else {
+                activeSession = recovered.session;
+              }
+            }
+          } catch (err) {
+            console.error('Failed reading session from storage', err);
+          }
+        }
+
+        setSession(activeSession);
+        if (activeSession) await loadProfile(activeSession.user.id);
+      } catch (err) {
+        console.error('Auth initialization failed', err);
+      } finally {
+        setLoading(false);
+      }
     };
     init();
 


### PR DESCRIPTION
## Summary
- hydrate session from persisted data on app startup
- document AsyncStorage web support for session persistence

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68725b47800c83269c783999576f06a9