### PR TITLE
Remove outdated yarn postinstall step

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Run `yarn install` to populate `node_modules`. ElectricSQL is required for web s
 yarn install
 ```
 
-If dependencies need patching, run `patch-package` after installation:
-
-```sh
-yarn postinstall
-```
-
 All data is stored locally; no external services are required.
 
 


### PR DESCRIPTION
## Summary
- drop mention of `patch-package` and `yarn postinstall` from README

## Testing
- `yarn install` *(fails: The engine `node` is incompatible)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885da28d07083268e29106223ce8517