### PR TITLE
Add database backup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,23 @@ yarn build:web:thebull
 Matching NGINX configs for each tenant are located in `nginx/` and assume the
 exported files are served from `/var/www/{tenant}/dist`.
 
+## Database Backup
+
+The project includes helper scripts to encrypt the `blue-ocean.db` SQLite file
+and store it on Pinata. Set your Pinata credentials in `.env` and provide a
+passphrase when running the scripts.
+
+### Backup the database
+
+```sh
+node scripts/backup-db.js mySecretPassphrase
+```
+
+### Restore the latest backup
+
+```sh
+node scripts/restore-db.js mySecretPassphrase
+```
+
 
 ***End of Document***

--- a/scripts/backup-db.js
+++ b/scripts/backup-db.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+// Backup blue-ocean.db using BackupService and upload to Pinata
+
+// Register ts-node so we can import TypeScript services
+try {
+  require('ts-node/register');
+} catch (err) {
+  console.error('ts-node is required to run this script');
+  process.exit(1);
+}
+
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const axios = require('axios');
+
+// Polyfill a minimal subset of expo-file-system for BackupService
+const FileSystem = {
+  documentDirectory: path.join(__dirname, '..') + path.sep,
+  cacheDirectory: os.tmpdir() + path.sep,
+  EncodingType: { Base64: 'base64' },
+  async readAsStringAsync(file, options) {
+    return fs.readFile(file, options?.encoding || 'utf8');
+  },
+  async writeAsStringAsync(file, data, options) {
+    await fs.writeFile(file, data, { encoding: options?.encoding });
+  },
+  async deleteAsync(file, opts = {}) {
+    try {
+      await fs.unlink(file);
+    } catch (err) {
+      if (!opts.idempotent) throw err;
+    }
+  },
+  async downloadAsync(url, file) {
+    const res = await axios.get(url, { responseType: 'arraybuffer' });
+    await fs.writeFile(file, res.data);
+    return { uri: file };
+  },
+};
+
+require.cache[require.resolve('expo-file-system')] = { exports: FileSystem };
+
+if (!global.crypto) {
+  global.crypto = require('crypto').webcrypto;
+}
+
+const { default: BackupService } = require('../services/backup');
+
+const DB_NAME = 'blue-ocean.db';
+const DB_SOURCE = path.join(__dirname, '..', DB_NAME);
+
+async function main() {
+  const passphrase = process.argv[2];
+  if (!passphrase) {
+    console.error('Usage: node scripts/backup-db.js <passphrase>');
+    process.exit(1);
+  }
+
+  const sqliteDir = path.join(FileSystem.documentDirectory, 'SQLite');
+  await fs.mkdir(sqliteDir, { recursive: true });
+  const target = path.join(sqliteDir, 'app.db');
+
+  await fs.copyFile(DB_SOURCE, target);
+
+  const service = BackupService.getInstance();
+  const url = await service.backupDatabase(passphrase);
+  console.log('Backup uploaded to:', url);
+
+  await FileSystem.deleteAsync(target, { idempotent: true });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/scripts/restore-db.js
+++ b/scripts/restore-db.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+// Restore blue-ocean.db from the latest Pinata backup using BackupService
+
+try {
+  require('ts-node/register');
+} catch (err) {
+  console.error('ts-node is required to run this script');
+  process.exit(1);
+}
+
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const axios = require('axios');
+
+const FileSystem = {
+  documentDirectory: path.join(__dirname, '..') + path.sep,
+  cacheDirectory: os.tmpdir() + path.sep,
+  EncodingType: { Base64: 'base64' },
+  async readAsStringAsync(file, options) {
+    return fs.readFile(file, options?.encoding || 'utf8');
+  },
+  async writeAsStringAsync(file, data, options) {
+    await fs.writeFile(file, data, { encoding: options?.encoding });
+  },
+  async deleteAsync(file, opts = {}) {
+    try {
+      await fs.unlink(file);
+    } catch (err) {
+      if (!opts.idempotent) throw err;
+    }
+  },
+  async downloadAsync(url, file) {
+    const res = await axios.get(url, { responseType: 'arraybuffer' });
+    await fs.writeFile(file, res.data);
+    return { uri: file };
+  },
+};
+
+require.cache[require.resolve('expo-file-system')] = { exports: FileSystem };
+
+if (!global.crypto) {
+  global.crypto = require('crypto').webcrypto;
+}
+
+const { default: BackupService } = require('../services/backup');
+const PINATA_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
+
+async function getLatestBackupCid() {
+  const headers = {};
+  if (process.env.EXPO_PUBLIC_PINATA_JWT) {
+    headers.Authorization = `Bearer ${process.env.EXPO_PUBLIC_PINATA_JWT}`;
+  } else {
+    headers.pinata_api_key = process.env.EXPO_PUBLIC_PINATA_API_KEY;
+    headers.pinata_secret_api_key = process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY;
+  }
+  const res = await axios.get('https://api.pinata.cloud/data/pinList', {
+    headers,
+    params: {
+      status: 'pinned',
+      'metadata[name]': 'app.db.enc',
+      pageLimit: 1,
+      sort: 'pin_date',
+      direction: -1,
+    },
+  });
+  const row = res.data.rows && res.data.rows[0];
+  return row ? row.ipfs_pin_hash : null;
+}
+
+async function main() {
+  const passphrase = process.argv[2];
+  if (!passphrase) {
+    console.error('Usage: node scripts/restore-db.js <passphrase>');
+    process.exit(1);
+  }
+
+  const cid = await getLatestBackupCid();
+  if (!cid) {
+    console.error('No backup found on Pinata');
+    process.exit(1);
+  }
+
+  const service = BackupService.getInstance();
+  const restoredPath = await service.restoreDatabase(cid, passphrase);
+  const target = path.join(__dirname, '..', 'blue-ocean.db');
+  await fs.copyFile(restoredPath, target);
+  console.log('Database restored to', target);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add Node helpers for encrypting and uploading the local db
- add script to restore latest backup
- document database backup usage in README

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d663c0ac08326a27d3da3c2969cbd