### PR TITLE
Handle Waku node cleanup

### DIFF
--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -2,15 +2,20 @@ export const sendWakuSettingsUpdate = async (key: string, value: string) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
-  await node.start();
-  await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
-    type: 'settings.update',
-    key,
-    value,
-  });
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+    const payload = JSON.stringify({
+      type: 'settings.update',
+      key,
+      value,
+    });
+
+    const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  } finally {
+    await node.stop();
+  }
 };

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -3,23 +3,26 @@ import { executeSql } from '../sqlite';
 
 export const useWakuSettingsSync = () => {
   useEffect(() => {
+    let node: any;
+    let decoder: any;
+
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
-      const node = await createLightNode({ defaultBootstrap: true });
+      node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const decoder = node.createDecoder({ contentTopic: '/congress/settings/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/settings/1' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
           if (parsed.type === 'settings.update') {
-            await executeSql(
-              'INSERT OR REPLACE INTO settings (key,value) VALUES (?, ?)',
-              [parsed.key, parsed.value]
-            );
+            await executeSql('INSERT OR REPLACE INTO settings (key,value) VALUES (?, ?)', [
+              parsed.key,
+              parsed.value,
+            ]);
           }
         } catch (e) {
           console.error('Invalid Waku message:', e);
@@ -28,5 +31,12 @@ export const useWakuSettingsSync = () => {
     };
 
     run();
+
+    return () => {
+      if (decoder && node?.filter) {
+        node.filter.unsubscribe(decoder).catch(() => {});
+      }
+      node?.stop();
+    };
   }, []);
 };

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -5,7 +5,9 @@ export interface TenantSettingsRow {
   theme_color?: string | null;
 }
 
-const API_BASE = process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
+function apiBase() {
+  return process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
+}
 
 class TenantSettingsService {
   private static instance: TenantSettingsService;
@@ -24,7 +26,7 @@ class TenantSettingsService {
     key: 'platform_name' | 'platform_logo' | 'theme_color'
   ): Promise<string | null> {
     try {
-      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`);
+      const res = await fetch(`${apiBase()}/tenant_settings/${tenant}`);
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -42,7 +44,7 @@ class TenantSettingsService {
     value: string
   ): Promise<void> {
     try {
-      const res = await fetch(`${API_BASE}/tenant_settings/${tenant}`, {
+      const res = await fetch(`${apiBase()}/tenant_settings/${tenant}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ [key]: value }),

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import TenantSettingsService from '../services/tenantSettings';
 describe('TenantSettingsService remote', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- close Waku nodes after pushing settings updates
- stop and unsubscribe in `useWakuSettingsSync`
- make tenant settings service read API base at runtime
- fix tenant settings service test for Node types

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887e2958d6c8326a28b05c0ac4adeee