### PR TITLE
Add local tenant settings

### DIFF
--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert } from 'react-native';
-import DatabaseService from '../services/database';
+import TenantSettingsService from '../services/tenantSettings';
 import MediaService from '../services/media';
 
 const TENANT = process.env.EXPO_PUBLIC_TENANT || 'default';
@@ -61,10 +61,10 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       if (storedLogo) setPlatformLogoState(storedLogo);
       if (storedColor) setThemeColorState(storedColor);
 
-      const db = DatabaseService.getInstance();
-      const dbName = await db.getTenantSetting(TENANT, 'platform_name');
-      const dbLogo = await db.getTenantSetting(TENANT, 'platform_logo');
-      const dbColor = await db.getTenantSetting(TENANT, 'theme_color');
+      const tenantSvc = TenantSettingsService.getInstance();
+      const dbName = await tenantSvc.getTenantSetting(TENANT, 'platform_name');
+      const dbLogo = await tenantSvc.getTenantSetting(TENANT, 'platform_logo');
+      const dbColor = await tenantSvc.getTenantSetting(TENANT, 'theme_color');
       if (dbName) {
         setPlatformNameState(dbName);
         await AsyncStorage.setItem(NAME_KEY, dbName);
@@ -94,9 +94,9 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   const setPlatformName = async (name: string) => {
     setPlatformNameState(name);
     await AsyncStorage.setItem(NAME_KEY, name);
-    const db = DatabaseService.getInstance();
+    const tenantSvc = TenantSettingsService.getInstance();
     try {
-      await db.updateTenantSetting(TENANT, 'platform_name', name);
+      await tenantSvc.updateTenantSetting(TENANT, 'platform_name', name);
       scheduleLoadInfo();
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת שם הפלטפורמה נכשלה');
@@ -115,8 +115,8 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
 
       setPlatformLogoState(finalLogo);
       await AsyncStorage.setItem(LOGO_KEY, finalLogo);
-      const db = DatabaseService.getInstance();
-      await db.updateTenantSetting(TENANT, 'platform_logo', finalLogo);
+      const tenantSvc = TenantSettingsService.getInstance();
+      await tenantSvc.updateTenantSetting(TENANT, 'platform_logo', finalLogo);
       scheduleLoadInfo();
     } catch (e) {
       console.error('Error setting platform logo:', e);
@@ -128,8 +128,8 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
     try {
       setThemeColorState(color);
       await AsyncStorage.setItem(COLOR_KEY, color);
-      const db = DatabaseService.getInstance();
-      await db.updateTenantSetting(TENANT, 'theme_color', color);
+      const tenantSvc = TenantSettingsService.getInstance();
+      await tenantSvc.updateTenantSetting(TENANT, 'theme_color', color);
       scheduleLoadInfo();
     } catch (e) {
       console.error('Error setting theme color:', e);

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -1,0 +1,83 @@
+import { executeSql } from '../lib/sqlite';
+
+export interface TenantSettingsRow {
+  tenant_id: string;
+  platform_name?: string | null;
+  platform_logo?: string | null;
+  theme_color?: string | null;
+}
+
+class TenantSettingsService {
+  private static instance: TenantSettingsService;
+
+  private constructor() {
+    // Initialize table
+    executeSql(
+      `CREATE TABLE IF NOT EXISTS tenant_settings (
+        tenant_id TEXT PRIMARY KEY NOT NULL,
+        platform_name TEXT,
+        platform_logo TEXT,
+        theme_color TEXT
+      )`
+    ).catch((err) => console.error('Error creating tenant_settings table:', err));
+  }
+
+  public static getInstance(): TenantSettingsService {
+    if (!TenantSettingsService.instance) {
+      TenantSettingsService.instance = new TenantSettingsService();
+    }
+    return TenantSettingsService.instance;
+  }
+
+  async getTenantSetting(
+    tenant: string,
+    key: 'platform_name' | 'platform_logo' | 'theme_color'
+  ): Promise<string | null> {
+    try {
+      const result = await executeSql(
+        `SELECT ${key} FROM tenant_settings WHERE tenant_id = ? LIMIT 1`,
+        [tenant]
+      );
+      const item = (result.rows as any)._array?.[0];
+      return item ? item[key] || null : null;
+    } catch (error) {
+      console.error(`Error fetching tenant setting ${key}:`, error);
+      return null;
+    }
+  }
+
+  async updateTenantSetting(
+    tenant: string,
+    key: 'platform_name' | 'platform_logo' | 'theme_color',
+    value: string
+  ): Promise<void> {
+    try {
+      const existing = await executeSql(
+        'SELECT tenant_id FROM tenant_settings WHERE tenant_id = ? LIMIT 1',
+        [tenant]
+      );
+      if ((existing.rows as any).length) {
+        await executeSql(
+          `UPDATE tenant_settings SET ${key} = ? WHERE tenant_id = ?`,
+          [value, tenant]
+        );
+      } else {
+        const cols = ['platform_name', 'platform_logo', 'theme_color'];
+        const idx = cols.indexOf(key);
+        const values = [null, null, null];
+        if (idx >= 0) {
+          values[idx] = value;
+        }
+        await executeSql(
+          'INSERT INTO tenant_settings (tenant_id, platform_name, platform_logo, theme_color) VALUES (?,?,?,?)',
+          [tenant, values[0], values[1], values[2]]
+        );
+      }
+    } catch (error) {
+      console.error(`Error updating tenant setting ${key}:`, error);
+      throw error;
+    }
+  }
+}
+
+export default TenantSettingsService;

--- a/types/index.ts
+++ b/types/index.ts
@@ -236,3 +236,10 @@ export interface ShippingAddress {
   postalCode: string;
   notes?: string;
 }
+
+export interface TenantSettings {
+  tenant_id: string;
+  platform_name?: string | null;
+  platform_logo?: string | null;
+  theme_color?: string | null;
+}


### PR DESCRIPTION
## Summary
- create `tenant_settings` SQLite service for local branding
- store and update platform name, logo, and color via SQLite
- expose `TenantSettings` type
- update `AppInfoContext` to use the new service

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_687d484540dc8326a1791d7799476254