### PR TITLE
Remove ElectricSQL install bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Run `yarn install` to populate `node_modules`. ElectricSQL is required for web s
 
 ```sh
 yarn install
-
-# install the ElectricSQL package
-yarn add -D electric-sql
 ```
 
 If dependencies need patching, run `patch-package` after installation:


### PR DESCRIPTION
## Summary
- remove the instruction to install `electric-sql` from the Setup guide

## Testing
- `npx -y node@22 yarn install`
- `npx -y node@22 yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6885c74446c083269b8450ac743f7cf0