### PR TITLE
Fix shadow styling for web

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -1245,15 +1245,25 @@ const styles = StyleSheet.create({
     borderRadius: 28,
     justifyContent: 'center',
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 4,
-    },
-    shadowOpacity: 0.3,
-    shadowRadius: 6,
-    elevation: 8,
     zIndex: 1000,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+      },
+      android: {
+        elevation: 8,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+      },
+      web: {
+        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.3)',
+      },
+    }),
   },
   chatContainer: {
     flex: 1,
@@ -1378,12 +1388,25 @@ const styles = StyleSheet.create({
     borderRadius: 25,
     paddingHorizontal: 8,
     paddingVertical: 8,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
-    elevation: 5,
     zIndex: 1000,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+      },
+      android: {
+        elevation: 5,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+      },
+      web: {
+        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.25)',
+      },
+    }),
   },
   reactionOption: {
     padding: 8,

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -120,6 +120,9 @@ const styles = StyleSheet.create({
       android: {
         elevation: 5,
       },
+      web: {
+        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.25)',
+      },
     }),
   },
   header: {


### PR DESCRIPTION
## Summary
- use `Platform.select` for `ChatWidget` shadows
- add web shadow for `ConfirmationModal`

## Testing
- `npx expo lint` *(fails: Cannot find module 'eslint')*
- `yarn install --ignore-scripts` *(fails: Couldn't find any versions for "expo-secure-store" that matches "~12.1.4")*

------
https://chatgpt.com/codex/tasks/task_e_687e9f005b7083268c7f1b923f35bc46