### PR TITLE
Fix webpack config for web polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 // webpack.config.js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const webpack = require('webpack');
 
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
@@ -11,6 +12,22 @@ module.exports = async function (env, argv) {
     );
     config.devtool = 'source-map';
   }
+
+  // Polyfill Node.js core modules used by some dependencies
+  config.resolve.fallback = {
+    ...config.resolve.fallback,
+    stream: require.resolve('stream-browserify'),
+    assert: require.resolve('assert'),
+    util: require.resolve('util'),
+    process: require.resolve('process/browser'),
+  };
+
+  config.plugins.push(
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+      Buffer: ['buffer', 'Buffer'],
+    })
+  );
 
   return config;
 };


### PR DESCRIPTION
## Summary
- polyfill Node core modules for web builds

## Testing
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9835ca948326898b3b9de71cd222