### PR TITLE
Refactor SQL parsing helper

### DIFF
--- a/lib/sqlUtils.ts
+++ b/lib/sqlUtils.ts
@@ -1,0 +1,27 @@
+export function parseSql(sql: string): string[] {
+  const lines = sql.split(/\r?\n/);
+  const statements: string[] = [];
+  let current: string[] = [];
+  let inTrigger = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    current.push(line);
+    const upper = trimmed.toUpperCase();
+    if (!inTrigger && upper.startsWith('CREATE TRIGGER')) {
+      inTrigger = true;
+    }
+    if (inTrigger && upper === 'END;') {
+      statements.push(current.join('\n'));
+      current = [];
+      inTrigger = false;
+      continue;
+    }
+    if (!inTrigger && upper.endsWith(';')) {
+      statements.push(current.join('\n'));
+      current = [];
+    }
+  }
+  return statements;
+}
+

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -2,6 +2,7 @@ import * as SQLite from 'expo-sqlite';
 import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
 import { Platform } from 'react-native';
+import { parseSql } from './sqlUtils';
 
 const DB_NAME = 'app.db';
 
@@ -44,32 +45,6 @@ async function tableExists(db: SQLite.SQLiteDatabase, name: string) {
   }
 }
 
-function parseSql(sql: string): string[] {
-  const lines = sql.split(/\r?\n/);
-  const statements: string[] = [];
-  let current: string[] = [];
-  let inTrigger = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === '') continue;
-    current.push(line);
-    const upper = trimmed.toUpperCase();
-    if (!inTrigger && upper.startsWith('CREATE TRIGGER')) {
-      inTrigger = true;
-    }
-    if (inTrigger && upper === 'END;') {
-      statements.push(current.join('\n'));
-      current = [];
-      inTrigger = false;
-      continue;
-    }
-    if (!inTrigger && upper.endsWith(';')) {
-      statements.push(current.join('\n'));
-      current = [];
-    }
-  }
-  return statements;
-}
 
 async function applySchema(db: SQLite.SQLiteDatabase) {
   const asset = Asset.fromModule(

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -1,5 +1,6 @@
 import * as SQLite from 'expo-sqlite';
 import { Asset } from 'expo-asset';
+import { parseSql } from './sqlUtils';
 
 const DB_NAME = 'app.db';
 
@@ -39,32 +40,6 @@ async function tableExists(db: SQLite.SQLiteDatabase, name: string) {
   }
 }
 
-function parseSql(sql: string): string[] {
-  const lines = sql.split(/\r?\n/);
-  const statements: string[] = [];
-  let current: string[] = [];
-  let inTrigger = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === '') continue;
-    current.push(line);
-    const upper = trimmed.toUpperCase();
-    if (!inTrigger && upper.startsWith('CREATE TRIGGER')) {
-      inTrigger = true;
-    }
-    if (inTrigger && upper === 'END;') {
-      statements.push(current.join('\n'));
-      current = [];
-      inTrigger = false;
-      continue;
-    }
-    if (!inTrigger && upper.endsWith(';')) {
-      statements.push(current.join('\n'));
-      current = [];
-    }
-  }
-  return statements;
-}
 
 async function applySchema(db: SQLite.SQLiteDatabase) {
   const asset = Asset.fromModule(


### PR DESCRIPTION
## Summary
- add `parseSql` helper in `sqlUtils`
- use `parseSql` in both SQLite implementations to reduce duplication

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6886a311ba3483269aa829c8a4ecd6dc