### PR TITLE
Add Waku unsubscribe support

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -329,9 +329,14 @@ const loadOrCreateDefaultRoom = async () => {
         setMessages((prev) => [...prev, m]);
       }
     };
-    waku.subscribe(selectedRoom.id, handler);
+    let unsubscribe: (() => void) | undefined;
+    waku.subscribe(selectedRoom.id, handler).then((unsub) => {
+      unsubscribe = unsub;
+    });
     waku.fetchHistory(selectedRoom.id, handler);
-    return () => {};
+    return () => {
+      unsubscribe?.();
+    };
   }, [selectedRoom]);
 
   const openSearchResult = async (result: {

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -25,7 +25,7 @@ export interface WakuClient {
   subscribe: (
     roomId: string,
     callback: (msg: ChatMessage) => void,
-  ) => Promise<void>;
+  ) => Promise<() => void>;
   fetchHistory: (
     roomId: string,
     callback: (msg: ChatMessage) => void,
@@ -82,8 +82,8 @@ export function useWakuClient(): WakuClient {
   const subscribe = async (
     roomId: string,
     cb: (msg: ChatMessage) => void,
-  ) => {
-    if (!USE_WAKU || !nodeRef.current) return;
+  ): Promise<() => void> => {
+    if (!USE_WAKU || !nodeRef.current) return () => {};
     const decoder = createDecoder(topic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
@@ -101,7 +101,18 @@ export function useWakuClient(): WakuClient {
       await db.sendChatMessage(roomId, { ...chat, message: encrypted });
       cb(chat);
     };
-    nodeRef.current.relay.addObserver(handler, [decoder]);
+    const maybeUnsub = (nodeRef.current.relay as any).addObserver(
+      handler,
+      [decoder],
+    ) as (() => void) | void;
+
+    return () => {
+      if (typeof maybeUnsub === 'function') {
+        maybeUnsub();
+      } else {
+        (nodeRef.current?.relay as any)?.deleteObserver?.(handler);
+      }
+    };
   };
 
   const fetchHistory = async (

--- a/hooks/useWakuClient.web.ts
+++ b/hooks/useWakuClient.web.ts
@@ -1,7 +1,7 @@
 export function useWakuClient() {
   return {
     send: async () => { /* noop */ },
-    subscribe: async () => {},
+    subscribe: async () => () => {},
     fetchHistory: async () => {},
   };
 }


### PR DESCRIPTION
## Summary
- extend `useWakuClient.subscribe` to return cleanup function
- handle cleanup in `ChatWidget`
- keep parity for web stub

## Testing
- `yarn test` *(fails: jest not found as deps could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a3108c008326b1cc2685b6108a65