### PR TITLE
Fix DB reuse without closing handles

### DIFF
--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -14,13 +14,6 @@ let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;
 let closeListenerAdded = false;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (dbPromise) {
-    try {
-      await closeDatabase();
-    } catch (e) {
-      console.warn('Failed to close existing database handle:', e);
-    }
-  }
   if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -12,14 +12,6 @@ let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let closeListenerAdded = false;
 let ensurePromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (dbPromise) {
-    try {
-      await closeDatabase();
-    } catch (e) {
-      console.warn('Failed to close existing database handle:', e);
-    }
-  }
-
   if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);


### PR DESCRIPTION
## Summary
- do not close the sqlite database every time `getDatabase` is called on native/web
- keep shutdown handling in HMR cleanup

## Testing
- `yarn test` *(fails: SyntaxError from expo-sqlite requiring Node 22)*

------
https://chatgpt.com/codex/tasks/task_e_688926ca043c8326bb82ebf8eaa8aa1b