### PR TITLE
Handle DB closing race

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,11 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/tests/__mocks__/fileMock.js',
+    '^expo-sqlite$': '<rootDir>/tests/__mocks__/expo-sqlite.js',
+    '^expo-file-system$': '<rootDir>/tests/__mocks__/expo-file-system.js',
+    '^expo-asset$': '<rootDir>/tests/__mocks__/expo-asset.js',
+    '^react-native$': '<rootDir>/tests/__mocks__/react-native.js',
   },
-  setupFiles: ['<rootDir>/tests/setupEnv.ts'],
+  setupFiles: ['<rootDir>/tests/initGlobals.ts'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],
 };

--- a/lib/sqlite.ts
+++ b/lib/sqlite.ts
@@ -13,11 +13,26 @@ const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let ensurePromise: Promise<void> | null = null;
 let closeListenerAdded = false;
+let closingPromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (dbPromise) {
+    console.warn(
+      'Attempting to open a second database handle while another is active. Waiting for the previous handle to close.'
+    );
+    if (!closingPromise) {
+      closingPromise = closeDatabase();
+    }
+    await closingPromise;
+  }
+
   if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
-      if (Platform.OS === 'web' && !closeListenerAdded && typeof window !== 'undefined') {
+      if (
+        Platform.OS === 'web' &&
+        !closeListenerAdded &&
+        typeof window !== 'undefined'
+      ) {
         const handler = () => {
           closeDatabase().catch((e) =>
             console.warn('Failed to close database on unload:', e)
@@ -117,16 +132,20 @@ export function ensureDatabase(): Promise<void> {
 
 export async function closeDatabase(): Promise<void> {
   if (!dbPromise) {
-    return;
+    return closingPromise ?? Promise.resolve();
   }
   const db = await dbPromise;
-  try {
-    await db.closeAsync();
-  } catch (e) {
-    console.warn('Failed to close database:', e);
-  } finally {
-    dbPromise = null;
-  }
+  closingPromise = (async () => {
+    try {
+      await db.closeAsync();
+    } catch (e) {
+      console.warn('Failed to close database:', e);
+    } finally {
+      dbPromise = null;
+      closingPromise = null;
+    }
+  })();
+  return closingPromise;
 }
 
 if (module?.hot) {

--- a/lib/sqlite.web.ts
+++ b/lib/sqlite.web.ts
@@ -11,7 +11,18 @@ const DB_NAME = `${process.env.EXPO_PUBLIC_TENANT || 'app'}.db`;
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 let closeListenerAdded = false;
 let ensurePromise: Promise<void> | null = null;
+let closingPromise: Promise<void> | null = null;
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (dbPromise) {
+    console.warn(
+      'Attempting to open a second database handle while another is active. Waiting for the previous handle to close.'
+    );
+    if (!closingPromise) {
+      closingPromise = closeDatabase();
+    }
+    await closingPromise;
+  }
+
   if (!dbPromise) {
     dbPromise = (async () => {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
@@ -104,16 +115,20 @@ export function ensureDatabase(): Promise<void> {
 
 export async function closeDatabase(): Promise<void> {
   if (!dbPromise) {
-    return;
+    return closingPromise ?? Promise.resolve();
   }
   const db = await dbPromise;
-  try {
-    await db.closeAsync();
-  } catch (e) {
-    console.warn('Failed to close database:', e);
-  } finally {
-    dbPromise = null;
-  }
+  closingPromise = (async () => {
+    try {
+      await db.closeAsync();
+    } catch (e) {
+      console.warn('Failed to close database:', e);
+    } finally {
+      dbPromise = null;
+      closingPromise = null;
+    }
+  })();
+  return closingPromise;
 }
 
 if (module?.hot) {

--- a/tests/__mocks__/expo-asset.js
+++ b/tests/__mocks__/expo-asset.js
@@ -1,0 +1,3 @@
+module.exports = {
+  Asset: { fromModule: jest.fn(() => ({ downloadAsync: jest.fn(), uri: '', localUri: '' })) },
+};

--- a/tests/__mocks__/expo-file-system.js
+++ b/tests/__mocks__/expo-file-system.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/tests/__mocks__/expo-sqlite.js
+++ b/tests/__mocks__/expo-sqlite.js
@@ -1,0 +1,11 @@
+module.exports = {
+  openDatabaseAsync: jest.fn(async () => ({
+    closeAsync: jest.fn(),
+    prepareAsync: jest.fn(async () => ({
+      executeAsync: jest.fn(async () => ({
+        getAllAsync: jest.fn(async () => []),
+      })),
+      finalizeAsync: jest.fn(),
+    })),
+  })),
+};

--- a/tests/__mocks__/react-native.js
+++ b/tests/__mocks__/react-native.js
@@ -1,0 +1,1 @@
+module.exports = { Platform: { OS: 'ios' } };

--- a/tests/initGlobals.ts
+++ b/tests/initGlobals.ts
@@ -1,0 +1,3 @@
+// Setup global variables required by React Native modules
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).__DEV__ = true;

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,6 +1,11 @@
 import { resetConfig } from './testUtils';
 import { loadTenantSettings } from '../constants/tenant';
 
+// React Native libraries expect __DEV__ global to exist
+// Define it here for the node test environment
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).__DEV__ = true;
+
 beforeEach(async () => {
   await resetConfig({
     EXPO_PUBLIC_JWT_SECRET: 'test_jwt_secret',

--- a/tests/sqliteHandle.test.ts
+++ b/tests/sqliteHandle.test.ts
@@ -1,0 +1,39 @@
+const closeAsync = jest.fn();
+const openDatabaseAsync = jest.fn(async () => ({ closeAsync }));
+
+jest.mock('expo-sqlite', () => ({ openDatabaseAsync }));
+
+describe('getDatabase handle reuse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('waits for closing before opening a new handle', async () => {
+    let resolveClose: () => void;
+    closeAsync.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolveClose = resolve;
+      })
+    );
+
+    const { getDatabase, closeDatabase } = await import('../lib/sqlite');
+
+    await getDatabase();
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const closing = closeDatabase();
+    const reopenPromise = getDatabase();
+
+    // while closing unresolved, openDatabaseAsync should not be called again
+    await Promise.resolve();
+    expect(openDatabaseAsync).toHaveBeenCalledTimes(1);
+
+    resolveClose!();
+    await closing;
+    await reopenPromise;
+
+    expect(openDatabaseAsync).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- wait for `closeDatabase()` to finish before a new handle can open
- add warning when a second handle is attempted
- provide mocks for Expo modules in tests
- add regression test for closing race condition

## Testing
- `yarn test` *(fails: Test Suites: 4 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68893fd7f780832681038ad1de67a9e8