### PR TITLE
Fix migrator import for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^electric-sql/migrators$': '<rootDir>/node_modules/electric-sql/dist/migrators',
   },
   transformIgnorePatterns: ['/node_modules/(?!(electric-sql)/)'],
 };


### PR DESCRIPTION
## Summary
- update Jest `moduleNameMapper` so imports of `electric-sql/migrators` resolve to the bundled output

## Testing
- `yarn install --ignore-engines`
- `yarn test tests/database.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68865f89b4e88326bcf631fae98ee5f6