### PR TITLE
Fix db init race and switch to async sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 expo-env.d.ts
 # @end expo-cli
+node_modules/
+.expo
+

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -1,30 +1,25 @@
 import * as SQLite from 'expo-sqlite';
 
-let db: SQLite.SQLiteDatabase | null = null;
+let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (!db) {
-    db = await SQLite.openDatabaseAsync('app.db');
+  if (!dbPromise) {
+    dbPromise = SQLite.openDatabaseAsync('app.db');
   }
-  return db;
+  return dbPromise;
 }
 
 export async function executeSql(
   sql: string,
   params: any[] = [],
-): Promise<SQLite.SQLResultSet> {
+): Promise<{ rows: { _array: any[] } }> {
   const database = await getDatabase();
-  return new Promise((resolve, reject) => {
-    database.transaction((tx) => {
-      tx.executeSql(
-        sql,
-        params,
-        (_tx, result) => resolve(result),
-        (_tx, error) => {
-          reject(error);
-          return false;
-        },
-      );
-    });
-  });
+  const statement = await database.prepareAsync(sql);
+  try {
+    const result = await statement.executeAsync(params);
+    const rows = await result.getAllAsync();
+    return { rows: { _array: rows } };
+  } finally {
+    await statement.finalizeAsync();
+  }
 }
 

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -12,14 +12,20 @@ class TenantSettingsService {
 
   private constructor() {
     // Initialize table
-    executeSql(
-      `CREATE TABLE IF NOT EXISTS tenant_settings (
-        tenant_id TEXT PRIMARY KEY NOT NULL,
-        platform_name TEXT,
-        platform_logo TEXT,
-        theme_color TEXT
-      )`
-    ).catch((err) => console.error('Error creating tenant_settings table:', err));
+    (async () => {
+      try {
+        await executeSql(
+          `CREATE TABLE IF NOT EXISTS tenant_settings (
+            tenant_id TEXT PRIMARY KEY NOT NULL,
+            platform_name TEXT,
+            platform_logo TEXT,
+            theme_color TEXT
+          )`
+        );
+      } catch (err) {
+        console.error('Error creating tenant_settings table:', err);
+      }
+    })();
   }
 
   public static getInstance(): TenantSettingsService {


### PR DESCRIPTION
## Summary
- prevent concurrent database opens with a single promise
- use new prepareAsync/executeAsync in `executeSql`
- await table setup in `TenantSettingsService`
- ignore node_modules and .expo

## Testing
- `yarn lint`
- `yarn test` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800bb038f48326a5c9422a4575b29f