### PR TITLE
Fix admin analytics and real profile counts

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,7 @@
 # NOTE: Replace placeholder values with your own credentials for local development.
 # Admin Configuration
+# Comma-separated list of usernames that should be admins
 EXPO_PUBLIC_ADMIN_USERNAME=roymichaels, thebull
-
-EXPO_PUBLIC_ADMIN_PASSWORD=admin
 
 
 # App Configuration

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # NOTE: Replace placeholder values with your own credentials for local development.
 # Admin Configuration
+# Comma-separated list of usernames that should be admins
 EXPO_PUBLIC_ADMIN_USERNAME=roymichaels
 
 # Matrix Configuration (for future use)

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -32,6 +32,9 @@ import { useAppInfo } from '../../contexts/AppInfoContext';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import AuthTabsModal from '../../components/AuthTabsModal';
+import OrderService from '../../services/orders';
+import CartService from '../../services/cart';
+import DatabaseService from '../../services/database';
 
 
 
@@ -47,6 +50,8 @@ export default function ProfileScreen() {
   const [showOrderTracking, setShowOrderTracking] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState(null);
   const [userOrders, setUserOrders] = useState([]);
+  const [wishlistCount, setWishlistCount] = useState(0);
+  const [reviewCount, setReviewCount] = useState(0);
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const scrollViewRef = useRef<ScrollView>(null);
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -64,6 +69,29 @@ export default function ProfileScreen() {
     // Load saved settings
     loadSettings();
   }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!isLoggedIn || !user) return;
+      const orderService = OrderService.getInstance();
+      const cartService = CartService.getInstance();
+      const db = DatabaseService.getInstance();
+
+      try {
+        const [ordersCount, reviews, wishlist] = await Promise.all([
+          orderService.getUserOrderCount(user.id),
+          db.getReviews(),
+          Promise.resolve(cartService.getWishlistItemsCount()),
+        ]);
+        setUserOrders(new Array(ordersCount).fill(null));
+        setWishlistCount(wishlist);
+        setReviewCount(reviews.filter((r) => r.userId === user.id).length);
+      } catch (err) {
+        console.error('Error loading profile data', err);
+      }
+    };
+    fetchData();
+  }, [isLoggedIn, user]);
 
   const loadSettings = async () => {
     try {
@@ -219,7 +247,9 @@ export default function ProfileScreen() {
               </Text>
             </View>
             <View style={styles.statItem}>
-              <Text style={[styles.statNumber, { color: colors.gold }]}>8</Text>
+              <Text style={[styles.statNumber, { color: colors.gold }]}>
+                {wishlistCount}
+              </Text>
               <Text
                 style={[styles.statLabel, { color: colors.text.secondary }]}
               >
@@ -227,7 +257,9 @@ export default function ProfileScreen() {
               </Text>
             </View>
             <View style={styles.statItem}>
-              <Text style={[styles.statNumber, { color: colors.gold }]}>5</Text>
+              <Text style={[styles.statNumber, { color: colors.gold }]}>
+                {reviewCount}
+              </Text>
               <Text
                 style={[styles.statLabel, { color: colors.text.secondary }]}
               >

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -4,8 +4,12 @@ import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
+import { TENANT } from '../constants/tenant';
 
-const ADMIN_USERNAME = process.env.EXPO_PUBLIC_ADMIN_USERNAME;
+const ADMIN_USERNAMES = (process.env.EXPO_PUBLIC_ADMIN_USERNAME || '')
+  .split(',')
+  .map((u) => u.trim())
+  .filter(Boolean);
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
 
 export class UsernameTakenError extends Error {
@@ -124,10 +128,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       const hash = await bcrypt.hash(password, 10);
       const id = `user_${Date.now()}`;
-      const role = ADMIN_USERNAME && username === ADMIN_USERNAME ? 'admin' : 'user';
+      const isAdminUsername = ADMIN_USERNAMES.includes(username);
+      const role = isAdminUsername ? 'admin' : 'user';
       await executeSql(
         'INSERT INTO users (id, username, password_hash, display_name, role) VALUES (?,?,?,?,?)',
         [id, username, hash, displayName, role],
+      );
+      await executeSql(
+        'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
+        [id, TENANT, id, username, null, displayName, role],
       );
       const token = JWT.encode(
         { sub: id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },


### PR DESCRIPTION
## Summary
- create admin profiles during signup and parse comma-separated admin usernames
- remove admin password from env files
- show real wishlist, order, and review counts in profile screen

## Testing
- `yarn install`
- `yarn test`
- `yarn lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6887d7b978d4832681b37b9e1f0bd083