### PR TITLE
Update Waku content topics

### DIFF
--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -35,7 +35,7 @@ export const sendWakuOrderUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
+  const encoder = node.createEncoder({ contentTopic: '/congress/orders/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -36,7 +36,7 @@ export const sendWakuProductUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
+  const encoder = node.createEncoder({ contentTopic: '/congress/products/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -43,7 +43,7 @@ export const sendWakuSettingsUpdate = async (
 
     const encrypted = await encryptWakuPayload(payload);
 
-    const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
+    const encoder = node.createEncoder({ contentTopic: '/congress/settings/1/proto' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 
   } finally {

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -43,7 +43,7 @@ export const sendWakuUserUpdate = async (
 
   const encrypted = await encryptWakuPayload(payload);
 
-  const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
+  const encoder = node.createEncoder({ contentTopic: '/congress/users/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 
 };

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -15,7 +15,7 @@ export const useWakuOrderSync = () => {
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      decoder = node.createDecoder({ contentTopic: '/congress/orders/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/orders/1/proto' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -15,7 +15,7 @@ export const useWakuProductSync = () => {
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      decoder = node.createDecoder({ contentTopic: '/congress/products/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/products/1/proto' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -14,7 +14,7 @@ export const useWakuSettingsSync = () => {
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      const topic = '/congress/settings/1';
+      const topic = '/congress/settings/1/proto';
       decoder = node.createDecoder({ contentTopic: topic });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload || !msg.timestamp) return;

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -17,7 +17,7 @@ export const useWakuUserSync = () => {
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
 
-      decoder = node.createDecoder({ contentTopic: '/congress/users/1' });
+      decoder = node.createDecoder({ contentTopic: '/congress/users/1/proto' });
       await node.filter!.subscribe(decoder, async (msg) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);


### PR DESCRIPTION
## Summary
- fix content topics in all Waku helpers to use `/proto`

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_6888ac3eaedc83268a2058a8cf9c2f62