### PR TITLE
Add timestamps to settings sync broadcast

### DIFF
--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,4 +1,9 @@
-export const sendWakuSettingsUpdate = async (key: string, value: string) => {
+export const sendWakuSettingsUpdate = async (
+  key: string,
+  value: string,
+  createdAt: number,
+  updatedAt: number,
+) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
@@ -9,6 +14,8 @@ export const sendWakuSettingsUpdate = async (key: string, value: string) => {
     type: 'settings.update',
     key,
     value,
+    createdAt,
+    updatedAt,
   });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -17,8 +17,12 @@ export const useWakuSettingsSync = () => {
           const parsed = JSON.parse(decoded);
           if (parsed.type === 'settings.update') {
             await executeSql(
-              'INSERT OR REPLACE INTO settings (key,value) VALUES (?, ?)',
-              [parsed.key, parsed.value]
+              `INSERT INTO settings (key,value,created_at,updated_at)
+               VALUES (?,?,?,?)
+               ON CONFLICT(key) DO UPDATE SET
+                 value=excluded.value,
+                 updated_at=excluded.updated_at`,
+              [parsed.key, parsed.value, parsed.createdAt, parsed.updatedAt]
             );
           }
         } catch (e) {

--- a/services/database.ts
+++ b/services/database.ts
@@ -845,11 +845,21 @@ class DatabaseService {
     if (exists) {
       await executeSql('UPDATE settings SET value=? WHERE key=?', [value, key]);
     } else {
-      await executeSql('INSERT INTO settings (key,value,type,description) VALUES (?,?,\'string\',?)', [key, value, `Setting for ${key}`]);
+      await executeSql(
+        'INSERT INTO settings (key,value,type,description) VALUES (?,?,\'string\',?)',
+        [key, value, `Setting for ${key}`],
+      );
     }
+    const rowRes = await executeSql(
+      'SELECT created_at, updated_at FROM settings WHERE key=?',
+      [key],
+    );
+    const row = (rowRes.rows as any)._array?.[0];
+    const createdAt = row?.created_at ?? Date.now();
+    const updatedAt = row?.updated_at ?? Date.now();
     try {
-      await sendWakuSettingsUpdate(key, value);
-    } catch (e) {
+      await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
+      } catch (e) {
       console.error('Failed to send Waku settings update:', e);
     }
   }
@@ -878,8 +888,15 @@ class DatabaseService {
     } else {
       await executeSql(`INSERT INTO tenant_settings (tenant_id, ${key}) VALUES (?, ?)`, [tenant, value]);
     }
+    const rowRes = await executeSql(
+      'SELECT created_at, updated_at FROM tenant_settings WHERE tenant_id=?',
+      [tenant],
+    );
+    const row = (rowRes.rows as any)._array?.[0];
+    const createdAt = row?.created_at ?? Date.now();
+    const updatedAt = row?.updated_at ?? Date.now();
     try {
-      await sendWakuSettingsUpdate(key, value);
+      await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
     } catch (e) {
       console.error('Failed to send Waku settings update:', e);
     }


### PR DESCRIPTION
## Summary
- broadcast createdAt/updatedAt in Waku settings updates
- persist timestamps when syncing settings from Waku
- fetch timestamps and include them in the broadcast when updating settings

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e2a93ab48326af25e9fc9622c691