### PR TITLE
Use tenant-specific SQLite DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ your shell:
 * `EXPO_PUBLIC_USE_WAKU` – set to `true` to enable Waku features
 * `EXPO_PUBLIC_DEBUG_LOGS` – enable verbose logging
 * `EXPO_PUBLIC_MATRIX_SERVER` – Matrix server URL (future use)
+* `EXPO_PUBLIC_TENANT` – identifier for the white‑label tenant; the local
+  SQLite database will be created as `<tenant>.db`
 
 ## SQLite Migrations
 

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -6,7 +6,7 @@ import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
 import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
-const DB_NAME = 'app.db';
+const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -4,7 +4,7 @@ import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
 import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
-const DB_NAME = 'app.db';
+const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;

--- a/scripts/backup-db.js
+++ b/scripts/backup-db.js
@@ -49,7 +49,9 @@ if (!global.crypto) {
 
 const { default: BackupService } = require('../services/backup');
 
-const DB_NAME = 'blue-ocean.db';
+const DB_NAME = process.env.EXPO_PUBLIC_TENANT
+  ? `${process.env.EXPO_PUBLIC_TENANT}.db`
+  : 'blue-ocean.db';
 const DB_SOURCE = path.join(__dirname, '..', DB_NAME);
 
 async function main() {
@@ -61,7 +63,7 @@ async function main() {
 
   const sqliteDir = path.join(FileSystem.documentDirectory, 'SQLite');
   await fs.mkdir(sqliteDir, { recursive: true });
-  const target = path.join(sqliteDir, 'app.db');
+  const target = path.join(sqliteDir, DB_NAME);
 
   await fs.copyFile(DB_SOURCE, target);
 

--- a/scripts/restore-db.js
+++ b/scripts/restore-db.js
@@ -46,6 +46,10 @@ if (!global.crypto) {
 }
 
 const { default: BackupService } = require('../services/backup');
+
+const DB_NAME = process.env.EXPO_PUBLIC_TENANT
+  ? `${process.env.EXPO_PUBLIC_TENANT}.db`
+  : 'blue-ocean.db';
 const PINATA_GATEWAY_URL = 'https://gateway.pinata.cloud/ipfs/';
 
 async function getLatestBackupCid() {
@@ -88,7 +92,7 @@ async function main() {
 
   const service = BackupService.getInstance();
   const restoredPath = await service.restoreDatabase(cid, passphrase);
-  const target = path.join(__dirname, '..', 'blue-ocean.db');
+  const target = path.join(__dirname, '..', DB_NAME);
   await fs.copyFile(restoredPath, target);
   console.log('Database restored to', target);
 }

--- a/services/backup.ts
+++ b/services/backup.ts
@@ -2,7 +2,8 @@ import * as FileSystem from 'expo-file-system';
 import { Buffer } from 'buffer';
 import PinataService from './pinata';
 
-const DB_PATH = FileSystem.documentDirectory + 'SQLite/app.db';
+const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
+const DB_PATH = FileSystem.documentDirectory + 'SQLite/' + DB_NAME;
 const TMP_ENC_PATH = FileSystem.cacheDirectory + 'app.db.enc';
 
 async function deriveKey(passphrase: string): Promise<CryptoKey> {


### PR DESCRIPTION
## Summary
- create tenant-specific database name
- adjust backup logic to use tenant DB
- update scripts for tenant DB paths
- document EXPO_PUBLIC_TENANT env variable

## Testing
- `yarn install`
- `yarn test` *(fails: Jest couldn't parse expo modules)*

------
https://chatgpt.com/codex/tasks/task_e_6888fab860688326b93c0560251c114a