### PR TITLE
Add signed Waku messages

### DIFF
--- a/lib/waku/identity.ts
+++ b/lib/waku/identity.ts
@@ -1,0 +1,20 @@
+let cached: { publicKey: string; privateKey: string } | null = null;
+
+export async function getWakuIdentity(): Promise<{ publicKey: string; privateKey: string }> {
+  if (cached) return cached;
+  const ed = await import('@noble/ed25519');
+  let privHex = process.env.EXPO_PUBLIC_WAKU_PRIVATE_KEY;
+  let pubHex = process.env.EXPO_PUBLIC_WAKU_PUBLIC_KEY;
+  if (!privHex) {
+    const priv = ed.utils.randomPrivateKey();
+    privHex = Buffer.from(priv).toString('hex');
+    const pub = await ed.getPublicKey(priv);
+    pubHex = Buffer.from(pub).toString('hex');
+  } else if (!pubHex) {
+    const priv = Uint8Array.from(Buffer.from(privHex, 'hex'));
+    const pub = await ed.getPublicKey(priv);
+    pubHex = Buffer.from(pub).toString('hex');
+  }
+  cached = { publicKey: pubHex!, privateKey: privHex };
+  return cached;
+}

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,15 +1,25 @@
+import { getWakuIdentity } from './identity';
+
 export const sendWakuOrderUpdate = async (order: any) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sha256 } = await import('@noble/hashes/sha256');
+  const ed = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const base = {
     type: 'order.update',
     order,
-  });
+  };
+  const payload = JSON.stringify(base);
+  const sender = await getWakuIdentity();
+  const hash = sha256(new TextEncoder().encode(payload));
+  const sigBytes = await ed.sign(hash, Buffer.from(sender.privateKey, 'hex'));
+  const signature = Buffer.from(sigBytes).toString('hex');
+  const message = JSON.stringify({ ...base, sender: { publicKey: sender.publicKey }, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,15 +1,25 @@
+import { getWakuIdentity } from './identity';
+
 export const sendWakuProductUpdate = async (product: any) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sha256 } = await import('@noble/hashes/sha256');
+  const ed = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const base = {
     type: 'product.update',
     product,
-  });
+  };
+  const payload = JSON.stringify(base);
+  const sender = await getWakuIdentity();
+  const hash = sha256(new TextEncoder().encode(payload));
+  const sigBytes = await ed.sign(hash, Buffer.from(sender.privateKey, 'hex'));
+  const signature = Buffer.from(sigBytes).toString('hex');
+  const message = JSON.stringify({ ...base, sender: { publicKey: sender.publicKey }, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,3 +1,5 @@
+import { getWakuIdentity } from './identity';
+
 export const sendWakuSettingsUpdate = async (
   key: string,
   value: string,
@@ -5,27 +7,27 @@ export const sendWakuSettingsUpdate = async (
   updatedAt: number,
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sha256 } = await import('@noble/hashes/sha256');
+  const ed = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const base = {
     type: 'settings.update',
     key,
     value,
     createdAt,
     updatedAt,
-  });
+  };
+  const payload = JSON.stringify(base);
+  const sender = await getWakuIdentity();
+  const hash = sha256(new TextEncoder().encode(payload));
+  const sigBytes = await ed.sign(hash, Buffer.from(sender.privateKey, 'hex'));
+  const signature = Buffer.from(sigBytes).toString('hex');
+  const message = JSON.stringify({ ...base, sender: { publicKey: sender.publicKey }, signature });
 
-
-    const payload = JSON.stringify({
-      type: 'settings.update',
-      key,
-      value,
-    });
-
-    const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
-    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
-  } finally {
-    await node.stop();
-  }
+  const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,15 +1,25 @@
+import { getWakuIdentity } from './identity';
+
 export const sendWakuUserUpdate = async (user: any) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sha256 } = await import('@noble/hashes/sha256');
+  const ed = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const base = {
     type: 'user.update',
     user,
-  });
+  };
+  const payload = JSON.stringify(base);
+  const sender = await getWakuIdentity();
+  const hash = sha256(new TextEncoder().encode(payload));
+  const sigBytes = await ed.sign(hash, Buffer.from(sender.privateKey, 'hex'));
+  const signature = Buffer.from(sigBytes).toString('hex');
+  const message = JSON.stringify({ ...base, sender: { publicKey: sender.publicKey }, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -6,6 +6,8 @@ export const useWakuOrderSync = () => {
   useEffect(() => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { sha256 } = await import('@noble/hashes/sha256');
+      const ed = await import('@noble/ed25519');
       const node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -16,8 +18,17 @@ export const useWakuOrderSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (parsed.type === 'order.update' && parsed.order) {
-            const o = parsed.order;
+          const { sender, signature, ...rest } = parsed;
+          if (!sender?.publicKey || !signature) return;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const ok = await ed.verify(
+            Uint8Array.from(Buffer.from(signature, 'hex')),
+            hash,
+            Uint8Array.from(Buffer.from(sender.publicKey, 'hex')),
+          );
+          if (!ok) return;
+          if (rest.type === 'order.update' && rest.order) {
+            const o = rest.order;
             await executeSql(
               `INSERT OR REPLACE INTO orders (
                 id, tenant_id, user_id, total, status, payment_method,

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -5,6 +5,8 @@ export const useWakuProductSync = () => {
   useEffect(() => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { sha256 } = await import('@noble/hashes/sha256');
+      const ed = await import('@noble/ed25519');
       const node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -15,8 +17,17 @@ export const useWakuProductSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (parsed.type === 'product.update' && parsed.product) {
-            const p = parsed.product;
+          const { sender, signature, ...rest } = parsed;
+          if (!sender?.publicKey || !signature) return;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const ok = await ed.verify(
+            Uint8Array.from(Buffer.from(signature, 'hex')),
+            hash,
+            Uint8Array.from(Buffer.from(sender.publicKey, 'hex')),
+          );
+          if (!ok) return;
+          if (rest.type === 'product.update' && rest.product) {
+            const p = rest.product;
             await executeSql(
               `INSERT OR REPLACE INTO products (
                 id, tenant_id, name, name_en, name_he, price, description, description_en,

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -8,6 +8,8 @@ export const useWakuSettingsSync = () => {
 
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { sha256 } = await import('@noble/hashes/sha256');
+      const ed = await import('@noble/ed25519');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -18,27 +20,35 @@ export const useWakuSettingsSync = () => {
         if (!msg.payload || !msg.timestamp) return;
         const id = msg.timestamp.getTime().toString();
 
-          const seen = await executeSql(
-            'SELECT 1 FROM waku_seen WHERE id=? AND topic=? LIMIT 1',
-            [id, topic]
-          );
+        const seen = await executeSql(
+          'SELECT 1 FROM waku_seen WHERE id=? AND topic=? LIMIT 1',
+          [id, topic]
+        );
         if ((seen.rows as any)._array.length > 0) return;
 
-          await executeSql('INSERT INTO waku_seen (id, topic) VALUES (?, ?)', [id, topic]);
+        await executeSql('INSERT INTO waku_seen (id, topic) VALUES (?, ?)', [id, topic]);
 
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (parsed.type === 'settings.update') {
+          const { sender, signature, ...rest } = parsed;
+          if (!sender?.publicKey || !signature) return;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const ok = await ed.verify(
+            Uint8Array.from(Buffer.from(signature, 'hex')),
+            hash,
+            Uint8Array.from(Buffer.from(sender.publicKey, 'hex'))
+          );
+          if (!ok) return;
+          if (rest.type === 'settings.update') {
             await executeSql(
               `INSERT INTO settings (key,value,created_at,updated_at)
                VALUES (?,?,?,?)
                ON CONFLICT(key) DO UPDATE SET
                  value=excluded.value,
                  updated_at=excluded.updated_at`,
-              [parsed.key, parsed.value, parsed.createdAt, parsed.updatedAt]
+              [rest.key, rest.value, rest.createdAt, rest.updatedAt]
             );
-
           }
         } catch (e) {
           console.error('Invalid Waku message:', e);

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -6,6 +6,8 @@ export const useWakuUserSync = () => {
   useEffect(() => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { sha256 } = await import('@noble/hashes/sha256');
+      const ed = await import('@noble/ed25519');
       const node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -16,8 +18,17 @@ export const useWakuUserSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (parsed.type === 'user.update' && parsed.user) {
-            const u = parsed.user;
+          const { sender, signature, ...rest } = parsed;
+          if (!sender?.publicKey || !signature) return;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const ok = await ed.verify(
+            Uint8Array.from(Buffer.from(signature, 'hex')),
+            hash,
+            Uint8Array.from(Buffer.from(sender.publicKey, 'hex')),
+          );
+          if (!ok) return;
+          if (rest.type === 'user.update' && rest.user) {
+            const u = rest.user;
             await executeSql(
               `INSERT OR REPLACE INTO user_profiles (
                 id, tenant_id, matrix_user_id, app_username, email, display_name,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@waku/sdk": "^0.0.33",
+    "@noble/ed25519": "^2.1.1",
     "axios": "^1.6.2",
     "bcryptjs": "^2.4.3",
     "buffer": "^6.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "expo",
       "react",
       "react-native",
-      "jest"
+      "jest",
+      "node"
     ],
     "skipLibCheck": true,
     "baseUrl": ".",

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -11,6 +11,8 @@ declare global {
       EXPO_PUBLIC_PINATA_SECRET_API_KEY?: string;
       EXPO_PUBLIC_CHAT_SECRET?: string;
       EXPO_PUBLIC_USE_WAKU?: string;
+      EXPO_PUBLIC_WAKU_PRIVATE_KEY?: string;
+      EXPO_PUBLIC_WAKU_PUBLIC_KEY?: string;
       VAPID_PUBLIC_KEY?: string;
       VAPID_PRIVATE_KEY?: string;
       EXPO_PUBLIC_TENANT?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,6 +2342,11 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
+"@noble/ed25519@^2.1.1":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-2.3.0.tgz#df0dbe424cfd7da4968b956b819c15db5fbe7f21"
+  integrity sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==
+
 "@noble/hashes@1.8.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.3.2", "@noble/hashes@^1.3.3", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"


### PR DESCRIPTION
## Summary
- sign Waku update payloads with a local Ed25519 key
- verify Waku signatures before applying incoming updates
- keep generated key in `getWakuIdentity`
- update TS config to include Node types
- add `@noble/ed25519` dependency

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887ea3bdfc48326a6fcc0c5c2a21578