### PR TITLE
Refactor tenant config loading

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,7 @@ import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
 import { ensureDatabase, executeSql } from '../lib/sqlite';
 import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
+import { loadTenantSettings } from '../constants/tenant';
 import { checkOnboarding } from '../utils/config';
 import OnboardingScreen from './onboarding';
 import { useWakuSettingsSync } from '../lib/waku/useWakuSettingsSync';
@@ -99,6 +100,7 @@ export default function RootLayout() {
     (async () => {
       await ensureDatabase();
       await ensureSettingsTable(executeSql);
+      await loadTenantSettings();
       const done = await checkOnboarding();
       setOnboarded(done);
       setDbReady(true);

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -16,7 +16,13 @@ async function getAdminUsernames(): Promise<string[]> {
     .map((u) => u.trim())
     .filter(Boolean);
 }
-const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+let jwtSecretPromise: Promise<string> | null = null;
+async function getJwtSecret(): Promise<string> {
+  if (!jwtSecretPromise) {
+    jwtSecretPromise = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+  }
+  return jwtSecretPromise;
+}
 const PRIVATE_KEY_KEY = 'ed25519_private_key';
 
 export class UsernameTakenError extends Error {
@@ -66,7 +72,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       try {
         const token = await getToken();
         if (token && (await isTokenValid(token))) {
-          const JWT_SECRET = await JWT_SECRET_PROMISE;
+          const JWT_SECRET = await getJwtSecret();
           const payload: any = JWT.decode(token, JWT_SECRET);
           setSession(token);
           if (payload?.sub) {
@@ -112,7 +118,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setLoading(false);
         return false;
       }
-      const JWT_SECRET = await JWT_SECRET_PROMISE;
+      const JWT_SECRET = await getJwtSecret();
       const token = JWT.encode(
         { sub: row.id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
         JWT_SECRET,
@@ -154,7 +160,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
         [id, tenant, id, username, null, displayName, role],
       );
-      const JWT_SECRET = await JWT_SECRET_PROMISE;
+      const JWT_SECRET = await getJwtSecret();
       const token = JWT.encode(
         { sub: id, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60 },
         JWT_SECRET,
@@ -191,7 +197,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setLoading(true);
     const token = await getToken();
     if (token && (await isTokenValid(token))) {
-      const JWT_SECRET = await JWT_SECRET_PROMISE;
+      const JWT_SECRET = await getJwtSecret();
       const payload: any = JWT.decode(token, JWT_SECRET);
       setSession(token);
       if (payload?.sub) {

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -1,19 +1,37 @@
 import { getConfig } from '../utils/config';
 
+export let TENANT = 'thecongress';
+
+export interface TenantSettings {
+  name: string;
+  primaryColor: string;
+  logo: any;
+}
+
+export let AppConfig: TenantSettings = {
+  name: 'Blue Ocean',
+  primaryColor: '#B99C5A',
+  logo: require('../assets/images/icon.png'),
+};
+
+export async function loadTenantSettings(): Promise<void> {
+  const tenant = (await getConfig('EXPO_PUBLIC_TENANT'))?.trim() || 'thecongress';
+  TENANT = tenant;
+
+  const name = (await getConfig('APP_NAME')) || 'Blue Ocean';
+  const primaryColor = (await getConfig('PRIMARY_COLOR')) || '#B99C5A';
+  const logo = (await getConfig('APP_LOGO')) || require('../assets/images/icon.png');
+  AppConfig = { name, primaryColor, logo };
+}
+
 export async function getTenant(): Promise<string> {
   const v = await getConfig('EXPO_PUBLIC_TENANT');
   return v?.trim() || 'thecongress';
 }
 
-export async function getAppConfig(): Promise<{
-  name: string;
-  primaryColor: string;
-  logo: any;
-}> {
+export async function getAppConfig(): Promise<TenantSettings> {
   const name = (await getConfig('APP_NAME')) || 'Blue Ocean';
   const primaryColor = (await getConfig('PRIMARY_COLOR')) || '#B99C5A';
   const logo = (await getConfig('APP_LOGO')) || require('../assets/images/icon.png');
   return { name, primaryColor, logo };
 }
-
-export type TenantSettings = Awaited<ReturnType<typeof getAppConfig>>;

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -12,8 +12,6 @@ import TenantSettingsService from '../services/tenantSettings';
 import MediaService from '../services/media';
 import { requireConfig } from '../utils/env';
 
-const TENANT_PROMISE = requireConfig('EXPO_PUBLIC_TENANT');
-
 interface AppInfoContextType {
   platformName: string;
   platformLogo: string;
@@ -50,7 +48,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   useEffect(() => {
     (async () => {
       try {
-        const t = await TENANT_PROMISE;
+        const t = await requireConfig('EXPO_PUBLIC_TENANT');
         setTenant(t || 'default');
       } catch {
         setTenant('default');

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -4,7 +4,13 @@ import DatabaseService from './database';
 import JWT from 'expo-jwt';
 import { requireConfig } from '../utils/env';
 
-const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+let jwtSecretPromise: Promise<string> | null = null;
+async function getJwtSecret(): Promise<string> {
+  if (!jwtSecretPromise) {
+    jwtSecretPromise = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+  }
+  return jwtSecretPromise;
+}
 import { getToken } from '../utils/tokenStorage';
 import { isTokenValid } from '../utils/jwtSession';
 
@@ -22,7 +28,7 @@ class CartService {
   private async getCurrentUserId(): Promise<string | null> {
     const token = await getToken();
     if (token && isTokenValid(token)) {
-      const JWT_SECRET = await JWT_SECRET_PROMISE;
+      const JWT_SECRET = await getJwtSecret();
       const payload: any = JWT.decode(token, JWT_SECRET);
       return payload?.sub || null;
     }

--- a/services/database.ts
+++ b/services/database.ts
@@ -2,7 +2,7 @@ import { executeSql } from '../lib/sqlite';
 import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
-import { getTenant } from '../constants/tenant';
+import { getTenant, TENANT } from '../constants/tenant';
 import { requireConfig } from '../utils/env';
 import {
   Product,
@@ -24,7 +24,18 @@ import {
 
 class DatabaseService {
   private static instance: DatabaseService;
-  private static readonly adminIdPromise = requireConfig('EXPO_PUBLIC_ADMIN_USERNAME');
+  private static adminIdPromise: Promise<string> | null = null;
+
+  private static get adminId(): Promise<string> {
+    if (!this.adminIdPromise) {
+      this.adminIdPromise = requireConfig('EXPO_PUBLIC_ADMIN_USERNAME');
+    }
+    return this.adminIdPromise;
+  }
+
+  static get tenantId(): string {
+    return TENANT;
+  }
 
   private constructor() {}
 
@@ -324,7 +335,7 @@ class DatabaseService {
   }
 
   async getOrCreateChatRoom(userId: string, userName: string): Promise<string> {
-    const adminId = await DatabaseService.adminIdPromise;
+    const adminId = await DatabaseService.adminId;
     const id = 'room_' + [userId, adminId || 'admin'].sort().join('_');
 
     // Check for existing room with the new deterministic id

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,4 +1,5 @@
 import { resetConfig } from './testUtils';
+import { loadTenantSettings } from '../constants/tenant';
 
 beforeEach(async () => {
   await resetConfig({
@@ -6,4 +7,5 @@ beforeEach(async () => {
     EXPO_PUBLIC_CHAT_SECRET: 'test_chat_secret',
     EXPO_PUBLIC_WAKU_SECRET: 'test_waku_secret',
   });
+  await loadTenantSettings();
 });

--- a/utils/jwtSession.ts
+++ b/utils/jwtSession.ts
@@ -1,11 +1,17 @@
 import JWT from 'expo-jwt';
 import { requireConfig } from './env';
 
-const JWT_SECRET_PROMISE = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+let jwtSecretPromise: Promise<string> | null = null;
+async function getJwtSecret(): Promise<string> {
+  if (!jwtSecretPromise) {
+    jwtSecretPromise = requireConfig('EXPO_PUBLIC_JWT_SECRET');
+  }
+  return jwtSecretPromise;
+}
 
 export async function isTokenValid(token: string): Promise<boolean> {
   try {
-    const JWT_SECRET = await JWT_SECRET_PROMISE;
+    const JWT_SECRET = await getJwtSecret();
     JWT.decode(token, JWT_SECRET);
     return true;
   } catch {
@@ -15,7 +21,7 @@ export async function isTokenValid(token: string): Promise<boolean> {
 
 export async function refreshToken(token: string, expiresIn: string | number = '7d'): Promise<string | null> {
   try {
-    const JWT_SECRET = await JWT_SECRET_PROMISE;
+    const JWT_SECRET = await getJwtSecret();
     const payload = JWT.decode(token, JWT_SECRET) as any;
     const { iat, exp, ...rest } = payload as any;
     const seconds = typeof expiresIn === 'number' ? expiresIn : parseExpires(expiresIn);


### PR DESCRIPTION
## Summary
- centralize tenant configuration in `constants/tenant`
- lazily fetch secrets in AuthContext, CartService and jwtSession
- adjust DatabaseService to use lazy admin lookup and tenant getter
- update AppInfoContext and app layout to load tenant settings at startup
- ensure tests load tenant settings before running

## Testing
- `yarn test` *(fails: Jest unable to parse expo-sqlite ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6888f008483c832690f03659adfb6f3b