### PR TITLE
Alias custom HMR client across build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ the web. The polyfill is automatically imported from `index.ts`.
 The project also uses `expo-standard-web-crypto` to polyfill the Web Crypto API,
 so ensure it's installed as a dependency.
 
+### Hot Reloading
+
+Metro, TypeScript and webpack alias `@expo/metro-runtime/src/HMRClient` to the
+local `HMRClient.ts` wrapper. This module applies the necessary polyfills before
+loading Metro's runtime so hot reloading works reliably on every platform.
+
 ### Session Persistence
 
 User sessions are stored using `@react-native-async-storage/async-storage`.

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,13 @@
+const path = require('path');
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push('wasm', 'sql');
+
+// Map the Expo HMR client to our local wrapper so Buffer and Web Crypto are polyfilled
+config.resolver.extraNodeModules = {
+  ...(config.resolver.extraNodeModules || {}),
+  '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+};
 
 module.exports = config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@expo/metro-runtime/src/HMRClient": ["./HMRClient.ts"]
     },
     "customConditions": ["browser"]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 // webpack.config.js
+const path = require('path');
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 const webpack = require('webpack');
 
@@ -28,6 +29,12 @@ module.exports = async function (env, argv) {
       Buffer: ['buffer', 'Buffer'],
     })
   );
+
+  // Match Metro alias for the custom HMR client
+  config.resolve.alias = {
+    ...(config.resolve.alias || {}),
+    '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+  };
 
   return config;
 };


### PR DESCRIPTION
## Summary
- map `@expo/metro-runtime/src/HMRClient` to local `HMRClient.ts` in `metro.config.js`
- add the same alias in `tsconfig.json` and `webpack.config.js`
- document the alias in `README.md`

## Testing
- `yarn install` *(fails: incompatible Node version)*
- `yarn test` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6886558c59d08326a1583539abd2831d