### PR TITLE
Add web no-op Waku client

### DIFF
--- a/hooks/useWakuClient.web.ts
+++ b/hooks/useWakuClient.web.ts
@@ -1,0 +1,7 @@
+export function useWakuClient() {
+  return {
+    send: async () => { /* noop */ },
+    subscribe: async () => {},
+    fetchHistory: async () => {},
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
+      "hooks/*": ["hooks/*"],
       "@expo/metro-runtime/src/HMRClient": ["./HMRClient.ts"],
       "@expo/metro-runtime/src/HMRClient.ts": ["./HMRClient.ts"],
       "react-native/Libraries/Utilities/HMRClient": ["./EmptyHMRClient.ts"]


### PR DESCRIPTION
## Summary
- provide a web-specific version of `useWakuClient`
- allow TypeScript to resolve hooks path mappings

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68868cf62f88832695120931c238f240