### PR TITLE
Add stub HMR client

### DIFF
--- a/EmptyHMRClient.ts
+++ b/EmptyHMRClient.ts
@@ -1,0 +1,5 @@
+export default {
+  registerBundle: () => {},
+  enable: () => {},
+  log: () => {},
+};

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Metro, TypeScript and webpack alias `@expo/metro-runtime/src/HMRClient` to the
 local `HMRClient.ts` wrapper. This module applies the necessary polyfills before
 loading Metro's runtime so hot reloading works reliably on every platform.
 
+Metro also maps `react-native/Libraries/Utilities/HMRClient` to a stub
+`EmptyHMRClient.ts` with no-op methods so bundling succeeds even when the native
+implementation isn't available.
+
 ### Session Persistence
 
 User sessions are stored using `@react-native-async-storage/async-storage`.

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,10 @@ config.resolver.assetExts.push('wasm', 'sql');
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
   '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+  'react-native/Libraries/Utilities/HMRClient': path.resolve(
+    __dirname,
+    'EmptyHMRClient.ts'
+  ),
 };
 
 module.exports = config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
-      "@expo/metro-runtime/src/HMRClient": ["./HMRClient.ts"]
+      "@expo/metro-runtime/src/HMRClient": ["./HMRClient.ts"],
+      "react-native/Libraries/Utilities/HMRClient": ["./EmptyHMRClient.ts"]
     },
     "customConditions": ["browser"]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,10 @@ module.exports = async function (env, argv) {
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+    'react-native/Libraries/Utilities/HMRClient': path.resolve(
+      __dirname,
+      'EmptyHMRClient.ts'
+    ),
   };
 
   return config;


### PR DESCRIPTION
## Summary
- add `EmptyHMRClient.ts` for RN HMR stub
- alias the stub in metro, webpack, and tsconfig
- document the new mapping for hot reloading

## Testing
- `yarn install --ignore-engines`
- `yarn test` *(fails: PinataService and databaseService tests)*

------
https://chatgpt.com/codex/tasks/task_e_68865a00a9e483269971aa46740b95b5