### PR TITLE
Add Waku config checks to sync hooks

### DIFF
--- a/lib/waku/useWakuOrderSync.ts
+++ b/lib/waku/useWakuOrderSync.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { getTenant } from '../../constants/tenant';
 import { decryptWakuPayload } from './wakuCrypto';
+import { requireConfig } from '../../utils/env';
 
 export const useWakuOrderSync = () => {
   useEffect(() => {
@@ -9,6 +10,8 @@ export const useWakuOrderSync = () => {
     let decoder: any;
 
     const run = async () => {
+      const enabled = await requireConfig('EXPO_PUBLIC_USE_WAKU').catch(() => 'false');
+      if (enabled !== 'true') return;
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
       const { sha256 } = await import('@noble/hashes/sha256');

--- a/lib/waku/useWakuProductSync.ts
+++ b/lib/waku/useWakuProductSync.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { decryptWakuPayload } from './wakuCrypto';
+import { requireConfig } from '../../utils/env';
 
 
 export const useWakuProductSync = () => {
@@ -9,6 +10,8 @@ export const useWakuProductSync = () => {
     let decoder: any;
 
     const run = async () => {
+      const enabled = await requireConfig('EXPO_PUBLIC_USE_WAKU').catch(() => 'false');
+      if (enabled !== 'true') return;
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
       const { sha256 } = await import('@noble/hashes/sha256');

--- a/lib/waku/useWakuSettingsSync.ts
+++ b/lib/waku/useWakuSettingsSync.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Buffer } from 'buffer';
 import { executeSql } from '../sqlite';
 import { decryptWakuPayload } from './wakuCrypto';
+import { requireConfig } from '../../utils/env';
 
 export const useWakuSettingsSync = () => {
   useEffect(() => {
@@ -9,6 +10,8 @@ export const useWakuSettingsSync = () => {
     let decoder: any;
 
     const run = async () => {
+      const enabled = await requireConfig('EXPO_PUBLIC_USE_WAKU').catch(() => 'false');
+      if (enabled !== 'true') return;
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
       const { sha256 } = await import('@noble/hashes/sha256');

--- a/lib/waku/useWakuUserSync.ts
+++ b/lib/waku/useWakuUserSync.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { executeSql } from '../sqlite';
 import { decryptWakuPayload } from './wakuCrypto';
 import { getTenant } from '../../constants/tenant';
+import { requireConfig } from '../../utils/env';
 
 export const useWakuUserSync = () => {
   useEffect(() => {
@@ -9,6 +10,8 @@ export const useWakuUserSync = () => {
     let decoder: any;
 
     const run = async () => {
+      const enabled = await requireConfig('EXPO_PUBLIC_USE_WAKU').catch(() => 'false');
+      if (enabled !== 'true') return;
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const { verify, etc: edBytes } = await import('@noble/ed25519');
       const { sha256 } = await import('@noble/hashes/sha256');

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,11 +1,14 @@
 import { resetConfig } from './testUtils';
 import { loadTenantSettings } from '../constants/tenant';
 
+var __DEV__ = false;
+
 beforeEach(async () => {
   await resetConfig({
     EXPO_PUBLIC_JWT_SECRET: 'test_jwt_secret',
     EXPO_PUBLIC_CHAT_SECRET: 'test_chat_secret',
     EXPO_PUBLIC_WAKU_SECRET: 'test_waku_secret',
+    EXPO_PUBLIC_USE_WAKU: 'false',
   });
   await loadTenantSettings();
 });


### PR DESCRIPTION
## Summary
- guard all Waku sync hooks with `EXPO_PUBLIC_USE_WAKU`
- disable Waku in test setup

## Testing
- `yarn test` *(fails: __DEV__ is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68893fd57d708326927077d07f613df7