### PR TITLE
Check Pinata config before allowing uploads

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -29,6 +29,7 @@ import * as Audio from 'expo-audio';
 // MatrixService has been removed
 import DatabaseService from '../services/database';
 import PinataService from '../services/pinata';
+import MediaService from '../services/media';
 import { debugLog } from '../utils/logger';
 import { ChatMessage, ChatRoom, User } from '../types';
 import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
@@ -71,6 +72,7 @@ export default function ChatWidget() {
   const [defaultRoomId, setDefaultRoomId] = useState<string | null>(null);
   const messageSoundRef = useRef<Audio.AudioPlayer | null>(null);
   const isMounted = useRef(true);
+  const [pinataConfigured, setPinataConfigured] = useState(true);
   // Modal states
   const [infoModal, setInfoModal] = useState({
     visible: false,
@@ -92,6 +94,12 @@ export default function ChatWidget() {
       }
     }
   }, [isOpen, isAdmin, isDriver, isLoggedIn]);
+
+  useEffect(() => {
+    MediaService.getInstance()
+      .isPinataConfigured()
+      .then(setPinataConfigured);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -447,6 +455,19 @@ const loadOrCreateDefaultRoom = async () => {
 
   const startRecording = async () => {
     try {
+      const configured = await MediaService.getInstance().isPinataConfigured();
+      setPinataConfigured(configured);
+      if (!configured) {
+        if (isMounted.current) {
+          setInfoModal({
+            visible: true,
+            title: 'שירות לא זמין',
+            message: 'העלאת מדיה אינה זמינה',
+            type: 'warning',
+          });
+        }
+        return;
+      }
       if (Platform.OS === 'web') {
         if (isMounted.current) {
           setInfoModal({
@@ -1214,6 +1235,7 @@ const loadOrCreateDefaultRoom = async () => {
                               },
                             ]}
                             onPress={startRecording}
+                            disabled={!pinataConfigured}
                           >
                             <Mic size={20} color={colors.gold} />
                           </TouchableOpacity>

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -42,9 +42,14 @@ export default function MediaUploader({
   const [uploading, setUploading] = useState(false);
   const [progressMap, setProgressMap] = useState<Record<string, number>>({});
   const [thumbnailMap, setThumbnailMap] = useState<Record<string, string>>({});
+  const [pinataConfigured, setPinataConfigured] = useState(true);
   const { colors } = useTheme();
 
   useEffect(() => {
+    MediaService.getInstance()
+      .isPinataConfigured()
+      .then(setPinataConfigured);
+
     const loadThumbnails = async () => {
       const svc = MediaService.getInstance();
       for (const item of media) {
@@ -137,6 +142,13 @@ export default function MediaUploader({
   };
 
   const pickMedia = async () => {
+    const configured = await MediaService.getInstance().isPinataConfigured();
+    setPinataConfigured(configured);
+    if (!configured) {
+      Alert.alert('Unavailable', 'Media uploads are not configured.');
+      return;
+    }
+
     const hasPermission = await requestPermissions();
     if (!hasPermission) return;
 
@@ -165,6 +177,13 @@ export default function MediaUploader({
   };
 
   const takePhoto = async () => {
+    const configured = await MediaService.getInstance().isPinataConfigured();
+    setPinataConfigured(configured);
+    if (!configured) {
+      Alert.alert('Unavailable', 'Media uploads are not configured.');
+      return;
+    }
+
     const hasPermission = await requestPermissions();
     if (!hasPermission) return;
 
@@ -264,7 +283,7 @@ export default function MediaUploader({
                 borderColor: colors.gold 
               }]}
               onPress={pickMedia}
-              disabled={uploading}
+              disabled={uploading || !pinataConfigured}
             >
               {uploading ? (
                 <ActivityIndicator size="small" color={colors.gold} />
@@ -285,7 +304,7 @@ export default function MediaUploader({
                   borderColor: colors.gold 
                 }]}
                 onPress={takePhoto}
-                disabled={uploading}
+                disabled={uploading || !pinataConfigured}
               >
                 <Camera size={20} color={colors.gold} />
                 <Text style={[styles.uploadButtonText, { color: colors.gold }]}>Camera</Text>

--- a/components/ProofUploader.tsx
+++ b/components/ProofUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -25,7 +25,14 @@ interface ProofUploaderProps {
 export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUploaderProps) {
   const [uri, setUri] = useState(proofUri);
   const [uploading, setUploading] = useState(false);
+  const [pinataConfigured, setPinataConfigured] = useState(true);
   const { colors } = useTheme();
+
+  useEffect(() => {
+    MediaService.getInstance()
+      .isPinataConfigured()
+      .then(setPinataConfigured);
+  }, []);
 
   const requestMediaPermission = async () => {
     if (Platform.OS !== 'web') {
@@ -38,7 +45,17 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
     return true;
   };
 
+  const ensureConfigured = async () => {
+    const configured = await MediaService.getInstance().isPinataConfigured();
+    setPinataConfigured(configured);
+    if (!configured) {
+      Alert.alert('Unavailable', 'Media uploads are not configured.');
+    }
+    return configured;
+  };
+
     const pickDocument = async () => {
+      if (!(await ensureConfigured())) return;
       if (!(await requestMediaPermission())) return;
       const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: false });
       if (result.canceled || !result.assets?.length) return;
@@ -47,6 +64,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
     };
 
   const pickImage = async () => {
+    if (!(await ensureConfigured())) return;
     if (!(await requestMediaPermission())) return;
     const result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: true,
@@ -58,6 +76,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
   };
 
   const takePhoto = async () => {
+    if (!(await ensureConfigured())) return;
     if (!(await requestMediaPermission())) return;
     const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, quality: 0.8 });
     if (result.canceled || result.assets.length === 0) return;
@@ -98,7 +117,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
           <TouchableOpacity
             style={[styles.button, { borderColor: colors.gold }]}
             onPress={pickImage}
-            disabled={uploading}
+            disabled={uploading || !pinataConfigured}
           >
             {uploading ? (
               <ActivityIndicator size="small" color={colors.gold} />
@@ -113,7 +132,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
             <TouchableOpacity
               style={[styles.button, { borderColor: colors.gold }]}
               onPress={takePhoto}
-              disabled={uploading}
+              disabled={uploading || !pinataConfigured}
             >
               <Camera size={20} color={colors.gold} />
               <Text style={[styles.buttonText, { color: colors.gold }]}>Camera</Text>
@@ -122,7 +141,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
           <TouchableOpacity
             style={[styles.button, { borderColor: colors.gold }]}
             onPress={pickDocument}
-            disabled={uploading}
+            disabled={uploading || !pinataConfigured}
           >
             <FileIcon size={20} color={colors.gold} />
             <Text style={[styles.buttonText, { color: colors.gold }]}>File</Text>

--- a/services/media.ts
+++ b/services/media.ts
@@ -14,6 +14,14 @@ class MediaService {
   }
 
   /**
+   * Check if Pinata credentials are configured
+   */
+  async isPinataConfigured(): Promise<boolean> {
+    const pinataService = PinataService.getInstance();
+    return await pinataService.isPinataConfigured();
+  }
+
+  /**
    * Upload media to Pinata IPFS
    * @param onProgress - Optional progress callback (0-100)
    */


### PR DESCRIPTION
## Summary
- add `isPinataConfigured` helper to `MediaService`
- block MediaUploader if Pinata is missing
- block ProofUploader if Pinata is missing
- disable voice recording if media uploads are disabled

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_688955a508108326b8cddc550e4b9508