### PR TITLE
Use direct sqlite migration in tests

### DIFF
--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1,6 +1,4 @@
 import Database from 'better-sqlite3';
-import { DatabaseAdapter } from 'electric-sql/node';
-import { SqliteBundleMigrator } from 'electric-sql/migrators';
 import fs from 'fs';
 
 function parseSqlFile(file: string): string[] {
@@ -31,17 +29,15 @@ function parseSqlFile(file: string): string[] {
 }
 
 describe('database initialization', () => {
-  it('creates tables using ElectricSQL migrator', async () => {
+  it('creates tables from migration SQL', () => {
     const statements = parseSqlFile('sqlite/migrations/001_initial_schema.sql');
     const db = new Database(':memory:');
-    const adapter = new DatabaseAdapter(db);
-    const migrator = new SqliteBundleMigrator(adapter, [
-      { version: '1', statements },
-    ]);
-    await migrator.up();
-    const rows = await adapter.query({
-      sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
-    });
+    for (const stmt of statements) {
+      db.exec(stmt);
+    }
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+      .all();
     expect(rows.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- update database.test.ts to execute migration SQL directly using better-sqlite3
- drop ElectricSQL-specific imports

## Testing
- `yarn test tests/database.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68867eeb037c8326a85433cbdc9cd72c