### PR TITLE
Fix crash when price tier list is undefined

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -223,7 +223,7 @@ export default function PricingTiersScreen() {
 
         {pricingTiers.length > 0 ? (
           <View style={styles.tiersGrid}>
-            {pricingTiers.map(renderTierCard)}
+            {(pricingTiers || []).map(renderTierCard)}
           </View>
         ) : (
           <View style={styles.emptyContainer}>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -1032,7 +1032,7 @@ export default function SubcategoryScreen() {
             </View>
             
             <ScrollView style={styles.categorySelectorList}>
-              {pricingTiers.map((tier) => (
+              {(pricingTiers || []).map((tier) => (
                 <TouchableOpacity
                   key={tier.id}
                   style={[styles.categorySelectorItem, { borderBottomColor: colors.border.secondary }]}

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -439,7 +439,7 @@ export default function ProductFormModal({
               </TouchableOpacity>
             </View>
             <ScrollView style={styles.categorySelectorList}>
-              {pricingTiers.map(tier => (
+              {(pricingTiers || []).map(tier => (
                 <TouchableOpacity key={tier.id} style={[styles.categorySelectorItem, { borderBottomColor: colors.border.secondary }]} onPress={() => selectPricingTier(tier.id)}>
                   <View style={styles.categorySelectorItemContent}>
                     <Text style={[styles.pricingTierDiscount, { color: colors.gold }]}>


### PR DESCRIPTION
## Summary
- fix app crash when price tier list is undefined by guarding against null arrays in product forms and pricing tier admin screen

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'expo')*

------
https://chatgpt.com/codex/tasks/task_e_68728c61a4a88326b9074c6cab912e06