### PR TITLE
Refactor sqlite init

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,7 @@ import { AppInfoProvider } from '../contexts/AppInfoContext';
 import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
-import { ensureDatabase } from '../lib/sqlite';
+import { ensureDatabase, executeSql } from '../lib/sqlite';
 import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
 import { checkOnboarding } from '../utils/config';
 import OnboardingScreen from './onboarding';
@@ -98,7 +98,7 @@ export default function RootLayout() {
   useEffect(() => {
     (async () => {
       await ensureDatabase();
-      await ensureSettingsTable();
+      await ensureSettingsTable(executeSql);
       const done = await checkOnboarding();
       setOnboarded(done);
       setDbReady(true);

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -4,6 +4,7 @@ import { Asset } from 'expo-asset';
 import { Platform } from 'react-native';
 import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
+import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
 const DB_NAME = 'app.db';
 
@@ -93,7 +94,8 @@ export function ensureDatabase(): Promise<void> {
       if (!(await tableExists(db, 'users'))) {
         await applySchema(db);
       }
-      await ensureConfigTable();
+      await ensureConfigTable(executeSql);
+      await ensureSettingsTable(executeSql);
     } finally {
       ensurePromise = null;
     }

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -2,6 +2,7 @@ import * as SQLite from 'expo-sqlite';
 import { Asset } from 'expo-asset';
 import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
+import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
 const DB_NAME = 'app.db';
 
@@ -77,7 +78,8 @@ export function ensureDatabase(): Promise<void> {
       if (!(await tableExists(db, 'users'))) {
         await applySchema(db);
       }
-      await ensureConfigTable();
+      await ensureConfigTable(executeSql);
+      await ensureSettingsTable(executeSql);
     } finally {
       ensurePromise = null;
     }

--- a/lib/sqlite/initConfigTable.ts
+++ b/lib/sqlite/initConfigTable.ts
@@ -1,10 +1,10 @@
-import { executeSql } from '../sqlite';
+import type { executeSql } from '../sqlite';
 
-export const ensureConfigTable = async () => {
-  await executeSql(`
+export async function ensureConfigTable(exec: typeof executeSql) {
+  await exec(`
     CREATE TABLE IF NOT EXISTS config (
       key TEXT PRIMARY KEY,
       value TEXT
     );
   `);
-};
+}

--- a/lib/sqlite/initSettingsTable.ts
+++ b/lib/sqlite/initSettingsTable.ts
@@ -1,7 +1,7 @@
-import { executeSql } from '../sqlite';
+import type { executeSql } from '../sqlite';
 
-export const ensureSettingsTable = async () => {
-  await executeSql(`
+export async function ensureSettingsTable(exec: typeof executeSql) {
+  await exec(`
     CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY NOT NULL,
       value TEXT NOT NULL,
@@ -12,7 +12,7 @@ export const ensureSettingsTable = async () => {
     );
   `);
 
-  await executeSql(`
+  await exec(`
     CREATE TABLE IF NOT EXISTS waku_seen (
       -- SHA-256 hash of the decrypted message
       id TEXT NOT NULL,
@@ -22,10 +22,10 @@ export const ensureSettingsTable = async () => {
     );
   `);
 
-  await executeSql(
+  await exec(
     `INSERT OR IGNORE INTO settings (key, value, type, description) VALUES
       ('storeName', 'The Congress', 'string', 'Store name'),
       ('color', '#000000', 'string', 'Theme color')
     `
   );
-};
+}


### PR DESCRIPTION
## Summary
- refactor table helpers to accept an executeSql param
- initialize both tables in native & web sqlite modules
- call ensureSettingsTable with executeSql in layout

## Testing
- `yarn install --ignore-scripts` *(fails: The engine "node" is incompatible with this module)*

------
https://chatgpt.com/codex/tasks/task_e_6888ed8c50ac832695447ec5bfff80f9