### PR TITLE
Fix expo-sqlite import path

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -1,12 +1,8 @@
-import * as SQLite from 'expo-sqlite/next';
-import { Platform } from 'react-native';
+import * as SQLite from 'expo-sqlite';
 
 let db: SQLite.SQLiteDatabase | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!db) {
-    if (Platform.OS === 'web') {
-      await SQLite.loadWebSQLiteAsync();
-    }
     db = await SQLite.openDatabaseAsync('app.db');
   }
   return db;


### PR DESCRIPTION
## Summary
- update `lib/sqlite.ts` to import from `expo-sqlite`
- remove web-specific loader usage

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68800567b3d083268bce9b79c2dc8306