### PR TITLE
Refactor RLS to call auth.uid via subquery

### DIFF
--- a/supabase/migrations/20250630002423_polished_sky.sql
+++ b/supabase/migrations/20250630002423_polished_sky.sql
@@ -93,29 +93,29 @@ ALTER TABLE order_tracking ENABLE ROW LEVEL SECURITY;
 -- Create policies for orders
 CREATE POLICY "Users can view their own orders" 
   ON orders FOR SELECT 
-  USING (user_id = auth.uid()::text);
+  USING (user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Users can insert their own orders" 
   ON orders FOR INSERT 
-  WITH CHECK (user_id = auth.uid()::text);
+  WITH CHECK (user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Users can update their own orders" 
   ON orders FOR UPDATE 
-  USING (user_id = auth.uid()::text);
+  USING (user_id = (SELECT auth.uid())::text);
 
 -- Create policies for order_items
 CREATE POLICY "Users can view their own order items" 
   ON order_items FOR SELECT 
-  USING (order_id IN (SELECT id FROM orders WHERE user_id = auth.uid()::text));
+  USING (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
 
 CREATE POLICY "Users can insert their own order items" 
   ON order_items FOR INSERT 
-  WITH CHECK (order_id IN (SELECT id FROM orders WHERE user_id = auth.uid()::text));
+  WITH CHECK (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
 
 -- Create policies for order_tracking
 CREATE POLICY "Users can view their own order tracking" 
   ON order_tracking FOR SELECT 
-  USING (order_id IN (SELECT id FROM orders WHERE user_id = auth.uid()::text));
+  USING (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
 
 CREATE POLICY "System can insert order tracking" 
   ON order_tracking FOR INSERT 

--- a/supabase/migrations/20250630231707_young_darkness.sql
+++ b/supabase/migrations/20250630231707_young_darkness.sql
@@ -151,17 +151,17 @@ CREATE POLICY "Public read access for reviews"
 CREATE POLICY "Users can insert reviews" 
   ON reviews FOR INSERT 
   TO public 
-  WITH CHECK (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Users can update their own reviews" 
   ON reviews FOR UPDATE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Users can delete their own reviews" 
   ON reviews FOR DELETE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin manage all reviews" 
   ON reviews FOR ALL 
@@ -175,7 +175,7 @@ DROP POLICY IF EXISTS "Public access for user_profiles" ON user_profiles;
 CREATE POLICY "Users can read their own profile" 
   ON user_profiles FOR SELECT 
   TO public 
-  USING (auth.uid() IS NOT NULL AND matrix_user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can read all profiles" 
   ON user_profiles FOR SELECT 
@@ -185,12 +185,12 @@ CREATE POLICY "Admin can read all profiles"
 CREATE POLICY "Users can insert their own profile" 
   ON user_profiles FOR INSERT 
   TO public 
-  WITH CHECK (auth.uid() IS NOT NULL AND matrix_user_id = auth.uid()::text);
+  WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Users can update their own profile" 
   ON user_profiles FOR UPDATE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND matrix_user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can update all profiles" 
   ON user_profiles FOR UPDATE 
@@ -209,7 +209,7 @@ DROP POLICY IF EXISTS "Public access for chat_rooms" ON chat_rooms;
 CREATE POLICY "Users can read their own chat rooms" 
   ON chat_rooms FOR SELECT 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can read all chat rooms" 
   ON chat_rooms FOR SELECT 
@@ -219,12 +219,12 @@ CREATE POLICY "Admin can read all chat rooms"
 CREATE POLICY "Users can insert chat rooms" 
   ON chat_rooms FOR INSERT 
   TO public 
-  WITH CHECK (auth.uid() IS NOT NULL);
+  WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
 
 CREATE POLICY "Users can update their own chat rooms" 
   ON chat_rooms FOR UPDATE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can update all chat rooms" 
   ON chat_rooms FOR UPDATE 
@@ -244,9 +244,9 @@ CREATE POLICY "Users can read messages in their rooms"
   ON chat_messages FOR SELECT 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
+    (SELECT auth.uid()) IS NOT NULL AND 
     room_id IN (
-      SELECT id FROM chat_rooms WHERE user_id = auth.uid()::text
+      SELECT id FROM chat_rooms WHERE user_id = (SELECT auth.uid())::text
     )
   );
 
@@ -259,11 +259,11 @@ CREATE POLICY "Users can insert messages"
   ON chat_messages FOR INSERT 
   TO public 
   WITH CHECK (
-    auth.uid() IS NOT NULL AND 
+    (SELECT auth.uid()) IS NOT NULL AND 
     (
-      sender_id = auth.uid()::text OR
+      sender_id = (SELECT auth.uid())::text OR
       room_id IN (
-        SELECT id FROM chat_rooms WHERE user_id = auth.uid()::text
+        SELECT id FROM chat_rooms WHERE user_id = (SELECT auth.uid())::text
       )
     )
   );
@@ -272,8 +272,8 @@ CREATE POLICY "Users can update their own messages"
   ON chat_messages FOR UPDATE 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
-    sender_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND 
+    sender_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admin can update all messages" 
@@ -294,7 +294,7 @@ DROP POLICY IF EXISTS "Users can update their own notifications" ON notification
 CREATE POLICY "Users can read their own notifications" 
   ON notifications FOR SELECT 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can read all notifications" 
   ON notifications FOR SELECT 
@@ -304,7 +304,7 @@ CREATE POLICY "Admin can read all notifications"
 CREATE POLICY "Users can update their own notifications" 
   ON notifications FOR UPDATE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 CREATE POLICY "Admin can update all notifications" 
   ON notifications FOR UPDATE 
@@ -314,7 +314,7 @@ CREATE POLICY "Admin can update all notifications"
 CREATE POLICY "Admin can insert notifications" 
   ON notifications FOR INSERT 
   TO public 
-  WITH CHECK (is_admin() OR auth.uid() IS NOT NULL);
+  WITH CHECK (is_admin() OR (SELECT auth.uid()) IS NOT NULL);
 
 CREATE POLICY "Admin can delete notifications" 
   ON notifications FOR DELETE 

--- a/supabase/migrations/20250701052542_square_flame.sql
+++ b/supabase/migrations/20250701052542_square_flame.sql
@@ -98,7 +98,7 @@ BEGIN
     auth.jwt() IS NOT NULL AND 
     EXISTS (
       SELECT 1 FROM user_profiles 
-      WHERE matrix_user_id = auth.uid()::text 
+      WHERE matrix_user_id = (SELECT auth.uid())::text 
       AND role = 'admin'
     )
   );

--- a/supabase/migrations/20250701053247_sweet_bread.sql
+++ b/supabase/migrations/20250701053247_sweet_bread.sql
@@ -88,7 +88,7 @@ BEGIN
     auth.jwt() IS NOT NULL AND 
     EXISTS (
       SELECT 1 FROM user_profiles 
-      WHERE matrix_user_id = auth.uid()::text 
+      WHERE matrix_user_id = (SELECT auth.uid())::text 
       AND role = 'admin'
     )
   );

--- a/supabase/migrations/20250701054429_turquoise_crystal.sql
+++ b/supabase/migrations/20250701054429_turquoise_crystal.sql
@@ -19,11 +19,11 @@ DECLARE
   current_role text;
 BEGIN
   -- Get the role from the JWT token or user_profiles table
-  SELECT role INTO current_role FROM user_profiles WHERE matrix_user_id = auth.uid()::text;
+  SELECT role INTO current_role FROM user_profiles WHERE matrix_user_id = (SELECT auth.uid())::text;
   
   RETURN (
     current_role = 'admin' OR
-    (SELECT count(*) FROM user_profiles WHERE matrix_user_id = auth.uid()::text AND role = 'admin') > 0
+    (SELECT count(*) FROM user_profiles WHERE matrix_user_id = (SELECT auth.uid())::text AND role = 'admin') > 0
   );
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20250701065326_tender_shape.sql
+++ b/supabase/migrations/20250701065326_tender_shape.sql
@@ -29,7 +29,7 @@ CREATE POLICY "Users can insert their own profile"
   ON user_profiles
   FOR INSERT
   TO authenticated
-  WITH CHECK (matrix_user_id = (auth.uid())::text);
+  WITH CHECK (matrix_user_id = (SELECT auth.uid())::text);
 
 -- Allow users to read their own profile (both authenticated and by matrix_user_id)
 CREATE POLICY "Users can read their own profile"
@@ -37,7 +37,7 @@ CREATE POLICY "Users can read their own profile"
   FOR SELECT
   TO public
   USING (
-    (auth.uid() IS NOT NULL AND matrix_user_id = (auth.uid())::text) OR
+    ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text) OR
     (auth.role() = 'anon')
   );
 
@@ -46,8 +46,8 @@ CREATE POLICY "Users can update their own profile"
   ON user_profiles
   FOR UPDATE
   TO authenticated
-  USING (matrix_user_id = (auth.uid())::text)
-  WITH CHECK (matrix_user_id = (auth.uid())::text);
+  USING (matrix_user_id = (SELECT auth.uid())::text)
+  WITH CHECK (matrix_user_id = (SELECT auth.uid())::text);
 
 -- Ensure admin policies remain intact
 -- (Admin policies should already exist and work correctly)

--- a/supabase/migrations/20250701101416_noisy_credit.sql
+++ b/supabase/migrations/20250701101416_noisy_credit.sql
@@ -54,19 +54,19 @@ CREATE POLICY "Public read access for reviews"
 CREATE POLICY "Users can insert reviews" 
   ON reviews FOR INSERT 
   TO public 
-  WITH CHECK (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 -- Create policy for users to update their own reviews
 CREATE POLICY "Users can update their own reviews" 
   ON reviews FOR UPDATE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 -- Create policy for users to delete their own reviews
 CREATE POLICY "Users can delete their own reviews" 
   ON reviews FOR DELETE 
   TO public 
-  USING (auth.uid() IS NOT NULL AND user_id = auth.uid()::text);
+  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
 
 -- Create policy for admins to manage all reviews
 CREATE POLICY "Admin manage all reviews" 

--- a/supabase/migrations/20250701191235_rough_peak.sql
+++ b/supabase/migrations/20250701191235_rough_peak.sql
@@ -26,8 +26,8 @@ CREATE POLICY "Users can read their own chat rooms"
   ON chat_rooms FOR SELECT 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
-    user_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND 
+    user_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admin can read all chat rooms" 
@@ -41,15 +41,15 @@ CREATE POLICY "Users can insert chat rooms"
   ON chat_rooms FOR INSERT 
   TO public 
   WITH CHECK (
-    auth.uid() IS NOT NULL
+    (SELECT auth.uid()) IS NOT NULL
   );
 
 CREATE POLICY "Users can update their own chat rooms" 
   ON chat_rooms FOR UPDATE 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
-    user_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND 
+    user_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admin can update all chat rooms" 
@@ -80,9 +80,9 @@ CREATE POLICY "Users can read messages in their rooms"
   ON chat_messages FOR SELECT 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
+    (SELECT auth.uid()) IS NOT NULL AND 
     room_id IN (
-      SELECT id FROM chat_rooms WHERE user_id = auth.uid()::text
+      SELECT id FROM chat_rooms WHERE user_id = (SELECT auth.uid())::text
     )
   );
 
@@ -97,15 +97,15 @@ CREATE POLICY "Users can insert messages"
   ON chat_messages FOR INSERT 
   TO public 
   WITH CHECK (
-    auth.uid() IS NOT NULL
+    (SELECT auth.uid()) IS NOT NULL
   );
 
 CREATE POLICY "Users can update their own messages" 
   ON chat_messages FOR UPDATE 
   TO public 
   USING (
-    auth.uid() IS NOT NULL AND 
-    sender_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND 
+    sender_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admin can update all messages" 

--- a/supabase/migrations/20250702130000_wishlist_items.sql
+++ b/supabase/migrations/20250702130000_wishlist_items.sql
@@ -25,22 +25,22 @@ ALTER TABLE wishlist_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Users can view their wishlist"
   ON wishlist_items FOR SELECT TO public
   USING (
-    auth.uid() IS NOT NULL AND
-    user_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND
+    user_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Users can add to wishlist"
   ON wishlist_items FOR INSERT TO public
   WITH CHECK (
-    auth.uid() IS NOT NULL AND
-    user_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND
+    user_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Users can remove from wishlist"
   ON wishlist_items FOR DELETE TO public
   USING (
-    auth.uid() IS NOT NULL AND
-    user_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND
+    user_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admin manage wishlist"

--- a/supabase/migrations/20250702133000_peach_route.sql
+++ b/supabase/migrations/20250702133000_peach_route.sql
@@ -29,8 +29,8 @@ ALTER TABLE delivery_jobs ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Drivers can view their jobs"
   ON delivery_jobs FOR SELECT TO public
   USING (
-    auth.uid() IS NOT NULL AND
-    driver_id = auth.uid()::text
+    (SELECT auth.uid()) IS NOT NULL AND
+    driver_id = (SELECT auth.uid())::text
   );
 
 CREATE POLICY "Admins can manage all jobs"


### PR DESCRIPTION
## Summary
- use `(SELECT auth.uid())` inside RLS policies

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6874ab8d47288326a014db13c3812b96