### PR TITLE
Wrap Waku updates with cleanup

### DIFF
--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuOrderUpdate = async (
   order: any,
@@ -10,8 +11,9 @@ export const sendWakuOrderUpdate = async (
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
-  await node.start();
-  await waitForRemotePeer(node, [Protocols.LightPush]);
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
 
   const payloadObj = {
     type: 'order.update',
@@ -35,7 +37,11 @@ export const sendWakuOrderUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+    const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+
+  } finally {
+    await node.stop();
+  }
 
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export const sendWakuProductUpdate = async (
@@ -11,8 +12,9 @@ export const sendWakuProductUpdate = async (
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
-  await node.start();
-  await waitForRemotePeer(node, [Protocols.LightPush]);
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
 
   const payloadObj = {
     type: 'product.update',
@@ -36,7 +38,11 @@ export const sendWakuProductUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+    const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+
+  } finally {
+    await node.stop();
+  }
 
 };

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,4 +1,5 @@
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export interface WakuSender {
@@ -18,8 +19,9 @@ export const sendWakuUserUpdate = async (
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   const node = await createLightNode({ defaultBootstrap: true });
-  await node.start();
-  await waitForRemotePeer(node, [Protocols.LightPush]);
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
 
   const payloadObj = {
     type: 'user.update',
@@ -43,7 +45,11 @@ export const sendWakuUserUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
-  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+    const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+
+  } finally {
+    await node.stop();
+  }
 
 };

--- a/tests/wakuUpdates.test.ts
+++ b/tests/wakuUpdates.test.ts
@@ -1,0 +1,58 @@
+import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
+import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
+import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
+
+jest.mock('../lib/waku/wakuCrypto', () => ({
+  encryptWakuPayload: jest.fn(async (p: string) => p),
+}));
+
+const start = jest.fn();
+const stop = jest.fn();
+const node = {
+  start,
+  stop,
+  createEncoder: jest.fn(() => ({})),
+  lightPush: { send: jest.fn() },
+};
+
+jest.mock(
+  '@waku/sdk',
+  () => ({
+    createLightNode: jest.fn(async () => node),
+    waitForRemotePeer: jest.fn(async () => undefined),
+    Protocols: { LightPush: 'lightpush' },
+  }),
+  { virtual: true }
+);
+
+jest.mock('@noble/ed25519', () => ({
+  sign: jest.fn(),
+  etc: { hexToBytes: jest.fn(), bytesToHex: jest.fn() },
+}));
+
+describe('Waku send updates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('user update creates and stops node', async () => {
+    await sendWakuUserUpdate({});
+    const { createLightNode } = await import('@waku/sdk');
+    expect(createLightNode).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('product update creates and stops node', async () => {
+    await sendWakuProductUpdate({});
+    const { createLightNode } = await import('@waku/sdk');
+    expect(createLightNode).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('order update creates and stops node', async () => {
+    await sendWakuOrderUpdate({});
+    const { createLightNode } = await import('@waku/sdk');
+    expect(createLightNode).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure sendWakuUserUpdate stops nodes
- ensure sendWakuProductUpdate stops nodes
- ensure sendWakuOrderUpdate stops nodes
- add tests verifying node creation and cleanup

## Testing
- `yarn test tests/wakuUpdates.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6888ab0784b08326b78d0c0f1651eab9