### PR TITLE
Add deduplication for Waku messages

### DIFF
--- a/lib/sqlite/initSettingsTable.ts
+++ b/lib/sqlite/initSettingsTable.ts
@@ -12,6 +12,15 @@ export const ensureSettingsTable = async () => {
     );
   `);
 
+  await executeSql(`
+    CREATE TABLE IF NOT EXISTS waku_seen (
+      id TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY(id, topic)
+    );
+  `);
+
   await executeSql(
     `INSERT OR IGNORE INTO settings (key, value, type, description) VALUES
       ('storeName', 'The Congress', 'string', 'Store name'),

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -9,9 +9,20 @@ export const useWakuSettingsSync = () => {
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const decoder = node.createDecoder({ contentTopic: '/congress/settings/1' });
+      const topic = '/congress/settings/1';
+      const decoder = node.createDecoder({ contentTopic: topic });
       await node.filter!.subscribe(decoder, async (msg) => {
-        if (!msg.payload) return;
+        if (!msg.payload || !msg.timestamp) return;
+        const id = msg.timestamp.getTime().toString();
+
+        const seen = await executeSql(
+          'SELECT 1 FROM waku_seen WHERE id=? AND topic=? LIMIT 1',
+          [id, topic]
+        );
+        if ((seen.rows as any)._array.length > 0) return;
+
+        await executeSql('INSERT INTO waku_seen (id, topic) VALUES (?, ?)', [id, topic]);
+
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -5,7 +5,7 @@ export interface TenantSettingsRow {
   theme_color?: string | null;
 }
 
-const API_BASE = process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
+const getApiBase = () => process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
 
 class TenantSettingsService {
   private static instance: TenantSettingsService;
@@ -24,7 +24,7 @@ class TenantSettingsService {
     key: 'platform_name' | 'platform_logo' | 'theme_color'
   ): Promise<string | null> {
     try {
-      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`);
+      const res = await fetch(`${getApiBase()}/tenant_settings/${tenant}`);
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -42,7 +42,7 @@ class TenantSettingsService {
     value: string
   ): Promise<void> {
     try {
-      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`, {
+      const res = await fetch(`${getApiBase()}/tenant_settings/${tenant}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ [key]: value }),

--- a/sqlite/migrations/001_initial_schema.sql
+++ b/sqlite/migrations/001_initial_schema.sql
@@ -313,3 +313,11 @@ CREATE TRIGGER update_tenant_settings_timestamp AFTER UPDATE ON tenant_settings
 BEGIN
   UPDATE tenant_settings SET updated_at = CURRENT_TIMESTAMP WHERE tenant_id = NEW.tenant_id;
 END;
+
+-- Table for tracking processed Waku messages
+CREATE TABLE waku_seen (
+  id TEXT NOT NULL,
+  topic TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, topic)
+);

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -1,7 +1,7 @@
 import TenantSettingsService from '../services/tenantSettings';
 describe('TenantSettingsService remote', () => {
   beforeEach(() => {
-    (global as any).fetch = jest.fn();
+    (globalThis as any).fetch = jest.fn();
     (TenantSettingsService as any).instance = undefined;
     process.env.EXPO_PUBLIC_SETTINGS_API_URL = 'https://api.example.com';
   });


### PR DESCRIPTION
## Summary
- track processed Waku messages in new `waku_seen` table
- create the table during DB init and migrations
- skip processing already-seen Waku messages
- tweak tenant settings service to read API base at call time
- fix tests to use `globalThis`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887e28cfd00832686ec737087ff9b9f