### PR TITLE
Add user PIN SQL script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ tables like `settings`, `tenant_settings` and `price_tier_rules` are created.
    ```sh
    npx supabase db push
    ```
+If you prefer not to use the CLI, copy the SQL from `scripts/user_pins.sql` into the Supabase SQL editor for each tenant.
 
 
 ## Running the Project

--- a/scripts/user_pins.sql
+++ b/scripts/user_pins.sql
@@ -1,0 +1,37 @@
+-- Run this file in the Supabase SQL editor to create the user_pins table
+
+/*
+  # Add User PIN Support
+
+  Create a user_pins table to securely store hashed PINs and a
+  verify_pin() helper for verifying user-provided PIN values.
+*/
+
+-- create table
+CREATE TABLE IF NOT EXISTS user_pins (
+  user_id TEXT PRIMARY KEY REFERENCES user_profiles(matrix_user_id) ON DELETE CASCADE,
+  pin_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE user_pins ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Owner access for user_pins"
+  ON user_pins FOR ALL TO authenticated
+  USING (user_id = (auth.uid())::text);
+
+CREATE TRIGGER update_user_pins_updated_at
+  BEFORE UPDATE ON user_pins
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- verification function
+CREATE OR REPLACE FUNCTION verify_pin(pin TEXT)
+RETURNS JSONB AS $$
+DECLARE stored TEXT;
+BEGIN
+  SELECT pin_hash INTO stored FROM user_pins WHERE user_id = (auth.uid())::text;
+  RETURN jsonb_build_object(
+    'success',
+    stored IS NOT NULL AND crypt(pin, stored) = stored
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20250704140000_user_pins.sql
+++ b/supabase/migrations/20250704140000_user_pins.sql
@@ -1,0 +1,35 @@
+/*
+  # Add User PIN Support
+
+  Create a user_pins table to securely store hashed PINs and a
+  verify_pin() helper for verifying user-provided PIN values.
+*/
+
+-- create table
+CREATE TABLE IF NOT EXISTS user_pins (
+  user_id TEXT PRIMARY KEY REFERENCES user_profiles(matrix_user_id) ON DELETE CASCADE,
+  pin_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE user_pins ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Owner access for user_pins"
+  ON user_pins FOR ALL TO authenticated
+  USING (user_id = (auth.uid())::text);
+
+CREATE TRIGGER update_user_pins_updated_at
+  BEFORE UPDATE ON user_pins
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- verification function
+CREATE OR REPLACE FUNCTION verify_pin(pin TEXT)
+RETURNS JSONB AS $$
+DECLARE stored TEXT;
+BEGIN
+  SELECT pin_hash INTO stored FROM user_pins WHERE user_id = (auth.uid())::text;
+  RETURN jsonb_build_object(
+    'success',
+    stored IS NOT NULL AND crypt(pin, stored) = stored
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- add `user_pins` migration
- provide ready-to-run SQL script under `scripts/`
- note manual execution option in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687678d16e908326aefadbba2cacd076