### PR TITLE
Add tenant_id columns and update queries for multi-tenant support

### DIFF
--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -24,6 +24,7 @@ function all(sql, params = []) {
 }
 
 async function seed() {
+  const tenants = ['thecongress', 'thebull'];
   const users = Array.from({ length: 5 }).map(() => ({
     id: `user_${Date.now()}_${faker.number.int()}`,
     matrix_user_id: faker.string.uuid(),
@@ -31,12 +32,13 @@ async function seed() {
     email: faker.internet.email(),
     display_name: faker.person.fullName(),
     role: 'user',
+    tenant_id: faker.helpers.arrayElement(tenants),
   }));
 
   for (const u of users) {
     await run(
-      'INSERT INTO user_profiles (id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?)',
-      [u.id, u.matrix_user_id, u.app_username, u.email, u.display_name, u.role],
+      'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
+      [u.id, u.tenant_id, u.matrix_user_id, u.app_username, u.email, u.display_name, u.role],
     );
   }
 
@@ -45,6 +47,7 @@ async function seed() {
 
   const products = Array.from({ length: 10 }).map(() => ({
     id: `prod_${Date.now()}_${faker.number.int()}`,
+    tenant_id: faker.helpers.arrayElement(tenants),
     name: faker.commerce.productName(),
     price: Number(faker.commerce.price({ min: 5, max: 100 })),
     description: faker.commerce.productDescription(),
@@ -54,8 +57,8 @@ async function seed() {
   }));
   for (const p of products) {
     await run(
-      'INSERT INTO products (id,name,price,description,category,images,stock,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)',
-      [p.id, p.name, p.price, p.description, p.category, p.images, p.stock, Date.now(), Date.now()],
+      'INSERT INTO products (id,tenant_id,name,price,description,category,images,stock,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)',
+      [p.id, p.tenant_id, p.name, p.price, p.description, p.category, p.images, p.stock, Date.now(), Date.now()],
     );
   }
 
@@ -71,6 +74,7 @@ async function seed() {
     const orderId = `order_${Date.now()}_${i}`;
     orders.push({
       id: orderId,
+      tenant_id: faker.helpers.arrayElement(tenants),
       user_id: userId,
       total: 0,
       status: 'pending',
@@ -86,9 +90,10 @@ async function seed() {
 
   for (const order of orders) {
     await run(
-      'INSERT INTO orders (id,user_id,total,status,payment_method,shipping_name,shipping_phone,shipping_street,shipping_city,shipping_postal_code,shipping_notes,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      'INSERT INTO orders (id,tenant_id,user_id,total,status,payment_method,shipping_name,shipping_phone,shipping_street,shipping_city,shipping_postal_code,shipping_notes,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
       [
         order.id,
+        order.tenant_id,
         order.user_id,
         order.total,
         order.status,
@@ -139,16 +144,16 @@ async function seed() {
     );
   }
 
-  const tenantRows = ['thecongress', 'thebull'].map((t) => ({
-    tenant: t,
+  const tenantRows = tenants.map((t) => ({
+    tenant_id: t,
     platform_name: faker.company.name(),
     platform_logo: faker.image.url(),
     theme_color: faker.color.rgb(),
   }));
   for (const row of tenantRows) {
     await run(
-      'INSERT OR REPLACE INTO tenant_settings (tenant, platform_name, platform_logo, theme_color) VALUES (?,?,?,?)',
-      [row.tenant, row.platform_name, row.platform_logo, row.theme_color],
+      'INSERT OR REPLACE INTO tenant_settings (tenant_id, platform_name, platform_logo, theme_color) VALUES (?,?,?,?)',
+      [row.tenant_id, row.platform_name, row.platform_logo, row.theme_color],
     );
   }
 

--- a/services/database.ts
+++ b/services/database.ts
@@ -1,4 +1,5 @@
 import { executeSql } from '../lib/sqlite';
+import { TENANT } from '../constants/tenant';
 import {
   Product,
   Category,
@@ -19,6 +20,7 @@ import {
 
 class DatabaseService {
   private static instance: DatabaseService;
+  private static readonly tenantId = TENANT;
 
   private constructor() {}
 
@@ -31,7 +33,7 @@ class DatabaseService {
 
   // Product methods
   async getProducts(): Promise<Product[]> {
-    const result = await executeSql('SELECT * FROM products ORDER BY created_at DESC');
+    const result = await executeSql('SELECT * FROM products WHERE tenant_id=? ORDER BY created_at DESC', [DatabaseService.tenantId]);
     const rows = (result.rows as any)._array || [];
     return rows.map((r: any) => ({
       id: r.id,
@@ -60,7 +62,7 @@ class DatabaseService {
   }
 
   async getProduct(id: string): Promise<Product | null> {
-    const res = await executeSql('SELECT * FROM products WHERE id = ? LIMIT 1', [id]);
+    const res = await executeSql('SELECT * FROM products WHERE id = ? AND tenant_id=? LIMIT 1', [id, DatabaseService.tenantId]);
     const item = (res.rows as any)._array?.[0];
     if (!item) return null;
     return {
@@ -96,13 +98,14 @@ class DatabaseService {
     const id = `prod_${Date.now()}`;
     await executeSql(
       `INSERT INTO products (
-        id, name, name_en, name_he, price, description, description_en,
+        id, tenant_id, name, name_en, name_he, price, description, description_en,
         description_he, category, subcategory, images, videos, colors,
         rating, reviews, badges, pricing_tier, mix_group_id, stock,
         created_at, updated_at
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         id,
+        DatabaseService.tenantId,
         dbProd.name,
         dbProd.name_en,
         dbProd.name_he,
@@ -138,7 +141,7 @@ class DatabaseService {
         description_en=?, description_he=?, category=?, subcategory=?,
         images=?, videos=?, colors=?, rating=?, reviews=?, badges=?,
         pricing_tier=?, mix_group_id=?, stock=?, updated_at=?
-      WHERE id=?`,
+      WHERE id=? AND tenant_id=?`,
       [
         dbProd.name,
         dbProd.name_en,
@@ -160,12 +163,13 @@ class DatabaseService {
         dbProd.stock ?? 0,
         Date.now(),
         id,
+        DatabaseService.tenantId,
       ],
     );
   }
 
   async deleteProduct(id: string): Promise<void> {
-    await executeSql('DELETE FROM products WHERE id = ?', [id]);
+    await executeSql('DELETE FROM products WHERE id = ? AND tenant_id=?', [id, DatabaseService.tenantId]);
   }
 
   // Categories and subcategories
@@ -312,7 +316,7 @@ class DatabaseService {
 
   // Users
   async getUserProfile(userId: string): Promise<User | null> {
-    const res = await executeSql('SELECT * FROM user_profiles WHERE matrix_user_id=? LIMIT 1', [userId]);
+    const res = await executeSql('SELECT * FROM user_profiles WHERE matrix_user_id=? AND tenant_id=? LIMIT 1', [userId, DatabaseService.tenantId]);
     const row = (res.rows as any)._array?.[0];
     if (!row) return null;
     return {
@@ -335,7 +339,7 @@ class DatabaseService {
   }
 
   async getAllUserProfiles(): Promise<User[]> {
-    const res = await executeSql('SELECT * FROM user_profiles ORDER BY created_at DESC');
+    const res = await executeSql('SELECT * FROM user_profiles WHERE tenant_id=? ORDER BY created_at DESC', [DatabaseService.tenantId]);
     const rows = (res.rows as any)._array || [];
     return rows.map((row: any) => ({
       id: row.id,
@@ -363,18 +367,18 @@ class DatabaseService {
   async searchUserProfiles(term: string): Promise<{ matrix_user_id: string; display_name: string; app_username: string }[]> {
     const like = `%${term}%`;
     const res = await executeSql(
-      `SELECT matrix_user_id, display_name, app_username FROM user_profiles WHERE display_name LIKE ? OR app_username LIKE ? LIMIT 10`,
-      [like, like],
+      `SELECT matrix_user_id, display_name, app_username FROM user_profiles WHERE tenant_id=? AND (display_name LIKE ? OR app_username LIKE ?) LIMIT 10`,
+      [DatabaseService.tenantId, like, like],
     );
     return (res.rows as any)._array || [];
   }
 
   async updateUserRole(userId: string, role: 'user' | 'driver' | 'admin'): Promise<void> {
-    await executeSql('UPDATE user_profiles SET role=? WHERE id=?', [role, userId]);
+    await executeSql('UPDATE user_profiles SET role=? WHERE id=? AND tenant_id=?', [role, userId, DatabaseService.tenantId]);
   }
 
   async updateUserCustomerTier(userId: string, customerTier: string): Promise<void> {
-    await executeSql('UPDATE user_profiles SET customer_tier=? WHERE id=?', [customerTier, userId]);
+    await executeSql('UPDATE user_profiles SET customer_tier=? WHERE id=? AND tenant_id=?', [customerTier, userId, DatabaseService.tenantId]);
   }
 
   async updateUserKycStatus(
@@ -394,13 +398,13 @@ class DatabaseService {
     const fields = Object.keys(updateData)
       .map((k) => `${k}=?`)
       .join(', ');
-    const params = [...Object.values(updateData), userId];
-    await executeSql(`UPDATE user_profiles SET ${fields} WHERE id=?`, params);
+    const params = [...Object.values(updateData), userId, DatabaseService.tenantId];
+    await executeSql(`UPDATE user_profiles SET ${fields} WHERE id=? AND tenant_id=?`, params);
     return true;
   }
 
   async getPendingKycRequests(): Promise<User[]> {
-    const res = await executeSql("SELECT * FROM user_profiles WHERE kyc_status='pending' ORDER BY kyc_requested_at ASC");
+    const res = await executeSql("SELECT * FROM user_profiles WHERE kyc_status='pending' AND tenant_id=? ORDER BY kyc_requested_at ASC", [DatabaseService.tenantId]);
     const rows = (res.rows as any)._array || [];
     return rows.map((row: any) => ({
       id: row.matrix_user_id,
@@ -748,7 +752,7 @@ class DatabaseService {
   }
 
   async getUserOrders(userId: string): Promise<{ id: string; total: number; status: string; createdAt: string }[]> {
-    const res = await executeSql('SELECT id,total,status,created_at FROM orders WHERE user_id=? ORDER BY created_at DESC', [userId]);
+    const res = await executeSql('SELECT id,total,status,created_at FROM orders WHERE user_id=? AND tenant_id=? ORDER BY created_at DESC', [userId, DatabaseService.tenantId]);
     const rows = (res.rows as any)._array || [];
     return rows.map((o: any) => ({ id: o.id, total: Number(o.total), status: o.status, createdAt: o.created_at }));
   }
@@ -832,18 +836,18 @@ class DatabaseService {
   }
 
   async getTenantSetting(tenant: string, key: string): Promise<string | null> {
-    const res = await executeSql(`SELECT ${key} FROM tenant_settings WHERE tenant=? LIMIT 1`, [tenant]);
+    const res = await executeSql(`SELECT ${key} FROM tenant_settings WHERE tenant_id=? LIMIT 1`, [tenant]);
     const row = (res.rows as any)._array?.[0];
     return row ? row[key] || null : null;
   }
 
   async updateTenantSetting(tenant: string, key: string, value: string): Promise<void> {
-    const res = await executeSql('SELECT tenant FROM tenant_settings WHERE tenant=?', [tenant]);
+    const res = await executeSql('SELECT tenant_id FROM tenant_settings WHERE tenant_id=?', [tenant]);
     const exists = (res.rows as any)._array?.length > 0;
     if (exists) {
-      await executeSql(`UPDATE tenant_settings SET ${key}=? WHERE tenant=?`, [value, tenant]);
+      await executeSql(`UPDATE tenant_settings SET ${key}=? WHERE tenant_id=?`, [value, tenant]);
     } else {
-      await executeSql(`INSERT INTO tenant_settings (tenant, ${key}) VALUES (?, ?)`, [tenant, value]);
+      await executeSql(`INSERT INTO tenant_settings (tenant_id, ${key}) VALUES (?, ?)`, [tenant, value]);
     }
   }
 }

--- a/sqlite/migrations/001_initial_schema.sql
+++ b/sqlite/migrations/001_initial_schema.sql
@@ -47,6 +47,7 @@ CREATE TABLE mix_groups (
 -- Products table
 CREATE TABLE products (
   id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
   name TEXT NOT NULL,
   price REAL NOT NULL,
   "originalPrice" REAL,
@@ -99,6 +100,7 @@ CREATE TABLE chat_messages (
 -- User profiles table
 CREATE TABLE user_profiles (
   id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
   matrix_user_id TEXT UNIQUE NOT NULL,
   app_username TEXT NOT NULL,
   email TEXT,
@@ -168,6 +170,7 @@ CREATE TABLE hero_banners (
 -- Orders table
 CREATE TABLE orders (
   id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
   total REAL NOT NULL CHECK(total >= 0),
   status TEXT NOT NULL,
@@ -253,7 +256,7 @@ CREATE TABLE settings (
 
 -- Tenant settings table
 CREATE TABLE tenant_settings (
-  tenant TEXT PRIMARY KEY,
+  tenant_id TEXT PRIMARY KEY,
   platform_name TEXT,
   platform_logo TEXT,
   theme_color TEXT,
@@ -299,5 +302,5 @@ END;
 
 CREATE TRIGGER update_tenant_settings_timestamp AFTER UPDATE ON tenant_settings
 BEGIN
-  UPDATE tenant_settings SET updated_at = CURRENT_TIMESTAMP WHERE tenant = NEW.tenant;
+  UPDATE tenant_settings SET updated_at = CURRENT_TIMESTAMP WHERE tenant_id = NEW.tenant_id;
 END;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,6 @@
 export interface Product {
   id: string;
+  tenant_id?: string;
   name: string;
   name_en?: string;
   name_he?: string;
@@ -101,6 +102,7 @@ export type CustomerTier = 'new' | 'regular' | 'vip' | 'banned';
 
 export interface User {
   id: string;
+  tenant_id?: string;
   username: string;
   isAdmin: boolean;
   isDriver?: boolean;
@@ -184,6 +186,7 @@ export interface WishlistItem {
 
 export interface Order {
   id: string;
+  tenant_id?: string;
   userId: string;
   items: CartItem[];
   total: number;


### PR DESCRIPTION
## Summary
- add `tenant_id` fields in initial SQLite schema
- update SQL queries in `DatabaseService` for multi-tenant filtering
- align `TenantSettingsService` with new schema
- seed demo data with tenant IDs
- expose tenant_id in relevant TypeScript interfaces

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'expo')*

------
https://chatgpt.com/codex/tasks/task_e_687d61bbfeb08326a1b475d9e6d54a1d