### PR TITLE
Add Supabase url log and env-cmd export

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -4,6 +4,8 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '';
 
+console.log('⚙️ SUPABASE URL AT RUNTIME:', process.env.EXPO_PUBLIC_SUPABASE_URL);
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     storage: AsyncStorage,

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "expo lint",
     "update:appjson": "node scripts/update-app-json.js",
     "build:web": "yarn update:appjson && expo export --platform web",
-    "build:web:thecongress": "env-cmd -f .env.thecongress yarn update:appjson && expo export --platform web --output-dir dist/thecongress",
-    "build:web:thebull": "env-cmd -f .env.thebull    yarn update:appjson && expo export --platform web --output-dir dist/thebull",
+    "build:web:thecongress": "env-cmd -f .env.thecongress yarn update:appjson && env-cmd -f .env.thecongress expo export --platform web --output-dir dist/thecongress",
+    "build:web:thebull": "env-cmd -f .env.thebull    yarn update:appjson && env-cmd -f .env.thebull expo export --platform web --output-dir dist/thebull",
     "build:web:all": "yarn build:web:thecongress && yarn build:web:thebull"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- log Supabase URL when creating the client
- ensure `expo export` also loads the environment

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_687670c3eea08326ae32599f02f535a6