### PR TITLE
Add remote tenant settings

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,8 @@ EXPO_PUBLIC_ADMIN_PASSWORD=admin
 EXPO_PUBLIC_APP_NAME=thebull
 
 EXPO_PUBLIC_TENANT=thebull
+# Endpoint for remote tenant settings API
+EXPO_PUBLIC_SETTINGS_API_URL=https://example.com/api
 
 # JWT used with Pinata IPFS uploads
 EXPO_PUBLIC_PINATA_API_KEY=e15b804d594eff291df61b93acdc4a60b7ee83188353923fe771fd174a8d5017

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,5 @@ VAPID_PRIVATE_KEY=your_private_key
 
 # Tenant Identifier used to load branding from tenant_settings table
 EXPO_PUBLIC_TENANT=thecongress
+# Endpoint for remote tenant settings API
+EXPO_PUBLIC_SETTINGS_API_URL=https://example.com/api

--- a/.env.thebull
+++ b/.env.thebull
@@ -9,6 +9,8 @@ EXPO_PUBLIC_ADMIN_PASSWORD=admin
 EXPO_PUBLIC_APP_NAME=thebull
 
 EXPO_PUBLIC_TENANT=thebull
+# Endpoint for remote tenant settings API
+EXPO_PUBLIC_SETTINGS_API_URL=https://example.com/api
 
 # JWT used with Pinata IPFS uploads
 EXPO_PUBLIC_PINATA_API_KEY=e15b804d594eff291df61b93acdc4a60b7ee83188353923fe771fd174a8d5017

--- a/.env.thecongress
+++ b/.env.thecongress
@@ -6,6 +6,8 @@ EXPO_PUBLIC_ADMIN_USERNAME=roymichaels
 EXPO_PUBLIC_APP_NAME=thecongress
 
 EXPO_PUBLIC_TENANT=thecongress
+# Endpoint for remote tenant settings API
+EXPO_PUBLIC_SETTINGS_API_URL=https://example.com/api
 
 # JWT used with Pinata IPFS uploads
 # JWT used with Pinata IPFS uploads

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -62,20 +62,24 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       if (storedColor) setThemeColorState(storedColor);
 
       const tenantSvc = TenantSettingsService.getInstance();
-      const dbName = await tenantSvc.getTenantSetting(TENANT, 'platform_name');
-      const dbLogo = await tenantSvc.getTenantSetting(TENANT, 'platform_logo');
-      const dbColor = await tenantSvc.getTenantSetting(TENANT, 'theme_color');
-      if (dbName) {
-        setPlatformNameState(dbName);
-        await AsyncStorage.setItem(NAME_KEY, dbName);
-      }
-      if (dbLogo) {
-        setPlatformLogoState(dbLogo);
-        await AsyncStorage.setItem(LOGO_KEY, dbLogo);
-      }
-      if (dbColor) {
-        setThemeColorState(dbColor);
-        await AsyncStorage.setItem(COLOR_KEY, dbColor);
+      try {
+        const dbName = await tenantSvc.getTenantSetting(TENANT, 'platform_name');
+        const dbLogo = await tenantSvc.getTenantSetting(TENANT, 'platform_logo');
+        const dbColor = await tenantSvc.getTenantSetting(TENANT, 'theme_color');
+        if (dbName) {
+          setPlatformNameState(dbName);
+          await AsyncStorage.setItem(NAME_KEY, dbName);
+        }
+        if (dbLogo) {
+          setPlatformLogoState(dbLogo);
+          await AsyncStorage.setItem(LOGO_KEY, dbLogo);
+        }
+        if (dbColor) {
+          setThemeColorState(dbColor);
+          await AsyncStorage.setItem(COLOR_KEY, dbColor);
+        }
+      } catch (err) {
+        console.error('Failed fetching branding from server:', err);
       }
     } catch (e) {
       console.error('Error loading app info:', e);
@@ -119,6 +123,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       await tenantSvc.updateTenantSetting(TENANT, 'platform_logo', finalLogo);
       scheduleLoadInfo();
     } catch (e) {
+      Alert.alert('שגיאה', 'שמירת לוגו נכשלה');
       console.error('Error setting platform logo:', e);
       throw e;
     }
@@ -132,6 +137,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       await tenantSvc.updateTenantSetting(TENANT, 'theme_color', color);
       scheduleLoadInfo();
     } catch (e) {
+      Alert.alert('שגיאה', 'שמירת צבע ערכת הנושא נכשלה');
       console.error('Error setting theme color:', e);
       throw e;
     }

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -1,5 +1,3 @@
-import { executeSql } from '../lib/sqlite';
-
 export interface TenantSettingsRow {
   tenant_id: string;
   platform_name?: string | null;
@@ -7,26 +5,12 @@ export interface TenantSettingsRow {
   theme_color?: string | null;
 }
 
+const API_BASE = process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
+
 class TenantSettingsService {
   private static instance: TenantSettingsService;
 
-  private constructor() {
-    // Initialize table
-    (async () => {
-      try {
-        await executeSql(
-          `CREATE TABLE IF NOT EXISTS tenant_settings (
-            tenant_id TEXT PRIMARY KEY NOT NULL,
-            platform_name TEXT,
-            platform_logo TEXT,
-            theme_color TEXT
-          )`
-        );
-      } catch (err) {
-        console.error('Error creating tenant_settings table:', err);
-      }
-    })();
-  }
+  private constructor() {}
 
   public static getInstance(): TenantSettingsService {
     if (!TenantSettingsService.instance) {
@@ -40,15 +24,15 @@ class TenantSettingsService {
     key: 'platform_name' | 'platform_logo' | 'theme_color'
   ): Promise<string | null> {
     try {
-      const result = await executeSql(
-        `SELECT ${key} FROM tenant_settings WHERE tenant_id = ? LIMIT 1`,
-        [tenant]
-      );
-      const item = (result.rows as any)._array?.[0];
-      return item ? item[key] || null : null;
+      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as Record<string, any>;
+      return data[key] ?? null;
     } catch (error) {
       console.error(`Error fetching tenant setting ${key}:`, error);
-      return null;
+      throw error;
     }
   }
 
@@ -58,27 +42,14 @@ class TenantSettingsService {
     value: string
   ): Promise<void> {
     try {
-      const existing = await executeSql(
-        'SELECT tenant_id FROM tenant_settings WHERE tenant_id = ? LIMIT 1',
-        [tenant]
-      );
-      const existingRows = (existing.rows as any)._array;
-      if (existingRows && existingRows.length > 0) {
-        await executeSql(
-          `UPDATE tenant_settings SET ${key} = ? WHERE tenant_id = ?`,
-          [value, tenant]
-        );
-      } else {
-        const cols = ['platform_name', 'platform_logo', 'theme_color'];
-        const idx = cols.indexOf(key);
-        const values = [null, null, null];
-        if (idx >= 0) {
-          values[idx] = value;
-        }
-        await executeSql(
-          'INSERT INTO tenant_settings (tenant_id, platform_name, platform_logo, theme_color) VALUES (?,?,?,?)',
-          [tenant, values[0], values[1], values[2]]
-        );
+      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [key]: value }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
       }
     } catch (error) {
       console.error(`Error updating tenant setting ${key}:`, error);

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -1,0 +1,26 @@
+import TenantSettingsService from '../services/tenantSettings';
+
+describe('TenantSettingsService remote', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+    (TenantSettingsService as any).instance = undefined;
+    process.env.EXPO_PUBLIC_SETTINGS_API_URL = 'https://api.example.com';
+  });
+
+  it('fetches tenant setting', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ platform_name: 'Test' }),
+    });
+    const svc = TenantSettingsService.getInstance();
+    const val = await svc.getTenantSetting('foo', 'platform_name');
+    expect(fetch).toHaveBeenCalledWith('https://api.example.com/tenant_settings/foo');
+    expect(val).toBe('Test');
+  });
+
+  it('throws on fetch error', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const svc = TenantSettingsService.getInstance();
+    await expect(svc.getTenantSetting('foo', 'platform_name')).rejects.toThrow('network');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch branding settings from a remote API
- show alert when saving branding fails
- support configuration of the remote API via `.env`
- test new TenantSettingsService behaviour

## Testing
- `yarn install --frozen-lockfile` *(fails: The engine "node" is incompatible with this module)*

------
https://chatgpt.com/codex/tasks/task_e_6887db2bba188326918fb001655a843e