### PR TITLE
Add env var typings

### DIFF
--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -5,6 +5,15 @@ declare global {
       EXPO_PUBLIC_MATRIX_SERVER: string;
       EXPO_PUBLIC_APP_NAME: string;
       EXPO_PUBLIC_DEBUG_LOGS?: string;
+      EXPO_PUBLIC_ADMIN_PASSWORD?: string;
+      EXPO_PUBLIC_JWT_SECRET?: string;
+      EXPO_PUBLIC_PINATA_JWT?: string;
+      EXPO_PUBLIC_PINATA_API_KEY?: string;
+      EXPO_PUBLIC_PINATA_SECRET_API_KEY?: string;
+      EXPO_PUBLIC_CHAT_SECRET?: string;
+      VAPID_PUBLIC_KEY?: string;
+      VAPID_PRIVATE_KEY?: string;
+      EXPO_PUBLIC_TENANT?: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- expand environment variable typings for Expo configuration

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d7b83a8a88326ad8c2a5ab043735d