### PR TITLE
Update seed db default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ After applying the migrations you can populate the local database with fake
 users, products, orders and tenant settings.
 
 ```sh
-DB_PATH=sqlite/blue-ocean.db yarn seed
+yarn seed
 ```
+
+The `seed.js` script defaults to `sqlite/blue-ocean.db`. Set `DB_PATH` to use a
+different location.
 
 ## Database Backup and Restore
 

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -2,7 +2,7 @@ const sqlite3 = require('sqlite3').verbose();
 const { faker } = require('@faker-js/faker');
 const path = require('path');
 
-const dbPath = process.env.DB_PATH || path.join(__dirname, '../sqlite/db.sqlite');
+const dbPath = process.env.DB_PATH || path.join(__dirname, '../sqlite/blue-ocean.db');
 const db = new sqlite3.Database(dbPath);
 
 function run(sql, params = []) {


### PR DESCRIPTION
## Summary
- default `scripts/seed.js` to use `../sqlite/blue-ocean.db`
- adjust README to reflect the default location for seeds

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6880e7c35e8c832693efaf877cff6fea