### PR TITLE
Fix SQLite handle issue

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,7 @@ import { AppInfoProvider } from '../contexts/AppInfoContext';
 import AgeVerificationModal from '../components/AgeVerificationModal';
 import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
-import { ensureDatabase, executeSql } from '../lib/sqlite';
+import { ensureDatabase, executeSql, closeDatabase } from '../lib/sqlite';
 import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
 import { loadTenantSettings } from '../constants/tenant';
 import { checkOnboarding } from '../utils/config';
@@ -105,6 +105,11 @@ export default function RootLayout() {
       setOnboarded(done);
       setDbReady(true);
     })();
+    return () => {
+      closeDatabase().catch((e) =>
+        console.warn('Failed to close database on unmount:', e)
+      );
+    };
   }, []);
 
   if (!dbReady || onboarded === null) {

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -10,10 +10,26 @@ const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;
+let closeListenerAdded = false;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
+    // ensure any previous connection is closed before opening a new one
+    try {
+      await closeDatabase();
+    } catch (e) {
+      console.warn('Failed to close existing database handle:', e);
+    }
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
+      if (Platform.OS === 'web' && !closeListenerAdded && typeof window !== 'undefined') {
+        const handler = () => {
+          closeDatabase().catch((e) =>
+            console.warn('Failed to close database on unload:', e)
+          );
+        };
+        window.addEventListener('beforeunload', handler);
+        closeListenerAdded = true;
+      }
       return db;
     })();
   }
@@ -101,4 +117,18 @@ export function ensureDatabase(): Promise<void> {
     }
   })();
   return ensurePromise;
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (!dbPromise) {
+    return;
+  }
+  const db = await dbPromise;
+  try {
+    await db.closeAsync();
+  } catch (e) {
+    console.warn('Failed to close database:', e);
+  } finally {
+    dbPromise = null;
+  }
 }

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -7,10 +7,29 @@ import { ensureSettingsTable } from './sqlite/initSettingsTable';
 const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
+let closeListenerAdded = false;
 let ensurePromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
-    dbPromise = SQLite.openDatabaseAsync(DB_NAME);
+    // ensure any previous connection is closed before opening a new one
+    try {
+      await closeDatabase();
+    } catch (e) {
+      console.warn('Failed to close existing database handle:', e);
+    }
+    dbPromise = (async () => {
+      const db = await SQLite.openDatabaseAsync(DB_NAME);
+      if (!closeListenerAdded && typeof window !== 'undefined') {
+        const handler = () => {
+          closeDatabase().catch((e) =>
+            console.warn('Failed to close database on unload:', e)
+          );
+        };
+        window.addEventListener('beforeunload', handler);
+        closeListenerAdded = true;
+      }
+      return db;
+    })();
   }
   return dbPromise;
 }
@@ -85,4 +104,18 @@ export function ensureDatabase(): Promise<void> {
     }
   })();
   return ensurePromise;
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (!dbPromise) {
+    return;
+  }
+  const db = await dbPromise;
+  try {
+    await db.closeAsync();
+  } catch (e) {
+    console.warn('Failed to close database:', e);
+  } finally {
+    dbPromise = null;
+  }
 }


### PR DESCRIPTION
## Summary
- close stale database handle before opening a new connection

## Testing
- `yarn install` *(fails: incompatible Node version)*

------
https://chatgpt.com/codex/tasks/task_e_6889029a036c832694a4e450f6b033f6