### PR TITLE
Disable auto admin creation and add DB reset script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # NOTE: Replace placeholder values with your own credentials for local development.
 # Admin Configuration
 EXPO_PUBLIC_ADMIN_USERNAME=roymichaels
-EXPO_PUBLIC_ADMIN_PASSWORD=admin
 
 # Matrix Configuration (for future use)
 EXPO_PUBLIC_MATRIX_SERVER=https://matrix.org

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ This applies the SQL files in `sqlite/migrations` and writes the database to
 
 When you run `yarn dev`, a `predev` script automatically executes the migrations and creates the database if it does not already exist.
 
+If you need to start from a clean database, run:
+
+```sh
+yarn reset-db
+```
+
+This deletes `sqlite/blue-ocean.db` and re-applies the migrations.
+
 
 ## Seeding Sample Data
 

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -6,7 +6,6 @@ import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 
 const ADMIN_USERNAME = process.env.EXPO_PUBLIC_ADMIN_USERNAME;
-const ADMIN_PASSWORD = process.env.EXPO_PUBLIC_ADMIN_PASSWORD || 'admin';
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 
 export class UsernameTakenError extends Error {
@@ -51,26 +50,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const ensureAdminAccount = async () => {
-    if (!ADMIN_USERNAME) return;
-    const res = await executeSql(
-      "SELECT COUNT(*) as count FROM users WHERE role='admin'",
-    );
-    const count = (res.rows as any)._array?.[0]?.count || 0;
-    if (count === 0) {
-      const id = `user_${Date.now()}`;
-      const hash = await bcrypt.hash(ADMIN_PASSWORD, 10);
-      await executeSql(
-        'INSERT INTO users (id, username, password_hash, display_name, role) VALUES (?,?,?,?,?)',
-        [id, ADMIN_USERNAME, hash, 'Admin', 'admin'],
-      );
-    }
-  };
-
   useEffect(() => {
     const init = async () => {
       try {
-        await ensureAdminAccount();
         const token = await getToken();
         if (token && isTokenValid(token)) {
           const payload: any = JWT.decode(token, JWT_SECRET);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "expo lint",
     "update:appjson": "node scripts/update-app-json.js",
     "seed": "node scripts/seed.js",
+    "reset-db": "node scripts/reset-db.js",
     "build:web": "env-cmd -f .env npx expo export --platform web --output-dir dist",
     "build:web:thecongress": "env-cmd -f .env.thecongress yarn  && expo export --platform web --output-dir dist/thecongress",
     "build:web:thebull": "env-cmd -f .env.thebull    yarn  && expo export --platform web --output-dir dist/thebull",

--- a/scripts/reset-db.js
+++ b/scripts/reset-db.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const migrationsDir = path.join(__dirname, '..', 'sqlite', 'migrations');
+const dbPath = path.join(__dirname, '..', 'sqlite', 'blue-ocean.db');
+
+if (fs.existsSync(dbPath)) {
+  fs.unlinkSync(dbPath);
+  console.log(`Deleted existing database at ${dbPath}`);
+}
+
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const db = new sqlite3.Database(dbPath);
+
+function execSql(sql) {
+  return new Promise((resolve, reject) => {
+    db.exec(sql, (err) => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  try {
+    const files = fs
+      .readdirSync(migrationsDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    for (const file of files) {
+      const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+      console.log(`Applying ${file}`);
+      await execSql(sql);
+    }
+
+    console.log(`Database reset at ${dbPath}`);
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    db.close();
+  }
+})();

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -5,7 +5,6 @@ declare global {
       EXPO_PUBLIC_MATRIX_SERVER: string;
       EXPO_PUBLIC_APP_NAME: string;
       EXPO_PUBLIC_DEBUG_LOGS?: string;
-      EXPO_PUBLIC_ADMIN_PASSWORD?: string;
       EXPO_PUBLIC_JWT_SECRET?: string;
       EXPO_PUBLIC_PINATA_JWT?: string;
       EXPO_PUBLIC_PINATA_API_KEY?: string;


### PR DESCRIPTION
## Summary
- stop automatically creating admin account
- remove unused admin password from environment
- add a script to reset the local SQLite DB
- document the new script in README

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6886e7bd371083268041d59b4664d3ce