### PR TITLE
Fix Jest transform ignore patterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
     '^.+\\.js$': 'babel-jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(@noble/ed25519|expo-sqlite)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(@noble/ed25519|expo-sqlite|react-native)/)'],
 
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',


### PR DESCRIPTION
## Summary
- allow transpiling `react-native` in Jest

## Testing
- `yarn install --ignore-engines`
- `yarn test` *(fails: `__DEV__ is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_688926cf83408326a107bb00e067957d