### PR TITLE
Implement dynamic app name for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ web PWA for a specific tenant using the scripts below. The output is placed in
 Each build sets `EXPO_PUBLIC_TENANT` so the app loads the matching row from
 `tenant_settings`.
 
+Before the export step runs, the `update:appjson` script updates `app.json`
+using the current `EXPO_PUBLIC_APP_NAME` and `EXPO_PUBLIC_TENANT` values. This
+ensures each build gets its own application name and slug.
+
 ```sh
 # Build The Congress
 yarn build:web:thecongress

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "start": "cross-env EXPO_NO_TELEMETRY=1 BROWSER=none expo start --web",
     "dev": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "lint": "expo lint",
-    "build:web": "expo export --platform web",
-    "build:web:thecongress": "cross-env ENVFILE=.env.thecongress EXPO_PUBLIC_TENANT=thecongress expo export --platform web --output-dir dist/thecongress",
-    "build:web:thebull": "cross-env ENVFILE=.env.thebull EXPO_PUBLIC_TENANT=thebull expo export --platform web --output-dir dist/thebull"
+    "update:appjson": "node scripts/update-app-json.js",
+    "build:web": "yarn update:appjson && expo export --platform web",
+    "build:web:thecongress": "yarn update:appjson && cross-env ENVFILE=.env.thecongress EXPO_PUBLIC_TENANT=thecongress expo export --platform web --output-dir dist/thecongress",
+    "build:web:thebull": "yarn update:appjson && cross-env ENVFILE=.env.thebull EXPO_PUBLIC_TENANT=thebull expo export --platform web --output-dir dist/thebull"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",

--- a/scripts/update-app-json.js
+++ b/scripts/update-app-json.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const appName = process.env.EXPO_PUBLIC_APP_NAME;
+const tenant = process.env.EXPO_PUBLIC_TENANT;
+
+if (!appName) {
+  console.error('EXPO_PUBLIC_APP_NAME environment variable not set');
+  process.exit(1);
+}
+
+const path = 'app.json';
+const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+config.expo = config.expo || {};
+config.expo.name = appName;
+if (tenant) {
+  config.expo.slug = tenant;
+}
+fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+console.log(`Updated ${path} with name="${appName}" slug="${tenant || config.expo.slug}"`);


### PR DESCRIPTION
## Summary
- add script to update `app.json` based on env vars
- call update script from build commands
- document automatic `app.json` update in README

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6875c800ee4c8326847e17b46dc1a415