### PR TITLE
Remove ElectricSQL docs and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ This Expo project uses React Native with the Expo Router.
 
 ## Setup
 
-Run `yarn install` to populate `node_modules`. ElectricSQL is required for web support, so install it as a development dependency:
+Run `yarn install` to populate `node_modules`. All data is stored locally; no external services are required.
 
 ```sh
 yarn install
 ```
 
-All data is stored locally; no external services are required.
 
 
 Some dependencies rely on Node.js globals like `Buffer` and `URL`. The project
@@ -70,25 +69,6 @@ This applies the SQL files in `sqlite/migrations` and writes the database to
 
 When you run `yarn dev`, a `predev` script automatically executes the migrations and creates the database if it does not already exist.
 
-## ElectricSQL on the Web
-
-`ensureDatabase` from `lib/sqlite.ts` checks whether any tables already exist. If not, it reads the SQL files in `sqlite/migrations` and creates the schema on the first run. When the app runs in the browser, ElectricSQL's **browser driver** (`electric-sql/browser`) provisions an IndexedDB-backed database and applies the same schema automatically. Once the tables are created the library begins syncing with the backend automatically.
-
-If you modify any migration file you need to regenerate the ElectricSQL schema so the web build picks up the changes:
-
-```sh
-npx electric-sql migrate
-```
-
-The project depends on the `electric-sql` package, and this command will generate the updated schema files under the `electric/` directory which `ensureDatabase` relies on when running on the web.
-
-After migrating, run the generator to produce the TypeScript schema used by the web build:
-
-```sh
-npx electric-sql generate
-```
-
-The resulting `electric/schema.ts` file is re-exported from `sqlite/migrations/index.ts`.
 
 ## Seeding Sample Data
 

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1,6 +1,4 @@
 import Database from 'better-sqlite3';
-import { DatabaseAdapter } from 'electric-sql/node';
-import { SqliteBundleMigrator } from 'electric-sql/migrators';
 import fs from 'fs';
 
 function parseSqlFile(file: string): string[] {
@@ -31,17 +29,15 @@ function parseSqlFile(file: string): string[] {
 }
 
 describe('database initialization', () => {
-  it('creates tables using ElectricSQL migrator', async () => {
+  it('creates tables from migration file', () => {
     const statements = parseSqlFile('sqlite/migrations/001_initial_schema.sql');
     const db = new Database(':memory:');
-    const adapter = new DatabaseAdapter(db);
-    const migrator = new SqliteBundleMigrator(adapter, [
-      { version: '1', statements },
-    ]);
-    await migrator.up();
-    const rows = await adapter.query({
-      sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
-    });
+    for (const stmt of statements) {
+      db.prepare(stmt).run();
+    }
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+      .all();
     expect(rows.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- remove references to ElectricSQL from README
- rewrite database.test.ts to use raw SQL migrations instead of ElectricSQL

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68867eeccafc832695d0e66f7d0d257a