### PR TITLE
Remove ElectricSQL references in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,4 @@ module.exports = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/tests/__mocks__/fileMock.js',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(electric-sql)/)'],
 };

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1,6 +1,4 @@
 import Database from 'better-sqlite3';
-import { DatabaseAdapter } from 'electric-sql/node';
-import { SqliteBundleMigrator } from 'electric-sql/migrators';
 import fs from 'fs';
 
 function parseSqlFile(file: string): string[] {
@@ -31,17 +29,17 @@ function parseSqlFile(file: string): string[] {
 }
 
 describe('database initialization', () => {
-  it('creates tables using ElectricSQL migrator', async () => {
+  it('creates tables from schema file', async () => {
     const statements = parseSqlFile('sqlite/migrations/001_initial_schema.sql');
     const db = new Database(':memory:');
-    const adapter = new DatabaseAdapter(db);
-    const migrator = new SqliteBundleMigrator(adapter, [
-      { version: '1', statements },
-    ]);
-    await migrator.up();
-    const rows = await adapter.query({
-      sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
-    });
+    for (const stmt of statements) {
+      db.exec(stmt);
+    }
+    const rows = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+      )
+      .all();
     expect(rows.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- update database initialization test to run SQL statements directly
- remove `transformIgnorePatterns` from `jest.config.js`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68867ee8c9d48326ba2e54938cb89f92