### PR TITLE
Handle HMR cleanup for SQLite

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -6,6 +6,8 @@ import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
 import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
+declare const module: any;
+
 const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
@@ -132,4 +134,12 @@ export async function closeDatabase(): Promise<void> {
   } finally {
     dbPromise = null;
   }
+}
+
+if (module?.hot) {
+  module.hot.dispose(() => {
+    closeDatabase().catch((e) =>
+      console.warn('Failed to close DB during module dispose:', e),
+    );
+  });
 }

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -4,6 +4,8 @@ import { parseSql } from './sqlUtils';
 import { ensureConfigTable } from './sqlite/initConfigTable';
 import { ensureSettingsTable } from './sqlite/initSettingsTable';
 
+declare const module: any;
+
 const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
@@ -120,4 +122,12 @@ export async function closeDatabase(): Promise<void> {
   } finally {
     dbPromise = null;
   }
+}
+
+if (module?.hot) {
+  module.hot.dispose(() => {
+    closeDatabase().catch((e) =>
+      console.warn('Failed to close DB during module dispose:', e),
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- close SQLite handles during hot reload
- mirror the logic in both SQLite implementations

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: incompatible Node engine @waku/sdk requires >=22)*

------
https://chatgpt.com/codex/tasks/task_e_6889243e6c7883269cdec8ba35d6adaa