### PR TITLE
Add chat config checks

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -37,6 +37,7 @@ import { useAuth } from './AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { requireConfig } from '../utils/env';
+import { isChatConfigured } from '../services/chatConfig';
 import InfoModal from './InfoModal';
 import UserProfileModal from './UserProfileModal';
 
@@ -81,6 +82,7 @@ export default function ChatWidget() {
   const [profileModalVisible, setProfileModalVisible] = useState(false);
   const [profileUserId, setProfileUserId] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
+  const [chatConfigOk, setChatConfigOk] = useState(true);
   const waku = useWakuClient();
 
   useEffect(() => {
@@ -92,6 +94,12 @@ export default function ChatWidget() {
       }
     }
   }, [isOpen, isAdmin, isDriver, isLoggedIn]);
+
+  useEffect(() => {
+    if (isOpen) {
+      isChatConfigured().then(setChatConfigOk);
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     return () => {
@@ -392,8 +400,23 @@ const loadOrCreateDefaultRoom = async () => {
     await openSearchResult({ id, displayName: name, isAppUser: true });
   };
 
+  const ensureChatConfigured = async (): Promise<boolean> => {
+    const ok = await isChatConfigured();
+    if (!ok && isMounted.current) {
+      setChatConfigOk(false);
+      setInfoModal({
+        visible: true,
+        title: 'Chat unavailable',
+        message: 'missing configuration',
+        type: 'error',
+      });
+    }
+    return ok;
+  };
+
   const sendMessage = async () => {
     if (!newMessage.trim() || isSending) return;
+    if (!(await ensureChatConfigured())) return;
     setIsSending(true);
 
     const db = DatabaseService.getInstance();
@@ -446,6 +469,7 @@ const loadOrCreateDefaultRoom = async () => {
   };
 
   const startRecording = async () => {
+    if (!(await ensureChatConfigured())) return;
     try {
       if (Platform.OS === 'web') {
         if (isMounted.current) {
@@ -509,6 +533,10 @@ const loadOrCreateDefaultRoom = async () => {
 
   const stopRecording = async () => {
     if (!recording) return;
+
+    if (!(await ensureChatConfigured())) {
+      return;
+    }
 
     try {
       if (isMounted.current) {
@@ -1211,9 +1239,11 @@ const loadOrCreateDefaultRoom = async () => {
                               {
                                 backgroundColor: colors.surface.primary,
                                 borderColor: colors.border.primary,
+                                opacity: chatConfigOk ? 1 : 0.5,
                               },
                             ]}
                             onPress={startRecording}
+                            disabled={!chatConfigOk}
                           >
                             <Mic size={20} color={colors.gold} />
                           </TouchableOpacity>
@@ -1223,13 +1253,13 @@ const loadOrCreateDefaultRoom = async () => {
                             styles.sendButton,
                             {
                               backgroundColor:
-                                newMessage.trim() && !isSending
+                                newMessage.trim() && !isSending && chatConfigOk
                                   ? colors.gold
                                   : colors.interactive.disabled,
                             },
                           ]}
                           onPress={sendMessage}
-                          disabled={!newMessage.trim() || isSending}
+                          disabled={!newMessage.trim() || isSending || !chatConfigOk}
                         >
                           <Send size={20} color={colors.text.inverse} />
                         </TouchableOpacity>

--- a/services/chatConfig.ts
+++ b/services/chatConfig.ts
@@ -1,0 +1,7 @@
+import { requireConfig } from '../utils/env';
+
+export async function isChatConfigured(): Promise<boolean> {
+  const admin = await requireConfig('EXPO_PUBLIC_ADMIN_USERNAME').catch(() => '');
+  const secret = await requireConfig('EXPO_PUBLIC_CHAT_SECRET').catch(() => '');
+  return !!(admin && secret);
+}

--- a/tests/chatConfig.test.ts
+++ b/tests/chatConfig.test.ts
@@ -1,0 +1,20 @@
+import { insertConfig } from './testUtils';
+import { isChatConfigured } from '../services/chatConfig';
+
+describe('chat configuration', () => {
+  it('returns false when config values are missing', async () => {
+    await insertConfig({
+      EXPO_PUBLIC_ADMIN_USERNAME: '',
+      EXPO_PUBLIC_CHAT_SECRET: ''
+    });
+    expect(await isChatConfigured()).toBe(false);
+  });
+
+  it('returns true when config values are present', async () => {
+    await insertConfig({
+      EXPO_PUBLIC_ADMIN_USERNAME: 'admin',
+      EXPO_PUBLIC_CHAT_SECRET: 'secret'
+    });
+    expect(await isChatConfigured()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- disable ChatWidget actions when chat configuration is missing
- expose `isChatConfigured` helper
- cover chat config helper with tests

## Testing
- `yarn install` *(fails: Fetching packages)*
- `yarn test tests/chatConfig.test.ts` *(jest not found due to above failure)*

------
https://chatgpt.com/codex/tasks/task_e_688955b03e248326830ca0efbae6204a