### PR TITLE
Add KYC status badge and prompts

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -19,6 +19,9 @@ import {
   Bell,
   Truck,
   Package,
+  CircleCheck as CheckCircle,
+  TriangleAlert as AlertTriangle,
+  Clock,
 } from 'lucide-react-native';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -163,6 +166,35 @@ export default function ProfileScreen() {
               </Text>
             </View>
           )}
+
+          {isLoggedIn && (
+            <View
+              style={[
+                styles.kycBadge,
+                {
+                  backgroundColor:
+                    user?.kycStatus === 'verified'
+                      ? colors.status.success
+                      : user?.kycStatus === 'pending'
+                      ? colors.interactive.primary
+                      : colors.status.error,
+                },
+              ]}
+            >
+              {user?.kycStatus === 'verified' && (
+                <CheckCircle size={16} color={colors.text.inverse} />
+              )}
+              {user?.kycStatus === 'pending' && (
+                <Clock size={16} color={colors.text.inverse} />
+              )}
+              {(user?.kycStatus === 'none' || user?.kycStatus === 'rejected') && (
+                <AlertTriangle size={16} color={colors.text.inverse} />
+              )}
+              <Text style={[styles.kycBadgeText, { color: colors.text.inverse }]}> 
+                {t(`kyc.${user?.kycStatus || 'none'}`)}
+              </Text>
+            </View>
+          )}
         </View>
 
         {/* Quick Stats for logged in users */}
@@ -245,6 +277,25 @@ export default function ProfileScreen() {
                 </Text>
               </View>
             </TouchableOpacity>
+            {(user?.kycStatus === 'none' || user?.kycStatus === 'rejected') && (
+              <TouchableOpacity
+                style={[
+                  styles.menuItem,
+                  {
+                    backgroundColor: colors.surface.primary,
+                    borderColor: colors.border.primary,
+                  },
+                ]}
+                onPress={() => router.push('/kyc')}
+              >
+                <View style={styles.menuItemContent}>
+                  <Shield size={24} color={colors.gold} />
+                  <Text style={[styles.menuText, { color: colors.text.primary }]}>
+                    {t('profile.kycVerification')}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            )}
           </View>
         )}
 
@@ -506,6 +557,19 @@ const styles = StyleSheet.create({
     borderRadius: 16,
   },
   adminBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    marginLeft: 4,
+  },
+  kycBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    marginTop: 8,
+  },
+  kycBadgeText: {
     fontSize: 12,
     fontWeight: '600',
     marginLeft: 4,

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -20,6 +20,7 @@ import { useAuth } from './AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useCurrency } from '../contexts/CurrencyContext';
 import { useNotifications } from './NotificationContext';
+import { useLanguage } from '../contexts/LanguageContext';
 import { router } from 'expo-router';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
@@ -47,6 +48,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const { showNotification } = useNotifications();
+  const { t } = useLanguage();
   const scrollViewRef = useRef<ScrollView>(null);
 
   // Modal states
@@ -60,6 +62,8 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     visible: false,
     title: '',
     message: '',
+    confirmText: '',
+    cancelText: '',
     action: () => {}
   });
 
@@ -149,29 +153,28 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     // Check KYC status
     if (user && user.kycStatus !== 'verified') {
       let message = '';
-      let actionText = '';
-      
+
       switch (user.kycStatus) {
         case 'none':
-          message = 'נדרש אימות KYC כדי לבצע הזמנות. האם ברצונך לעבור לתהליך האימות?';
-          actionText = 'עבור לאימות KYC';
+          message = t('kyc.requiredForOrders');
           break;
         case 'pending':
-          message = 'האימות שלך בהמתנה. לא ניתן לבצע הזמנות עד להשלמת האימות.';
+          message = t('kyc.pendingOrdersMessage');
           break;
         case 'rejected':
-          message = 'האימות שלך נדחה. אנא השלם את תהליך האימות כדי לבצע הזמנות.';
-          actionText = 'עבור לאימות KYC';
+          message = t('kyc.rejectedOrdersMessage');
           break;
         default:
-          message = 'נדרש אימות KYC כדי לבצע הזמנות.';
+          message = t('kyc.requiredForOrders');
       }
-      
+
       if (user.kycStatus === 'none' || user.kycStatus === 'rejected') {
         setConfirmModal({
           visible: true,
-          title: 'נדרש אימות KYC',
+          title: t('kyc.verification'),
           message,
+          confirmText: t('kyc.goToKyc'),
+          cancelText: t('common.cancel'),
           action: () => {
             onClose();
             router.push('/kyc');
@@ -180,7 +183,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       } else {
         setInfoModal({
           visible: true,
-          title: 'נדרש אימות KYC',
+          title: t('kyc.verification'),
           message,
           type: 'warning'
         });
@@ -869,13 +872,13 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         visible={confirmModal.visible}
         title={confirmModal.title}
         message={confirmModal.message}
-        confirmText="אישור"
-        cancelText="ביטול"
+        confirmText={confirmModal.confirmText || t('common.confirm')}
+        cancelText={confirmModal.cancelText || t('common.cancel')}
         onConfirm={() => {
           confirmModal.action();
-          setConfirmModal({...confirmModal, visible: false});
+          setConfirmModal({ ...confirmModal, visible: false });
         }}
-        onCancel={() => setConfirmModal({...confirmModal, visible: false})}
+        onCancel={() => setConfirmModal({ ...confirmModal, visible: false })}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- show KYC verification badge in profile
- allow starting verification from profile
- require KYC before checkout with button to start verification

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6875ce8c30508326b62cf6ed4de27579