### PR TITLE
Consolidate RLS policies

### DIFF
--- a/supabase/migrations/20250630002423_polished_sky.sql
+++ b/supabase/migrations/20250630002423_polished_sky.sql
@@ -91,63 +91,72 @@ ALTER TABLE order_items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE order_tracking ENABLE ROW LEVEL SECURITY;
 
 -- Create policies for orders
-CREATE POLICY "Users can view their own orders" 
-  ON orders FOR SELECT 
-  USING (user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can view their own orders"
+  ON orders FOR SELECT
+  USING (user_id = (SELECT auth.uid())::text OR is_admin());
 
-CREATE POLICY "Users can insert their own orders" 
-  ON orders FOR INSERT 
-  WITH CHECK (user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can insert their own orders"
+  ON orders FOR INSERT
+  WITH CHECK (user_id = (SELECT auth.uid())::text OR is_admin());
 
-CREATE POLICY "Users can update their own orders" 
-  ON orders FOR UPDATE 
-  USING (user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can update their own orders"
+  ON orders FOR UPDATE
+  USING (user_id = (SELECT auth.uid())::text OR is_admin());
 
 -- Create policies for order_items
-CREATE POLICY "Users can view their own order items" 
-  ON order_items FOR SELECT 
-  USING (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
+CREATE POLICY "Users can view their own order items"
+  ON order_items FOR SELECT
+  USING (
+    order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
-CREATE POLICY "Users can insert their own order items" 
-  ON order_items FOR INSERT 
-  WITH CHECK (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
+CREATE POLICY "Users can insert their own order items"
+  ON order_items FOR INSERT
+  WITH CHECK (
+    order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 -- Create policies for order_tracking
-CREATE POLICY "Users can view their own order tracking" 
-  ON order_tracking FOR SELECT 
-  USING (order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text));
+CREATE POLICY "Users can view their own order tracking"
+  ON order_tracking FOR SELECT
+  USING (
+    order_id IN (SELECT id FROM orders WHERE user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
-CREATE POLICY "System can insert order tracking" 
-  ON order_tracking FOR INSERT 
-  WITH CHECK (true);
+CREATE POLICY "System can insert order tracking"
+  ON order_tracking FOR INSERT
+  WITH CHECK (true OR is_admin());
 
-CREATE POLICY "System can update order tracking" 
-  ON order_tracking FOR UPDATE 
-  USING (true);
+CREATE POLICY "System can update order tracking"
+  ON order_tracking FOR UPDATE
+  USING (true OR is_admin());
 
 -- Admin policies (using proper PostgreSQL syntax)
-CREATE POLICY "Admins can manage all orders" 
-  ON orders FOR ALL 
+CREATE POLICY "Admins can delete orders"
+  ON orders FOR DELETE
   USING (
-    CASE 
+    CASE
       WHEN auth.jwt() IS NOT NULL AND auth.jwt()->>'role' = 'admin' THEN true
       ELSE false
     END
   );
 
-CREATE POLICY "Admins can manage all order items" 
-  ON order_items FOR ALL 
+CREATE POLICY "Admins can delete order items"
+  ON order_items FOR DELETE
   USING (
-    CASE 
+    CASE
       WHEN auth.jwt() IS NOT NULL AND auth.jwt()->>'role' = 'admin' THEN true
       ELSE false
     END
   );
 
-CREATE POLICY "Admins can manage all order tracking" 
-  ON order_tracking FOR ALL 
+CREATE POLICY "Admins can delete order tracking"
+  ON order_tracking FOR DELETE
   USING (
-    CASE 
+    CASE
       WHEN auth.jwt() IS NOT NULL AND auth.jwt()->>'role' = 'admin' THEN true
       ELSE false
     END

--- a/supabase/migrations/20250630231707_young_darkness.sql
+++ b/supabase/migrations/20250630231707_young_darkness.sql
@@ -112,15 +112,10 @@ DROP POLICY IF EXISTS "Public read access for hero_banners" ON hero_banners;
 DROP POLICY IF EXISTS "Admin write access for hero_banners" ON hero_banners;
 
 -- Create proper policies for hero_banners
-CREATE POLICY "Public read access for hero_banners" 
-  ON hero_banners FOR SELECT 
-  TO public 
-  USING (is_active = true);
-
-CREATE POLICY "Admin read access for hero_banners" 
-  ON hero_banners FOR SELECT 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Public read access for hero_banners"
+  ON hero_banners FOR SELECT
+  TO public
+  USING (is_active = true OR is_admin());
 
 CREATE POLICY "Admin insert access for hero_banners" 
   ON hero_banners FOR INSERT 
@@ -143,59 +138,59 @@ DROP POLICY IF EXISTS "Users can insert reviews" ON reviews;
 DROP POLICY IF EXISTS "Users can update their own reviews" ON reviews;
 
 -- Create proper policies for reviews
-CREATE POLICY "Public read access for reviews" 
-  ON reviews FOR SELECT 
-  TO public 
-  USING (true);
+CREATE POLICY "Public read access for reviews"
+  ON reviews FOR SELECT
+  TO public
+  USING (true OR is_admin());
 
-CREATE POLICY "Users can insert reviews" 
-  ON reviews FOR INSERT 
-  TO public 
-  WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can insert reviews"
+  ON reviews FOR INSERT
+  TO public
+  WITH CHECK (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
-CREATE POLICY "Users can update their own reviews" 
-  ON reviews FOR UPDATE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can update their own reviews"
+  ON reviews FOR UPDATE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
-CREATE POLICY "Users can delete their own reviews" 
-  ON reviews FOR DELETE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin manage all reviews" 
-  ON reviews FOR ALL 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can delete their own reviews"
+  ON reviews FOR DELETE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 -- Fix user_profiles table policies
 DROP POLICY IF EXISTS "Public access for user_profiles" ON user_profiles;
 
 -- Create proper policies for user_profiles
-CREATE POLICY "Users can read their own profile" 
-  ON user_profiles FOR SELECT 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin can read all profiles" 
-  ON user_profiles FOR SELECT 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can read their own profile"
+  ON user_profiles FOR SELECT
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 CREATE POLICY "Users can insert their own profile" 
   ON user_profiles FOR INSERT 
   TO public 
   WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
 
-CREATE POLICY "Users can update their own profile" 
-  ON user_profiles FOR UPDATE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin can update all profiles" 
-  ON user_profiles FOR UPDATE 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can update their own profile"
+  ON user_profiles FOR UPDATE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND matrix_user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 CREATE POLICY "Admin can delete profiles" 
   ON user_profiles FOR DELETE 
@@ -206,30 +201,26 @@ CREATE POLICY "Admin can delete profiles"
 DROP POLICY IF EXISTS "Public access for chat_rooms" ON chat_rooms;
 
 -- Create proper policies for chat_rooms
-CREATE POLICY "Users can read their own chat rooms" 
-  ON chat_rooms FOR SELECT 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin can read all chat rooms" 
-  ON chat_rooms FOR SELECT 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can read their own chat rooms"
+  ON chat_rooms FOR SELECT
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 CREATE POLICY "Users can insert chat rooms" 
   ON chat_rooms FOR INSERT 
   TO public 
   WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
 
-CREATE POLICY "Users can update their own chat rooms" 
-  ON chat_rooms FOR UPDATE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin can update all chat rooms" 
-  ON chat_rooms FOR UPDATE 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can update their own chat rooms"
+  ON chat_rooms FOR UPDATE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 CREATE POLICY "Admin can delete chat rooms" 
   ON chat_rooms FOR DELETE 
@@ -240,20 +231,18 @@ CREATE POLICY "Admin can delete chat rooms"
 DROP POLICY IF EXISTS "Public access for chat_messages" ON chat_messages;
 
 -- Create proper policies for chat_messages
-CREATE POLICY "Users can read messages in their rooms" 
-  ON chat_messages FOR SELECT 
-  TO public 
+CREATE POLICY "Users can read messages in their rooms"
+  ON chat_messages FOR SELECT
+  TO public
   USING (
-    (SELECT auth.uid()) IS NOT NULL AND 
-    room_id IN (
-      SELECT id FROM chat_rooms WHERE user_id = (SELECT auth.uid())::text
+    (
+      (SELECT auth.uid()) IS NOT NULL AND
+      room_id IN (
+        SELECT id FROM chat_rooms WHERE user_id = (SELECT auth.uid())::text
+      )
     )
+    OR is_admin()
   );
-
-CREATE POLICY "Admin can read all messages" 
-  ON chat_messages FOR SELECT 
-  TO public 
-  USING (is_admin());
 
 CREATE POLICY "Users can insert messages" 
   ON chat_messages FOR INSERT 
@@ -268,18 +257,16 @@ CREATE POLICY "Users can insert messages"
     )
   );
 
-CREATE POLICY "Users can update their own messages" 
-  ON chat_messages FOR UPDATE 
-  TO public 
+CREATE POLICY "Users can update their own messages"
+  ON chat_messages FOR UPDATE
+  TO public
   USING (
-    (SELECT auth.uid()) IS NOT NULL AND 
-    sender_id = (SELECT auth.uid())::text
+    (
+      (SELECT auth.uid()) IS NOT NULL AND
+      sender_id = (SELECT auth.uid())::text
+    )
+    OR is_admin()
   );
-
-CREATE POLICY "Admin can update all messages" 
-  ON chat_messages FOR UPDATE 
-  TO public 
-  USING (is_admin());
 
 CREATE POLICY "Admin can delete messages" 
   ON chat_messages FOR DELETE 
@@ -291,25 +278,21 @@ DROP POLICY IF EXISTS "Users can read their own notifications" ON notifications;
 DROP POLICY IF EXISTS "Users can update their own notifications" ON notifications;
 
 -- Create proper policies for notifications
-CREATE POLICY "Users can read their own notifications" 
-  ON notifications FOR SELECT 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can read their own notifications"
+  ON notifications FOR SELECT
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
-CREATE POLICY "Admin can read all notifications" 
-  ON notifications FOR SELECT 
-  TO public 
-  USING (is_admin());
-
-CREATE POLICY "Users can update their own notifications" 
-  ON notifications FOR UPDATE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
-
-CREATE POLICY "Admin can update all notifications" 
-  ON notifications FOR UPDATE 
-  TO public 
-  USING (is_admin());
+CREATE POLICY "Users can update their own notifications"
+  ON notifications FOR UPDATE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 CREATE POLICY "Admin can insert notifications" 
   ON notifications FOR INSERT 
@@ -330,7 +313,17 @@ CREATE POLICY "Public read access for pricing_tiers"
   TO public 
   USING (true);
 
-CREATE POLICY "Admin write access for pricing_tiers" 
-  ON pricing_tiers FOR ALL 
-  TO public 
+CREATE POLICY "Admin insert access for pricing_tiers"
+  ON pricing_tiers FOR INSERT
+  TO public
+  WITH CHECK (is_admin());
+
+CREATE POLICY "Admin update access for pricing_tiers"
+  ON pricing_tiers FOR UPDATE
+  TO public
+  USING (is_admin());
+
+CREATE POLICY "Admin delete access for pricing_tiers"
+  ON pricing_tiers FOR DELETE
+  TO public
   USING (is_admin());

--- a/supabase/migrations/20250701101416_noisy_credit.sql
+++ b/supabase/migrations/20250701101416_noisy_credit.sql
@@ -45,34 +45,39 @@ DROP POLICY IF EXISTS "Users can delete their own reviews" ON reviews;
 DROP POLICY IF EXISTS "Admin manage all reviews" ON reviews;
 
 -- Create policy for public read access
-CREATE POLICY "Public read access for reviews" 
-  ON reviews FOR SELECT 
-  TO public 
-  USING (true);
+CREATE POLICY "Public read access for reviews"
+  ON reviews FOR SELECT
+  TO public
+  USING (true OR is_admin());
 
 -- Create policy for authenticated users to insert reviews
-CREATE POLICY "Users can insert reviews" 
-  ON reviews FOR INSERT 
-  TO public 
-  WITH CHECK ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can insert reviews"
+  ON reviews FOR INSERT
+  TO public
+  WITH CHECK (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 -- Create policy for users to update their own reviews
-CREATE POLICY "Users can update their own reviews" 
-  ON reviews FOR UPDATE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can update their own reviews"
+  ON reviews FOR UPDATE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 -- Create policy for users to delete their own reviews
-CREATE POLICY "Users can delete their own reviews" 
-  ON reviews FOR DELETE 
-  TO public 
-  USING ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text);
+CREATE POLICY "Users can delete their own reviews"
+  ON reviews FOR DELETE
+  TO public
+  USING (
+    ((SELECT auth.uid()) IS NOT NULL AND user_id = (SELECT auth.uid())::text)
+    OR is_admin()
+  );
 
 -- Create policy for admins to manage all reviews
-CREATE POLICY "Admin manage all reviews" 
-  ON reviews FOR ALL 
-  TO public 
-  USING (is_admin());
 
 -- Create indexes for better performance if they don't exist
 CREATE INDEX IF NOT EXISTS idx_reviews_product_id ON reviews(product_id);

--- a/supabase/migrations/20250702130000_wishlist_items.sql
+++ b/supabase/migrations/20250702130000_wishlist_items.sql
@@ -25,26 +25,35 @@ ALTER TABLE wishlist_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Users can view their wishlist"
   ON wishlist_items FOR SELECT TO public
   USING (
-    (SELECT auth.uid()) IS NOT NULL AND
-    user_id = (SELECT auth.uid())::text
+    (
+      (SELECT auth.uid()) IS NOT NULL AND
+      user_id = (SELECT auth.uid())::text
+    )
+    OR is_admin()
   );
 
 CREATE POLICY "Users can add to wishlist"
   ON wishlist_items FOR INSERT TO public
   WITH CHECK (
-    (SELECT auth.uid()) IS NOT NULL AND
-    user_id = (SELECT auth.uid())::text
+    (
+      (SELECT auth.uid()) IS NOT NULL AND
+      user_id = (SELECT auth.uid())::text
+    )
+    OR is_admin()
   );
 
 CREATE POLICY "Users can remove from wishlist"
   ON wishlist_items FOR DELETE TO public
   USING (
-    (SELECT auth.uid()) IS NOT NULL AND
-    user_id = (SELECT auth.uid())::text
+    (
+      (SELECT auth.uid()) IS NOT NULL AND
+      user_id = (SELECT auth.uid())::text
+    )
+    OR is_admin()
   );
 
-CREATE POLICY "Admin manage wishlist"
-  ON wishlist_items FOR ALL TO public
+CREATE POLICY "Admin update wishlist"
+  ON wishlist_items FOR UPDATE TO public
   USING (is_admin());
 
 CREATE INDEX idx_wishlist_items_user_id ON wishlist_items(user_id);


### PR DESCRIPTION
## Summary
- merge permissive policies for hero banners, reviews, profiles, chat, notifications, pricing tiers
- update order and wishlist policies to combine admin and user rules
- drop redundant admin policies

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874aeee19fc8326a6feecafdaa9a208