### PR TITLE
Initialize expo SQLite db on startup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ import { AppInfoProvider } from '../contexts/AppInfoContext';
 import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
+import { ensureDatabase } from '../lib/sqlite';
 
 function AppContent() {
   const [showCartModal, setShowCartModal] = useState(false);
@@ -78,6 +79,20 @@ function AppContent() {
 
 export default function RootLayout() {
   useFrameworkReady();
+
+  const [dbReady, setDbReady] = useState(false);
+
+  useEffect(() => {
+    ensureDatabase().finally(() => setDbReady(true));
+  }, []);
+
+  if (!dbReady) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
 
   return (
     <AppInfoProvider>

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -1,4 +1,8 @@
 import * as SQLite from 'expo-sqlite';
+import * as FileSystem from 'expo-file-system';
+import { Asset } from 'expo-asset';
+
+const DB_NAME = 'app.db';
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
@@ -20,6 +24,50 @@ export async function executeSql(
     return { rows: { _array: rows } };
   } finally {
     await statement.finalizeAsync();
+  }
+}
+
+async function tableExists(db: SQLite.SQLiteDatabase, name: string) {
+  const stmt = await db.prepareAsync(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+  );
+  try {
+    const res = await stmt.executeAsync([name]);
+    const rows = await res.getAllAsync();
+    return rows.length > 0;
+  } finally {
+    await stmt.finalizeAsync();
+  }
+}
+
+export async function ensureDatabase(): Promise<void> {
+  const sqliteDir = FileSystem.documentDirectory + 'SQLite';
+  await FileSystem.makeDirectoryAsync(sqliteDir, { intermediates: true });
+  const dbPath = sqliteDir + '/' + DB_NAME;
+
+  let needsSetup = false;
+  const info = await FileSystem.getInfoAsync(dbPath);
+  if (info.exists) {
+    try {
+      const db = await SQLite.openDatabaseAsync(DB_NAME);
+      if (!(await tableExists(db, 'users'))) {
+        needsSetup = true;
+      }
+    } catch {
+      needsSetup = true;
+    }
+  } else {
+    needsSetup = true;
+  }
+
+  if (needsSetup) {
+    try {
+      const asset = Asset.fromModule(require('../sqlite/blue-ocean.db'));
+      await asset.downloadAsync();
+      await FileSystem.copyAsync({ from: asset.localUri!, to: dbPath });
+    } catch (err) {
+      console.error('Failed to copy prepopulated database:', err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the bundled SQLite database is present before app startup
- load prepopulated `blue-ocean.db` into Expo's document directory when needed
- wait for database initialization before rendering the app

## Testing
- `yarn lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e714681c8326a8bb73bb3a49b8e5