### PR TITLE
Add users table and admin initialization

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -6,6 +6,7 @@ import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 
 const ADMIN_USERNAME = process.env.EXPO_PUBLIC_ADMIN_USERNAME;
+const ADMIN_PASSWORD = process.env.EXPO_PUBLIC_ADMIN_PASSWORD || 'admin';
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 
 interface AuthContextType {
@@ -43,9 +44,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const ensureAdminAccount = async () => {
+    if (!ADMIN_USERNAME) return;
+    const res = await executeSql(
+      "SELECT COUNT(*) as count FROM users WHERE role='admin'",
+    );
+    const count = (res.rows as any)._array?.[0]?.count || 0;
+    if (count === 0) {
+      const id = `user_${Date.now()}`;
+      const hash = await bcrypt.hash(ADMIN_PASSWORD, 10);
+      await executeSql(
+        'INSERT INTO users (id, username, password_hash, display_name, role) VALUES (?,?,?,?,?)',
+        [id, ADMIN_USERNAME, hash, 'Admin', 'admin'],
+      );
+    }
+  };
+
   useEffect(() => {
     const init = async () => {
       try {
+        await ensureAdminAccount();
         const token = await getToken();
         if (token && isTokenValid(token)) {
           const payload: any = jwt.decode(token);

--- a/scripts/init-sqlite-db.sh
+++ b/scripts/init-sqlite-db.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 # Initialize local SQLite database using migration files
 
+set -e
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 command not found" >&2
+  exit 1
+fi
+
 DB_PATH="${1:-sqlite/db.sqlite}"
 mkdir -p "$(dirname "$DB_PATH")"
 

--- a/sqlite/migrations/001_initial_schema.sql
+++ b/sqlite/migrations/001_initial_schema.sql
@@ -96,6 +96,15 @@ CREATE TABLE chat_messages (
   reactions TEXT DEFAULT '{}'
 );
 
+-- Users table
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  role TEXT NOT NULL CHECK(role IN ('user','driver','admin'))
+);
+
 -- User profiles table
 CREATE TABLE user_profiles (
   id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- extend SQLite schema with `users` table
- create initial admin user automatically when app starts
- harden `init-sqlite-db.sh` with sanity checks

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d61a25dbc83268f86eda43feb1f5d