### PR TITLE
Add ed25519 signature support for Waku messages

### DIFF
--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,21 +1,37 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuOrderUpdate = async (
   order: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' }
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadObj = {
     type: 'order.update',
     order,
-    sender,
-  });
+    sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+  };
+  const payload = JSON.stringify(payloadObj);
+
+  let signature = '';
+  if (sender.privateKey) {
+    try {
+      const hash = sha256(new TextEncoder().encode(payload));
+      const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+      signature = edBytes.bytesToHex(sig);
+    } catch (e) {
+      console.error('Failed to sign Waku message', e);
+    }
+  }
+
+  const message = JSON.stringify({ ...payloadObj, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,21 +1,37 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuProductUpdate = async (
   product: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' }
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadObj = {
     type: 'product.update',
     product,
-    sender,
-  });
+    sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+  };
+  const payload = JSON.stringify(payloadObj);
+
+  let signature = '';
+  if (sender.privateKey) {
+    try {
+      const hash = sha256(new TextEncoder().encode(payload));
+      const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+      signature = edBytes.bytesToHex(sig);
+    } catch (e) {
+      console.error('Failed to sign Waku message', e);
+    }
+  }
+
+  const message = JSON.stringify({ ...payloadObj, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,4 +1,5 @@
 import type { WakuSender } from './sendWakuUserUpdate';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuSettingsUpdate = async (
   key: string,
@@ -8,22 +9,38 @@ export const sendWakuSettingsUpdate = async (
   sender: WakuSender = { id: '', publicKey: '', role: '' }
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);
 
-    const payload = JSON.stringify({
+    const payloadObj = {
       type: 'settings.update',
       key,
       value,
       createdAt,
       updatedAt,
-    });
+      sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+    };
+    const payload = JSON.stringify(payloadObj);
+
+    let signature = '';
+    if (sender.privateKey) {
+      try {
+        const hash = sha256(new TextEncoder().encode(payload));
+        const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+        signature = edBytes.bytesToHex(sig);
+      } catch (e) {
+        console.error('Failed to sign Waku message', e);
+      }
+    }
+
+    const message = JSON.stringify({ ...payloadObj, signature });
 
     const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
-    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
   } finally {
     await node.stop();
   }

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -2,24 +2,42 @@ export interface WakuSender {
   id: string;
   publicKey: string;
   role: string;
+  privateKey?: string;
 }
+
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuUserUpdate = async (
   user: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' }
 ) => {
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
   await node.start();
   await waitForRemotePeer(node, [Protocols.LightPush]);
 
-  const payload = JSON.stringify({
+  const payloadObj = {
     type: 'user.update',
     user,
-    sender,
-  });
+    sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+  };
+  const payload = JSON.stringify(payloadObj);
+
+  let signature = '';
+  if (sender.privateKey) {
+    try {
+      const hash = sha256(new TextEncoder().encode(payload));
+      const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+      signature = edBytes.bytesToHex(sig);
+    } catch (e) {
+      console.error('Failed to sign Waku message', e);
+    }
+  }
+
+  const message = JSON.stringify({ ...payloadObj, signature });
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(payload) });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(message) });
 };

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { TENANT } from '../../constants/tenant';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuOrderSync = () => {
   useEffect(() => {
@@ -9,6 +10,7 @@ export const useWakuOrderSync = () => {
 
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { verify, etc: edBytes } = await import('@noble/ed25519');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -19,7 +21,16 @@ export const useWakuOrderSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender) return;
+          const { signature, ...unsigned } = parsed;
+          const payloadStr = JSON.stringify(unsigned);
+          const hash = sha256(new TextEncoder().encode(payloadStr));
+          const valid = await verify(
+            edBytes.hexToBytes(signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey),
+          );
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuProductSync = () => {
   useEffect(() => {
@@ -8,6 +9,7 @@ export const useWakuProductSync = () => {
 
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { verify, etc: edBytes } = await import('@noble/ed25519');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -18,7 +20,16 @@ export const useWakuProductSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender) return;
+          const { signature, ...unsigned } = parsed;
+          const payloadStr = JSON.stringify(unsigned);
+          const hash = sha256(new TextEncoder().encode(payloadStr));
+          const valid = await verify(
+            edBytes.hexToBytes(signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey),
+          );
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuSettingsSync = () => {
   useEffect(() => {
@@ -8,6 +9,7 @@ export const useWakuSettingsSync = () => {
 
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { verify, etc: edBytes } = await import('@noble/ed25519');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -29,7 +31,16 @@ export const useWakuSettingsSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender) return;
+          const { signature, ...unsigned } = parsed;
+          const payloadStr = JSON.stringify(unsigned);
+          const hash = sha256(new TextEncoder().encode(payloadStr));
+          const valid = await verify(
+            edBytes.hexToBytes(signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey),
+          );
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
+import { sha256 } from '@noble/hashes/sha256';
 import { TENANT } from '../../constants/tenant';
 
 export const useWakuUserSync = () => {
@@ -9,6 +10,7 @@ export const useWakuUserSync = () => {
 
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const { verify, etc: edBytes } = await import('@noble/ed25519');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -19,7 +21,16 @@ export const useWakuUserSync = () => {
         const decoded = new TextDecoder().decode(msg.payload);
         try {
           const parsed = JSON.parse(decoded);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender) return;
+          const { signature, ...unsigned } = parsed;
+          const payloadStr = JSON.stringify(unsigned);
+          const hash = sha256(new TextEncoder().encode(payloadStr));
+          const valid = await verify(
+            edBytes.hexToBytes(signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey),
+          );
+          if (!valid || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);


### PR DESCRIPTION
## Summary
- sign Waku payloads with sender private keys
- send signatures alongside sender info
- verify signatures when handling Waku updates

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6887edbcbf40832688910657b6138fa8