### PR TITLE
Add Waku signature verification

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
     '^.+\\.js$': 'babel-jest',
   },
+  transformIgnorePatterns: ['/node_modules/(?!@noble/ed25519)'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/tests/__mocks__/fileMock.js',

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const sendWakuOrderUpdate = async (
   order: any,
@@ -33,7 +34,7 @@ export const sendWakuOrderUpdate = async (
 
   const message = JSON.stringify({ ...payloadObj, signature });
 
-  const encrypted = await encryptWakuPayload(payload);
+  const encrypted = await encryptWakuPayload(message);
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export const sendWakuProductUpdate = async (
@@ -34,7 +35,7 @@ export const sendWakuProductUpdate = async (
 
   const message = JSON.stringify({ ...payloadObj, signature });
 
-  const encrypted = await encryptWakuPayload(payload);
+  const encrypted = await encryptWakuPayload(message);
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,5 +1,6 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export const sendWakuSettingsUpdate = async (
@@ -41,7 +42,7 @@ export const sendWakuSettingsUpdate = async (
 
     const message = JSON.stringify({ ...payloadObj, signature });
 
-    const encrypted = await encryptWakuPayload(payload);
+    const encrypted = await encryptWakuPayload(message);
 
     const encoder = node.createEncoder({ contentTopic: '/congress/settings/1' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,4 +1,5 @@
 import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
 
 
 export interface WakuSender {
@@ -41,7 +42,7 @@ export const sendWakuUserUpdate = async (
 
   const message = JSON.stringify({ ...payloadObj, signature });
 
-  const encrypted = await encryptWakuPayload(payload);
+  const encrypted = await encryptWakuPayload(message);
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });

--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -11,6 +11,7 @@ export const useWakuOrderSync = () => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
+      const { sha256 } = await import('@noble/hashes/sha256');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -22,7 +23,25 @@ export const useWakuOrderSync = () => {
         const plaintext = await decryptWakuPayload(decoded);
         try {
           const parsed = JSON.parse(plaintext);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender?.publicKey) {
+            return;
+          }
+          const verifyObj = {
+            type: parsed.type,
+            order: parsed.order,
+            sender: {
+              id: parsed.sender.id,
+              publicKey: parsed.sender.publicKey,
+              role: parsed.sender.role,
+            },
+          };
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+          const ok = await verify(
+            edBytes.hexToBytes(parsed.signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey)
+          );
+          if (!ok || parsed.sender.role !== 'admin') {
 
             return;
           }

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -11,6 +11,7 @@ export const useWakuProductSync = () => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
+      const { sha256 } = await import('@noble/hashes/sha256');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -22,8 +23,25 @@ export const useWakuProductSync = () => {
         const plaintext = await decryptWakuPayload(decoded);
         try {
           const parsed = JSON.parse(plaintext);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
-
+          if (!parsed.signature || !parsed.sender?.publicKey) {
+            return;
+          }
+          const verifyObj = {
+            type: parsed.type,
+            product: parsed.product,
+            sender: {
+              id: parsed.sender.id,
+              publicKey: parsed.sender.publicKey,
+              role: parsed.sender.role,
+            },
+          };
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+          const ok = await verify(
+            edBytes.hexToBytes(parsed.signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey)
+          );
+          if (!ok || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -10,6 +10,7 @@ export const useWakuSettingsSync = () => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
+      const { sha256 } = await import('@noble/hashes/sha256');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -32,7 +33,28 @@ export const useWakuSettingsSync = () => {
         const plaintext = await decryptWakuPayload(decoded);
         try {
           const parsed = JSON.parse(plaintext);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
+          if (!parsed.signature || !parsed.sender?.publicKey) {
+            return;
+          }
+          const verifyObj = {
+            type: parsed.type,
+            key: parsed.key,
+            value: parsed.value,
+            createdAt: parsed.createdAt,
+            updatedAt: parsed.updatedAt,
+            sender: {
+              id: parsed.sender.id,
+              publicKey: parsed.sender.publicKey,
+              role: parsed.sender.role,
+            },
+          };
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+          const ok = await verify(
+            edBytes.hexToBytes(parsed.signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey)
+          );
+          if (!ok || parsed.sender.role !== 'admin') {
 
             return;
           }

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { decryptWakuPayload } from './wakuCrypto';
 import { TENANT } from '../../constants/tenant';
-import { verify } from '@noble/ed25519';
-import { sha256 } from '@noble/hashes/sha256';
 
 export const useWakuUserSync = () => {
   useEffect(() => {
@@ -13,6 +11,7 @@ export const useWakuUserSync = () => {
     const run = async () => {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
+      const { sha256 } = await import('@noble/hashes/sha256');
       node = await createLightNode({ defaultBootstrap: true });
       await node.start();
       await waitForRemotePeer(node, [Protocols.Store, Protocols.LightPush]);
@@ -24,8 +23,25 @@ export const useWakuUserSync = () => {
         const plaintext = await decryptWakuPayload(decoded);
         try {
           const parsed = JSON.parse(plaintext);
-          if (!parsed.sender || parsed.sender.role !== 'admin') {
-
+          if (!parsed.signature || !parsed.sender?.publicKey) {
+            return;
+          }
+          const verifyObj = {
+            type: parsed.type,
+            user: parsed.user,
+            sender: {
+              id: parsed.sender.id,
+              publicKey: parsed.sender.publicKey,
+              role: parsed.sender.role,
+            },
+          };
+          const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+          const ok = await verify(
+            edBytes.hexToBytes(parsed.signature),
+            hash,
+            edBytes.hexToBytes(parsed.sender.publicKey)
+          );
+          if (!ok || parsed.sender.role !== 'admin') {
             return;
           }
           const exists = await executeSql('SELECT 1 FROM users WHERE id=? LIMIT 1', [parsed.sender.id]);

--- a/tests/wakuSignature.test.ts
+++ b/tests/wakuSignature.test.ts
@@ -1,0 +1,30 @@
+import { encryptWakuPayload, decryptWakuPayload } from '../lib/waku/wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
+
+let ed: any;
+beforeAll(async () => {
+  ed = await import('@noble/ed25519');
+});
+
+test('signature verifies after encryption round trip', async () => {
+  const priv = ed.utils.randomPrivateKey();
+  const pub = await ed.getPublicKeyAsync(priv);
+  const sender = { id: '1', publicKey: ed.etc.bytesToHex(pub), role: 'admin' };
+
+  const payloadObj = { type: 'user.update', user: { name: 'A' }, sender };
+  const payloadStr = JSON.stringify(payloadObj);
+  const hash = sha256(new TextEncoder().encode(payloadStr));
+  const sig = await ed.signAsync(hash, priv);
+  const signature = ed.etc.bytesToHex(sig);
+  const messageStr = JSON.stringify({ ...payloadObj, signature });
+
+  const enc = await encryptWakuPayload(messageStr);
+  const dec = await decryptWakuPayload(enc);
+  expect(dec).toBe(messageStr);
+
+  const parsed = JSON.parse(dec);
+  const verifyObj = { type: parsed.type, user: parsed.user, sender: parsed.sender };
+  const verifyHash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+  const ok = await ed.verifyAsync(ed.etc.hexToBytes(parsed.signature), verifyHash, pub);
+  expect(ok).toBe(true);
+});


### PR DESCRIPTION
## Summary
- encrypt signed Waku messages before sending
- verify signatures in Waku sync hooks
- add regression test for encryption/signature round trip

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6888ab03a6d48326a76783179a7e7136