### PR TITLE
Fix avatar display on init

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -12,6 +12,7 @@ import { router } from 'expo-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAppInfo } from '../contexts/AppInfoContext';
+import { useAuth } from './AuthContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from './WishlistModal';
 import CartService from '../services/cart';
@@ -30,6 +31,7 @@ export default function GlobalHeader({
   const { t } = useLanguage();
   const { colors } = useTheme();
   const { platformName, platformLogo } = useAppInfo();
+  const { isLoggedIn, user } = useAuth();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
 
@@ -101,7 +103,7 @@ export default function GlobalHeader({
                 </View>
               )}
             </TouchableOpacity>
-            <UserAvatar />
+            {isLoggedIn && user && <UserAvatar />}
           </View>
         </View>
 

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -281,6 +281,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     paddingTop: 60,
     paddingRight: 16,
+    zIndex: 1000,
   },
   dropdown: {
     borderRadius: 12,


### PR DESCRIPTION
## Summary
- load auth state in `GlobalHeader`
- only show `<UserAvatar />` once user state is available
- ensure avatar menu dropdown sits above other UI

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6880fb60e1288326b3e5bbfe1c9411ce