### PR TITLE
Add public key support and admin message filtering

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useEffect, useState, ReactNode } from
 import { executeSql } from '../lib/sqlite';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
+import * as SecureStore from 'expo-secure-store';
+import { getPublicKey, utils as edUtils } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 import { TENANT } from '../constants/tenant';
@@ -11,6 +13,7 @@ const ADMIN_USERNAMES = (process.env.EXPO_PUBLIC_ADMIN_USERNAME || '')
   .map((u) => u.trim())
   .filter(Boolean);
 const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
+const PRIVATE_KEY_KEY = 'ed25519_private_key';
 
 export class UsernameTakenError extends Error {
   constructor() {
@@ -83,6 +86,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         username: data.username,
         displayName: data.display_name,
         role: data.role,
+        publicKey: data.public_key,
       });
     } else {
       setUser({ id: uid, role: 'user', username: '', displayName: '' });
@@ -130,9 +134,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const id = `user_${Date.now()}`;
       const isAdminUsername = ADMIN_USERNAMES.includes(username);
       const role = isAdminUsername ? 'admin' : 'user';
+      const priv = edUtils.randomPrivateKey();
+      const pub = await getPublicKey(priv);
+      const privateKey = edUtils.bytesToHex(priv);
+      const publicKey = edUtils.bytesToHex(pub);
+      await SecureStore.setItemAsync(PRIVATE_KEY_KEY, privateKey);
       await executeSql(
-        'INSERT INTO users (id, username, password_hash, display_name, role) VALUES (?,?,?,?,?)',
-        [id, username, hash, displayName, role],
+        'INSERT INTO users (id, username, password_hash, display_name, role, public_key) VALUES (?,?,?,?,?,?)',
+        [id, username, hash, displayName, role, publicKey],
       );
       await executeSql(
         'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,4 +1,9 @@
-export const sendWakuOrderUpdate = async (order: any) => {
+import type { WakuSender } from './sendWakuUserUpdate';
+
+export const sendWakuOrderUpdate = async (
+  order: any,
+  sender: WakuSender = { id: '', publicKey: '', role: '' }
+) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
@@ -8,6 +13,7 @@ export const sendWakuOrderUpdate = async (order: any) => {
   const payload = JSON.stringify({
     type: 'order.update',
     order,
+    sender,
   });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,4 +1,9 @@
-export const sendWakuProductUpdate = async (product: any) => {
+import type { WakuSender } from './sendWakuUserUpdate';
+
+export const sendWakuProductUpdate = async (
+  product: any,
+  sender: WakuSender = { id: '', publicKey: '', role: '' }
+) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
@@ -8,6 +13,7 @@ export const sendWakuProductUpdate = async (product: any) => {
   const payload = JSON.stringify({
     type: 'product.update',
     product,
+    sender,
   });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,8 +1,11 @@
+import type { WakuSender } from './sendWakuUserUpdate';
+
 export const sendWakuSettingsUpdate = async (
   key: string,
   value: string,
   createdAt: number,
   updatedAt: number,
+  sender: WakuSender = { id: '', publicKey: '', role: '' }
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
@@ -14,15 +17,12 @@ export const sendWakuSettingsUpdate = async (
     value,
     createdAt,
     updatedAt,
+    sender,
   });
 
-
-    const payload = JSON.stringify({
-      type: 'settings.update',
-      key,
-      value,
-    });
-
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
     const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
   } finally {

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,4 +1,13 @@
-export const sendWakuUserUpdate = async (user: any) => {
+export interface WakuSender {
+  id: string;
+  publicKey: string;
+  role: string;
+}
+
+export const sendWakuUserUpdate = async (
+  user: any,
+  sender: WakuSender = { id: '', publicKey: '', role: '' }
+) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
@@ -8,6 +17,7 @@ export const sendWakuUserUpdate = async (user: any) => {
   const payload = JSON.stringify({
     type: 'user.update',
     user,
+    sender,
   });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -16,6 +16,11 @@ export const useWakuOrderSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
+          if (!parsed.sender || parsed.sender.role !== 'admin') {
+            return;
+          }
+          const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);
+          if ((exists.rows as any)._array.length === 0) return;
           if (parsed.type === 'order.update' && parsed.order) {
             const o = parsed.order;
             await executeSql(

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -15,6 +15,11 @@ export const useWakuProductSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
+          if (!parsed.sender || parsed.sender.role !== 'admin') {
+            return;
+          }
+          const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);
+          if ((exists.rows as any)._array.length === 0) return;
           if (parsed.type === 'product.update' && parsed.product) {
             const p = parsed.product;
             await executeSql(

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -29,6 +29,11 @@ export const useWakuSettingsSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
+          if (!parsed.sender || parsed.sender.role !== 'admin') {
+            return;
+          }
+          const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);
+          if ((exists.rows as any)._array.length === 0) return;
           if (parsed.type === 'settings.update') {
             await executeSql(
               `INSERT INTO settings (key,value,created_at,updated_at)

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -16,6 +16,11 @@ export const useWakuUserSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
+          if (!parsed.sender || parsed.sender.role !== 'admin') {
+            return;
+          }
+          const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);
+          if ((exists.rows as any)._array.length === 0) return;
           if (parsed.type === 'user.update' && parsed.user) {
             const u = parsed.user;
             await executeSql(

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
     "sqlite3": "^5.1.7",
+    "@noble/ed25519": "^2.1.1",
     "web-push": "^3.6.7"
   },
   "devDependencies": {

--- a/sqlite/migrations/002_add_public_key_to_users.sql
+++ b/sqlite/migrations/002_add_public_key_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN public_key TEXT;

--- a/types/index.ts
+++ b/types/index.ts
@@ -110,6 +110,7 @@ export interface User {
   avatar?: string;
   email?: string;
   role?: string;
+  publicKey?: string;
   createdAt?: string;
   updatedAt?: string;
   kycStatus?: KycStatus;


### PR DESCRIPTION
## Summary
- add `@noble/ed25519` dependency
- create migration for `public_key` column
- generate keypair and store keys during signup
- extend `User` type with `publicKey`
- include sender info in Waku messages
- filter Waku messages by admin sender

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ea3a181c8326b03315d51d00c638