### PR TITLE
Improve SQLite cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ yarn reset-db
 
 This deletes `sqlite/blue-ocean.db` and re-applies the migrations.
 
+When developing, be sure to call `closeDatabase()` when the app is unloaded or
+replaced during hot reloads. The database module adds a `beforeunload` listener
+on the web and the root layout disposes of the database using HMR cleanup so
+handles don't remain open.
+
 
 ## Seeding Sample Data
 


### PR DESCRIPTION
## Summary
- document closing the SQLite DB during unload and HMR

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688924407010832689c1b5cda87cd4e8