### PR TITLE
Remove unused dump.sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ sqlite/*.db
 
 # Environment files
 .env*
+dump.sql

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Restore the database from a dump:
 ./scripts/restore-db.sh sqlite/blue-ocean.db dump.sql
 ```
 
+These scripts assume a dump file named `dump.sql`, but the repository no longer
+tracks one. Run `backup-db.sh` to generate the dump before restoring or specify
+your own dump file path.
+
 ## Running the Project
 
 Start the Expo development server with:


### PR DESCRIPTION
## Summary
- remove empty `dump.sql`
- mention creating the dump file in README
- ignore generated `dump.sql` files

## Testing
- `yarn install --frozen-lockfile` *(fails: incompatible node version)*

------
https://chatgpt.com/codex/tasks/task_e_6885da24e48c8326a213749b2215e85a