### PR TITLE
Add web-friendly SQLite migration logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Disable it by setting `fastRefresh: false` in your web configuration.
 The Waku chat integration is also not available on the web; the
 `useWakuClient.web.ts` file provides a stub so the rest of the app can build
 without the Waku SDK.
+The web build also fetches the initial SQLite migration over HTTP so it doesn't
+need `expo-file-system`.
 
 ## Environment Variables
 

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -1,17 +1,12 @@
 import * as SQLite from 'expo-sqlite';
-import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
-import { Platform } from 'react-native';
 
 const DB_NAME = 'app.db';
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
-    dbPromise = (async () => {
-      const db = await SQLite.openDatabaseAsync(DB_NAME);
-      return db;
-    })();
+    dbPromise = SQLite.openDatabaseAsync(DB_NAME);
   }
   return dbPromise;
 }
@@ -76,15 +71,8 @@ async function applySchema(db: SQLite.SQLiteDatabase) {
     require('../sqlite/migrations/001_initial_schema.sql')
   );
   await asset.downloadAsync();
-  let sql: string;
-  if (Platform.OS === 'web') {
-    const res = await fetch(asset.uri);
-    sql = await res.text();
-  } else {
-    sql = await FileSystem.readAsStringAsync(asset.localUri!, {
-      encoding: FileSystem.EncodingType.UTF8,
-    });
-  }
+  const res = await fetch(asset.uri);
+  const sql = await res.text();
   const statements = parseSql(sql);
   for (const stmt of statements) {
     const st = await db.prepareAsync(stmt);
@@ -94,10 +82,6 @@ async function applySchema(db: SQLite.SQLiteDatabase) {
 }
 
 export async function ensureDatabase(): Promise<void> {
-  if (Platform.OS !== 'web') {
-    const sqliteDir = FileSystem.documentDirectory + 'SQLite';
-    await FileSystem.makeDirectoryAsync(sqliteDir, { intermediates: true });
-  }
   const db = await getDatabase();
   if (!(await tableExists(db, 'users'))) {
     await applySchema(db);


### PR DESCRIPTION
## Summary
- adapt ensureDatabase to fetch migrations on web
- add a platform-specific sqlite.web.ts without expo-file-system
- document the web fallback

## Testing
- `yarn install` *(fails: @waku/sdk requires node >=22)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869822c9088326ac10379745126054