### PR TITLE
Add config table

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -3,6 +3,7 @@ import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
 import { Platform } from 'react-native';
 import { parseSql } from './sqlUtils';
+import { ensureConfigTable } from './sqlite/initConfigTable';
 
 const DB_NAME = 'app.db';
 
@@ -92,6 +93,7 @@ export function ensureDatabase(): Promise<void> {
       if (!(await tableExists(db, 'users'))) {
         await applySchema(db);
       }
+      await ensureConfigTable();
     } finally {
       ensurePromise = null;
     }

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -1,6 +1,7 @@
 import * as SQLite from 'expo-sqlite';
 import { Asset } from 'expo-asset';
 import { parseSql } from './sqlUtils';
+import { ensureConfigTable } from './sqlite/initConfigTable';
 
 const DB_NAME = 'app.db';
 
@@ -76,6 +77,7 @@ export function ensureDatabase(): Promise<void> {
       if (!(await tableExists(db, 'users'))) {
         await applySchema(db);
       }
+      await ensureConfigTable();
     } finally {
       ensurePromise = null;
     }

--- a/lib/sqlite/initConfigTable.ts
+++ b/lib/sqlite/initConfigTable.ts
@@ -1,0 +1,10 @@
+import { executeSql } from '../sqlite';
+
+export const ensureConfigTable = async () => {
+  await executeSql(`
+    CREATE TABLE IF NOT EXISTS config (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    );
+  `);
+};

--- a/sqlite/migrations/003_add_config_table.sql
+++ b/sqlite/migrations/003_add_config_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS config (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,0 +1,10 @@
+import { executeSql } from '../lib/sqlite';
+
+export async function saveConfigValue(key: string, value: string): Promise<void> {
+  await executeSql('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)', [key, value]);
+}
+
+export async function getConfig(key: string): Promise<string | null> {
+  const res = await executeSql('SELECT value FROM config WHERE key=?', [key]);
+  return (res.rows as any)._array?.[0]?.value ?? null;
+}


### PR DESCRIPTION
## Summary
- add migration for config table
- create helper to init config table
- expose helpers for getting & saving config values
- ensure config table creation for SQLite usage

## Testing
- `yarn test` *(fails: lib/waku/sendWakuUserUpdate.ts parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6888b7d950548326a0f3f124f0ecf0f6