### PR TITLE
Add signature support for Waku messages

### DIFF
--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,8 +1,11 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sign, utils as edUtils } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuOrderUpdate = async (
   order: any,
-  sender: WakuSender = { id: '', publicKey: '', role: '' }
+  sender: WakuSender = { id: '', publicKey: '', role: '' },
+  privateKey = ''
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
@@ -10,12 +13,22 @@ export const sendWakuOrderUpdate = async (
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadData = {
     type: 'order.update',
     order,
     sender,
-  });
+  };
+  const payload = JSON.stringify(payloadData);
+
+  const hash = sha256(new TextEncoder().encode(payload));
+  const signature = privateKey
+    ? edUtils.bytesToHex(await sign(hash, privateKey))
+    : '';
+
+  const finalPayload = JSON.stringify({ ...payloadData, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, {
+    payload: new TextEncoder().encode(finalPayload),
+  });
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,8 +1,11 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sign, utils as edUtils } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuProductUpdate = async (
   product: any,
-  sender: WakuSender = { id: '', publicKey: '', role: '' }
+  sender: WakuSender = { id: '', publicKey: '', role: '' },
+  privateKey = ''
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
@@ -10,12 +13,22 @@ export const sendWakuProductUpdate = async (
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadData = {
     type: 'product.update',
     product,
     sender,
-  });
+  };
+  const payload = JSON.stringify(payloadData);
+
+  const hash = sha256(new TextEncoder().encode(payload));
+  const signature = privateKey
+    ? edUtils.bytesToHex(await sign(hash, privateKey))
+    : '';
+
+  const finalPayload = JSON.stringify({ ...payloadData, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, {
+    payload: new TextEncoder().encode(finalPayload),
+  });
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,11 +1,14 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sign, utils as edUtils } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuSettingsUpdate = async (
   key: string,
   value: string,
   createdAt: number,
   updatedAt: number,
-  sender: WakuSender = { id: '', publicKey: '', role: '' }
+  sender: WakuSender = { id: '', publicKey: '', role: '' },
+  privateKey = ''
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
@@ -14,16 +17,27 @@ export const sendWakuSettingsUpdate = async (
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);
 
-    const payload = JSON.stringify({
+    const payloadData = {
       type: 'settings.update',
       key,
       value,
       createdAt,
       updatedAt,
-    });
+      sender,
+    };
+    const payload = JSON.stringify(payloadData);
+
+    const hash = sha256(new TextEncoder().encode(payload));
+    const signature = privateKey
+      ? edUtils.bytesToHex(await sign(hash, privateKey))
+      : '';
+
+    const finalPayload = JSON.stringify({ ...payloadData, signature });
 
     const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
-    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+    await node.lightPush!.send(encoder, {
+      payload: new TextEncoder().encode(finalPayload),
+    });
   } finally {
     await node.stop();
   }

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -4,9 +4,13 @@ export interface WakuSender {
   role: string;
 }
 
+import { sign, utils as edUtils } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+
 export const sendWakuUserUpdate = async (
   user: any,
-  sender: WakuSender = { id: '', publicKey: '', role: '' }
+  sender: WakuSender = { id: '', publicKey: '', role: '' },
+  privateKey = ''
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
 
@@ -14,12 +18,22 @@ export const sendWakuUserUpdate = async (
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadData = {
     type: 'user.update',
     user,
     sender,
-  });
+  };
+  const payload = JSON.stringify(payloadData);
+
+  const hash = sha256(new TextEncoder().encode(payload));
+  const signature = privateKey
+    ? edUtils.bytesToHex(await sign(hash, privateKey))
+    : '';
+
+  const finalPayload = JSON.stringify({ ...payloadData, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, {
+    payload: new TextEncoder().encode(finalPayload),
+  });
 };

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { TENANT } from '../../constants/tenant';
+import { verify } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuOrderSync = () => {
   useEffect(() => {
@@ -19,7 +21,13 @@ export const useWakuOrderSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.sender || !parsed.signature) {
+            return;
+          }
+          const { signature, ...rest } = parsed;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const valid = await verify(signature, hash, parsed.sender.publicKey);
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
+import { verify } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuProductSync = () => {
   useEffect(() => {
@@ -18,7 +20,13 @@ export const useWakuProductSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.sender || !parsed.signature) {
+            return;
+          }
+          const { signature, ...rest } = parsed;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const valid = await verify(signature, hash, parsed.sender.publicKey);
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
+import { verify } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuSettingsSync = () => {
   useEffect(() => {
@@ -29,7 +31,13 @@ export const useWakuSettingsSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.sender || !parsed.signature) {
+            return;
+          }
+          const { signature, ...rest } = parsed;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const valid = await verify(signature, hash, parsed.sender.publicKey);
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { TENANT } from '../../constants/tenant';
+import { verify } from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuUserSync = () => {
   useEffect(() => {
@@ -19,7 +21,13 @@ export const useWakuUserSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.sender || !parsed.signature) {
+            return;
+          }
+          const { signature, ...rest } = parsed;
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(rest)));
+          const valid = await verify(signature, hash, parsed.sender.publicKey);
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);


### PR DESCRIPTION
## Summary
- sign Waku payloads in all send helpers
- store signature alongside sender information
- verify signatures in all Waku sync listeners

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module)*

------
https://chatgpt.com/codex/tasks/task_e_6887ed6aeb5083268f84f626620f8294