### PR TITLE
Add ElectricSQL replication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ VAPID_PRIVATE_KEY=your_private_key
 
 # Tenant Identifier used to load branding from tenant_settings table
 EXPO_PUBLIC_TENANT=thecongress
+
+# ElectricSQL sync service URL
+EXPO_PUBLIC_ELECTRIC_URL=http://localhost:5133

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ the same value is used for all clients so they can decrypt messages.
 `EXPO_PUBLIC_TENANT` specifies which tenant's branding to load from the
 `tenant_settings` table. Example values are `thecongress` or `thebull`.
 
+Set `EXPO_PUBLIC_ELECTRIC_URL` to point at your ElectricSQL sync service so
+the app can replicate the `users`, `products` and `orders` tables.
+
 Logos and other uploaded images are stored on IPFS via Pinata. Set
 `EXPO_PUBLIC_PINATA_JWT` (or API key/secret) in your `.env` file so uploads can
 succeed.
@@ -63,7 +66,8 @@ Create a local SQLite database:
 This applies the SQL files in `sqlite/migrations` and writes the database to
 `sqlite/blue-ocean.db`.
 
-When you run `yarn dev`, a `predev` script automatically executes the migrations and creates the database if it does not already exist.
+When you run `yarn dev`, a `predev` script automatically executes the migrations,
+creates the database if needed, and starts ElectricSQL replication.
 
 ## Seeding Sample Data
 
@@ -73,6 +77,12 @@ users, products, orders and tenant settings.
 ```sh
 DB_PATH=sqlite/blue-ocean.db yarn seed
 ```
+
+## ElectricSQL Replication
+
+ElectricSQL keeps local tables in sync with Postgres. The `predev` script
+starts replication for the `users`, `products` and `orders` tables using the
+service URL defined in `EXPO_PUBLIC_ELECTRIC_URL`.
 
 ## Database Backup and Restore
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "cross-env EXPO_NO_TELEMETRY=1 BROWSER=none expo start --web",
-    "predev": "node scripts/init-db.js",
+    "predev": "node scripts/init-db.js && node scripts/init-electric.js",
     "dev": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "lint": "expo lint",
     "update:appjson": "node scripts/update-app-json.js",
@@ -72,7 +72,8 @@
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
     "web-push": "^3.6.7",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "@electric-sql/client": "^1.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.27.7",

--- a/scripts/init-electric.js
+++ b/scripts/init-electric.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const { ShapeStream, isChangeMessage } = require('@electric-sql/client');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const ELECTRIC_URL = process.env.ELECTRIC_URL || process.env.EXPO_PUBLIC_ELECTRIC_URL || 'http://localhost:5133';
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../sqlite/blue-ocean.db');
+
+function openDb(file) {
+  return new sqlite3.Database(file);
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+async function upsert(db, table, row) {
+  const keys = Object.keys(row);
+  const placeholders = keys.map(() => '?').join(',');
+  const updates = keys.map((k) => `${k}=?`).join(',');
+  const values = keys.map((k) => row[k]);
+  await run(
+    db,
+    `INSERT INTO ${table} (${keys.join(',')}) VALUES (${placeholders}) ON CONFLICT(id) DO UPDATE SET ${updates}`,
+    [...values, ...values]
+  );
+}
+
+async function handleMessage(db, table, msg) {
+  if (!isChangeMessage(msg)) return;
+  const op = msg.headers.operation;
+  const row = msg.value;
+  if (op === 'delete') {
+    await run(db, `DELETE FROM ${table} WHERE id=?`, [row.id]);
+  } else {
+    await upsert(db, table, row);
+  }
+}
+
+async function start() {
+  const tables = ['users', 'products', 'orders'];
+  const db = openDb(DB_PATH);
+  tables.forEach((table) => {
+    const stream = new ShapeStream({
+      url: `${ELECTRIC_URL}/v1/shape`,
+      params: { table, replica: 'full' },
+      subscribe: true,
+      onError: (err) => console.error(`ElectricSQL ${table} error`, err),
+    });
+    stream.subscribe(async (messages) => {
+      for (const m of messages) {
+        await handleMessage(db, table, m);
+      }
+    });
+  });
+  console.log('ElectricSQL replication started');
+}
+
+start().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,6 +854,15 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
+"@electric-sql/client@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@electric-sql/client/-/client-1.0.7.tgz#28fffdfcf60948638c3f941a2ac70ad73361a6f4"
+  integrity sha512-w9geRoZL1gn294Nn68YxicRvWFJEXWYPr+jZubSOyjaSa6tVQJk0rjYuFmOwpQyudFQrsL17HFrGga9UOaBhdA==
+  dependencies:
+    "@microsoft/fetch-event-source" "^2.0.1"
+  optionalDependencies:
+    "@rollup/rollup-darwin-arm64" "^4.18.1"
+
 "@emnapi/core@^1.4.3":
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.4.tgz#76620673f3033626c6d79b1420d69f06a6bb153c"
@@ -1769,6 +1778,11 @@
   resolved "https://registry.npmjs.org/@lucide/lab/-/lab-0.1.2.tgz"
   integrity sha512-VprF2BJa7ZuTGOhUd5cf8tHJXyL63wdxcGieAiVVoR9hO0YmPsnZO0AGqDiX2/br+/MC6n8BoJcmPilltOXIJA==
 
+"@microsoft/fetch-event-source@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"
+  integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
+
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
@@ -2148,6 +2162,11 @@
   integrity sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==
   dependencies:
     nanoid "^3.3.11"
+
+"@rollup/rollup-darwin-arm64@^4.18.1":
+  version "4.45.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz#7efce10220293a22e7b7b595d05d8b8400a7bcf3"
+  integrity sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary
- integrate `@electric-sql/client`
- replicate `users`, `products` and `orders` tables
- launch replication in `predev` script
- document ElectricSQL config and replication
- expose `EXPO_PUBLIC_ELECTRIC_URL` in `.env.example`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6880e871778483268b3f3aa02111d176