### PR TITLE
Improve product page and feed UX

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -503,6 +503,9 @@ export default function HomeScreen() {
                     product={item}
                     isAdmin={isAdmin}
                     onEdit={editProduct}
+                    categoryName={
+                      categories.find((c) => c.id === item.category)?.name
+                    }
                   />
                 </View>
               ))}

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -403,8 +403,29 @@ export default function ProductDetailScreen() {
           </View>
         </View>
 
+        {/* Main Product Image */}
+        <TouchableOpacity
+          style={styles.coverImageContainer}
+          onPress={() => openMediaViewer(0)}
+        >
+          {bannerImageUri ? (
+            <Image
+              source={{ uri: bannerImageUri }}
+              style={styles.coverImage}
+              resizeMode="cover"
+            />
+          ) : (
+            <View style={styles.noImageContainer}>
+              <ImageIcon size={64} color={colors.text.secondary} />
+              <Text style={[styles.noImageText, { color: colors.text.secondary }]}>
+                אין תמונה
+              </Text>
+            </View>
+          )}
+        </TouchableOpacity>
+
         {/* ——— Product Media Carousel ——— */}
-        {allMedia.length > 0 && (
+        {allMedia.length > 1 && (
           <View style={styles.galleryContainer}>
             <ScrollView
               horizontal
@@ -867,7 +888,8 @@ const styles = StyleSheet.create({
   },
   coverImageContainer: {
     width: '100%',
-    height: 300,
+    aspectRatio: 1,
+    marginBottom: 16,
   },
   coverImage: {
     width: '100%',

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -22,15 +22,17 @@ interface ProductCardProps {
   isAdmin?: boolean;
   onEdit?: (product: Product) => void;
   onDelete?: (productId: string) => void;
+  categoryName?: string;
   style?: any;
 }
 
-export default function ProductCard({ 
-  product, 
-  isAdmin = false, 
-  onEdit, 
+export default function ProductCard({
+  product,
+  isAdmin = false,
+  onEdit,
   onDelete,
-  style 
+  categoryName,
+  style
 }: ProductCardProps) {
   const [isInWishlist, setIsInWishlist] = useState(false);
   const [pricingTier, setPricingTier] = useState<PricingTier | null>(null);
@@ -233,13 +235,11 @@ export default function ProductCard({
           )}
         </View>
 
-        {/* Tiered Pricing Info */}
-        {hasTieredPricing && (
+        {/* Category */}
+        {categoryName && (
           <View style={styles.tieredPricingContainer}>
             <Tag size={12} color={colors.status.info} />
-            <Text style={[styles.tieredPricingText, { color: colors.status.info }]}>
-              {`${currencySymbol}${pricingTier?.pricePerUnit?.toFixed(2)} (${pricingTier?.minQuantity}+)`}
-            </Text>
+            <Text style={[styles.tieredPricingText, { color: colors.status.info }]}> {categoryName} </Text>
           </View>
         )}
 


### PR DESCRIPTION
## Summary
- feature: show main product image as a large banner on the product detail screen
- feature: display product category instead of undefined tier text in feed cards

## Testing
- `npm install -g expo`
- `npm install -g eslint`
- `npx expo lint` *(fails: Command "eslint" not found)*
- `yarn install` *(fails: Couldn't find any versions for "expo-video-thumbnails" that matches "~6.5.2")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'expo')*

------
https://chatgpt.com/codex/tasks/task_e_6872b94b229c8326a76c20b4fedd6e50