### PR TITLE
Add service tests

### DIFF
--- a/tests/databaseService.test.ts
+++ b/tests/databaseService.test.ts
@@ -1,0 +1,79 @@
+import DatabaseService from '../services/database';
+import { executeSql } from '../lib/sqlite';
+
+jest.mock('../lib/sqlite', () => ({
+  executeSql: jest.fn(),
+}));
+
+describe('DatabaseService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a singleton instance', () => {
+    const first = DatabaseService.getInstance();
+    const second = DatabaseService.getInstance();
+    expect(first).toBe(second);
+  });
+
+  it('maps getProduct response correctly', async () => {
+    (executeSql as jest.Mock).mockResolvedValue({
+      rows: {
+        _array: [
+          {
+            id: '1',
+            name: 'Product',
+            name_en: 'Product EN',
+            name_he: 'Product HE',
+            price: 10,
+            originalPrice: null,
+            description: 'desc',
+            description_en: 'desc',
+            description_he: 'desc',
+            category: 'cat',
+            subcategory: null,
+            images: '["img1"]',
+            videos: '["vid1"]',
+            colors: '["red"]',
+            rating: 4,
+            reviews: 2,
+            badges: '["sale"]',
+            pricing_tier: 'tier1',
+            mix_group_id: 'mix1',
+            stock: 5,
+            created_at: 'c',
+            updated_at: 'u',
+          },
+        ],
+      },
+    });
+
+    const service = DatabaseService.getInstance();
+    const product = await service.getProduct('1');
+
+    expect(product).toEqual({
+      id: '1',
+      name: 'Product',
+      name_en: 'Product EN',
+      name_he: 'Product HE',
+      price: 10,
+      originalPrice: undefined,
+      description: 'desc',
+      description_en: 'desc',
+      description_he: 'desc',
+      category: 'cat',
+      subcategory: undefined,
+      images: ['img1'],
+      videos: ['vid1'],
+      colors: ['red'],
+      rating: 4,
+      reviews: 2,
+      badges: ['sale'],
+      pricingTier: 'tier1',
+      mixGroupId: 'mix1',
+      stock: 5,
+      createdAt: 'c',
+      updatedAt: 'u',
+    });
+  });
+});

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,0 +1,26 @@
+import PinataService from '../services/pinata';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('PinataService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('detects missing credentials', () => {
+    process.env.EXPO_PUBLIC_PINATA_JWT = '';
+    process.env.EXPO_PUBLIC_PINATA_API_KEY = '';
+    process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY = '';
+    const service = PinataService.getInstance();
+    expect(service.isPinataConfigured()).toBe(false);
+  });
+
+  it('skips upload when URI is already a URL', async () => {
+    const url = 'https://example.com/file.png';
+    const service = PinataService.getInstance();
+    const result = await service.uploadFile(url, 'file');
+    expect(result).toBe(url);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for DatabaseService singleton behavior and product mapping
- add unit tests for PinataService configuration detection and upload skip logic

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885da2d592c83268849f691797649fa