### PR TITLE
Add GlobalHeader to product page and make logo clickable

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -38,6 +38,7 @@ import InfoModal from '../../components/InfoModal';
 import ProductFormModal from '../../components/ProductFormModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import MediaService from '../../services/media';
+import GlobalHeader from '../../components/GlobalHeader';
 
 
 
@@ -315,6 +316,7 @@ export default function ProductDetailScreen() {
       <SafeAreaView
         style={[styles.container, { backgroundColor: colors.background }]}
       >
+        <GlobalHeader showSearch={false} />
         <View
           style={[styles.header, { borderBottomColor: colors.border.primary }]}
         >
@@ -345,6 +347,7 @@ export default function ProductDetailScreen() {
     <SafeAreaView
       style={[styles.container, { backgroundColor: colors.background }]}
     >
+      <GlobalHeader showSearch={false} />
       <ScrollView showsVerticalScrollIndicator={false}>
         {/* Header */}
         <View style={styles.header}>

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -54,7 +54,10 @@ export default function GlobalHeader({
     <>
       <View style={[styles.header, { backgroundColor: colors.background }]}>
         <View style={styles.headerTop}>
-          <View style={styles.logo}>
+          <TouchableOpacity
+            style={styles.logo}
+            onPress={() => router.push('/(tabs)')}
+          >
             {platformLogo ? (
               <Image
                 source={{ uri: platformLogo }}
@@ -69,7 +72,7 @@ export default function GlobalHeader({
             <Text style={[styles.logoText, { color: colors.gold }]}>
               {platformName || t('ageVerification.platformName')}
             </Text>
-          </View>
+          </TouchableOpacity>
           <View style={styles.headerIcons}>
             <TouchableOpacity
               style={[


### PR DESCRIPTION
## Summary
- use `GlobalHeader` on product details page
- make the logo in `GlobalHeader` route to the home screen when tapped

## Testing
- `yarn install` *(fails: Couldn't find any versions for "expo-video-thumbnails" that matches "~6.5.2")*

------
https://chatgpt.com/codex/tasks/task_e_6873fe81d8108326ad5bb754a1b0f825