### PR TITLE
Init DB automatically before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Create a local SQLite database:
 This applies the SQL files in `sqlite/migrations` and writes the database to
 `sqlite/blue-ocean.db`.
 
+When you run `yarn dev`, a `predev` script automatically executes the migrations and creates the database if it does not already exist.
+
 ## Seeding Sample Data
 
 After applying the migrations you can populate the local database with fake

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "start": "cross-env EXPO_NO_TELEMETRY=1 BROWSER=none expo start --web",
+    "predev": "node scripts/init-db.js",
     "dev": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "lint": "expo lint",
     "update:appjson": "node scripts/update-app-json.js",

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const migrationsDir = path.join(__dirname, '..', 'sqlite', 'migrations');
+const dbPath = path.join(__dirname, '..', 'sqlite', 'blue-ocean.db');
+
+if (fs.existsSync(dbPath)) {
+  console.log(`Database already exists at ${dbPath}`);
+  process.exit(0);
+}
+
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const db = new sqlite3.Database(dbPath);
+
+function execSql(sql) {
+  return new Promise((resolve, reject) => {
+    db.exec(sql, (err) => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  try {
+    const files = fs
+      .readdirSync(migrationsDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    for (const file of files) {
+      const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+      console.log(`Applying ${file}`);
+      await execSql(sql);
+    }
+
+    console.log(`Database initialized at ${dbPath}`);
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    db.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- create `scripts/init-db.js` to run SQLite migrations
- automatically run DB initialization with `predev`
- document automatic initialization in README

## Testing
- `yarn install`
- `timeout 20 yarn dev` (database created)
- `timeout 10 yarn dev` (skip when db exists)


------
https://chatgpt.com/codex/tasks/task_e_688019d401b48326bf1bb435e98e808b