### PR TITLE
Fix SQLite initialization for web

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -1,10 +1,13 @@
-import * as SQLite from 'expo-sqlite';
+import * as SQLite from 'expo-sqlite/next';
+import { Platform } from 'react-native';
 
-let db: SQLite.Database | null = null;
-
-export function getDatabase(): SQLite.Database {
+let db: SQLite.SQLiteDatabase | null = null;
+export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!db) {
-    db = SQLite.openDatabase('app.db');
+    if (Platform.OS === 'web') {
+      await SQLite.loadWebSQLiteAsync();
+    }
+    db = await SQLite.openDatabaseAsync('app.db');
   }
   return db;
 }
@@ -13,7 +16,7 @@ export async function executeSql(
   sql: string,
   params: any[] = [],
 ): Promise<SQLite.SQLResultSet> {
-  const database = getDatabase();
+  const database = await getDatabase();
   return new Promise((resolve, reject) => {
     database.transaction((tx) => {
       tx.executeSql(

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native": "^7.0.14",
     "bcryptjs": "^2.4.3",
     "expo-secure-store": "^14.2.3",
-    "expo-sqlite": "^11.1.1",
+    "expo-sqlite": "^11.2.0",
     "js-cookie": "^3.0.5",
     "expo-jwt": "^1.8.2",
     "axios": "^1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5384,7 +5384,7 @@ expo-splash-screen@~0.30.6:
   dependencies:
     "@expo/prebuild-config" "^9.0.10"
 
-expo-sqlite@^11.1.1:
+expo-sqlite@^11.2.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/expo-sqlite/-/expo-sqlite-11.8.0.tgz#e83ab693cce7283d8bbae3acf80c9f840478f5ca"
   integrity sha512-xKoX4N08GAldohqnkVBcmKUxBcqcIia12PX+D/CfiNmRzC/p6sjKrOx7zwcql2qUpAFlVoKMI637C+AWY3sWSQ==


### PR DESCRIPTION
## Summary
- initialize `expo-sqlite` using the new `/next` API
- load the WASM backend on web
- bump `expo-sqlite` dependency

## Testing
- `yarn install` *(fails: Integrity check failed for expo-jwt)*

------
https://chatgpt.com/codex/tasks/task_e_687ec0349bc88326b47cc4f08463a009