### PR TITLE
Internationalize login and signup

### DIFF
--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -38,8 +38,8 @@ export default function AuthLoginScreen() {
     if (!username || !password) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'אנא הכנס שם משתמש וסיסמה',
+        title: t('common.error'),
+        message: t('auth.fillAllFields'),
         type: 'error'
       });
       return;
@@ -54,8 +54,8 @@ export default function AuthLoginScreen() {
       } else {
         setInfoModal({
           visible: true,
-          title: 'שגיאה',
-          message: 'פרטי התחברות שגויים או אין לך הרשאות מנהל. רק מנהלים יכולים להתחבר.',
+          title: t('common.error'),
+          message: t('auth.adminOnly'),
           type: 'error'
         });
       }
@@ -63,8 +63,8 @@ export default function AuthLoginScreen() {
       console.error('Login error:', error);
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'ההתחברות נכשלה. אנא נסה שוב.',
+        title: t('common.error'),
+        message: t('auth.loginError'),
         type: 'error'
       });
     } finally {
@@ -82,7 +82,7 @@ export default function AuthLoginScreen() {
           <TouchableOpacity onPress={() => router.back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>התחברות</Text>
+          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{t('auth.login')}</Text>
           <View style={{ width: 24 }} />
         </View>
 
@@ -95,21 +95,21 @@ export default function AuthLoginScreen() {
             <Lock size={60} color={colors.gold} />
           </View>
           
-          <Text style={[styles.title, { color: colors.text.primary }]}>ברוכים השבים</Text>
-          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-            התחבר לחשבון שלך
+          <Text style={[styles.title, { color: colors.text.primary }]}>{t('auth.welcomeBack')}</Text>
+          <Text style={[styles.subtitle, { color: colors.text.secondary }]}> 
+            {t('auth.loginSubtitle')} 
           </Text>
           
           <View style={styles.adminNote}>
             <Shield size={16} color={colors.gold} />
             <Text style={[styles.adminNoteText, { color: colors.text.secondary }]}>
-              רק מנהלים יכולים להתחבר למערכת
+              {t('auth.adminInfo')}
             </Text>
           </View>
 
           <View style={styles.form}>
           <View style={styles.inputGroup}>
-            <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
+            <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.username')}</Text>
             <TextInput
               style={[styles.input, {
                 borderColor: colors.border.primary,
@@ -118,7 +118,7 @@ export default function AuthLoginScreen() {
               }]}
               value={username}
               onChangeText={setUsername}
-              placeholder="הכנס שם משתמש"
+              placeholder={t('auth.usernamePlaceholder')}
               autoCapitalize="none"
               autoCorrect={false}
               textAlign="right"
@@ -127,7 +127,7 @@ export default function AuthLoginScreen() {
             </View>
 
             <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>סיסמה</Text>
+              <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.password')}</Text>
               <TextInput
                 style={[styles.input, { 
                   borderColor: colors.border.primary,
@@ -136,7 +136,7 @@ export default function AuthLoginScreen() {
                 }]}
                 value={password}
                 onChangeText={setPassword}
-                placeholder="הכנס סיסמה"
+                placeholder={t('auth.passwordPlaceholder')}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -158,7 +158,7 @@ export default function AuthLoginScreen() {
                 <ActivityIndicator size="small" color={colors.text.inverse} />
               ) : (
                 <Text style={[styles.loginButtonText, { color: colors.text.inverse }]}>
-                  התחבר
+                  {t('auth.login')}
                 </Text>
               )}
             </TouchableOpacity>
@@ -166,12 +166,12 @@ export default function AuthLoginScreen() {
 
           <View style={styles.footer}>
             <Text style={[styles.footerText, { color: colors.text.secondary }]}>
-              אין לך חשבון?{' '}
-              <Text 
-                style={[styles.linkText, { color: colors.gold }]} 
+              {t('auth.noAccount')} {' '}
+              <Text
+                style={[styles.linkText, { color: colors.gold }]}
                 onPress={() => router.push('/auth/signup')}
               >
-                הירשם
+                {t('auth.signup')}
               </Text>
             </Text>
           </View>

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -34,13 +34,14 @@ export default function AuthSignupScreen() {
   });
   const { colors } = useTheme();
   const { signup } = useAuth();
+  const { t } = useLanguage();
 
   const handleSignup = async () => {
     if (!username || !password || !confirmPassword) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'אנא מלא את כל השדות',
+        title: t('common.error'),
+        message: t('auth.fillAllFields'),
         type: 'error'
       });
       return;
@@ -49,8 +50,8 @@ export default function AuthSignupScreen() {
     if (password !== confirmPassword) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'הסיסמאות אינן תואמות',
+        title: t('common.error'),
+        message: t('auth.passwordMismatch'),
         type: 'error'
       });
       return;
@@ -63,8 +64,8 @@ export default function AuthSignupScreen() {
       if (success) {
         setInfoModal({
           visible: true,
-          title: 'הצלחה',
-          message: 'החשבון נוצר בהצלחה! כעת תוכל להתחבר.',
+          title: t('common.success'),
+          message: t('auth.signupSuccess'),
           type: 'success'
         });
       }
@@ -72,8 +73,8 @@ export default function AuthSignupScreen() {
       console.error('Signup error:', error);
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: error instanceof Error ? error.message : 'ההרשמה נכשלה. אנא נסה שוב.',
+        title: t('common.error'),
+        message: error instanceof Error ? error.message : t('auth.signupError'),
         type: 'error'
       });
     } finally {
@@ -95,7 +96,7 @@ export default function AuthSignupScreen() {
           <TouchableOpacity onPress={() => router.back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הרשמה</Text>
+          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{t('auth.signup')}</Text>
           <View style={{ width: 24 }} />
         </View>
 
@@ -108,16 +109,16 @@ export default function AuthSignupScreen() {
             <UserPlus size={60} color={colors.gold} />
           </View>
           
-          <Text style={[styles.title, { color: colors.text.primary }]}>יצירת חשבון</Text>
-          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-            הצטרף אלינו והתחל לקנות
+          <Text style={[styles.title, { color: colors.text.primary }]}>{t('auth.createAccount')}</Text>
+          <Text style={[styles.subtitle, { color: colors.text.secondary }]}> 
+            {t('auth.signupSubtitle')} 
           </Text>
 
           <View style={styles.form}>
 
 
             <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
+              <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.username')}</Text>
               <TextInput
                 style={[styles.input, { 
                   borderColor: colors.border.primary,
@@ -126,7 +127,7 @@ export default function AuthSignupScreen() {
                 }]}
                 value={username}
                 onChangeText={setUsername}
-                placeholder="בחר שם משתמש"
+                placeholder={t('auth.usernamePlaceholder')}
                 autoCapitalize="none"
                 autoCorrect={false}
                 textAlign="right"
@@ -135,7 +136,7 @@ export default function AuthSignupScreen() {
             </View>
 
             <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>שם מלא</Text>
+              <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.fullName')}</Text>
               <TextInput
                 style={[styles.input, { 
                   borderColor: colors.border.primary,
@@ -144,7 +145,7 @@ export default function AuthSignupScreen() {
                 }]}
                 value={displayName}
                 onChangeText={setDisplayName}
-                placeholder="הכנס את שמך המלא"
+                placeholder={t('auth.fullNamePlaceholder')}
                 autoCorrect={false}
                 textAlign="right"
                 placeholderTextColor={colors.text.tertiary}
@@ -152,7 +153,7 @@ export default function AuthSignupScreen() {
             </View>
 
             <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>סיסמה</Text>
+              <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.password')}</Text>
               <TextInput
                 style={[styles.input, { 
                   borderColor: colors.border.primary,
@@ -161,7 +162,7 @@ export default function AuthSignupScreen() {
                 }]}
                 value={password}
                 onChangeText={setPassword}
-                placeholder="צור סיסמה"
+                placeholder={t('auth.createPasswordPlaceholder')}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -171,7 +172,7 @@ export default function AuthSignupScreen() {
             </View>
 
             <View style={styles.inputGroup}>
-              <Text style={[styles.label, { color: colors.text.primary }]}>אישור סיסמה</Text>
+              <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.confirmPassword')}</Text>
               <TextInput
                 style={[styles.input, { 
                   borderColor: colors.border.primary,
@@ -180,7 +181,7 @@ export default function AuthSignupScreen() {
                 }]}
                 value={confirmPassword}
                 onChangeText={setConfirmPassword}
-                placeholder="אשר את הסיסמה"
+                placeholder={t('auth.confirmPasswordPlaceholder')}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -202,7 +203,7 @@ export default function AuthSignupScreen() {
                 <ActivityIndicator size="small" color={colors.text.inverse} />
               ) : (
                 <Text style={[styles.signupButtonText, { color: colors.text.inverse }]}>
-                  צור חשבון
+                  {t('auth.createAccount')}
                 </Text>
               )}
             </TouchableOpacity>
@@ -210,12 +211,12 @@ export default function AuthSignupScreen() {
 
           <View style={styles.footer}>
             <Text style={[styles.footerText, { color: colors.text.secondary }]}>
-              כבר יש לך חשבון?{' '}
-              <Text 
-                style={[styles.linkText, { color: colors.gold }]} 
+              {t('auth.hasAccount')} {' '}
+              <Text
+                style={[styles.linkText, { color: colors.gold }]}
                 onPress={() => router.push('/auth/login')}
               >
-                התחבר
+                {t('auth.login')}
               </Text>
             </Text>
           </View>

--- a/components/AuthTabsModal.tsx
+++ b/components/AuthTabsModal.tsx
@@ -15,6 +15,7 @@ import {
 import { X, LogIn, UserPlus, Lock, User } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from './AuthContext';
+import { useLanguage } from '../contexts/LanguageContext';
 import { router } from 'expo-router';
 import InfoModal from './InfoModal';
 
@@ -46,6 +47,7 @@ export default function AuthTabsModal({
   
   const { login, signup } = useAuth();
   const { colors } = useTheme();
+  const { t } = useLanguage();
 
   const resetForm = () => {
     setUsername('');
@@ -63,8 +65,8 @@ export default function AuthTabsModal({
     if (!username || !password) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'אנא הכנס שם משתמש וסיסמה',
+        title: t('common.error'),
+        message: t('auth.fillAllFields'),
         type: 'error'
       });
       return;
@@ -80,8 +82,8 @@ export default function AuthTabsModal({
       } else {
         setInfoModal({
           visible: true,
-          title: 'שגיאה',
-          message: 'פרטי התחברות שגויים. אנא נסה שוב.',
+          title: t('common.error'),
+          message: t('auth.loginError'),
           type: 'error'
         });
       }
@@ -89,8 +91,8 @@ export default function AuthTabsModal({
       console.error('Login error:', error);
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'ההתחברות נכשלה. אנא נסה שוב.',
+        title: t('common.error'),
+        message: t('auth.loginError'),
         type: 'error'
       });
     } finally {
@@ -102,8 +104,8 @@ export default function AuthTabsModal({
     if (!username || !password || !confirmPassword) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'אנא מלא את כל השדות',
+        title: t('common.error'),
+        message: t('auth.fillAllFields'),
         type: 'error'
       });
       return;
@@ -112,8 +114,8 @@ export default function AuthTabsModal({
     if (password !== confirmPassword) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'הסיסמאות אינן תואמות',
+        title: t('common.error'),
+        message: t('auth.passwordMismatch'),
         type: 'error'
       });
       return;
@@ -126,8 +128,8 @@ export default function AuthTabsModal({
       if (success) {
         setInfoModal({
           visible: true,
-          title: 'הצלחה',
-          message: 'החשבון נוצר בהצלחה! כעת תוכל להתחבר.',
+          title: t('common.success'),
+          message: t('auth.signupSuccess'),
           type: 'success'
         });
       }
@@ -135,8 +137,8 @@ export default function AuthTabsModal({
       console.error('Signup error:', error);
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: error instanceof Error ? error.message : 'ההרשמה נכשלה. אנא נסה שוב.',
+        title: t('common.error'),
+        message: error instanceof Error ? error.message : t('auth.signupError'),
         type: 'error'
       });
     } finally {
@@ -156,14 +158,14 @@ export default function AuthTabsModal({
         </View>
       </View>
       
-      <Text style={[styles.title, { color: colors.text.primary }]}>ברוכים השבים</Text>
-      <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-        התחבר לחשבון שלך
+      <Text style={[styles.title, { color: colors.text.primary }]}>{t('auth.welcomeBack')}</Text>
+      <Text style={[styles.subtitle, { color: colors.text.secondary }]}> 
+        {t('auth.loginSubtitle')} 
       </Text>
       
       <View style={styles.form}>
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.username')}</Text>
           <TextInput
             style={[styles.input, {
               borderColor: colors.border.primary,
@@ -172,7 +174,7 @@ export default function AuthTabsModal({
             }]}
             value={username}
             onChangeText={setUsername}
-            placeholder="הכנס שם משתמש"
+            placeholder={t('auth.usernamePlaceholder')}
             autoCapitalize="none"
             autoCorrect={false}
             textAlign="right"
@@ -181,7 +183,7 @@ export default function AuthTabsModal({
         </View>
 
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>סיסמה</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.password')}</Text>
           <TextInput
             style={[styles.input, { 
               borderColor: colors.border.primary,
@@ -190,7 +192,7 @@ export default function AuthTabsModal({
             }]}
             value={password}
             onChangeText={setPassword}
-            placeholder="הכנס סיסמה"
+            placeholder={t('auth.passwordPlaceholder')}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -212,18 +214,18 @@ export default function AuthTabsModal({
             <ActivityIndicator size="small" color={colors.text.inverse} />
           ) : (
             <Text style={[styles.actionButtonText, { color: colors.text.inverse }]}>
-              התחבר
+              {t('auth.login')}
             </Text>
           )}
         </TouchableOpacity>
       </View>
       
       <View style={styles.switchContainer}>
-        <Text style={[styles.switchText, { color: colors.text.secondary }]}>
-          אין לך חשבון?{' '}
+        <Text style={[styles.switchText, { color: colors.text.secondary }]}> 
+          {t('auth.noAccount')} {' '}
         </Text>
         <TouchableOpacity onPress={() => handleTabChange('signup')}>
-          <Text style={[styles.switchLink, { color: colors.gold }]}>הירשם</Text>
+          <Text style={[styles.switchLink, { color: colors.gold }]}>{t('auth.signup')}</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -237,15 +239,15 @@ export default function AuthTabsModal({
         </View>
       </View>
       
-      <Text style={[styles.title, { color: colors.text.primary }]}>יצירת חשבון</Text>
-      <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
-        הצטרף אלינו והתחל לקנות
+      <Text style={[styles.title, { color: colors.text.primary }]}>{t('auth.createAccount')}</Text>
+      <Text style={[styles.subtitle, { color: colors.text.secondary }]}> 
+        {t('auth.signupSubtitle')} 
       </Text>
       
       <View style={styles.form}>
 
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>שם משתמש</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.username')}</Text>
           <TextInput
             style={[styles.input, { 
               borderColor: colors.border.primary,
@@ -254,7 +256,7 @@ export default function AuthTabsModal({
             }]}
             value={username}
             onChangeText={setUsername}
-            placeholder="בחר שם משתמש"
+            placeholder={t('auth.usernamePlaceholder')}
             autoCapitalize="none"
             autoCorrect={false}
             textAlign="right"
@@ -263,7 +265,7 @@ export default function AuthTabsModal({
         </View>
 
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>שם מלא</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.fullName')}</Text>
           <TextInput
             style={[styles.input, { 
               borderColor: colors.border.primary,
@@ -272,7 +274,7 @@ export default function AuthTabsModal({
             }]}
             value={displayName}
             onChangeText={setDisplayName}
-            placeholder="הכנס את שמך המלא"
+            placeholder={t('auth.fullNamePlaceholder')}
             autoCorrect={false}
             textAlign="right"
             placeholderTextColor={colors.text.tertiary}
@@ -280,7 +282,7 @@ export default function AuthTabsModal({
         </View>
 
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>סיסמה</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.password')}</Text>
           <TextInput
             style={[styles.input, { 
               borderColor: colors.border.primary,
@@ -289,7 +291,7 @@ export default function AuthTabsModal({
             }]}
             value={password}
             onChangeText={setPassword}
-            placeholder="צור סיסמה"
+            placeholder={t('auth.createPasswordPlaceholder')}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -299,7 +301,7 @@ export default function AuthTabsModal({
         </View>
 
         <View style={styles.inputGroup}>
-          <Text style={[styles.label, { color: colors.text.primary }]}>אישור סיסמה</Text>
+          <Text style={[styles.label, { color: colors.text.primary }]}>{t('auth.confirmPassword')}</Text>
           <TextInput
             style={[styles.input, { 
               borderColor: colors.border.primary,
@@ -308,7 +310,7 @@ export default function AuthTabsModal({
             }]}
             value={confirmPassword}
             onChangeText={setConfirmPassword}
-            placeholder="אשר את הסיסמה"
+            placeholder={t('auth.confirmPasswordPlaceholder')}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -330,18 +332,18 @@ export default function AuthTabsModal({
             <ActivityIndicator size="small" color={colors.text.inverse} />
           ) : (
             <Text style={[styles.actionButtonText, { color: colors.text.inverse }]}>
-              צור חשבון
+              {t('auth.createAccount')}
             </Text>
           )}
         </TouchableOpacity>
       </View>
       
       <View style={styles.switchContainer}>
-        <Text style={[styles.switchText, { color: colors.text.secondary }]}>
-          כבר יש לך חשבון?{' '}
+        <Text style={[styles.switchText, { color: colors.text.secondary }]}> 
+          {t('auth.hasAccount')} {' '}
         </Text>
         <TouchableOpacity onPress={() => handleTabChange('login')}>
-          <Text style={[styles.switchLink, { color: colors.gold }]}>התחבר</Text>
+          <Text style={[styles.switchLink, { color: colors.gold }]}>{t('auth.login')}</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -377,7 +379,7 @@ export default function AuthTabsModal({
                   { color: colors.text.primary },
                   activeTab === 'login' && { color: colors.text.inverse }
                 ]}>
-                  התחברות
+                  {t('auth.login')}
                 </Text>
               </TouchableOpacity>
               
@@ -393,7 +395,7 @@ export default function AuthTabsModal({
                   { color: colors.text.primary },
                   activeTab === 'signup' && { color: colors.text.inverse }
                 ]}>
-                  הרשמה
+                  {t('auth.signup')}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
+import { useLanguage } from '../contexts/LanguageContext';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 
 type InfoType = 'success' | 'error' | 'info' | 'warning';
@@ -30,12 +31,14 @@ export default function InfoModal({
   title,
   message,
   type = 'info',
-  buttonText = 'אישור',
+  buttonText,
   onClose,
   autoClose = true,
   autoCloseTime = 3000,
 }: InfoModalProps) {
   const { colors } = useTheme();
+  const { t } = useLanguage();
+  const buttonLabel = buttonText ?? t('common.confirm');
   const scaleAnim = useRef(new Animated.Value(0.9)).current;
   const opacityAnim = useRef(new Animated.Value(0)).current;
 
@@ -135,8 +138,8 @@ export default function InfoModal({
                 style={[styles.button, { backgroundColor: color }]}
                 onPress={onClose}
               >
-                <Text style={[styles.buttonText, { color: colors.text.inverse }]}>
-                  {buttonText}
+                <Text style={[styles.buttonText, { color: colors.text.inverse }]}> 
+                  {buttonLabel}
                 </Text>
               </TouchableOpacity>
             </Animated.View>

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -204,12 +204,12 @@ export default function UserAvatar() {
                 {theme === 'dark' ? (
                   <>
                     <Sun size={20} color={colors.gold} />
-                    <Text style={[styles.menuText, { color: colors.text.primary }]}>מצב בהיר</Text>
+                    <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.lightMode')}</Text>
                   </>
                 ) : (
                   <>
                     <Moon size={20} color={colors.gold} />
-                    <Text style={[styles.menuText, { color: colors.text.primary }]}>מצב כהה</Text>
+                    <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.darkMode')}</Text>
                   </>
                 )}
               </TouchableOpacity>

--- a/translations/en.json
+++ b/translations/en.json
@@ -55,6 +55,13 @@
     "creatingAccount": "Creating account...",
     "adminNote": "Current admin: roymichaels",
     "adminInfo": "Admins can login with the same credentials",
+    "adminOnly": "Only admins can login",
+    "usernamePlaceholder": "Enter username",
+    "passwordPlaceholder": "Enter password",
+    "fullName": "Full Name",
+    "fullNamePlaceholder": "Enter your full name",
+    "createPasswordPlaceholder": "Create password",
+    "confirmPasswordPlaceholder": "Confirm your password",
     "logoutConfirm": "Are you sure you want to logout?"
   },
   "home": {
@@ -225,6 +232,7 @@
     "deliveries": "Deliveries",
     "manageCategories": "Manage Categories",
     "darkMode": "Dark Mode",
+    "lightMode": "Light Mode",
     "pushNotifications": "Push Notifications",
     "language": "Language",
     "english": "English",

--- a/translations/he.json
+++ b/translations/he.json
@@ -55,6 +55,13 @@
     "creatingAccount": "יוצר חשבון...",
     "adminNote": "מנהל נוכחי: roymichaels",
     "adminInfo": "מנהלים יכולים להתחבר עם אותם פרטים",
+    "adminOnly": "רק מנהלים יכולים להתחבר",
+    "usernamePlaceholder": "הכנס שם משתמש",
+    "passwordPlaceholder": "הכנס סיסמה",
+    "fullName": "שם מלא",
+    "fullNamePlaceholder": "הכנס את שמך המלא",
+    "createPasswordPlaceholder": "צור סיסמה",
+    "confirmPasswordPlaceholder": "אשר את הסיסמה",
     "logoutConfirm": "האם אתה בטוח שברצונך להתנתק?"
   },
   "home": {
@@ -225,6 +232,7 @@
     "deliveries": "משלוחים",
     "manageCategories": "ניהול קטגוריות",
     "darkMode": "מצב לילה",
+    "lightMode": "מצב בהיר",
     "pushNotifications": "התראות פוש",
     "language": "שפה",
     "english": "English",


### PR DESCRIPTION
## Summary
- add translation keys for auth placeholders and admin-only message
- translate theme mode options
- default `InfoModal` button text to translation key
- use translations in login/signup screens and auth tabs

## Testing
- `npx expo --version` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750b0838b88326bb3a3ac473f2b431