### PR TITLE
Hash Waku messages for dedup

### DIFF
--- a/lib/sqlite/initSettingsTable.ts
+++ b/lib/sqlite/initSettingsTable.ts
@@ -14,6 +14,7 @@ export const ensureSettingsTable = async () => {
 
   await executeSql(`
     CREATE TABLE IF NOT EXISTS waku_seen (
+      -- SHA-256 hash of the decrypted message
       id TEXT NOT NULL,
       topic TEXT NOT NULL,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { Buffer } from 'buffer';
 import { executeSql } from '../sqlite';
 import { decryptWakuPayload } from './wakuCrypto';
 
@@ -17,19 +18,22 @@ export const useWakuSettingsSync = () => {
       const topic = '/congress/settings/1';
       decoder = node.createDecoder({ contentTopic: topic });
       await node.filter!.subscribe(decoder, async (msg) => {
-        if (!msg.payload || !msg.timestamp) return;
-        const id = msg.timestamp.getTime().toString();
-
-          const seen = await executeSql(
-            'SELECT 1 FROM waku_seen WHERE id=? AND topic=? LIMIT 1',
-            [id, topic]
-          );
-        if ((seen.rows as any)._array.length > 0) return;
-
-          await executeSql('INSERT INTO waku_seen (id, topic) VALUES (?, ?)', [id, topic]);
-
+        if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
         const plaintext = await decryptWakuPayload(decoded);
+        const hashBuffer = await crypto.subtle.digest(
+          'SHA-256',
+          new TextEncoder().encode(plaintext),
+        );
+        const id = Buffer.from(new Uint8Array(hashBuffer)).toString('hex');
+
+        const seen = await executeSql(
+          'SELECT 1 FROM waku_seen WHERE id=? AND topic=? LIMIT 1',
+          [id, topic],
+        );
+        if ((seen.rows as any)._array.length > 0) return;
+
+        await executeSql('INSERT INTO waku_seen (id, topic) VALUES (?, ?)', [id, topic]);
         try {
           const parsed = JSON.parse(plaintext);
           if (!parsed.sender || parsed.sender.role !== 'admin') {

--- a/sqlite/migrations/001_initial_schema.sql
+++ b/sqlite/migrations/001_initial_schema.sql
@@ -316,6 +316,7 @@ END;
 
 -- Table for tracking processed Waku messages
 CREATE TABLE waku_seen (
+  -- SHA-256 hash of the decrypted message
   id TEXT NOT NULL,
   topic TEXT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- compute SHA-256 hash of decrypted Waku payloads
- track hashed values in `waku_seen`
- document hashed message ID in SQL schema

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ab0e5dfc8326be090866596a6980