### PR TITLE
Require env vars for secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ EXPO_PUBLIC_MATRIX_SERVER=https://matrix.org
 # App Configuration
 EXPO_PUBLIC_APP_NAME=TheCongress
 EXPO_PUBLIC_DEBUG_LOGS=false
+# Required secret used for JWT signing
 EXPO_PUBLIC_JWT_SECRET=your_jwt_secret
 
 # Pinata credentials for IPFS uploads
@@ -16,6 +17,7 @@ EXPO_PUBLIC_PINATA_API_KEY=YOUR_PINATA_API_KEY
 EXPO_PUBLIC_PINATA_SECRET_API_KEY=YOUR_PINATA_SECRET_KEY
 EXPO_PUBLIC_PINATA_JWT=YOUR_PINATA_JWT
 # Chat Encryption
+# Required secrets for encryption
 EXPO_PUBLIC_CHAT_SECRET=changeme
 EXPO_PUBLIC_WAKU_SECRET=changeme
 EXPO_PUBLIC_USE_WAKU=false

--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ cp .env.example .env
 # then edit .env and provide your keys
 ```
 
-The file includes a `EXPO_PUBLIC_CHAT_SECRET` variable used to derive
-encryption keys for chat messages. Set it to any random string but make sure
-the same value is used for all clients so they can decrypt messages.
-`EXPO_PUBLIC_WAKU_SECRET` is similarly used to encrypt synchronization
-messages sent over Waku.
+The file includes several **required** secrets:
+
+* `EXPO_PUBLIC_JWT_SECRET` for signing JSON Web Tokens
+* `EXPO_PUBLIC_CHAT_SECRET` to derive chat encryption keys
+* `EXPO_PUBLIC_WAKU_SECRET` to encrypt Waku synchronization messages
+
+These must be defined at runtime; the application will throw an error if any of
+them are missing. Set them to random strings and use the same value across all
+clients so messages can be decrypted.
 
 `EXPO_PUBLIC_TENANT` specifies which tenant's branding to load from the
 `tenant_settings` table. Example values are `thecongress` or `thebull`.

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -6,13 +6,14 @@ import * as SecureStore from 'expo-secure-store';
 import { getPublicKey, utils as edUtils } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
+import { requireEnv } from '../utils/env';
 import { TENANT } from '../constants/tenant';
 
 const ADMIN_USERNAMES = (process.env.EXPO_PUBLIC_ADMIN_USERNAME || '')
   .split(',')
   .map((u) => u.trim())
   .filter(Boolean);
-const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
+const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
 const PRIVATE_KEY_KEY = 'ed25519_private_key';
 
 export class UsernameTakenError extends Error {

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
     '^.+\\.js$': 'babel-jest',
   },
+  setupFiles: ['<rootDir>/tests/setupEnv.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/tests/__mocks__/fileMock.js',

--- a/lib/waku/wakuCrypto.ts
+++ b/lib/waku/wakuCrypto.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { requireEnv } from '../../utils/env';
 
 const wakuKeyPromise: { key?: CryptoKey } = {};
 
@@ -7,7 +8,7 @@ const wakuKeyPromise: { key?: CryptoKey } = {};
  */
 export async function getWakuKey(): Promise<CryptoKey> {
   if (wakuKeyPromise.key) return wakuKeyPromise.key;
-  const secret = process.env.EXPO_PUBLIC_WAKU_SECRET || 'default_waku_secret';
+  const secret = requireEnv('EXPO_PUBLIC_WAKU_SECRET');
   const enc = new TextEncoder().encode(secret);
   const hash = await crypto.subtle.digest('SHA-256', enc);
   const key = await crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, [

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -2,8 +2,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
 import DatabaseService from './database';
 import JWT from 'expo-jwt';
+import { requireEnv } from '../utils/env';
 
-const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
+const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
 import { getToken } from '../utils/tokenStorage';
 import { isTokenValid } from '../utils/jwtSession';
 

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,0 +1,3 @@
+process.env.EXPO_PUBLIC_JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'test_jwt_secret';
+process.env.EXPO_PUBLIC_CHAT_SECRET = process.env.EXPO_PUBLIC_CHAT_SECRET || 'test_chat_secret';
+process.env.EXPO_PUBLIC_WAKU_SECRET = process.env.EXPO_PUBLIC_WAKU_SECRET || 'test_waku_secret';

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -3,10 +3,12 @@ const roomKeys: Record<string, CryptoKey> = {};
 /**
  * Derive a deterministic key per room using a shared secret.
  */
+import { requireEnv } from './env';
+
 export async function getRoomKey(roomId: string): Promise<CryptoKey> {
   if (roomKeys[roomId]) return roomKeys[roomId];
 
-  const secret = process.env.EXPO_PUBLIC_CHAT_SECRET || 'default_chat_secret';
+  const secret = requireEnv('EXPO_PUBLIC_CHAT_SECRET');
   const enc = new TextEncoder().encode(roomId + secret);
   const hash = await crypto.subtle.digest('SHA-256', enc);
 

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,0 +1,7 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
+}

--- a/utils/jwtSession.ts
+++ b/utils/jwtSession.ts
@@ -1,6 +1,7 @@
 import JWT from 'expo-jwt';
+import { requireEnv } from './env';
 
-const JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'secret_key';
+const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
 
 export function isTokenValid(token: string): boolean {
   try {


### PR DESCRIPTION
## Summary
- enforce required environment variables via `requireEnv`
- document required secrets in README and `.env.example`
- configure Jest to set example secrets for tests

## Testing
- `yarn install` *(fails: incompatible Node version)*

------
https://chatgpt.com/codex/tasks/task_e_6888ab0b3e808326ae207c67a799679b