### PR TITLE
Add Waku sync for core entities

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,9 @@ import ChatWidget from '../components/ChatWidget';
 import { ensureDatabase } from '../lib/sqlite';
 import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
 import { useWakuSettingsSync } from '../lib/waku/useWakuSettingsSync';
+import { useWakuUserSync } from '../lib/waku/useWakuUserSync';
+import { useWakuProductSync } from '../lib/waku/useWakuProductSync';
+import { useWakuOrderSync } from '../lib/waku/useWakuOrderSync';
 
 function AppContent() {
   const [showCartModal, setShowCartModal] = useState(false);
@@ -28,6 +31,9 @@ function AppContent() {
   const { isAdmin, loading } = useAuth();
 
   useWakuSettingsSync();
+  useWakuUserSync();
+  useWakuProductSync();
+  useWakuOrderSync();
 
   if (loading) {
     return (

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,0 +1,15 @@
+export const sendWakuOrderUpdate = async (order: any) => {
+  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+
+  const node = await createLightNode({ defaultBootstrap: true });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.LightPush]);
+
+  const payload = JSON.stringify({
+    type: 'order.update',
+    order,
+  });
+
+  const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+};

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,0 +1,15 @@
+export const sendWakuProductUpdate = async (product: any) => {
+  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+
+  const node = await createLightNode({ defaultBootstrap: true });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.LightPush]);
+
+  const payload = JSON.stringify({
+    type: 'product.update',
+    product,
+  });
+
+  const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+};

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,0 +1,15 @@
+export const sendWakuUserUpdate = async (user: any) => {
+  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+
+  const node = await createLightNode({ defaultBootstrap: true });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.LightPush]);
+
+  const payload = JSON.stringify({
+    type: 'user.update',
+    user,
+  });
+
+  const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+};

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import { executeSql } from '../sqlite';
+import { TENANT } from '../../constants/tenant';
+
+export const useWakuOrderSync = () => {
+  useEffect(() => {
+    const run = async () => {
+      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const node = await createLightNode({ defaultBootstrap: true });
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
+
+      const decoder = node.createDecoder({ contentTopic: '/congress/orders/1' });
+      await node.filter!.subscribe(decoder, async (msg) => {
+        if (!msg.payload) return;
+        const decoded = new TextDecoder().decode(msg.payload);
+        try {
+          const parsed = JSON.parse(decoded);
+          if (parsed.type === 'order.update' && parsed.order) {
+            const o = parsed.order;
+            await executeSql(
+              `INSERT OR REPLACE INTO orders (
+                id, tenant_id, user_id, total, status, payment_method,
+                shipping_name, shipping_phone, shipping_street, shipping_city,
+                shipping_postal_code, shipping_notes, created_at, updated_at
+              ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+              [
+                o.id,
+                o.tenant_id ?? TENANT,
+                o.userId,
+                o.total,
+                o.status,
+                o.paymentMethod,
+                o.shippingAddress.name,
+                o.shippingAddress.phone,
+                o.shippingAddress.street,
+                o.shippingAddress.city,
+                o.shippingAddress.postalCode ?? null,
+                o.shippingAddress.notes ?? null,
+                o.createdAt,
+                o.updatedAt,
+              ]
+            );
+            if (o.items) {
+              await executeSql('DELETE FROM order_items WHERE order_id=?', [o.id]);
+              for (const item of o.items) {
+                await executeSql(
+                  `INSERT OR REPLACE INTO order_items (
+                    id, order_id, product_id, product_name, product_image,
+                    quantity, price, selected_color, created_at
+                  ) VALUES (?,?,?,?,?,?,?,?,?)`,
+                  [
+                    item.id,
+                    o.id,
+                    item.productId,
+                    item.product.name,
+                    item.product.images[0],
+                    item.quantity,
+                    item.unitPrice ?? item.product.price,
+                    item.selectedColor ?? null,
+                    item.addedAt,
+                  ]
+                );
+              }
+            }
+          }
+        } catch (e) {
+          console.error('Invalid Waku message:', e);
+        }
+      });
+    };
+
+    run();
+  }, []);
+};

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { executeSql } from '../sqlite';
+
+export const useWakuProductSync = () => {
+  useEffect(() => {
+    const run = async () => {
+      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const node = await createLightNode({ defaultBootstrap: true });
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
+
+      const decoder = node.createDecoder({ contentTopic: '/congress/products/1' });
+      await node.filter!.subscribe(decoder, async (msg) => {
+        if (!msg.payload) return;
+        const decoded = new TextDecoder().decode(msg.payload);
+        try {
+          const parsed = JSON.parse(decoded);
+          if (parsed.type === 'product.update' && parsed.product) {
+            const p = parsed.product;
+            await executeSql(
+              `INSERT OR REPLACE INTO products (
+                id, tenant_id, name, name_en, name_he, price, description, description_en,
+                description_he, category, subcategory, images, videos, colors,
+                rating, reviews, badges, pricing_tier, mix_group_id, stock,
+                created_at, updated_at
+              ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+              [
+                p.id,
+                p.tenant_id,
+                p.name,
+                p.name_en ?? null,
+                p.name_he ?? null,
+                p.price,
+                p.description,
+                p.description_en ?? null,
+                p.description_he ?? null,
+                p.category,
+                p.subcategory ?? null,
+                JSON.stringify(p.images || []),
+                JSON.stringify(p.videos || []),
+                JSON.stringify(p.colors || []),
+                p.rating ?? 0,
+                p.reviews ?? 0,
+                JSON.stringify(p.badges || []),
+                p.pricingTier ?? null,
+                p.mixGroupId ?? null,
+                p.stock ?? 0,
+                p.createdAt ?? Date.now(),
+                p.updatedAt ?? Date.now(),
+              ]
+            );
+          }
+        } catch (e) {
+          console.error('Invalid Waku message:', e);
+        }
+      });
+    };
+
+    run();
+  }, []);
+};

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { executeSql } from '../sqlite';
+import { TENANT } from '../../constants/tenant';
+
+export const useWakuUserSync = () => {
+  useEffect(() => {
+    const run = async () => {
+      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const node = await createLightNode({ defaultBootstrap: true });
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
+
+      const decoder = node.createDecoder({ contentTopic: '/congress/users/1' });
+      await node.filter!.subscribe(decoder, async (msg) => {
+        if (!msg.payload) return;
+        const decoded = new TextDecoder().decode(msg.payload);
+        try {
+          const parsed = JSON.parse(decoded);
+          if (parsed.type === 'user.update' && parsed.user) {
+            const u = parsed.user;
+            await executeSql(
+              `INSERT OR REPLACE INTO user_profiles (
+                id, tenant_id, matrix_user_id, app_username, email, display_name,
+                role, created_at, updated_at, kyc_status, customer_tier,
+                kyc_request_notes, kyc_requested_at, kyc_approved_by, kyc_approved_at
+              ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+              [
+                u.id,
+                u.tenant_id ?? TENANT,
+                u.id,
+                u.username,
+                u.email ?? null,
+                u.displayName,
+                u.role ?? (u.isAdmin ? 'admin' : u.isDriver ? 'driver' : 'user'),
+                u.createdAt ?? new Date().toISOString(),
+                u.updatedAt ?? new Date().toISOString(),
+                u.kycStatus ?? 'none',
+                u.customerTier ?? 'new',
+                u.kycRequestNotes ?? null,
+                u.kycRequestedAt ?? null,
+                u.kycApprovedBy ?? null,
+                u.kycApprovedAt ?? null,
+              ]
+            );
+          }
+        } catch (e) {
+          console.error('Invalid Waku message:', e);
+        }
+      });
+    };
+
+    run();
+  }, []);
+};

--- a/services/database.ts
+++ b/services/database.ts
@@ -1,5 +1,7 @@
 import { executeSql } from '../lib/sqlite';
 import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
+import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
+import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
 import { TENANT } from '../constants/tenant';
 import {
   Product,
@@ -131,6 +133,14 @@ class DatabaseService {
         Date.now(),
       ],
     );
+    try {
+      const prod = await this.getProduct(id);
+      if (prod) {
+        await sendWakuProductUpdate(prod);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku product update:', e);
+    }
     return id;
   }
 
@@ -169,6 +179,14 @@ class DatabaseService {
         DatabaseService.tenantId,
       ],
     );
+    try {
+      const prod = await this.getProduct(id);
+      if (prod) {
+        await sendWakuProductUpdate(prod);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku product update:', e);
+    }
   }
 
   async deleteProduct(id: string): Promise<void> {
@@ -399,10 +417,26 @@ class DatabaseService {
 
   async updateUserRole(userId: string, role: 'user' | 'driver' | 'admin'): Promise<void> {
     await executeSql('UPDATE user_profiles SET role=? WHERE id=? AND tenant_id=?', [role, userId, DatabaseService.tenantId]);
+    try {
+      const user = await this.getUserProfile(userId);
+      if (user) {
+        await sendWakuUserUpdate(user);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku user update:', e);
+    }
   }
 
   async updateUserCustomerTier(userId: string, customerTier: string): Promise<void> {
     await executeSql('UPDATE user_profiles SET customer_tier=? WHERE id=? AND tenant_id=?', [customerTier, userId, DatabaseService.tenantId]);
+    try {
+      const user = await this.getUserProfile(userId);
+      if (user) {
+        await sendWakuUserUpdate(user);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku user update:', e);
+    }
   }
 
   async updateUserKycStatus(
@@ -424,6 +458,14 @@ class DatabaseService {
       .join(', ');
     const params = [...Object.values(updateData), userId, DatabaseService.tenantId];
     await executeSql(`UPDATE user_profiles SET ${fields} WHERE id=? AND tenant_id=?`, params);
+    try {
+      const user = await this.getUserProfile(userId);
+      if (user) {
+        await sendWakuUserUpdate(user);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku user update:', e);
+    }
     return true;
   }
 

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -2,6 +2,7 @@ import { executeSql } from '../lib/sqlite';
 import { Order, OrderStatus, OrderTrackingStep, CartItem, ShippingAddress } from '../types';
 import DatabaseService from './database';
 import { TENANT } from '../constants/tenant';
+import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
 
 class OrderService {
   private static instance: OrderService;
@@ -150,6 +151,14 @@ class OrderService {
     // Simulate order progression
     this.simulateOrderProgress(orderId);
 
+    try {
+      if (order) {
+        await sendWakuOrderUpdate(order);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku order update:', e);
+    }
+
     if (!order) {
       throw new Error('ORDER_NOT_CREATED');
     }
@@ -177,6 +186,14 @@ class OrderService {
   public async updateOrderStatus(orderId: string, status: OrderStatus): Promise<void> {
     await executeSql('UPDATE orders SET status=? WHERE id=?', [status, orderId]);
     this.notifyListeners();
+    try {
+      const order = await this.getOrder(orderId);
+      if (order) {
+        await sendWakuOrderUpdate(order);
+      }
+    } catch (e) {
+      console.error('Failed to send Waku order update:', e);
+    }
   }
 
   private async mapOrderRow(row: any): Promise<Order> {


### PR DESCRIPTION
## Summary
- extend Waku integration with helpers for users, products, and orders
- broadcast updates when rows change in database and order services
- sync incoming Waku messages into SQLite
- start all sync hooks in the main layout

## Testing
- `yarn install --ignore-engines`
- `yarn test` *(fails: Cannot find name 'global')*

------
https://chatgpt.com/codex/tasks/task_e_6887e28872ac8326bba7fe73bda6acbe