### PR TITLE
Update HMRClient alias paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ so ensure it's installed as a dependency.
 
 ### Hot Reloading
 
-Metro, TypeScript and webpack alias `@expo/metro-runtime/src/HMRClient` to the
-local `HMRClient.ts` wrapper. This module applies the necessary polyfills before
+Metro now resolves `@expo/metro-runtime/src/HMRClient.ts` to the
+local `HMRClient.ts` wrapper. TypeScript and webpack also alias the path
+without the extension for compatibility. This module applies the necessary polyfills before
 loading Metro's runtime so hot reloading works reliably on every platform.
 
 Metro also maps `react-native/Libraries/Utilities/HMRClient` to a stub

--- a/metro.config.js
+++ b/metro.config.js
@@ -7,7 +7,7 @@ config.resolver.assetExts.push('wasm', 'sql');
 // Map the Expo HMR client to our local wrapper so Buffer and Web Crypto are polyfilled
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
-  '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+  '@expo/metro-runtime/src/HMRClient.ts': path.resolve(__dirname, 'HMRClient.ts'),
   'react-native/Libraries/Utilities/HMRClient': path.resolve(
     __dirname,
     'EmptyHMRClient.ts'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "paths": {
       "@/*": ["./*"],
       "@expo/metro-runtime/src/HMRClient": ["./HMRClient.ts"],
+      "@expo/metro-runtime/src/HMRClient.ts": ["./HMRClient.ts"],
       "react-native/Libraries/Utilities/HMRClient": ["./EmptyHMRClient.ts"]
     },
     "customConditions": ["browser"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = async function (env, argv) {
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
+    '@expo/metro-runtime/src/HMRClient.ts': path.resolve(__dirname, 'HMRClient.ts'),
     'react-native/Libraries/Utilities/HMRClient': path.resolve(
       __dirname,
       'EmptyHMRClient.ts'


### PR DESCRIPTION
## Summary
- point Metro to `@expo/metro-runtime/src/HMRClient.ts`
- add path for `@expo/metro-runtime/src/HMRClient.ts` in tsconfig
- expose the alias in webpack
- document the alias in the Hot Reloading docs

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68865f8580388326b4c4c9484117de71