### PR TITLE
Implement Waku settings sync

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,11 +19,15 @@ import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
 import { ensureDatabase } from '../lib/sqlite';
+import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
+import { useWakuSettingsSync } from '../lib/waku/useWakuSettingsSync';
 
 function AppContent() {
   const [showCartModal, setShowCartModal] = useState(false);
   const { colors, theme } = useTheme();
   const { isAdmin, loading } = useAuth();
+
+  useWakuSettingsSync();
 
   if (loading) {
     return (
@@ -83,7 +87,11 @@ export default function RootLayout() {
   const [dbReady, setDbReady] = useState(false);
 
   useEffect(() => {
-    ensureDatabase().finally(() => setDbReady(true));
+    (async () => {
+      await ensureDatabase();
+      await ensureSettingsTable();
+      setDbReady(true);
+    })();
   }, []);
 
   if (!dbReady) {

--- a/lib/sqlite/initSettingsTable.ts
+++ b/lib/sqlite/initSettingsTable.ts
@@ -1,0 +1,21 @@
+import { executeSql } from '../sqlite';
+
+export const ensureSettingsTable = async () => {
+  await executeSql(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY NOT NULL,
+      value TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'string',
+      description TEXT NOT NULL DEFAULT '',
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  await executeSql(
+    `INSERT OR IGNORE INTO settings (key, value, type, description) VALUES
+      ('storeName', 'The Congress', 'string', 'Store name'),
+      ('color', '#000000', 'string', 'Theme color')
+    `
+  );
+};

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,0 +1,16 @@
+export const sendWakuSettingsUpdate = async (key: string, value: string) => {
+  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+
+  const node = await createLightNode({ defaultBootstrap: true });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.LightPush]);
+
+  const payload = JSON.stringify({
+    type: 'settings.update',
+    key,
+    value,
+  });
+
+  const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+};

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { executeSql } from '../sqlite';
+
+export const useWakuSettingsSync = () => {
+  useEffect(() => {
+    const run = async () => {
+      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const node = await createLightNode({ defaultBootstrap: true });
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
+
+      const decoder = node.createDecoder({ contentTopic: '/congress/settings/1' });
+      await node.filter!.subscribe(decoder, async (msg) => {
+        if (!msg.payload) return;
+        const decoded = new TextDecoder().decode(msg.payload);
+        try {
+          const parsed = JSON.parse(decoded);
+          if (parsed.type === 'settings.update') {
+            await executeSql(
+              'INSERT OR REPLACE INTO settings (key,value) VALUES (?, ?)',
+              [parsed.key, parsed.value]
+            );
+          }
+        } catch (e) {
+          console.error('Invalid Waku message:', e);
+        }
+      });
+    };
+
+    run();
+  }, []);
+};

--- a/services/database.ts
+++ b/services/database.ts
@@ -1,4 +1,5 @@
 import { executeSql } from '../lib/sqlite';
+import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
 import { TENANT } from '../constants/tenant';
 import {
   Product,
@@ -846,6 +847,11 @@ class DatabaseService {
     } else {
       await executeSql('INSERT INTO settings (key,value,type,description) VALUES (?,?,\'string\',?)', [key, value, `Setting for ${key}`]);
     }
+    try {
+      await sendWakuSettingsUpdate(key, value);
+    } catch (e) {
+      console.error('Failed to send Waku settings update:', e);
+    }
   }
 
   async getAllSettings(): Promise<Record<string, string>> {
@@ -871,6 +877,11 @@ class DatabaseService {
       await executeSql(`UPDATE tenant_settings SET ${key}=? WHERE tenant_id=?`, [value, tenant]);
     } else {
       await executeSql(`INSERT INTO tenant_settings (tenant_id, ${key}) VALUES (?, ?)`, [tenant, value]);
+    }
+    try {
+      await sendWakuSettingsUpdate(key, value);
+    } catch (e) {
+      console.error('Failed to send Waku settings update:', e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Waku helpers for sending and receiving settings updates
- create `ensureSettingsTable` helper
- use Waku sync hook in app layout
- broadcast updates when settings change

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887ddf3b77083269fab3cb99baa0572