### PR TITLE
Handle errors starting Waku node

### DIFF
--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -43,12 +43,24 @@ export function useWakuClient(): WakuClient {
     if (!USE_WAKU) return;
     let cancelled = false;
     (async () => {
-      const node = await createLightNode({
-        libp2p: { bootstrap: [BOOTSTRAP] },
-      });
-      await node.start();
-      await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);
-      if (!cancelled) nodeRef.current = node;
+      let node: LightNode | undefined;
+      try {
+        node = await createLightNode({
+          libp2p: { bootstrap: [BOOTSTRAP] },
+        });
+        await node.start();
+        await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);
+        if (!cancelled) nodeRef.current = node;
+      } catch (err) {
+        console.error('Failed to start Waku node', err);
+        if (node) {
+          try {
+            await node.stop();
+          } catch (_) {
+            // ignore
+          }
+        }
+      }
     })();
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- guard `createLightNode` startup with try/catch
- log failures and ensure node shutdown

## Testing
- `yarn install` *(fails: incompatible Node version)*

------
https://chatgpt.com/codex/tasks/task_e_6886a31064b08326b518ac6573e7e054