### PR TITLE
Ensure sqlite handles existing connections

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -12,13 +12,14 @@ let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;
 let closeListenerAdded = false;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (!dbPromise) {
-    // ensure any previous connection is closed before opening a new one
+  if (dbPromise) {
     try {
       await closeDatabase();
     } catch (e) {
       console.warn('Failed to close existing database handle:', e);
     }
+  }
+  if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
       if (Platform.OS === 'web' && !closeListenerAdded && typeof window !== 'undefined') {

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -10,14 +10,15 @@ let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let closeListenerAdded = false;
 let ensurePromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (!dbPromise) {
-    // ensure any previous connection is closed before opening a new one
+  if (dbPromise) {
     try {
       await closeDatabase();
     } catch (e) {
       console.warn('Failed to close existing database handle:', e);
     }
+  }
 
+  if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
       if (!closeListenerAdded && typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- update `getDatabase` to close existing DB handles before opening new ones
- keep `dbPromise` synchronized when closing

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install --check-files` *(fails: incompatible node version)*

------
https://chatgpt.com/codex/tasks/task_e_688908d3b07083268dc13cc96962d5b7