### PR TITLE
Handle duplicate username on signup

### DIFF
--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -13,7 +13,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, UserPlus } from 'lucide-react-native';
-import { useAuth } from '../../components/AuthContext';
+import { useAuth, UsernameTakenError } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import InfoModal from '../../components/InfoModal';
@@ -71,10 +71,16 @@ export default function AuthSignupScreen() {
       }
     } catch (error) {
       console.error('Signup error:', error);
+      const message =
+        error instanceof UsernameTakenError
+          ? t('auth.usernameTaken')
+          : error instanceof Error
+          ? error.message
+          : t('auth.signupError');
       setInfoModal({
         visible: true,
         title: t('common.error'),
-        message: error instanceof Error ? error.message : t('auth.signupError'),
+        message,
         type: 'error'
       });
     } finally {

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -9,6 +9,13 @@ const ADMIN_USERNAME = process.env.EXPO_PUBLIC_ADMIN_USERNAME;
 const ADMIN_PASSWORD = process.env.EXPO_PUBLIC_ADMIN_PASSWORD || 'admin';
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 
+export class UsernameTakenError extends Error {
+  constructor() {
+    super('usernameTaken');
+    this.name = 'UsernameTakenError';
+  }
+}
+
 interface AuthContextType {
   isLoggedIn: boolean;
   isAdmin: boolean;
@@ -149,10 +156,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await loadProfile(id);
       setLoading(false);
       return true;
-    } catch (err) {
-      console.error('Signup failed', err);
+    } catch (err: any) {
       setLoading(false);
-      return false;
+      if (
+        err &&
+        typeof err === 'object' &&
+        'message' in err &&
+        (err as Error).message.includes('UNIQUE constraint failed: users.username')
+      ) {
+        throw new UsernameTakenError();
+      }
+      console.error('Signup failed', err);
+      throw err;
     }
   };
 

--- a/components/AuthTabsModal.tsx
+++ b/components/AuthTabsModal.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { X, LogIn, UserPlus, Lock, User } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { useAuth } from './AuthContext';
+import { useAuth, UsernameTakenError } from './AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { router } from 'expo-router';
 import InfoModal from './InfoModal';
@@ -135,10 +135,16 @@ export default function AuthTabsModal({
       }
     } catch (error) {
       console.error('Signup error:', error);
+      const message =
+        error instanceof UsernameTakenError
+          ? t('auth.usernameTaken')
+          : error instanceof Error
+          ? error.message
+          : t('auth.signupError');
       setInfoModal({
         visible: true,
         title: t('common.error'),
-        message: error instanceof Error ? error.message : t('auth.signupError'),
+        message,
         type: 'error'
       });
     } finally {

--- a/translations/en.json
+++ b/translations/en.json
@@ -49,6 +49,7 @@
     "loginSuccess": "Login successful!",
     "signupSuccess": "Account created successfully!",
     "signupError": "Registration failed. Please try again.",
+    "usernameTaken": "This username is already taken.",
     "fillAllFields": "Please fill in all fields",
     "passwordMismatch": "Passwords do not match",
     "loggingIn": "Logging in...",

--- a/translations/he.json
+++ b/translations/he.json
@@ -49,6 +49,7 @@
     "loginSuccess": "ההתחברות הצליחה!",
     "signupSuccess": "החשבון נוצר בהצלחה!",
     "signupError": "ההרשמה נכשלה. אנא נסה שוב.",
+    "usernameTaken": "שם המשתמש כבר קיים.",
     "fillAllFields": "אנא מלא את כל השדות",
     "passwordMismatch": "הסיסמאות אינן תואמות",
     "loggingIn": "מתחבר...",


### PR DESCRIPTION
## Summary
- detect duplicate username signup errors
- show friendly message in auth forms
- add translation strings for duplicate-username message

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e517efb88326ad6f63ef4be3509f