### PR TITLE
Fix Waku helpers cleanup and start logic

### DIFF
--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -7,20 +7,16 @@ export const sendWakuSettingsUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
   const node = await createLightNode({ defaultBootstrap: true });
-
-  const payload = JSON.stringify({
-    type: 'settings.update',
-    key,
-    value,
-    createdAt,
-    updatedAt,
-  });
-
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
 
     const payload = JSON.stringify({
       type: 'settings.update',
       key,
       value,
+      createdAt,
+      updatedAt,
     });
 
     const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -4,13 +4,16 @@ import { TENANT } from '../../constants/tenant';
 
 export const useWakuOrderSync = () => {
   useEffect(() => {
+    let node: any;
+    let decoder: any;
+
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
-      const node = await createLightNode({ defaultBootstrap: true });
+      node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const decoder = node.createDecoder({ contentTopic: '/congress/orders/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/orders/1' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
@@ -71,5 +74,12 @@ export const useWakuOrderSync = () => {
     };
 
     run();
+
+    return () => {
+      if (decoder && node?.filter) {
+        node.filter.unsubscribe(decoder).catch(() => {});
+      }
+      node?.stop();
+    };
   }, []);
 };

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -3,13 +3,16 @@ import { executeSql } from '../sqlite';
 
 export const useWakuProductSync = () => {
   useEffect(() => {
+    let node: any;
+    let decoder: any;
+
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
-      const node = await createLightNode({ defaultBootstrap: true });
+      node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const decoder = node.createDecoder({ contentTopic: '/congress/products/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/products/1' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
@@ -57,5 +60,12 @@ export const useWakuProductSync = () => {
     };
 
     run();
+
+    return () => {
+      if (decoder && node?.filter) {
+        node.filter.unsubscribe(decoder).catch(() => {});
+      }
+      node?.stop();
+    };
   }, []);
 };

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -4,13 +4,16 @@ import { TENANT } from '../../constants/tenant';
 
 export const useWakuUserSync = () => {
   useEffect(() => {
+    let node: any;
+    let decoder: any;
+
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
-      const node = await createLightNode({ defaultBootstrap: true });
+      node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const decoder = node.createDecoder({ contentTopic: '/congress/users/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/users/1' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
@@ -50,5 +53,12 @@ export const useWakuUserSync = () => {
     };
 
     run();
+
+    return () => {
+      if (decoder && node?.filter) {
+        node.filter.unsubscribe(decoder).catch(() => {});
+      }
+      node?.stop();
+    };
   }, []);
 };


### PR DESCRIPTION
## Summary
- add cleanup handlers for product/order/user Waku sync hooks
- fix sendWakuSettingsUpdate to start/stop nodes and remove dead code

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887ea4252488326bc2516faf98158e6