### PR TITLE
Use SQLite config in tests

### DIFF
--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,6 +1,6 @@
 import PinataService from '../services/pinata';
 import axios from 'axios';
-import { saveConfigValue } from '../utils/config';
+import { insertConfig } from './testUtils';
 
 jest.mock('axios');
 
@@ -10,33 +10,41 @@ describe('PinataService', () => {
   });
 
   it('detects missing credentials', async () => {
-    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', '');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
+    await insertConfig({
+      EXPO_PUBLIC_PINATA_JWT: '',
+      EXPO_PUBLIC_PINATA_API_KEY: '',
+      EXPO_PUBLIC_PINATA_SECRET_API_KEY: '',
+    });
     const service = PinataService.getInstance();
     expect(await service.isPinataConfigured()).toBe(false);
   });
 
   it('detects JWT credentials', async () => {
-    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', 'token');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', '');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
+    await insertConfig({
+      EXPO_PUBLIC_PINATA_JWT: 'token',
+      EXPO_PUBLIC_PINATA_API_KEY: '',
+      EXPO_PUBLIC_PINATA_SECRET_API_KEY: '',
+    });
     const service = PinataService.getInstance();
     expect(await service.isPinataConfigured()).toBe(true);
   });
 
   it('detects API key credentials', async () => {
-    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', 'key');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', 'secret');
+    await insertConfig({
+      EXPO_PUBLIC_PINATA_JWT: '',
+      EXPO_PUBLIC_PINATA_API_KEY: 'key',
+      EXPO_PUBLIC_PINATA_SECRET_API_KEY: 'secret',
+    });
     const service = PinataService.getInstance();
     expect(await service.isPinataConfigured()).toBe(true);
   });
 
   it('requires both API key and secret', async () => {
-    await saveConfigValue('EXPO_PUBLIC_PINATA_JWT', '');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_API_KEY', 'key');
-    await saveConfigValue('EXPO_PUBLIC_PINATA_SECRET_API_KEY', '');
+    await insertConfig({
+      EXPO_PUBLIC_PINATA_JWT: '',
+      EXPO_PUBLIC_PINATA_API_KEY: 'key',
+      EXPO_PUBLIC_PINATA_SECRET_API_KEY: '',
+    });
     const service = PinataService.getInstance();
     expect(await service.isPinataConfigured()).toBe(false);
   });

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,16 +1,9 @@
-import { saveConfigValue } from '../utils/config';
+import { resetConfig } from './testUtils';
 
-beforeAll(async () => {
-  await saveConfigValue(
-    'EXPO_PUBLIC_JWT_SECRET',
-    process.env.EXPO_PUBLIC_JWT_SECRET || 'test_jwt_secret',
-  );
-  await saveConfigValue(
-    'EXPO_PUBLIC_CHAT_SECRET',
-    process.env.EXPO_PUBLIC_CHAT_SECRET || 'test_chat_secret',
-  );
-  await saveConfigValue(
-    'EXPO_PUBLIC_WAKU_SECRET',
-    process.env.EXPO_PUBLIC_WAKU_SECRET || 'test_waku_secret',
-  );
+beforeEach(async () => {
+  await resetConfig({
+    EXPO_PUBLIC_JWT_SECRET: 'test_jwt_secret',
+    EXPO_PUBLIC_CHAT_SECRET: 'test_chat_secret',
+    EXPO_PUBLIC_WAKU_SECRET: 'test_waku_secret',
+  });
 });

--- a/tests/tenantSettingsService.test.ts
+++ b/tests/tenantSettingsService.test.ts
@@ -1,11 +1,13 @@
 /// <reference types="node" />
 import TenantSettingsService from '../services/tenantSettings';
-import { saveConfigValue } from '../utils/config';
+import { insertConfig } from './testUtils';
 describe('TenantSettingsService remote', () => {
   beforeEach(async () => {
     (globalThis as any).fetch = jest.fn();
     (TenantSettingsService as any).instance = undefined;
-    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', 'https://api.example.com');
+    await insertConfig({
+      EXPO_PUBLIC_SETTINGS_API_URL: 'https://api.example.com',
+    });
   });
 
   it('fetches tenant setting', async () => {
@@ -26,7 +28,7 @@ describe('TenantSettingsService remote', () => {
   });
 
   it('returns null when API url is empty', async () => {
-    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', '');
+    await insertConfig({ EXPO_PUBLIC_SETTINGS_API_URL: '' });
     const svc = TenantSettingsService.getInstance();
     const val = await svc.getTenantSetting('foo', 'platform_name');
     expect(val).toBeNull();
@@ -34,7 +36,7 @@ describe('TenantSettingsService remote', () => {
   });
 
   it('skips update when API url is empty', async () => {
-    await saveConfigValue('EXPO_PUBLIC_SETTINGS_API_URL', '');
+    await insertConfig({ EXPO_PUBLIC_SETTINGS_API_URL: '' });
     const svc = TenantSettingsService.getInstance();
     await svc.updateTenantSetting('foo', 'platform_name', 'bar');
     expect(fetch).not.toHaveBeenCalled();

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,0 +1,15 @@
+import { executeSql } from '../lib/sqlite';
+
+export async function insertConfig(values: Record<string, string>): Promise<void> {
+  for (const [key, value] of Object.entries(values)) {
+    await executeSql('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)', [
+      key,
+      value,
+    ]);
+  }
+}
+
+export async function resetConfig(values: Record<string, string> = {}): Promise<void> {
+  await executeSql('DELETE FROM config');
+  await insertConfig(values);
+}


### PR DESCRIPTION
## Summary
- ensure Jest setup inserts required config values into SQLite
- add helpers to modify config values per-test
- update Pinata and tenant settings tests to use config helpers

## Testing
- `yarn test` *(fails: expo-sqlite ESM syntax not handled by Jest)*

------
https://chatgpt.com/codex/tasks/task_e_6888c592a0ac8326a85d14ff11b9514a