### PR TITLE
Extract pricing tier form modal

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -1,17 +1,15 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  TextInput,
-  Modal,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import { ArrowLeft, Plus, Pencil, X, Save, Trash2, DollarSign, Percent, Package, Users } from 'lucide-react-native';
+import { ArrowLeft, Plus, Pencil, DollarSign, Percent, Package, Users } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
@@ -19,6 +17,7 @@ import DatabaseService from '../../services/database';
 import { PricingTier } from '../../types';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
+import PricingTierFormModal from '../../components/PricingTierFormModal';
 
 
 
@@ -27,34 +26,9 @@ export default function PricingTiersScreen() {
   const [loading, setLoading] = useState(true);
   const [showTierModal, setShowTierModal] = useState(false);
   const [editingTier, setEditingTier] = useState<PricingTier | null>(null);
-  const [newTier, setNewTier] = useState<Partial<PricingTier>>({
-    id: '',
-    name: '',
-    description: '',
-    rules: [
-      { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any
-    ]
-  });
-  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
-  const validateRules = (rules: { minQty: number; maxQty: number; pricePerBaseUnit?: number; discountPct?: number; }[]): string | null => {
-    const sorted = [...rules].sort((a, b) => a.minQty - b.minQty);
-    for (let i = 0; i < sorted.length; i++) {
-      const r = sorted[i];
-      if (r.minQty < 1) return 'כמות מינימלית חייבת להיות מספר גדול מ-0';
-      if (r.maxQty < r.minQty) return 'ערך מקסימום חייב להיות גדול או שווה למינימום';
-      if (r.pricePerBaseUnit == null && r.discountPct == null) return 'יש להזין מחיר או הנחה לכל כלל';
-      if (i > 0) {
-        const prev = sorted[i - 1];
-        if (r.minQty !== prev.maxQty + 1) return 'טווחי הכמויות חופפים או מכילים חוסרים';
-      }
-    }
-    return null;
-  };
-
-  // Modal states
   const [infoModal, setInfoModal] = useState({
     visible: false,
     title: '',
@@ -91,117 +65,16 @@ export default function PricingTiersScreen() {
   };
 
   const addTier = () => {
+  const addTier = () => {
     setEditingTier(null);
-    setNewTier({
-      id: '',
-      name: '',
-      description: '',
-      rules: [
-        { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any
-      ]
-    });
     setShowTierModal(true);
   };
 
   const editTier = (tier: PricingTier) => {
     setEditingTier(tier);
-    setNewTier({...tier});
     setShowTierModal(true);
   };
 
-  const saveTier = async () => {
-    if (!newTier.id || !newTier.name || !newTier.description) {
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'אנא מלא את כל השדות הנדרשים',
-        type: 'error'
-      });
-      return;
-    }
-
-    if (newTier.rules) {
-      const errorMsg = validateRules(newTier.rules);
-      if (errorMsg) {
-        setInfoModal({ visible: true, title: 'שגיאה', message: errorMsg, type: 'error' });
-        return;
-      }
-    }
-
-    setLoading(true);
-    try {
-      const db = DatabaseService.getInstance();
-      
-      if (editingTier) {
-        // Update existing tier
-        await db.updatePricingTier(editingTier.id, newTier);
-        
-        // Refresh tiers from database
-        await loadPricingTiers();
-        
-        setInfoModal({
-          visible: true,
-          title: 'הצלחה',
-          message: 'מדרג המחירים עודכן בהצלחה',
-          type: 'success'
-        });
-      } else {
-        // Add new tier
-        await db.addPricingTier(newTier as PricingTier);
-        
-        // Refresh tiers from database
-        await loadPricingTiers();
-        
-        setInfoModal({
-          visible: true,
-          title: 'הצלחה',
-          message: 'מדרג המחירים נוסף בהצלחה',
-          type: 'success'
-        });
-      }
-      
-      setShowTierModal(false);
-    } catch (error) {
-      console.error('Error saving pricing tier:', error);
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: error instanceof Error ? error.message : 'שמירת מדרג המחירים נכשלה',
-        type: 'error'
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const deleteTier = async (tierId: string) => {
-    setLoading(true);
-    try {
-      const db = DatabaseService.getInstance();
-      await db.deletePricingTier(tierId);
-      
-      // Refresh tiers from database
-      await loadPricingTiers();
-      
-      setShowTierModal(false);
-      setInfoModal({
-        visible: true,
-        title: 'הצלחה',
-        message: 'מדרג המחירים נמחק בהצלחה',
-        type: 'success'
-      });
-    } catch (error) {
-      console.error('Error deleting pricing tier:', error);
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: error instanceof Error ? error.message : 'מחיקת מדרג המחירים נכשלה',
-        type: 'error'
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const renderTierCard = (tier: PricingTier) => (
     <TouchableOpacity
@@ -322,210 +195,20 @@ export default function PricingTiersScreen() {
         )}
       </ScrollView>
 
-      {/* Pricing Tier Edit/Add Modal */}
-      <Modal
+      <PricingTierFormModal
         visible={showTierModal}
-        animationType="slide"
-        transparent={false}
-        onRequestClose={() => setShowTierModal(false)}
-      >
-        <SafeAreaView style={[styles.modalContainer, { backgroundColor: colors.background }]}>
-          <View style={[styles.modalHeader, { borderBottomColor: colors.border.primary }]}>
-            <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
-              {editingTier ? 'עריכת מדרג מחירים' : 'הוספת מדרג מחירים חדש'}
-            </Text>
-            <TouchableOpacity onPress={() => setShowTierModal(false)}>
-              <X size={24} color={colors.text.primary} />
-            </TouchableOpacity>
-          </View>
+        tier={editingTier}
+        onClose={() => setShowTierModal(false)}
+        onSaved={loadPricingTiers}
+        onDeleted={loadPricingTiers}
+      />
 
-          <ScrollView style={styles.modalContent}>
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מזהה מדרג *</Text>
-              <TextInput
-                style={[styles.formInput, { 
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary 
-                }]}
-                value={newTier.id}
-                onChangeText={(text) => setNewTier({...newTier, id: text})}
-                placeholder="הכנס מזהה מדרג (באנגלית, לדוגמה: bulk_discount)"
-                textAlign="left"
-                editable={!editingTier} // Don't allow editing ID for existing tiers
-              />
-            </View>
-
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>שם המדרג *</Text>
-              <TextInput
-                style={[styles.formInput, { 
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary 
-                }]}
-                value={newTier.name}
-                onChangeText={(text) => setNewTier({...newTier, name: text})}
-                placeholder="הכנס שם מדרג (לדוגמה: הנחת כמות)"
-                textAlign="right"
-              />
-            </View>
-
-            {newTier.rules?.map((rule, idx) => (
-              <View key={idx} style={styles.formRow}>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מינימום</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary
-                    }]}
-                    value={rule.minQty.toString()}
-                    onChangeText={(text) => {
-                      const updated = [...(newTier.rules || [])];
-                      updated[idx].minQty = parseInt(text) || 1;
-                      setNewTier({...newTier, rules: updated});
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מקסימום</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary
-                    }]}
-                    value={rule.maxQty.toString()}
-                    onChangeText={(text) => {
-                      const updated = [...(newTier.rules || [])];
-                      updated[idx].maxQty = parseInt(text) || 0;
-                      setNewTier({...newTier, rules: updated});
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר ליחידה</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary
-                    }]}
-                    value={rule.pricePerBaseUnit?.toString() || ''}
-                    onChangeText={(text) => {
-                      const updated = [...(newTier.rules || [])];
-                      updated[idx].pricePerBaseUnit = text ? parseFloat(text) : undefined;
-                      setNewTier({...newTier, rules: updated});
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>הנחה %</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary
-                    }]}
-                    value={rule.discountPct?.toString() || ''}
-                    onChangeText={(text) => {
-                      const updated = [...(newTier.rules || [])];
-                      updated[idx].discountPct = text ? parseFloat(text) : undefined;
-                      setNewTier({...newTier, rules: updated});
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <TouchableOpacity onPress={() => {
-                  const updated = [...(newTier.rules || [])];
-                  updated.splice(idx,1);
-                  setNewTier({...newTier, rules: updated});
-                }}>
-                  <Trash2 size={20} color={colors.status.error} />
-                </TouchableOpacity>
-              </View>
-            ))}
-              <TouchableOpacity onPress={() => setNewTier({
-                ...newTier,
-                rules: [
-                  ...(newTier.rules || []),
-                  {
-                    id: '',
-                    tierId: '',
-                    minQty: 1,
-                    maxQty: 1,
-                    pricePerBaseUnit: undefined,
-                    discountPct: undefined,
-                  },
-                ],
-              })} style={{marginBottom:10}}>
-              <Text style={{color: colors.gold}}>הוסף כלל</Text>
-            </TouchableOpacity>
-
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תיאור *</Text>
-              <TextInput
-                style={[styles.formInput, styles.textArea, { 
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary 
-                }]}
-                value={newTier.description}
-                onChangeText={(text) => setNewTier({...newTier, description: text})}
-                placeholder="הכנס תיאור מדרג (לדוגמה: מחיר מיוחד של 8₪ ליחידה בקנייה של 5 פריטים ומעלה)"
-                multiline
-                numberOfLines={4}
-                textAlign="right"
-              />
-            </View>
-
-            <View style={styles.modalActions}>
-              <TouchableOpacity 
-                style={[styles.saveButton, { backgroundColor: colors.gold }]}
-                onPress={saveTier}
-                disabled={loading}
-              >
-                {loading ? (
-                  <LoadingSpinner size="small" color={colors.text.inverse} style={styles.buttonSpinner} />
-                ) : (
-                  <>
-                    <Save size={20} color={colors.text.inverse} />
-                    <Text style={[styles.saveButtonText, { color: colors.text.inverse }]}>שמור מדרג מחירים</Text>
-                  </>
-                )}
-              </TouchableOpacity>
-
-              {editingTier && (
-                <TouchableOpacity 
-                  style={[styles.deleteButton, { backgroundColor: colors.status.error }]}
-                  onPress={() => deleteTier(editingTier.id)}
-                  disabled={loading}
-                >
-                  <Trash2 size={20} color={colors.text.inverse} />
-                  <Text style={[styles.deleteButtonText, { color: colors.text.inverse }]}>מחק מדרג מחירים</Text>
-                </TouchableOpacity>
-              )}
-            </View>
-          </ScrollView>
-        </SafeAreaView>
-      </Modal>
-
-      {/* Info Modal */}
       <InfoModal
         visible={infoModal.visible}
         title={infoModal.title}
         message={infoModal.message}
         type={infoModal.type}
-        onClose={() => setInfoModal({...infoModal, visible: false})}
+        onClose={() => setInfoModal({ ...infoModal, visible: false })}
       />
     </SafeAreaView>
   );
@@ -682,84 +365,5 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginLeft: 8,
-  },
-  modalContainer: {
-    flex: 1,
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    borderBottomWidth: 1,
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  modalContent: {
-    padding: 16,
-  },
-  formGroup: {
-    marginBottom: 20,
-  },
-  formRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 20,
-    gap: 12,
-  },
-  formGroupHalf: {
-    flex: 1,
-  },
-  formLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 8,
-    textAlign: 'right',
-  },
-  formInput: {
-    borderWidth: 1,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    fontSize: 16,
-  },
-  textArea: {
-    height: 100,
-    textAlignVertical: 'top',
-  },
-  modalActions: {
-    gap: 16,
-    marginTop: 20,
-    marginBottom: 40,
-  },
-  saveButton: {
-    borderRadius: 12,
-    paddingVertical: 16,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  saveButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  deleteButton: {
-    borderRadius: 12,
-    paddingVertical: 16,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  deleteButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  buttonSpinner: {
-    marginRight: 8,
   },
 });

--- a/components/PricingTierFormModal.tsx
+++ b/components/PricingTierFormModal.tsx
@@ -1,0 +1,384 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  TextInput,
+  SafeAreaView,
+  ActivityIndicator,
+} from 'react-native';
+import { X, Save, Trash2 } from 'lucide-react-native';
+import { PricingTier } from '../types';
+import { useTheme } from '../contexts/ThemeContext';
+import DatabaseService from '../services/database';
+import InfoModal from './InfoModal';
+
+interface PricingTierFormModalProps {
+  visible: boolean;
+  onClose: () => void;
+  tier?: PricingTier | null;
+  onSaved?: (tier: PricingTier, isNew: boolean) => void;
+  onDeleted?: (id: string) => void;
+}
+
+export default function PricingTierFormModal({
+  visible,
+  onClose,
+  tier,
+  onSaved,
+  onDeleted,
+}: PricingTierFormModalProps) {
+  const { colors } = useTheme();
+  const [editingTier, setEditingTier] = useState<PricingTier | null>(tier ?? null);
+  const [formData, setFormData] = useState<Partial<PricingTier>>({
+    id: '',
+    name: '',
+    description: '',
+    rules: [
+      { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any,
+    ],
+  });
+  const [loading, setLoading] = useState(false);
+  const [infoModal, setInfoModal] = useState({
+    visible: false,
+    title: '',
+    message: '',
+    type: 'info' as 'success' | 'error' | 'info' | 'warning',
+  });
+
+  useEffect(() => {
+    if (visible) {
+      setEditingTier(tier ?? null);
+      if (tier) {
+        setFormData({ ...tier });
+      } else {
+        setFormData({
+          id: '',
+          name: '',
+          description: '',
+          rules: [
+            { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any,
+          ],
+        });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, tier]);
+
+  const validateRules = (
+    rules: { minQty: number; maxQty: number; pricePerBaseUnit?: number; discountPct?: number }[],
+  ): string | null => {
+    const sorted = [...rules].sort((a, b) => a.minQty - b.minQty);
+    for (let i = 0; i < sorted.length; i++) {
+      const r = sorted[i];
+      if (r.minQty < 1) return 'כמות מינימלית חייבת להיות מספר גדול מ-0';
+      if (r.maxQty < r.minQty) return 'ערך מקסימום חייב להיות גדול או שווה למינימום';
+      if (r.pricePerBaseUnit == null && r.discountPct == null) return 'יש להזין מחיר או הנחה לכל כלל';
+      if (i > 0) {
+        const prev = sorted[i - 1];
+        if (r.minQty !== prev.maxQty + 1) return 'טווחי הכמויות חופפים או מכילים חוסרים';
+      }
+    }
+    return null;
+  };
+
+  const saveTier = async () => {
+    if (!formData.id || !formData.name || !formData.description) {
+      setInfoModal({ visible: true, title: 'שגיאה', message: 'אנא מלא את כל השדות הנדרשים', type: 'error' });
+      return;
+    }
+
+    if (formData.rules) {
+      const errorMsg = validateRules(formData.rules);
+      if (errorMsg) {
+        setInfoModal({ visible: true, title: 'שגיאה', message: errorMsg, type: 'error' });
+        return;
+      }
+    }
+
+    setLoading(true);
+    try {
+      const db = DatabaseService.getInstance();
+      if (editingTier) {
+        await db.updatePricingTier(editingTier.id, formData);
+        const updated = { ...editingTier, ...formData } as PricingTier;
+        onSaved?.(updated, false);
+      } else {
+        await db.addPricingTier(formData as PricingTier);
+        const added = formData as PricingTier;
+        onSaved?.(added, true);
+      }
+      onClose();
+    } catch (error) {
+      console.error('Error saving pricing tier:', error);
+      setInfoModal({
+        visible: true,
+        title: 'שגיאה',
+        message: error instanceof Error ? error.message : 'שמירת מדרג המחירים נכשלה',
+        type: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deleteTier = async () => {
+    if (!editingTier) return;
+    setLoading(true);
+    try {
+      const db = DatabaseService.getInstance();
+      await db.deletePricingTier(editingTier.id);
+      onDeleted?.(editingTier.id);
+      onClose();
+    } catch (error) {
+      console.error('Error deleting pricing tier:', error);
+      setInfoModal({
+        visible: true,
+        title: 'שגיאה',
+        message: error instanceof Error ? error.message : 'מחיקת מדרג המחירים נכשלה',
+        type: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Modal visible={visible} animationType="slide" transparent={false} onRequestClose={onClose}>
+        <SafeAreaView style={[styles.modalContainer, { backgroundColor: colors.background }]}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.border.primary }]}>
+            <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
+              {editingTier ? 'עריכת מדרג מחירים' : 'הוספת מדרג מחירים חדש'}
+            </Text>
+            <TouchableOpacity onPress={onClose}>
+              <X size={24} color={colors.text.primary} />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.modalContent}>
+            <View style={styles.formGroup}>
+              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מזהה מדרג *</Text>
+              <TextInput
+                style={[styles.formInput, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.primary,
+                  color: colors.text.primary,
+                }]}
+                value={formData.id}
+                onChangeText={text => setFormData({ ...formData, id: text })}
+                placeholder="הכנס מזהה מדרג (באנגלית, לדוגמה: bulk_discount)"
+                textAlign="left"
+                editable={!editingTier}
+              />
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={[styles.formLabel, { color: colors.text.primary }]}>שם המדרג *</Text>
+              <TextInput
+                style={[styles.formInput, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.primary,
+                  color: colors.text.primary,
+                }]}
+                value={formData.name}
+                onChangeText={text => setFormData({ ...formData, name: text })}
+                placeholder="הכנס שם מדרג (לדוגמה: הנחת כמות)"
+                textAlign="right"
+              />
+            </View>
+
+            {formData.rules?.map((rule, idx) => (
+              <View key={idx} style={styles.formRow}>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מינימום</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={rule.minQty.toString()}
+                    onChangeText={text => {
+                      const updated = [...(formData.rules || [])];
+                      updated[idx].minQty = parseInt(text) || 1;
+                      setFormData({ ...formData, rules: updated });
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מקסימום</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={rule.maxQty.toString()}
+                    onChangeText={text => {
+                      const updated = [...(formData.rules || [])];
+                      updated[idx].maxQty = parseInt(text) || 0;
+                      setFormData({ ...formData, rules: updated });
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר ליחידה</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={rule.pricePerBaseUnit?.toString() || ''}
+                    onChangeText={text => {
+                      const updated = [...(formData.rules || [])];
+                      updated[idx].pricePerBaseUnit = text ? parseFloat(text) : undefined;
+                      setFormData({ ...formData, rules: updated });
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <View style={styles.formGroupHalf}>
+                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>הנחה %</Text>
+                  <TextInput
+                    style={[styles.formInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={rule.discountPct?.toString() || ''}
+                    onChangeText={text => {
+                      const updated = [...(formData.rules || [])];
+                      updated[idx].discountPct = text ? parseFloat(text) : undefined;
+                      setFormData({ ...formData, rules: updated });
+                    }}
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                </View>
+                <TouchableOpacity
+                  onPress={() => {
+                    const updated = [...(formData.rules || [])];
+                    updated.splice(idx, 1);
+                    setFormData({ ...formData, rules: updated });
+                  }}
+                >
+                  <Trash2 size={20} color={colors.status.error} />
+                </TouchableOpacity>
+              </View>
+            ))}
+            <TouchableOpacity
+              onPress={() =>
+                setFormData({
+                  ...formData,
+                  rules: [
+                    ...(formData.rules || []),
+                    {
+                      id: '',
+                      tierId: '',
+                      minQty: 1,
+                      maxQty: 1,
+                      pricePerBaseUnit: undefined,
+                      discountPct: undefined,
+                    },
+                  ],
+                })
+              }
+              style={{ marginBottom: 10 }}
+            >
+              <Text style={{ color: colors.gold }}>הוסף כלל</Text>
+            </TouchableOpacity>
+
+            <View style={styles.formGroup}>
+              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תיאור *</Text>
+              <TextInput
+                style={[styles.formInput, styles.textArea, {
+                  borderColor: colors.border.primary,
+                  backgroundColor: colors.surface.primary,
+                  color: colors.text.primary,
+                }]}
+                value={formData.description}
+                onChangeText={text => setFormData({ ...formData, description: text })}
+                placeholder="הכנס תיאור מדרג (לדוגמה: מחיר מיוחד של 8₪ ליחידה בקנייה של 5 פריטים ומעלה)"
+                multiline
+                numberOfLines={4}
+                textAlign="right"
+              />
+            </View>
+
+            <View style={styles.modalActions}>
+              <TouchableOpacity
+                style={[styles.saveButton, { backgroundColor: colors.gold }]}
+                onPress={saveTier}
+                disabled={loading}
+              >
+                {loading ? (
+                  <ActivityIndicator size="small" color={colors.text.inverse} style={styles.buttonSpinner} />
+                ) : (
+                  <>
+                    <Save size={20} color={colors.text.inverse} />
+                    <Text style={[styles.saveButtonText, { color: colors.text.inverse }]}>שמור מדרג מחירים</Text>
+                  </>
+                )}
+              </TouchableOpacity>
+
+              {editingTier && (
+                <TouchableOpacity
+                  style={[styles.deleteButton, { backgroundColor: colors.status.error }]}
+                  onPress={deleteTier}
+                  disabled={loading}
+                >
+                  <Trash2 size={20} color={colors.text.inverse} />
+                  <Text style={[styles.deleteButtonText, { color: colors.text.inverse }]}>מחק מדרג מחירים</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </ScrollView>
+        </SafeAreaView>
+      </Modal>
+
+      <InfoModal
+        visible={infoModal.visible}
+        title={infoModal.title}
+        message={infoModal.message}
+        type={infoModal.type}
+        onClose={() => setInfoModal({ ...infoModal, visible: false })}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalContainer: { flex: 1 },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+  },
+  modalTitle: { fontSize: 18, fontWeight: 'bold' },
+  modalContent: { padding: 16 },
+  formGroup: { marginBottom: 20 },
+  formRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20, gap: 12 },
+  formGroupHalf: { flex: 1 },
+  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
+  formInput: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
+  textArea: { height: 100, textAlignVertical: 'top' },
+  modalActions: { gap: 16, marginTop: 20, marginBottom: 40 },
+  saveButton: { borderRadius: 12, paddingVertical: 16, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' },
+  saveButtonText: { fontSize: 16, fontWeight: '600', marginLeft: 8 },
+  deleteButton: { borderRadius: 12, paddingVertical: 16, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' },
+  deleteButtonText: { fontSize: 16, fontWeight: '600', marginLeft: 8 },
+  buttonSpinner: { marginRight: 8 },
+});

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -19,6 +19,7 @@ import DatabaseService from '../services/database';
 import MediaUploader from './MediaUploader';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
+import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
 
 interface MediaItem {
@@ -53,6 +54,7 @@ export default function ProductFormModal({
   const [showSubcategorySelector, setShowSubcategorySelector] = useState(false);
   const [availableSubcategories, setAvailableSubcategories] = useState<Subcategory[]>([]);
   const [showPricingTierSelector, setShowPricingTierSelector] = useState(false);
+  const [showPricingTierForm, setShowPricingTierForm] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const [infoModal, setInfoModal] = useState({
@@ -454,7 +456,7 @@ export default function ProductFormModal({
                 style={[styles.categorySelectorItem, { borderBottomColor: colors.border.secondary, backgroundColor: colors.interactive.secondary }]}
                 onPress={() => {
                   setShowPricingTierSelector(false);
-                  router.push('/admin/pricing-tiers');
+                  setShowPricingTierForm(true);
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>
@@ -466,6 +468,15 @@ export default function ProductFormModal({
           </View>
         </View>
       </Modal>
+
+      <PricingTierFormModal
+        visible={showPricingTierForm}
+        onClose={() => setShowPricingTierForm(false)}
+        onSaved={(tier) => {
+          setShowPricingTierForm(false);
+          loadPricingTiers();
+        }}
+      />
 
       <InfoModal
         visible={infoModal.visible}


### PR DESCRIPTION
## Summary
- extract pricing tier form to `PricingTierFormModal`
- reuse this modal in pricing tiers screen
- open pricing tier modal from product form instead of navigating
- refresh tier list after adding a new tier

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726b5d629c8326953bd422c9c84927