### PR TITLE
Adjust price tier logic

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -341,7 +341,7 @@ export default function ProductDetailScreen() {
     tier => tier.id === product.pricingTier,
   );
   const effectivePrice = getEffectivePrice(product.price, quantity);
-  const showTieredPricing = effectivePrice !== product.price;
+  const showTieredPricing = !!product.pricingTier;
 
   return (
     <SafeAreaView
@@ -486,9 +486,9 @@ export default function ProductDetailScreen() {
           <View style={styles.priceContainer}>
             <Text style={[styles.currentPrice, { color: colors.gold }]}>
               {currencySymbol}
-              {product.price.toFixed(2)}
+              {effectivePrice.toFixed(2)}
             </Text>
-            {product.originalPrice && (
+            {product.originalPrice && !product.pricingTier && (
               <Text
                 style={[styles.originalPrice, { color: colors.text.tertiary }]}
               >
@@ -496,7 +496,7 @@ export default function ProductDetailScreen() {
                 {product.originalPrice.toFixed(2)}
               </Text>
             )}
-            {product.originalPrice && (
+            {product.originalPrice && !product.pricingTier && (
               <View
                 style={[
                   styles.discountBadge,
@@ -666,9 +666,7 @@ export default function ProductDetailScreen() {
                   { color: colors.text.secondary },
                 ]}
               >
-                {`מחיר ליחידה: ${currencySymbol}${effectivePrice.toFixed(
-                  2
-                )} (במקום ${currencySymbol}${product.price.toFixed(2)})`}
+                {`מחיר ליחידה: ${currencySymbol}${effectivePrice.toFixed(2)}`}
               </Text>
               <Text style={[styles.tieredPricingTotal, { color: colors.gold }]}>
                 {`סה"כ: ${currencySymbol}${getTotalPrice().toFixed(2)}`}

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -39,6 +39,20 @@ export default function SubcategoryScreen() {
   const [products, setProducts] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [pricingTiers, setPricingTiers] = useState<PricingTier[]>([]);
+  const getEffectivePrice = (p: Product): number => {
+    if (!p.pricingTier) return p.price;
+    const tier = pricingTiers.find(t => t.id === p.pricingTier);
+    if (!tier) return p.price;
+    if (tier.rules && tier.rules.length > 0) {
+      const sorted = [...tier.rules].sort((a, b) => a.minQty - b.minQty);
+      const rule = sorted[0];
+      if (typeof rule.pricePerBaseUnit === 'number') return rule.pricePerBaseUnit;
+      if (typeof rule.discountPct === 'number')
+        return p.price * (1 - rule.discountPct / 100);
+    }
+    if (typeof tier.pricePerUnit === 'number') return tier.pricePerUnit;
+    return p.price;
+  };
   const [loading, setLoading] = useState(true);
   const [showProductModal, setShowProductModal] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
@@ -253,7 +267,12 @@ export default function SubcategoryScreen() {
       return;
     }
 
-    if (!newProduct.name || !newProduct.description || !newProduct.price || newProduct.price <= 0) {
+    const requiresPrice = !newProduct.pricingTier;
+    if (
+      !newProduct.name ||
+      !newProduct.description ||
+      (requiresPrice && (!newProduct.price || newProduct.price <= 0))
+    ) {
       setInfoModal({
         visible: true,
         title: 'שגיאה',
@@ -312,6 +331,7 @@ export default function SubcategoryScreen() {
       const db = DatabaseService.getInstance();
       const productData = {
         ...newProduct,
+        price: newProduct.pricingTier ? 0 : newProduct.price,
         images: productMedia.filter(m => m.type === 'image').map(m => m.uri),
         videos: productMedia.filter(m => m.type === 'video').map(m => m.uri)
       };
@@ -417,7 +437,7 @@ export default function SubcategoryScreen() {
   };
 
   const selectPricingTier = (tierId: string) => {
-    setNewProduct({...newProduct, pricingTier: tierId});
+    setNewProduct({ ...newProduct, pricingTier: tierId, price: 0 });
     setShowPricingTierSelector(false);
   };
 
@@ -481,9 +501,15 @@ export default function SubcategoryScreen() {
         <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={2}>{item.name}</Text>
         
         <View style={styles.priceContainer}>
-          <Text style={[styles.currentPrice, { color: colors.gold }]}>{currencySymbol}{item.price.toFixed(2)}</Text>
-          {item.originalPrice && (
-            <Text style={[styles.originalPrice, { color: colors.text.tertiary }]}>{currencySymbol}{item.originalPrice.toFixed(2)}</Text>
+          <Text style={[styles.currentPrice, { color: colors.gold }]}>
+            {currencySymbol}
+            {getEffectivePrice(item).toFixed(2)}
+          </Text>
+          {item.originalPrice && !item.pricingTier && (
+            <Text style={[styles.originalPrice, { color: colors.text.tertiary }]}>
+              {currencySymbol}
+              {item.originalPrice.toFixed(2)}
+            </Text>
           )}
         </View>
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -40,6 +40,16 @@ export default function ProductCard({
 }: ProductCardProps) {
   const [isInWishlist, setIsInWishlist] = useState(false);
   const [pricingTier, setPricingTier] = useState<PricingTier | null>(null);
+  const getDisplayPrice = (): number => {
+    if (!pricingTier) return product.price;
+    if (pricingTier.rules && pricingTier.rules.length > 0) {
+      const rule = [...pricingTier.rules].sort((a, b) => a.minQty - b.minQty)[0];
+      if (typeof rule.pricePerBaseUnit === 'number') return rule.pricePerBaseUnit;
+      if (typeof rule.discountPct === 'number') return product.price * (1 - rule.discountPct / 100);
+    }
+    if (typeof pricingTier.pricePerUnit === 'number') return pricingTier.pricePerUnit;
+    return product.price;
+  };
   const [videoThumbnail, setVideoThumbnail] = useState<string | null>(null);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
@@ -233,8 +243,11 @@ export default function ProductCard({
 
         {/* Price */}
         <View style={styles.priceContainer}>
-          <Text style={[styles.currentPrice, { color: colors.gold }]}>{currencySymbol}{product.price.toFixed(2)}</Text>
-          {product.originalPrice && (
+          <Text style={[styles.currentPrice, { color: colors.gold }]}>
+            {currencySymbol}
+            {getDisplayPrice().toFixed(2)}
+          </Text>
+          {product.originalPrice && !product.pricingTier && (
             <Text style={[styles.originalPrice, { color: colors.text.tertiary }]}>{currencySymbol}{product.originalPrice.toFixed(2)}</Text>
           )}
         </View>

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -133,13 +133,27 @@ export default function ProductFormModal({
   };
 
   const selectPricingTier = (id: string) => {
-    setEditingProduct({ ...editingProduct, pricingTier: id });
+    setEditingProduct({
+      ...editingProduct,
+      pricingTier: id,
+      price: 0,
+    });
     setShowPricingTierSelector(false);
   };
 
   const saveProduct = async () => {
-    if (!editingProduct.name || !editingProduct.description || !editingProduct.price || editingProduct.price <= 0) {
-      setInfoModal({ visible: true, title: 'שגיאה', message: 'אנא מלא את כל השדות הנדרשים', type: 'error' });
+    const requiresPrice = !editingProduct.pricingTier;
+    if (
+      !editingProduct.name ||
+      !editingProduct.description ||
+      (requiresPrice && (!editingProduct.price || editingProduct.price <= 0))
+    ) {
+      setInfoModal({
+        visible: true,
+        title: 'שגיאה',
+        message: 'אנא מלא את כל השדות הנדרשים',
+        type: 'error',
+      });
       return;
     }
     if (productMedia.length === 0) {
@@ -230,21 +244,25 @@ export default function ProductFormModal({
               />
             </View>
 
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.price?.toString()}
-                onChangeText={text => setEditingProduct({ ...editingProduct, price: parseFloat(text) || 0 })}
-                placeholder="הכנס מחיר"
-                keyboardType="numeric"
-                textAlign="right"
-              />
-            </View>
+            {!editingProduct.pricingTier && (
+              <View style={styles.formGroup}>
+                <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר *</Text>
+                <TextInput
+                  style={[styles.formInput, {
+                    borderColor: colors.border.primary,
+                    backgroundColor: colors.surface.primary,
+                    color: colors.text.primary,
+                  }]}
+                  value={editingProduct.price?.toString()}
+                  onChangeText={text =>
+                    setEditingProduct({ ...editingProduct, price: parseFloat(text) || 0 })
+                  }
+                  placeholder="הכנס מחיר"
+                  keyboardType="numeric"
+                  textAlign="right"
+                />
+              </View>
+            )}
 
 
             <View style={styles.formGroup}>

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -154,6 +154,8 @@ class CartService {
           it.unitPrice = rule.pricePerBaseUnit * conversionFactor;
         } else if (rule?.discountPct !== undefined && rule.discountPct !== null) {
           it.unitPrice = it.product.price * (1 - rule.discountPct / 100);
+        } else if (tier?.pricePerUnit !== undefined && tier.pricePerUnit !== null) {
+          it.unitPrice = tier.pricePerUnit * conversionFactor;
         } else {
           it.unitPrice = it.product.price;
         }

--- a/services/database.ts
+++ b/services/database.ts
@@ -120,6 +120,7 @@ class DatabaseService {
     try {
       const dbProduct: any = {
         ...product,
+        price: (product as any).pricingTier ? 0 : product.price,
         pricing_tier: (product as any).pricingTier,
         created_at: (product as any).createdAt,
         updated_at: (product as any).updatedAt,
@@ -160,6 +161,7 @@ class DatabaseService {
     try {
       const dbProduct: any = {
         ...product,
+        price: (product as any).pricingTier ? 0 : product.price,
         pricing_tier: (product as any).pricingTier,
         updated_at: (product as any).updatedAt,
       };


### PR DESCRIPTION
## Summary
- support products that only use pricing tiers
- hide price field when a pricing tier is selected
- display tier-based pricing in product pages and lists
- calculate cart prices from tiers when no regular price
- store zero price for tiered products in the DB

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749ddd135083269b86b9dba3cbb1ca