### PR TITLE
Fix updateProduct createdAt bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.expo/

--- a/services/database.ts
+++ b/services/database.ts
@@ -198,6 +198,7 @@ class DatabaseService {
 
       delete dbProduct.pricingTier;
       delete dbProduct.mixGroupId;
+      delete dbProduct.createdAt;
       delete dbProduct.updatedAt;
 
       const { error } = await supabase


### PR DESCRIPTION
## Summary
- ignore node_modules and .expo
- remove `createdAt` field before updating product so Supabase update succeeds

## Testing
- `yarn install`
- `yarn lint` *(fails: expo not found after cleaning)*

------
https://chatgpt.com/codex/tasks/task_e_687678dd49e483269743d2abdb760ffe