### PR TITLE
Add tenant prompt and runtime config

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -19,10 +19,10 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { saveConfigValue } from '../../utils/config';
 import { executeSql } from '../../lib/sqlite';
 import InfoModal from '../../components/InfoModal';
-import { TENANT } from '../../constants/tenant';
 
 export default function OnboardingScreen() {
   const { colors } = useTheme();
+  const [tenant, setTenant] = useState('thecongress');
   const [appName, setAppName] = useState('');
   const [primaryColor, setPrimaryColor] = useState('');
   const [logo, setLogo] = useState('');
@@ -54,6 +54,7 @@ export default function OnboardingScreen() {
     }
     setLoading(true);
     try {
+      await saveConfigValue('EXPO_PUBLIC_TENANT', tenant);
       await saveConfigValue('APP_NAME', appName);
       await saveConfigValue('PRIMARY_COLOR', primaryColor);
       if (logo) await saveConfigValue('APP_LOGO', logo);
@@ -75,7 +76,7 @@ export default function OnboardingScreen() {
       );
       await executeSql(
         'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
-        [id, TENANT, id, adminUser, null, 'Admin', 'admin'],
+        [id, tenant, id, adminUser, null, 'Admin', 'admin'],
       );
 
       await saveConfigValue('ONBOARD_COMPLETE', 'true');
@@ -113,6 +114,22 @@ export default function OnboardingScreen() {
           <View style={styles.formGroup}>
             <Text style={[styles.label, { color: colors.text.primary }]}>App Name</Text>
             <TextInput style={[styles.input, { borderColor: colors.border.primary, color: colors.text.primary, backgroundColor: colors.surface.primary }]} value={appName} onChangeText={setAppName} />
+          </View>
+          <View style={styles.formGroup}>
+            <Text style={[styles.label, { color: colors.text.primary }]}>Tenant ID</Text>
+            <TextInput
+              style={[
+                styles.input,
+                {
+                  borderColor: colors.border.primary,
+                  color: colors.text.primary,
+                  backgroundColor: colors.surface.primary,
+                },
+              ]}
+              value={tenant}
+              onChangeText={setTenant}
+              autoCapitalize="none"
+            />
           </View>
           <View style={styles.formGroup}>
             <Text style={[styles.label, { color: colors.text.primary }]}>Primary Color</Text>

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -1,20 +1,11 @@
-import { requireConfig } from '../utils/env';
+import { getConfig } from '../utils/config';
 
-export const TENANT: string = (await requireConfig('EXPO_PUBLIC_TENANT')).trim() || 'thecongress';
+export const TENANT: string = (await getConfig('EXPO_PUBLIC_TENANT'))?.trim() || 'thecongress';
 
-export const tenantSettings = {
-  thecongress: {
-    name: 'The Congress',
-    primaryColor: '#000000',
-    logo: require('../assets/images/icon.png'),
-  },
-  thebull: {
-    name: 'The Bull',
-    primaryColor: '#ff0000',
-    logo: require('../assets/images/icon.png'),
-  },
-} as const;
+export const AppConfig = {
+  name: (await getConfig('APP_NAME')) || 'Blue Ocean',
+  primaryColor: (await getConfig('PRIMARY_COLOR')) || '#B99C5A',
+  logo: (await getConfig('APP_LOGO')) || require('../assets/images/icon.png'),
+};
 
-export type TenantName = keyof typeof tenantSettings;
-
-export const AppConfig = tenantSettings[TENANT as TenantName];
+export type TenantSettings = typeof AppConfig;


### PR DESCRIPTION
## Summary
- add Tenant ID field during onboarding and store value in config
- load TENANT and tenant settings from config at runtime

## Testing
- `yarn test` *(fails: jest not found / node engine mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6888e92aa5f88326b07e00de1b949484