### PR TITLE
Generate thumbnails for video-only products

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -37,6 +37,7 @@ import FullScreenMediaViewer from '../../components/FullScreenMediaViewer';
 import InfoModal from '../../components/InfoModal';
 import ProductFormModal from '../../components/ProductFormModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import MediaService from '../../services/media';
 
 
 
@@ -45,6 +46,7 @@ interface MediaItem {
   uri: string;
   type: 'image' | 'video';
   name?: string;
+  thumbnail?: string;
 }
 
 const { width } = Dimensions.get('window');
@@ -64,6 +66,7 @@ export default function ProductDetailScreen() {
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const [categoryBanner, setCategoryBanner] = useState<HeroBanner | null>(null);
+  const [videoThumbnails, setVideoThumbnails] = useState<Record<string, string>>({});
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -107,6 +110,27 @@ export default function ProductDetailScreen() {
     };
 
     fetchBanner();
+  }, [product]);
+
+  useEffect(() => {
+    const loadThumbs = async () => {
+      if (!product?.videos) return;
+      const svc = MediaService.getInstance();
+      for (let i = 0; i < product.videos.length; i++) {
+        const id = `video_${i}`;
+        if (!videoThumbnails[id]) {
+          try {
+            const thumb = await svc.generateVideoThumbnail(product.videos[i]);
+            if (thumb) {
+              setVideoThumbnails((prev) => ({ ...prev, [id]: thumb }));
+            }
+          } catch (err) {
+            console.error('Error generating video thumbnail:', err);
+          }
+        }
+      }
+    };
+    loadThumbs();
   }, [product]);
 
   const loadProduct = async () => {
@@ -309,7 +333,10 @@ export default function ProductDetailScreen() {
   }
 
   const allMedia = getAllMedia();
-  const bannerImageUri = categoryBanner?.image || product.images?.[0];
+  const bannerImageUri =
+    categoryBanner?.image ||
+    product.images?.[0] ||
+    videoThumbnails['video_0'];
   const currentPricingTier = pricingTiers.find(
     (tier) => tier.id === product.pricingTier
   );
@@ -394,7 +421,7 @@ export default function ProductDetailScreen() {
                   onPress={() => openMediaViewer(idx)}
                 >
                   <Image
-                    source={{ uri: media.uri }}
+                    source={{ uri: media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri }}
                     style={styles.galleryImage}
                     resizeMode="cover"
                   />
@@ -568,7 +595,7 @@ export default function ProductDetailScreen() {
                     onPress={() => openMediaViewer(index)}
                   >
                     <Image
-                      source={{ uri: media.uri }}
+                      source={{ uri: media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri }}
                       style={styles.galleryImage}
                       resizeMode="cover"
                     />

--- a/components/BannerFormModal.tsx
+++ b/components/BannerFormModal.tsx
@@ -24,6 +24,7 @@ interface MediaItem {
   uri: string;
   type: 'image' | 'video';
   name?: string;
+  thumbnail?: string;
 }
 
 interface BannerFormModalProps {

--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -32,6 +32,7 @@ interface MediaItem {
   uri: string;
   type: 'image' | 'video';
   name?: string;
+  thumbnail?: string;
 }
 
 interface FullScreenMediaViewerProps {

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -20,6 +20,7 @@ interface MediaItem {
   uri: string;
   type: 'image' | 'video';
   name?: string;
+  thumbnail?: string;
   file?: File | Blob; // For new uploads
 }
 
@@ -40,7 +41,27 @@ export default function MediaUploader({
 }: MediaUploaderProps) {
   const [uploading, setUploading] = useState(false);
   const [progressMap, setProgressMap] = useState<Record<string, number>>({});
+  const [thumbnailMap, setThumbnailMap] = useState<Record<string, string>>({});
   const { colors } = useTheme();
+
+  useEffect(() => {
+    const loadThumbnails = async () => {
+      const svc = MediaService.getInstance();
+      for (const item of media) {
+        if (item.type === 'video' && !thumbnailMap[item.id]) {
+          try {
+            const thumb = await svc.generateVideoThumbnail(item.uri);
+            if (thumb) {
+              setThumbnailMap(prev => ({ ...prev, [item.id]: thumb }));
+            }
+          } catch (err) {
+            console.error('Error loading thumbnail:', err);
+          }
+        }
+      }
+    };
+    loadThumbnails();
+  }, [media]);
 
   const requestPermissions = async () => {
     if (Platform.OS !== 'web') {
@@ -73,6 +94,17 @@ export default function MediaUploader({
           type: asset.type === 'video' ? 'video' : 'image',
           name: asset.fileName || `media_${Date.now()}`,
         };
+
+        if (placeholder.type === 'video') {
+          try {
+            const thumb = await mediaService.generateVideoThumbnail(asset.uri);
+            if (thumb) {
+              setThumbnailMap((m) => ({ ...m, [id]: thumb }));
+            }
+          } catch (err) {
+            console.error('Error generating thumbnail:', err);
+          }
+        }
 
         currentMedia = [...currentMedia, placeholder];
         onMediaChange(currentMedia);
@@ -157,6 +189,10 @@ export default function MediaUploader({
 
   const removeMedia = (id: string) => {
     onMediaChange(media.filter(item => item.id !== id));
+    setThumbnailMap((prev) => {
+      const { [id]: _removed, ...rest } = prev;
+      return rest;
+    });
   };
 
   const renderMediaItem = (item: MediaItem, index: number) => (
@@ -167,7 +203,7 @@ export default function MediaUploader({
       }]}>
         {item.type === 'video' ? (
           <View style={styles.videoContainer}>
-            <Image source={{ uri: item.uri }} style={styles.mediaThumbnail} />
+            <Image source={{ uri: thumbnailMap[item.id] || item.uri }} style={styles.mediaThumbnail} />
             <View style={styles.playOverlay}>
               <Play size={24} color={colors.text.inverse} fill={colors.text.inverse} />
             </View>

--- a/components/MediaViewer.tsx
+++ b/components/MediaViewer.tsx
@@ -22,6 +22,7 @@ const { width, height } = Dimensions.get('window');
 interface MediaItem {
   type: 'image' | 'video';
   url: string;
+  thumbnail?: string;
 }
 
 interface Props {

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useCurrency } from '../contexts/CurrencyContext';
 import CartService from '../services/cart';
 import DatabaseService from '../services/database';
+import MediaService from '../services/media';
 
 interface ProductCardProps {
   product: Product;
@@ -33,6 +34,7 @@ export default function ProductCard({
 }: ProductCardProps) {
   const [isInWishlist, setIsInWishlist] = useState(false);
   const [pricingTier, setPricingTier] = useState<PricingTier | null>(null);
+  const [videoThumbnail, setVideoThumbnail] = useState<string | null>(null);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
@@ -53,6 +55,21 @@ export default function ProductCard({
     
     return () => cartService.removeListener(handleUpdate);
   }, [product.id, product.pricingTier]);
+
+  useEffect(() => {
+    const loadThumb = async () => {
+      if ((!product.images || product.images.length === 0) && product.videos && product.videos.length > 0) {
+        try {
+          const svc = MediaService.getInstance();
+          const thumb = await svc.generateVideoThumbnail(product.videos[0]);
+          if (thumb) setVideoThumbnail(thumb);
+        } catch (err) {
+          console.error('Error generating video thumbnail:', err);
+        }
+      }
+    };
+    loadThumb();
+  }, [product.images, product.videos]);
 
   const loadPricingTier = async (tierId: string) => {
     try {
@@ -132,6 +149,14 @@ export default function ProductCard({
       <View style={styles.imageContainer}>
         {product.images && product.images.length > 0 ? (
           <Image source={{ uri: product.images[0] }} style={styles.image} resizeMode="cover" />
+        ) : product.videos && product.videos.length > 0 ? (
+          videoThumbnail ? (
+            <Image source={{ uri: videoThumbnail }} style={styles.image} resizeMode="cover" />
+          ) : (
+            <View style={styles.noImageContainer}>
+              <Text style={styles.noImageText}>אין תמונה</Text>
+            </View>
+          )
         ) : (
           <View style={styles.noImageContainer}>
             <Text style={styles.noImageText}>אין תמונה</Text>

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -27,6 +27,7 @@ interface MediaItem {
   uri: string;
   type: 'image' | 'video';
   name?: string;
+  thumbnail?: string;
 }
 
 interface ProductFormModalProps {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.3",
     "expo-image-picker": "~16.1.0",
+    "expo-video-thumbnails": "~6.5.2",
     "expo-linear-gradient": "~14.1.3",
     "expo-linking": "~7.1.3",
     "expo-router": "~5.1.3",

--- a/services/media.ts
+++ b/services/media.ts
@@ -1,4 +1,5 @@
 import PinataService from './pinata';
+import * as VideoThumbnails from 'expo-video-thumbnails';
 
 class MediaService {
   private static instance: MediaService;
@@ -81,6 +82,21 @@ class MediaService {
     };
     
     return mimeToExt[mimeType] || 'bin';
+  }
+
+  /**
+   * Generate a thumbnail for a video at the given time in ms
+   */
+  async generateVideoThumbnail(uri: string, timeMs = 1000): Promise<string | null> {
+    try {
+      const { uri: thumbnailUri } = await VideoThumbnails.getThumbnailAsync(uri, {
+        time: timeMs,
+      });
+      return thumbnailUri;
+    } catch (error) {
+      console.error('Error generating video thumbnail:', error);
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- create MediaService helper to produce thumbnails with `expo-video-thumbnails`
- show thumbnails for videos inside the uploader
- use generated thumbnails in product cards and product details
- update various media item types to include optional thumbnail field
- add `expo-video-thumbnails` dependency

## Testing
- `yarn lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729faaa16c8326a4823b6fc729b9f0