### PR TITLE
Update backup scripts to use config table

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Ensure all dependencies are installed using `yarn install` before running the te
 ## Database Backup
 
 The project includes helper scripts to encrypt the `blue-ocean.db` SQLite file
-and store it on Pinata. Set your Pinata credentials in `.env` and provide a
-passphrase when running the scripts.
+and store it on Pinata. Pinata credentials are read from the `config` table, so
+only a passphrase is required when running the scripts.
 
 ### Backup the database
 

--- a/scripts/backup-db.js
+++ b/scripts/backup-db.js
@@ -14,6 +14,7 @@ const fs = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const axios = require('axios');
+const { getConfig } = require('../utils/config');
 
 // Polyfill a minimal subset of expo-file-system for BackupService
 const FileSystem = {

--- a/scripts/restore-db.js
+++ b/scripts/restore-db.js
@@ -13,6 +13,7 @@ const fs = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const axios = require('axios');
+const { getConfig } = require('../utils/config');
 
 const FileSystem = {
   documentDirectory: path.join(__dirname, '..') + path.sep,
@@ -49,11 +50,14 @@ const PINATA_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
 
 async function getLatestBackupCid() {
   const headers = {};
-  if (process.env.EXPO_PUBLIC_PINATA_JWT) {
-    headers.Authorization = `Bearer ${process.env.EXPO_PUBLIC_PINATA_JWT}`;
+  const jwt = await getConfig('EXPO_PUBLIC_PINATA_JWT');
+  const apiKey = await getConfig('EXPO_PUBLIC_PINATA_API_KEY');
+  const secret = await getConfig('EXPO_PUBLIC_PINATA_SECRET_API_KEY');
+  if (jwt) {
+    headers.Authorization = `Bearer ${jwt}`;
   } else {
-    headers.pinata_api_key = process.env.EXPO_PUBLIC_PINATA_API_KEY;
-    headers.pinata_secret_api_key = process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY;
+    headers.pinata_api_key = apiKey;
+    headers.pinata_secret_api_key = secret;
   }
   const res = await axios.get('https://api.pinata.cloud/data/pinList', {
     headers,


### PR DESCRIPTION
## Summary
- import new `getConfig()` helper in database backup scripts
- read Pinata credentials from the config table when restoring backups
- clarify README instructions for using the scripts

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with module @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_6888c593b2448326b9ad43f32d43538a