### PR TITLE
Switch ElectricSQL driver for web

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ This Expo project uses React Native with the Expo Router.
 
 ## Setup
 
-Run `yarn install` to populate `node_modules`:
+Run `yarn install` to populate `node_modules`. ElectricSQL is required for web support, so install it as a development dependency:
 
 ```sh
 yarn install
+
+# install the ElectricSQL package
+yarn add -D electric-sql
 ```
 
 If dependencies need patching, run `patch-package` after installation:
@@ -67,7 +70,7 @@ When you run `yarn dev`, a `predev` script automatically executes the migrations
 
 ## ElectricSQL on the Web
 
-`ensureDatabase` from `lib/sqlite.ts` behaves slightly differently when the application runs in the browser. Instead of copying the bundled `blue-ocean.db` file, ElectricSQL provisions an IndexedDB-backed database and applies the schema generated from the SQL files in `sqlite/migrations`. Once the tables are created the library begins syncing with the backend automatically.
+`ensureDatabase` from `lib/sqlite.ts` behaves slightly differently when the application runs in the browser. It relies on ElectricSQL's **browser driver** (`electric-sql/browser`) instead of the React Native package. Rather than copying the bundled `blue-ocean.db` file, the driver provisions an IndexedDB-backed database and applies the schema generated from the SQL files in `sqlite/migrations`. Once the tables are created the library begins syncing with the backend automatically.
 
 If you modify any migration file you need to regenerate the ElectricSQL schema so the web build picks up the changes:
 

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -11,7 +11,7 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
       if (Platform.OS === 'web') {
-        const { electrify } = await import('@electric-sql/react-native');
+        const { electrify } = await import('electric-sql/browser');
         const { schema } = await import('../sqlite/migrations');
         await electrify(db, schema);
       }


### PR DESCRIPTION
## Summary
- use `electric-sql/browser` in the dynamic import
- document installing ElectricSQL and note browser driver

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6880ff6704ec8326b20e1f2dc023be81