### PR TITLE
Use DatabaseService for profile fetching

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { executeSql } from '../lib/sqlite';
+import DatabaseService from '../services/database';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
@@ -82,17 +83,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const loadProfile = async (uid: string) => {
-    const result = await executeSql('SELECT * FROM users WHERE id = ?', [uid]);
-    const data = (result.rows as any)._array?.[0];
-    if (data) {
+    const db = DatabaseService.getInstance();
+    const profile = await db.getUserProfile(uid);
+    if (profile) {
+      if (profile.email === 'deandeanazulay@gmail.com') {
+        profile.role = 'admin';
+      }
       setUser({
-        id: data.id,
-        username: data.username,
-        displayName: data.display_name,
-        role: data.role,
+        id: profile.id,
+        username: profile.username,
+        displayName: profile.displayName,
+        email: profile.email,
+        role: profile.role,
       });
     } else {
-      setUser({ id: uid, role: 'user', username: '', displayName: '' });
+      setUser({ id: uid, role: 'user', username: '', displayName: '', email: '' });
     }
   };
 


### PR DESCRIPTION
## Summary
- update `AuthContext` to load profiles via `DatabaseService`
- fetch `email` and force admin privileges for the given address

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6880fb201a3483269b487b83e05f8ee7