### PR TITLE
Switch env vars to async config helper

### DIFF
--- a/components/AdminChatList.tsx
+++ b/components/AdminChatList.tsx
@@ -14,6 +14,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Search, MessageCircle, Send, X } from 'lucide-react-native';
 import { ChatRoom, ChatMessage } from '../types';
 import DatabaseService from '../services/database';
+import { requireConfig } from '../utils/env';
 
 interface Props {
   chatRooms: ChatRoom[];
@@ -48,9 +49,10 @@ export default function AdminChatList({ chatRooms }: Props) {
     if (!newMessage.trim() || !selectedRoom || isSending) return;
     setIsSending(true);
 
+    const admin = await requireConfig('EXPO_PUBLIC_ADMIN_USERNAME');
     const message: ChatMessage = {
       id: Date.now().toString(),
-      senderId: process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin',
+      senderId: admin || 'admin',
       senderName: 'Admin',
       message: newMessage.trim(),
       timestamp: Date.now(),

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -6,14 +6,17 @@ import * as SecureStore from 'expo-secure-store';
 import { getPublicKey, utils as edUtils } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
-import { requireEnv } from '../utils/env';
+import { requireConfig } from '../utils/env';
 import { TENANT } from '../constants/tenant';
 
-const ADMIN_USERNAMES = (process.env.EXPO_PUBLIC_ADMIN_USERNAME || '')
-  .split(',')
-  .map((u) => u.trim())
-  .filter(Boolean);
-const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
+async function getAdminUsernames(): Promise<string[]> {
+  const raw = await requireConfig('EXPO_PUBLIC_ADMIN_USERNAME');
+  return raw
+    .split(',')
+    .map((u) => u.trim())
+    .filter(Boolean);
+}
+const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
 const PRIVATE_KEY_KEY = 'ed25519_private_key';
 
 export class UsernameTakenError extends Error {
@@ -62,7 +65,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const init = async () => {
       try {
         const token = await getToken();
-        if (token && isTokenValid(token)) {
+        if (token && (await isTokenValid(token))) {
+          const JWT_SECRET = await JWT_SECRET_PROMISE;
           const payload: any = JWT.decode(token, JWT_SECRET);
           setSession(token);
           if (payload?.sub) {
@@ -108,6 +112,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setLoading(false);
         return false;
       }
+      const JWT_SECRET = await JWT_SECRET_PROMISE;
       const token = JWT.encode(
         { sub: row.id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
         JWT_SECRET,
@@ -133,7 +138,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       const hash = await bcrypt.hash(password, 10);
       const id = `user_${Date.now()}`;
-      const isAdminUsername = ADMIN_USERNAMES.includes(username);
+      const isAdminUsername = (await getAdminUsernames()).includes(username);
       const role = isAdminUsername ? 'admin' : 'user';
       const priv = edUtils.randomPrivateKey();
       const pub = await getPublicKey(priv);
@@ -148,6 +153,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
         [id, TENANT, id, username, null, displayName, role],
       );
+      const JWT_SECRET = await JWT_SECRET_PROMISE;
       const token = JWT.encode(
         { sub: id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
         JWT_SECRET,
@@ -183,7 +189,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const checkAuthState = async () => {
     setLoading(true);
     const token = await getToken();
-    if (token && isTokenValid(token)) {
+    if (token && (await isTokenValid(token))) {
+      const JWT_SECRET = await JWT_SECRET_PROMISE;
       const payload: any = JWT.decode(token, JWT_SECRET);
       setSession(token);
       if (payload?.sub) {
@@ -199,8 +206,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const refreshSession = async () => {
     const token = await getToken();
-    if (token && isTokenValid(token)) {
-      const newToken = refreshToken(token);
+    if (token && (await isTokenValid(token))) {
+      const newToken = await refreshToken(token);
       if (newToken) {
         await saveToken(newToken);
         setSession(newToken);

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -36,6 +36,7 @@ import { useWakuClient } from '../hooks/useWakuClient';
 import { useAuth } from './AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
+import { requireConfig } from '../utils/env';
 import InfoModal from './InfoModal';
 import UserProfileModal from './UserProfileModal';
 
@@ -407,7 +408,7 @@ const loadOrCreateDefaultRoom = async () => {
       const msg: Omit<ChatMessage, 'id' | 'timestamp'> = {
         senderId:
           isAdmin || isDriver
-            ? process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin'
+            ? (await requireConfig('EXPO_PUBLIC_ADMIN_USERNAME')) || 'admin'
             : user?.id || 'user_guest',
         senderName:
           isAdmin || isDriver ? 'מנהל' : user?.displayName || 'משתמש אורח',
@@ -539,7 +540,7 @@ const loadOrCreateDefaultRoom = async () => {
           id: Date.now().toString(),
           senderId:
             isAdmin || isDriver
-              ? process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin'
+              ? (await requireConfig('EXPO_PUBLIC_ADMIN_USERNAME')) || 'admin'
               : user?.id || 'user_guest',
           senderName:
             isAdmin || isDriver ? 'מנהל' : user?.displayName || 'משתמש אורח',

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -1,4 +1,6 @@
-export const TENANT = process.env.EXPO_PUBLIC_TENANT || 'thecongress';
+import { requireConfig } from '../utils/env';
+
+export const TENANT: string = (await requireConfig('EXPO_PUBLIC_TENANT')).trim() || 'thecongress';
 
 export const tenantSettings = {
   thecongress: {

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -10,8 +10,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert } from 'react-native';
 import TenantSettingsService from '../services/tenantSettings';
 import MediaService from '../services/media';
+import { requireConfig } from '../utils/env';
 
-const TENANT = process.env.EXPO_PUBLIC_TENANT || 'default';
+const TENANT_PROMISE = requireConfig('EXPO_PUBLIC_TENANT');
 
 interface AppInfoContextType {
   platformName: string;
@@ -38,21 +39,30 @@ interface AppInfoProviderProps {
 }
 
 // Store branding separately for each tenant to avoid cross-tenant mixing
-const NAME_KEY = `app_platform_name_${TENANT}`;
-const LOGO_KEY = `app_platform_logo_${TENANT}`;
-const COLOR_KEY = `app_theme_color_${TENANT}`;
 
 export function AppInfoProvider({ children }: AppInfoProviderProps) {
+  const [tenant, setTenant] = useState<string>('default');
   const [platformName, setPlatformNameState] = useState('');
   const [platformLogo, setPlatformLogoState] = useState('');
   const [themeColor, setThemeColorState] = useState('#B99C5A');
   const reloadTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    loadInfo();
+    (async () => {
+      try {
+        const t = await TENANT_PROMISE;
+        setTenant(t || 'default');
+      } catch {
+        setTenant('default');
+      }
+      loadInfo();
+    })();
   }, []);
 
   const loadInfo = async () => {
+    const NAME_KEY = `app_platform_name_${tenant}`;
+    const LOGO_KEY = `app_platform_logo_${tenant}`;
+    const COLOR_KEY = `app_theme_color_${tenant}`;
     try {
       const storedName = await AsyncStorage.getItem(NAME_KEY);
       const storedLogo = await AsyncStorage.getItem(LOGO_KEY);
@@ -63,9 +73,10 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
 
       const tenantSvc = TenantSettingsService.getInstance();
       try {
-        const dbName = await tenantSvc.getTenantSetting(TENANT, 'platform_name');
-        const dbLogo = await tenantSvc.getTenantSetting(TENANT, 'platform_logo');
-        const dbColor = await tenantSvc.getTenantSetting(TENANT, 'theme_color');
+        const t = tenant;
+        const dbName = await tenantSvc.getTenantSetting(t, 'platform_name');
+        const dbLogo = await tenantSvc.getTenantSetting(t, 'platform_logo');
+        const dbColor = await tenantSvc.getTenantSetting(t, 'theme_color');
         if (dbName) {
           setPlatformNameState(dbName);
           await AsyncStorage.setItem(NAME_KEY, dbName);
@@ -96,11 +107,12 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   };
 
   const setPlatformName = async (name: string) => {
+    const NAME_KEY = `app_platform_name_${tenant}`;
     setPlatformNameState(name);
     await AsyncStorage.setItem(NAME_KEY, name);
     const tenantSvc = TenantSettingsService.getInstance();
     try {
-      await tenantSvc.updateTenantSetting(TENANT, 'platform_name', name);
+      await tenantSvc.updateTenantSetting(tenant, 'platform_name', name);
       scheduleLoadInfo();
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת שם הפלטפורמה נכשלה');
@@ -117,10 +129,11 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
         finalLogo = await mediaSvc.uploadMedia(logo, 'tenant_logo');
       }
 
+      const LOGO_KEY = `app_platform_logo_${tenant}`;
       setPlatformLogoState(finalLogo);
       await AsyncStorage.setItem(LOGO_KEY, finalLogo);
       const tenantSvc = TenantSettingsService.getInstance();
-      await tenantSvc.updateTenantSetting(TENANT, 'platform_logo', finalLogo);
+      await tenantSvc.updateTenantSetting(tenant, 'platform_logo', finalLogo);
       scheduleLoadInfo();
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת לוגו נכשלה');
@@ -131,10 +144,11 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
 
   const setThemeColor = async (color: string) => {
     try {
+      const COLOR_KEY = `app_theme_color_${tenant}`;
       setThemeColorState(color);
       await AsyncStorage.setItem(COLOR_KEY, color);
       const tenantSvc = TenantSettingsService.getInstance();
-      await tenantSvc.updateTenantSetting(TENANT, 'theme_color', color);
+      await tenantSvc.updateTenantSetting(tenant, 'theme_color', color);
       scheduleLoadInfo();
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת צבע ערכת הנושא נכשלה');

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -12,8 +12,15 @@ import {
 import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
 import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
+import { requireConfig } from '../utils/env';
 
-const USE_WAKU = process.env.EXPO_PUBLIC_USE_WAKU === 'true';
+async function useWaku(): Promise<boolean> {
+  try {
+    return (await requireConfig('EXPO_PUBLIC_USE_WAKU')) === 'true';
+  } catch {
+    return false;
+  }
+}
 const BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 
@@ -40,9 +47,9 @@ export function useWakuClient(): WakuClient {
   const nodeRef = useRef<LightNode>();
 
   useEffect(() => {
-    if (!USE_WAKU) return;
     let cancelled = false;
     (async () => {
+      if (!(await useWaku())) return;
       let node: LightNode | undefined;
       try {
         node = await createLightNode({
@@ -82,7 +89,7 @@ export function useWakuClient(): WakuClient {
     };
     await db.sendChatMessage(roomId, { ...full, message: encrypted });
 
-    if (USE_WAKU && nodeRef.current) {
+    if ((await useWaku()) && nodeRef.current) {
       const encoder = createEncoder({ contentTopic: topic(roomId) });
       await nodeRef.current.lightPush.push(encoder, {
         payload: utf8ToBytes(encrypted),
@@ -95,7 +102,7 @@ export function useWakuClient(): WakuClient {
     roomId: string,
     cb: (msg: ChatMessage) => void,
   ): Promise<() => void> => {
-    if (!USE_WAKU || !nodeRef.current) return () => {};
+    if (!(await useWaku()) || !nodeRef.current) return () => {};
     const decoder = createDecoder(topic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
@@ -131,7 +138,7 @@ export function useWakuClient(): WakuClient {
     roomId: string,
     cb: (msg: ChatMessage) => void,
   ) => {
-    if (!USE_WAKU || !nodeRef.current) return;
+    if (!(await useWaku()) || !nodeRef.current) return;
     const decoder = createDecoder(topic(roomId));
     for await (const msgs of nodeRef.current.store.queryGenerator({
       contentTopics: [topic(roomId)],

--- a/lib/waku/wakuCrypto.ts
+++ b/lib/waku/wakuCrypto.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { requireEnv } from '../../utils/env';
+import { requireConfig } from '../../utils/env';
 
 const wakuKeyPromise: { key?: CryptoKey } = {};
 
@@ -8,7 +8,7 @@ const wakuKeyPromise: { key?: CryptoKey } = {};
  */
 export async function getWakuKey(): Promise<CryptoKey> {
   if (wakuKeyPromise.key) return wakuKeyPromise.key;
-  const secret = requireEnv('EXPO_PUBLIC_WAKU_SECRET');
+  const secret = await requireConfig('EXPO_PUBLIC_WAKU_SECRET');
   const enc = new TextEncoder().encode(secret);
   const hash = await crypto.subtle.digest('SHA-256', enc);
   const key = await crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, [

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -2,9 +2,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
 import DatabaseService from './database';
 import JWT from 'expo-jwt';
-import { requireEnv } from '../utils/env';
+import { requireConfig } from '../utils/env';
 
-const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
+const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
 import { getToken } from '../utils/tokenStorage';
 import { isTokenValid } from '../utils/jwtSession';
 
@@ -22,6 +22,7 @@ class CartService {
   private async getCurrentUserId(): Promise<string | null> {
     const token = await getToken();
     if (token && isTokenValid(token)) {
+      const JWT_SECRET = await JWT_SECRET_PROMISE;
       const payload: any = JWT.decode(token, JWT_SECRET);
       return payload?.sub || null;
     }

--- a/services/database.ts
+++ b/services/database.ts
@@ -3,6 +3,7 @@ import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
 import { TENANT } from '../constants/tenant';
+import { requireConfig } from '../utils/env';
 import {
   Product,
   Category,
@@ -24,8 +25,7 @@ import {
 class DatabaseService {
   private static instance: DatabaseService;
   private static readonly tenantId = TENANT;
-  private static readonly adminId =
-    process.env.EXPO_PUBLIC_ADMIN_USERNAME || 'admin';
+  private static readonly adminIdPromise = requireConfig('EXPO_PUBLIC_ADMIN_USERNAME');
 
   private constructor() {}
 
@@ -320,8 +320,8 @@ class DatabaseService {
   }
 
   async getOrCreateChatRoom(userId: string, userName: string): Promise<string> {
-    const id =
-      'room_' + [userId, DatabaseService.adminId].sort().join('_');
+    const adminId = await DatabaseService.adminIdPromise;
+    const id = 'room_' + [userId, adminId || 'admin'].sort().join('_');
 
     // Check for existing room with the new deterministic id
     let res = await executeSql(

--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { debugLog } from '../utils/logger';
+import { requireConfig } from '../utils/env';
 
 // Pinata API configuration
 const PINATA_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
@@ -87,9 +88,9 @@ class PinataService {
 
       // Upload to Pinata
       const headers: any = {};
-      const jwt = process.env.EXPO_PUBLIC_PINATA_JWT;
-      const apiKey = process.env.EXPO_PUBLIC_PINATA_API_KEY;
-      const secret = process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY;
+      const jwt = await requireConfig('EXPO_PUBLIC_PINATA_JWT').catch(() => '');
+      const apiKey = await requireConfig('EXPO_PUBLIC_PINATA_API_KEY').catch(() => '');
+      const secret = await requireConfig('EXPO_PUBLIC_PINATA_SECRET_API_KEY').catch(() => '');
       if (jwt) {
         headers.Authorization = `Bearer ${jwt}`;
       } else {
@@ -163,10 +164,10 @@ class PinataService {
    * Check if Pinata credentials are configured
    * @returns True if Pinata is configured, false otherwise
    */
-  public isPinataConfigured(): boolean {
-    const jwt = process.env.EXPO_PUBLIC_PINATA_JWT;
-    const apiKey = process.env.EXPO_PUBLIC_PINATA_API_KEY;
-    const secret = process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY;
+  public async isPinataConfigured(): Promise<boolean> {
+    const jwt = await requireConfig('EXPO_PUBLIC_PINATA_JWT').catch(() => '');
+    const apiKey = await requireConfig('EXPO_PUBLIC_PINATA_API_KEY').catch(() => '');
+    const secret = await requireConfig('EXPO_PUBLIC_PINATA_SECRET_API_KEY').catch(() => '');
     return !!(jwt || (apiKey && secret));
   }
 }

--- a/services/tenantSettings.ts
+++ b/services/tenantSettings.ts
@@ -5,8 +5,15 @@ export interface TenantSettingsRow {
   theme_color?: string | null;
 }
 
-function apiBase() {
-  return process.env.EXPO_PUBLIC_SETTINGS_API_URL || '';
+import { requireConfig } from '../utils/env';
+
+async function apiBase() {
+  try {
+    const url = await requireConfig('EXPO_PUBLIC_SETTINGS_API_URL');
+    return url || '';
+  } catch {
+    return '';
+  }
 }
 
 class TenantSettingsService {
@@ -25,7 +32,7 @@ class TenantSettingsService {
     tenant: string,
     key: 'platform_name' | 'platform_logo' | 'theme_color'
   ): Promise<string | null> {
-    const base = apiBase();
+    const base = await apiBase();
     if (!base) {
       return null;
     }
@@ -48,7 +55,7 @@ class TenantSettingsService {
     key: 'platform_name' | 'platform_logo' | 'theme_color',
     value: string
   ): Promise<void> {
-    const base = apiBase();
+    const base = await apiBase();
     if (!base) {
       return;
     }

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,5 +1,6 @@
 import PinataService from '../services/pinata';
 import axios from 'axios';
+import { saveConfigValue } from '../utils/config';
 
 jest.mock('axios');
 
@@ -8,36 +9,36 @@ describe('PinataService', () => {
     jest.clearAllMocks();
   });
 
-  it('detects missing credentials', () => {
-    process.env.EXPO_PUBLIC_PINATA_JWT = '';
-    process.env.EXPO_PUBLIC_PINATA_API_KEY = '';
-    process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY = '';
+  it('detects missing credentials', async () => {
+    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', '');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
     const service = PinataService.getInstance();
-    expect(service.isPinataConfigured()).toBe(false);
+    expect(await service.isPinataConfigured()).toBe(false);
   });
 
-  it('detects JWT credentials', () => {
-    process.env.EXPO_PUBLIC_PINATA_JWT = 'token';
-    process.env.EXPO_PUBLIC_PINATA_API_KEY = '';
-    process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY = '';
+  it('detects JWT credentials', async () => {
+    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', 'token');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', '');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
     const service = PinataService.getInstance();
-    expect(service.isPinataConfigured()).toBe(true);
+    expect(await service.isPinataConfigured()).toBe(true);
   });
 
-  it('detects API key credentials', () => {
-    process.env.EXPO_PUBLIC_PINATA_JWT = '';
-    process.env.EXPO_PUBLIC_PINATA_API_KEY = 'key';
-    process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY = 'secret';
+  it('detects API key credentials', async () => {
+    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', 'key');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', 'secret');
     const service = PinataService.getInstance();
-    expect(service.isPinataConfigured()).toBe(true);
+    expect(await service.isPinataConfigured()).toBe(true);
   });
 
-  it('requires both API key and secret', () => {
-    process.env.EXPO_PUBLIC_PINATA_JWT = '';
-    process.env.EXPO_PUBLIC_PINATA_API_KEY = 'key';
-    process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY = '';
+  it('requires both API key and secret', async () => {
+    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', 'key');
+    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
     const service = PinataService.getInstance();
-    expect(service.isPinataConfigured()).toBe(false);
+    expect(await service.isPinataConfigured()).toBe(false);
   });
 
   it('skips upload when URI is already a URL', async () => {

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,3 +1,16 @@
-process.env.EXPO_PUBLIC_JWT_SECRET = process.env.EXPO_PUBLIC_JWT_SECRET || 'test_jwt_secret';
-process.env.EXPO_PUBLIC_CHAT_SECRET = process.env.EXPO_PUBLIC_CHAT_SECRET || 'test_chat_secret';
-process.env.EXPO_PUBLIC_WAKU_SECRET = process.env.EXPO_PUBLIC_WAKU_SECRET || 'test_waku_secret';
+import { saveConfigValue } from '../utils/config';
+
+beforeAll(async () => {
+  await saveConfigValue(
+    'EXPO_PUBLIC_JWT_SECRET',
+    process.env.EXPO_PUBLIC_JWT_SECRET || 'test_jwt_secret',
+  );
+  await saveConfigValue(
+    'EXPO_PUBLIC_CHAT_SECRET',
+    process.env.EXPO_PUBLIC_CHAT_SECRET || 'test_chat_secret',
+  );
+  await saveConfigValue(
+    'EXPO_PUBLIC_WAKU_SECRET',
+    process.env.EXPO_PUBLIC_WAKU_SECRET || 'test_waku_secret',
+  );
+});

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="node" />
 import TenantSettingsService from '../services/tenantSettings';
+import { saveConfigValue } from '../utils/config';
 describe('TenantSettingsService remote', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     (globalThis as any).fetch = jest.fn();
     (TenantSettingsService as any).instance = undefined;
-    process.env.EXPO_PUBLIC_SETTINGS_API_URL = 'https://api.example.com';
+    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', 'https://api.example.com');
   });
 
   it('fetches tenant setting', async () => {
@@ -25,7 +26,7 @@ describe('TenantSettingsService remote', () => {
   });
 
   it('returns null when API url is empty', async () => {
-    process.env.EXPO_PUBLIC_SETTINGS_API_URL = '';
+    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', '');
     const svc = TenantSettingsService.getInstance();
     const val = await svc.getTenantSetting('foo', 'platform_name');
     expect(val).toBeNull();
@@ -33,7 +34,7 @@ describe('TenantSettingsService remote', () => {
   });
 
   it('skips update when API url is empty', async () => {
-    process.env.EXPO_PUBLIC_SETTINGS_API_URL = '';
+    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', '');
     const svc = TenantSettingsService.getInstance();
     await svc.updateTenantSetting('foo', 'platform_name', 'bar');
     expect(fetch).not.toHaveBeenCalled();

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,9 +1,9 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      EXPO_PUBLIC_ADMIN_USERNAME: string;
-      EXPO_PUBLIC_MATRIX_SERVER: string;
-      EXPO_PUBLIC_APP_NAME: string;
+      EXPO_PUBLIC_ADMIN_USERNAME?: string;
+      EXPO_PUBLIC_MATRIX_SERVER?: string;
+      EXPO_PUBLIC_APP_NAME?: string;
       EXPO_PUBLIC_DEBUG_LOGS?: string;
       EXPO_PUBLIC_JWT_SECRET?: string;
       EXPO_PUBLIC_PINATA_JWT?: string;

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -3,12 +3,12 @@ const roomKeys: Record<string, CryptoKey> = {};
 /**
  * Derive a deterministic key per room using a shared secret.
  */
-import { requireEnv } from './env';
+import { requireConfig } from './env';
 
 export async function getRoomKey(roomId: string): Promise<CryptoKey> {
   if (roomKeys[roomId]) return roomKeys[roomId];
 
-  const secret = requireEnv('EXPO_PUBLIC_CHAT_SECRET');
+  const secret = await requireConfig('EXPO_PUBLIC_CHAT_SECRET');
   const enc = new TextEncoder().encode(roomId + secret);
   const hash = await crypto.subtle.digest('SHA-256', enc);
 

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,7 +1,9 @@
-export function requireEnv(name: string): string {
-  const value = process.env[name];
+import { getConfig } from './config';
+
+export async function requireConfig(key: string): Promise<string> {
+  const value = await getConfig(key);
   if (!value) {
-    throw new Error(`Environment variable ${name} is required`);
+    throw new Error(`Config value ${key} is required`);
   }
   return value;
 }

--- a/utils/jwtSession.ts
+++ b/utils/jwtSession.ts
@@ -1,10 +1,11 @@
 import JWT from 'expo-jwt';
-import { requireEnv } from './env';
+import { requireConfig } from './env';
 
-const JWT_SECRET = requireEnv('EXPO_PUBLIC_JWT_SECRET');
+const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
 
-export function isTokenValid(token: string): boolean {
+export async function isTokenValid(token: string): Promise<boolean> {
   try {
+    const JWT_SECRET = await JWT_SECRET_PROMISE;
     JWT.decode(token, JWT_SECRET);
     return true;
   } catch {
@@ -12,8 +13,9 @@ export function isTokenValid(token: string): boolean {
   }
 }
 
-export function refreshToken(token: string, expiresIn: string | number = '7d'): string | null {
+export async function refreshToken(token: string, expiresIn: string | number = '7d'): Promise<string | null> {
   try {
+    const JWT_SECRET = await JWT_SECRET_PROMISE;
     const payload = JWT.decode(token, JWT_SECRET) as any;
     const { iat, exp, ...rest } = payload as any;
     const seconds = typeof expiresIn === 'number' ? expiresIn : parseExpires(expiresIn);

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,4 +1,11 @@
-export const DEBUG_LOGS = process.env.EXPO_PUBLIC_DEBUG_LOGS === 'true';
+import { requireConfig } from './env';
+
+let DEBUG_LOGS = false;
+requireConfig('EXPO_PUBLIC_DEBUG_LOGS')
+  .then((v) => {
+    DEBUG_LOGS = v === 'true';
+  })
+  .catch(() => {});
 
 export function debugLog(...args: unknown[]): void {
   if (DEBUG_LOGS) {


### PR DESCRIPTION
## Summary
- introduce `requireConfig` for loading config values from sqlite
- switch all modules off of process.env and requireEnv
- make JWT and Pinata helpers async
- update environment type definitions
- adapt tests for new async helpers

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module)*

------
https://chatgpt.com/codex/tasks/task_e_6888ba8341388326adabbd33a987b308