### PR TITLE
Skip tenant API calls when URL unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,4 +27,6 @@ VAPID_PRIVATE_KEY=your_private_key
 # Tenant Identifier used to load branding from tenant_settings table
 EXPO_PUBLIC_TENANT=thecongress
 # Endpoint for remote tenant settings API
-EXPO_PUBLIC_SETTINGS_API_URL=https://example.com/api
+# Must point to a server that sends CORS headers.
+# Leave empty to disable remote fetches.
+EXPO_PUBLIC_SETTINGS_API_URL=

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ messages sent over Waku.
 `EXPO_PUBLIC_TENANT` specifies which tenant's branding to load from the
 `tenant_settings` table. Example values are `thecongress` or `thebull`.
 
+`EXPO_PUBLIC_SETTINGS_API_URL` must point to a server that sets CORS headers.
+Leave it empty to disable fetching tenant settings from a remote API.
+
 Logos and other uploaded images are stored on IPFS via Pinata. Set
 `EXPO_PUBLIC_PINATA_JWT` (or API key/secret) in your `.env` file so uploads can
 succeed.

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuOrderUpdate = async (
   order: any,

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export const sendWakuProductUpdate = async (

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export const sendWakuSettingsUpdate = async (

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,4 +1,5 @@
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export interface WakuSender {

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -25,8 +25,12 @@ class TenantSettingsService {
     tenant: string,
     key: 'platform_name' | 'platform_logo' | 'theme_color'
   ): Promise<string | null> {
+    const base = apiBase();
+    if (!base) {
+      return null;
+    }
     try {
-      const res = await fetch(`${apiBase()}/tenant_settings/${tenant}`);
+      const res = await fetch(`${base}/tenant_settings/${tenant}`);
 
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
@@ -44,8 +48,12 @@ class TenantSettingsService {
     key: 'platform_name' | 'platform_logo' | 'theme_color',
     value: string
   ): Promise<void> {
+    const base = apiBase();
+    if (!base) {
+      return;
+    }
     try {
-      const res = await fetch(`${apiBase()}/tenant_settings/${tenant}`, {
+      const res = await fetch(`${base}/tenant_settings/${tenant}`, {
 
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -23,4 +23,19 @@ describe('TenantSettingsService remote', () => {
     const svc = TenantSettingsService.getInstance();
     await expect(svc.getTenantSetting('foo', 'platform_name')).rejects.toThrow('network');
   });
+
+  it('returns null when API url is empty', async () => {
+    process.env.EXPO_PUBLIC_SETTINGS_API_URL = '';
+    const svc = TenantSettingsService.getInstance();
+    const val = await svc.getTenantSetting('foo', 'platform_name');
+    expect(val).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('skips update when API url is empty', async () => {
+    process.env.EXPO_PUBLIC_SETTINGS_API_URL = '';
+    const svc = TenantSettingsService.getInstance();
+    await svc.updateTenantSetting('foo', 'platform_name', 'bar');
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- skip tenant settings API calls when `EXPO_PUBLIC_SETTINGS_API_URL` is empty
- clarify CORS requirement in README
- add explanatory comments to `.env.example`
- update tests
- fix missing sha256 imports so tests run

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6888ac404b808326a88d740a6cc65936