### PR TITLE
Add sql asset extension

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,6 @@
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
-config.resolver.assetExts.push('wasm');
+config.resolver.assetExts.push('wasm', 'sql');
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- include `.sql` files in the Metro bundler asset extensions

## Testing
- `yarn build:web`

------
https://chatgpt.com/codex/tasks/task_e_6885ec3d141083268e5b6eccca5555fe