### PR TITLE
Fix database init race condition

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -7,6 +7,7 @@ import { parseSql } from './sqlUtils';
 const DB_NAME = 'app.db';
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
+let ensurePromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
     dbPromise = (async () => {
@@ -68,13 +69,23 @@ async function applySchema(db: SQLite.SQLiteDatabase) {
   }
 }
 
-export async function ensureDatabase(): Promise<void> {
-  if (Platform.OS !== 'web') {
-    const sqliteDir = FileSystem.documentDirectory + 'SQLite';
-    await FileSystem.makeDirectoryAsync(sqliteDir, { intermediates: true });
+export function ensureDatabase(): Promise<void> {
+  if (ensurePromise) {
+    return ensurePromise;
   }
-  const db = await getDatabase();
-  if (!(await tableExists(db, 'users'))) {
-    await applySchema(db);
-  }
+  ensurePromise = (async () => {
+    try {
+      if (Platform.OS !== 'web') {
+        const sqliteDir = FileSystem.documentDirectory + 'SQLite';
+        await FileSystem.makeDirectoryAsync(sqliteDir, { intermediates: true });
+      }
+      const db = await getDatabase();
+      if (!(await tableExists(db, 'users'))) {
+        await applySchema(db);
+      }
+    } finally {
+      ensurePromise = null;
+    }
+  })();
+  return ensurePromise;
 }

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -5,6 +5,7 @@ import { parseSql } from './sqlUtils';
 const DB_NAME = 'app.db';
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
+let ensurePromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
     dbPromise = SQLite.openDatabaseAsync(DB_NAME);
@@ -56,9 +57,19 @@ async function applySchema(db: SQLite.SQLiteDatabase) {
   }
 }
 
-export async function ensureDatabase(): Promise<void> {
-  const db = await getDatabase();
-  if (!(await tableExists(db, 'users'))) {
-    await applySchema(db);
+export function ensureDatabase(): Promise<void> {
+  if (ensurePromise) {
+    return ensurePromise;
   }
+  ensurePromise = (async () => {
+    try {
+      const db = await getDatabase();
+      if (!(await tableExists(db, 'users'))) {
+        await applySchema(db);
+      }
+    } finally {
+      ensurePromise = null;
+    }
+  })();
+  return ensurePromise;
 }


### PR DESCRIPTION
## Summary
- make database initialization return a single promise
- ensure web build uses the same logic

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886da8530f88326ac1620db4b1fa56c