### PR TITLE
Fix SQLite settings query

### DIFF
--- a/services/database.ts
+++ b/services/database.ts
@@ -844,7 +844,7 @@ class DatabaseService {
     if (exists) {
       await executeSql('UPDATE settings SET value=? WHERE key=?', [value, key]);
     } else {
-      await executeSql('INSERT INTO settings (key,value,type,description) VALUES (?,?,"string",?)', [key, value, `Setting for ${key}`]);
+      await executeSql('INSERT INTO settings (key,value,type,description) VALUES (?,?,\'string\',?)', [key, value, `Setting for ${key}`]);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure new settings insert query uses single quotes for the type literal

## Testing
- `yarn test` *(fails: jest not found)*
- `npx jest` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68872225a934832689e837bc0fbe0c37