### PR TITLE
Switch to expo-jwt for token handling

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { executeSql } from '../lib/sqlite';
 import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
+import JWT from 'expo-jwt';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 
@@ -66,7 +66,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         await ensureAdminAccount();
         const token = await getToken();
         if (token && isTokenValid(token)) {
-          const payload: any = jwt.decode(token);
+          const payload: any = JWT.decode(token, JWT_SECRET);
           setSession(token);
           if (payload?.sub) {
             await loadProfile(payload.sub);
@@ -110,7 +110,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setLoading(false);
         return false;
       }
-      const token = jwt.sign({ sub: row.id }, JWT_SECRET, { expiresIn: '7d' });
+      const token = JWT.encode(
+        { sub: row.id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
+        JWT_SECRET,
+      );
       await saveToken(token);
       setSession(token);
       await loadProfile(row.id);
@@ -137,7 +140,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         'INSERT INTO users (id, username, password_hash, display_name, role) VALUES (?,?,?,?,?)',
         [id, username, hash, displayName, role],
       );
-      const token = jwt.sign({ sub: id }, JWT_SECRET, { expiresIn: '7d' });
+      const token = JWT.encode(
+        { sub: id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
+        JWT_SECRET,
+      );
       await saveToken(token);
       setSession(token);
       await loadProfile(id);
@@ -162,7 +168,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setLoading(true);
     const token = await getToken();
     if (token && isTokenValid(token)) {
-      const payload: any = jwt.decode(token);
+      const payload: any = JWT.decode(token, JWT_SECRET);
       setSession(token);
       if (payload?.sub) {
         await loadProfile(payload.sub);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "expo-secure-store": "~12.1.4",
     "expo-sqlite": "^11.1.1",
     "js-cookie": "^3.0.5",
-    "jsonwebtoken": "^9.0.2",
+    "expo-jwt": "^1.8.2",
     "axios": "^1.6.2",
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -1,7 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
 import DatabaseService from './database';
-import jwt from 'jsonwebtoken';
+import JWT from 'expo-jwt';
+
+const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 import { getToken } from '../utils/tokenStorage';
 import { isTokenValid } from '../utils/jwtSession';
 
@@ -19,7 +21,7 @@ class CartService {
   private async getCurrentUserId(): Promise<string | null> {
     const token = await getToken();
     if (token && isTokenValid(token)) {
-      const payload: any = jwt.decode(token);
+      const payload: any = JWT.decode(token, JWT_SECRET);
       return payload?.sub || null;
     }
     return null;

--- a/utils/jwtSession.ts
+++ b/utils/jwtSession.ts
@@ -1,13 +1,10 @@
-import jwt from 'jsonwebtoken';
+import JWT from 'expo-jwt';
 
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 
 export function isTokenValid(token: string): boolean {
   try {
-    const payload = jwt.verify(token, JWT_SECRET) as any;
-    if (payload && typeof payload === 'object' && payload.exp) {
-      return Date.now() < payload.exp * 1000;
-    }
+    JWT.decode(token, JWT_SECRET);
     return true;
   } catch {
     return false;
@@ -16,10 +13,30 @@ export function isTokenValid(token: string): boolean {
 
 export function refreshToken(token: string, expiresIn: string | number = '7d'): string | null {
   try {
-    const payload = jwt.verify(token, JWT_SECRET) as any;
+    const payload = JWT.decode(token, JWT_SECRET) as any;
     const { iat, exp, ...rest } = payload as any;
-    return jwt.sign(rest, JWT_SECRET, { expiresIn });
+    const seconds = typeof expiresIn === 'number' ? expiresIn : parseExpires(expiresIn);
+    const newExp = Math.floor(Date.now() / 1000) + seconds;
+    return JWT.encode({ ...rest, exp: newExp }, JWT_SECRET);
   } catch {
     return null;
+  }
+}
+
+function parseExpires(input: string): number {
+  const match = /^\s*(\d+)\s*([smhd])?\s*$/.exec(input);
+  if (!match) return parseInt(input, 10) || 0;
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  switch (unit) {
+    case 'd':
+      return value * 86400;
+    case 'h':
+      return value * 3600;
+    case 'm':
+      return value * 60;
+    case 's':
+    default:
+      return value;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7009,21 +7009,6 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonwebtoken@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
-  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
-  dependencies:
-    jws "^3.2.2"
-    lodash.includes "^4.3.0"
-    lodash.isboolean "^3.0.3"
-    lodash.isinteger "^4.0.4"
-    lodash.isnumber "^3.0.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.once "^4.0.0"
-    ms "^2.1.1"
-    semver "^7.5.4"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -11057,3 +11042,15 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+expo-jwt@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/expo-jwt/-/expo-jwt-1.8.2.tgz"
+  integrity sha512-I2l4WTKWdzQ74ZWcLijXumo/DJltId/gVVgNHBCNsVp0KvJB9rXuXYo+zGx1GnMPsDh1Y5Qei+W+Ym9vwZ9CQ==
+  dependencies:
+    crypto-js "^4.2.0"
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JO2KGL+AizD70Q==


### PR DESCRIPTION
## Summary
- remove `jsonwebtoken` and add `expo-jwt`
- use `expo-jwt` in `AuthContext` to encode/decode tokens
- update cart service to decode JWT using the new library
- rewrite JWT helper to sign/verify with `expo-jwt`

## Testing
- `yarn lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9efc056c83269a85e6fb80d9c2bc