### PR TITLE
Refactor orders to SQLite

### DIFF
--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -54,10 +54,10 @@ export default function OrdersScreen() {
     return () => orderService.removeListener(handleOrderUpdate);
   }, [isLoggedIn, user]);
 
-  const loadOrders = () => {
+  const loadOrders = async () => {
     try {
       const orderService = OrderService.getInstance();
-      const userOrders = orderService.getUserOrders(user?.id || '');
+      const userOrders = await orderService.getUserOrders(user?.id || '');
       setOrders(userOrders);
     } catch (error) {
       console.error('Error loading orders:', error);

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -83,8 +83,8 @@ export default function ReviewsScreen() {
       // Load user orders if logged in
       if (isLoggedIn && user) {
         const orderService = OrderService.getInstance();
-        const orders = orderService.getUserOrders(user.id);
-        
+        const orders = await orderService.getUserOrders(user.id);
+
         // Only get delivered orders
         const deliveredOrders = orders.filter(order => order.status === 'delivered');
         setUserOrders(deliveredOrders);

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,11 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { executeSql } from '../lib/sqlite';
 import { Order, OrderStatus, OrderTrackingStep, CartItem, ShippingAddress } from '../types';
-
-const ORDERS_STORAGE_KEY = 'user_orders';
+import DatabaseService from './database';
+import { TENANT } from '../constants/tenant';
 
 class OrderService {
   private static instance: OrderService;
-  private orders: Order[] = [];
   private listeners: (() => void)[] = [];
 
   public static getInstance(): OrderService {
@@ -15,32 +14,10 @@ class OrderService {
     return OrderService.instance;
   }
 
-  constructor() {
-    this.loadFromStorage();
-  }
-
-  private async loadFromStorage() {
-    try {
-      const ordersData = await AsyncStorage.getItem(ORDERS_STORAGE_KEY);
-      if (ordersData) {
-        this.orders = JSON.parse(ordersData);
-      }
-      this.notifyListeners();
-    } catch (error) {
-      console.error('Error loading orders from storage:', error);
-    }
-  }
-
-  private async saveToStorage() {
-    try {
-      await AsyncStorage.setItem(ORDERS_STORAGE_KEY, JSON.stringify(this.orders));
-    } catch (error) {
-      console.error('Error saving orders to storage:', error);
-    }
-  }
+  private constructor() {}
 
   private notifyListeners() {
-    this.listeners.forEach(listener => listener());
+    this.listeners.forEach((listener) => listener());
   }
 
   public addListener(listener: () => void) {
@@ -48,7 +25,7 @@ class OrderService {
   }
 
   public removeListener(listener: () => void) {
-    this.listeners = this.listeners.filter(l => l !== listener);
+    this.listeners = this.listeners.filter((l) => l !== listener);
   }
 
   private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
@@ -112,33 +89,70 @@ class OrderService {
   public async createOrder(
     userId: string,
     items: CartItem[],
-    shippingAddress: ShippingAddress
+    shippingAddress: ShippingAddress,
   ): Promise<Order> {
     const total = items.reduce((sum, item) => {
       const price = item.unitPrice ?? item.product.price;
       return sum + price * item.quantity;
     }, 0);
-    
-    const order: Order = {
-      id: `order_${Date.now()}`,
-      userId,
-      items,
-      total,
-      status: 'order_received',
-      shippingAddress,
-      paymentMethod: 'cash_on_delivery',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      trackingSteps: this.getTrackingSteps('order_received')
-    };
 
-    this.orders.unshift(order); // Add to beginning
-    await this.saveToStorage();
+    const orderId = `order_${Date.now()}`;
+    const timestamp = new Date().toISOString();
+
+    await executeSql(
+      `INSERT INTO orders (
+        id, tenant_id, user_id, total, status, payment_method,
+        shipping_name, shipping_phone, shipping_street, shipping_city,
+        shipping_postal_code, shipping_notes, created_at, updated_at
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        orderId,
+        TENANT,
+        userId,
+        total,
+        'order_received',
+        'cash_on_delivery',
+        shippingAddress.name,
+        shippingAddress.phone,
+        shippingAddress.street,
+        shippingAddress.city,
+        shippingAddress.postalCode,
+        shippingAddress.notes ?? null,
+        timestamp,
+        timestamp,
+      ],
+    );
+
+    for (const item of items) {
+      const price = item.unitPrice ?? item.product.price;
+      await executeSql(
+        `INSERT INTO order_items (
+          id, order_id, product_id, product_name, product_image,
+          quantity, price, selected_color, created_at
+        ) VALUES (?,?,?,?,?,?,?,?,?)`,
+        [
+          `item_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          orderId,
+          item.product.id,
+          item.product.name,
+          item.product.images[0],
+          item.quantity,
+          price,
+          item.selectedColor ?? null,
+          timestamp,
+        ],
+      );
+    }
+
+    const order = await this.getOrder(orderId);
     this.notifyListeners();
 
     // Simulate order progression
-    this.simulateOrderProgress(order.id);
+    this.simulateOrderProgress(orderId);
 
+    if (!order) {
+      throw new Error('ORDER_NOT_CREATED');
+    }
     return order;
   }
 
@@ -161,57 +175,106 @@ class OrderService {
   }
 
   public async updateOrderStatus(orderId: string, status: OrderStatus): Promise<void> {
-    const orderIndex = this.orders.findIndex(order => order.id === orderId);
-    if (orderIndex >= 0) {
-      this.orders[orderIndex].status = status;
-      this.orders[orderIndex].updatedAt = new Date().toISOString();
-      this.orders[orderIndex].trackingSteps = this.getTrackingSteps(status);
-      
-      await this.saveToStorage();
-      this.notifyListeners();
+    await executeSql('UPDATE orders SET status=? WHERE id=?', [status, orderId]);
+    this.notifyListeners();
+  }
+
+  private async mapOrderRow(row: any): Promise<Order> {
+    const itemsRes = await executeSql('SELECT * FROM order_items WHERE order_id=?', [row.id]);
+    const itemRows = (itemsRes.rows as any)._array || [];
+    const db = DatabaseService.getInstance();
+    const items: CartItem[] = [];
+    for (const r of itemRows) {
+      const product = await db.getProduct(r.product_id);
+      if (!product) continue;
+      items.push({
+        id: r.id,
+        productId: r.product_id,
+        product,
+        quantity: r.quantity,
+        addedAt: r.created_at,
+        unitPrice: r.price,
+        selectedColor: r.selected_color || undefined,
+      });
     }
+
+    return {
+      id: row.id,
+      userId: row.user_id,
+      items,
+      total: Number(row.total),
+      status: row.status as OrderStatus,
+      shippingAddress: {
+        name: row.shipping_name,
+        phone: row.shipping_phone,
+        street: row.shipping_street,
+        city: row.shipping_city,
+        postalCode: row.shipping_postal_code || '',
+        notes: row.shipping_notes || undefined,
+      },
+      paymentMethod: row.payment_method,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      trackingSteps: this.getTrackingSteps(row.status as OrderStatus),
+    };
   }
 
-  public getOrders(): Order[] {
-    return [...this.orders];
+  public async getOrders(): Promise<Order[]> {
+    const res = await executeSql('SELECT * FROM orders WHERE tenant_id=? ORDER BY created_at DESC', [TENANT]);
+    const rows = (res.rows as any)._array || [];
+    const orders: Order[] = [];
+    for (const row of rows) {
+      orders.push(await this.mapOrderRow(row));
+    }
+    return orders;
   }
 
-  public getOrder(orderId: string): Order | undefined {
-    return this.orders.find(order => order.id === orderId);
+  public async getOrder(orderId: string): Promise<Order | null> {
+    const res = await executeSql('SELECT * FROM orders WHERE id=? LIMIT 1', [orderId]);
+    const row = (res.rows as any)._array?.[0];
+    if (!row) return null;
+    return this.mapOrderRow(row);
   }
 
-  public getUserOrders(userId: string): Order[] {
-    return this.orders.filter(order => order.userId === userId);
+  public async getUserOrders(userId: string): Promise<Order[]> {
+    const res = await executeSql(
+      'SELECT * FROM orders WHERE user_id=? AND tenant_id=? ORDER BY created_at DESC',
+      [userId, TENANT],
+    );
+    const rows = (res.rows as any)._array || [];
+    const orders: Order[] = [];
+    for (const row of rows) {
+      orders.push(await this.mapOrderRow(row));
+    }
+    return orders;
   }
 
-  // Cancel an order (only possible if not yet picked up)
   public async cancelOrder(orderId: string): Promise<boolean> {
-    const orderIndex = this.orders.findIndex(order => order.id === orderId);
-    if (orderIndex >= 0) {
-      const order = this.orders[orderIndex];
-      
-      // Can only cancel if not yet picked up
-      if (order.status === 'order_received' || order.status === 'courier_found') {
-        // Mark as cancelled (we could add a 'cancelled' status, but for simplicity we'll just remove it)
-        this.orders.splice(orderIndex, 1);
-        await this.saveToStorage();
-        this.notifyListeners();
-        return true;
-      }
+    const order = await this.getOrder(orderId);
+    if (!order) return false;
+    if (order.status === 'order_received' || order.status === 'courier_found') {
+      await executeSql('DELETE FROM orders WHERE id=?', [orderId]);
+      this.notifyListeners();
+      return true;
     }
     return false;
   }
 
-  // Get order count for a user
-  public getUserOrderCount(userId: string): number {
-    return this.orders.filter(order => order.userId === userId).length;
+  public async getUserOrderCount(userId: string): Promise<number> {
+    const res = await executeSql(
+      'SELECT COUNT(*) as cnt FROM orders WHERE user_id=? AND tenant_id=?',
+      [userId, TENANT],
+    );
+    return (res.rows as any)._array?.[0]?.cnt ?? 0;
   }
 
-  // Get total spent by a user
-  public getUserTotalSpent(userId: string): number {
-    return this.orders
-      .filter(order => order.userId === userId && order.status === 'delivered')
-      .reduce((total, order) => total + order.total, 0);
+  public async getUserTotalSpent(userId: string): Promise<number> {
+    const res = await executeSql(
+      "SELECT SUM(total) as sum FROM orders WHERE user_id=? AND tenant_id=? AND status='delivered'",
+      [userId, TENANT],
+    );
+    const val = (res.rows as any)._array?.[0]?.sum;
+    return val ? Number(val) : 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- rewrite `OrderService` to use SQLite storage instead of AsyncStorage
- adapt order listing screens for new async API

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: missing expo type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_687d7b7a88dc8326bd2cf1fc0a909814