### PR TITLE
Check Waku config before broadcasting

### DIFF
--- a/lib/waku/isWakuConfigured.ts
+++ b/lib/waku/isWakuConfigured.ts
@@ -1,0 +1,8 @@
+import { requireConfig } from '../../utils/env';
+
+export async function isWakuConfigured(): Promise<boolean> {
+  const enabled = await requireConfig('EXPO_PUBLIC_USE_WAKU').catch(() => 'false');
+  const secret = await requireConfig('EXPO_PUBLIC_WAKU_SECRET').catch(() => '');
+  return enabled === 'true' && !!secret;
+}
+

--- a/services/database.ts
+++ b/services/database.ts
@@ -2,6 +2,7 @@ import { executeSql } from '../lib/sqlite';
 import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
+import { isWakuConfigured } from '../lib/waku/isWakuConfigured';
 import { getTenant, TENANT } from '../constants/tenant';
 import { requireConfig } from '../utils/env';
 import {
@@ -147,9 +148,11 @@ class DatabaseService {
       ],
     );
     try {
-      const prod = await this.getProduct(id);
-      if (prod) {
-        await sendWakuProductUpdate(prod);
+      if (await isWakuConfigured()) {
+        const prod = await this.getProduct(id);
+        if (prod) {
+          await sendWakuProductUpdate(prod);
+        }
       }
     } catch (e) {
       console.error('Failed to send Waku product update:', e);
@@ -194,9 +197,11 @@ class DatabaseService {
       ],
     );
     try {
-      const prod = await this.getProduct(id);
-      if (prod) {
-        await sendWakuProductUpdate(prod);
+      if (await isWakuConfigured()) {
+        const prod = await this.getProduct(id);
+        if (prod) {
+          await sendWakuProductUpdate(prod);
+        }
       }
     } catch (e) {
       console.error('Failed to send Waku product update:', e);
@@ -437,9 +442,11 @@ class DatabaseService {
     const tenant = await getTenant();
     await executeSql('UPDATE user_profiles SET role=? WHERE id=? AND tenant_id=?', [role, userId, tenant]);
     try {
-      const user = await this.getUserProfile(userId);
-      if (user) {
-        await sendWakuUserUpdate(user);
+      if (await isWakuConfigured()) {
+        const user = await this.getUserProfile(userId);
+        if (user) {
+          await sendWakuUserUpdate(user);
+        }
       }
     } catch (e) {
       console.error('Failed to send Waku user update:', e);
@@ -450,9 +457,11 @@ class DatabaseService {
     const tenant = await getTenant();
     await executeSql('UPDATE user_profiles SET customer_tier=? WHERE id=? AND tenant_id=?', [customerTier, userId, tenant]);
     try {
-      const user = await this.getUserProfile(userId);
-      if (user) {
-        await sendWakuUserUpdate(user);
+      if (await isWakuConfigured()) {
+        const user = await this.getUserProfile(userId);
+        if (user) {
+          await sendWakuUserUpdate(user);
+        }
       }
     } catch (e) {
       console.error('Failed to send Waku user update:', e);
@@ -480,9 +489,11 @@ class DatabaseService {
     const params = [...Object.values(updateData), userId, tenant];
     await executeSql(`UPDATE user_profiles SET ${fields} WHERE id=? AND tenant_id=?`, params);
     try {
-      const user = await this.getUserProfile(userId);
-      if (user) {
-        await sendWakuUserUpdate(user);
+      if (await isWakuConfigured()) {
+        const user = await this.getUserProfile(userId);
+        if (user) {
+          await sendWakuUserUpdate(user);
+        }
       }
     } catch (e) {
       console.error('Failed to send Waku user update:', e);
@@ -923,8 +934,10 @@ class DatabaseService {
     const createdAt = row?.created_at ?? Date.now();
     const updatedAt = row?.updated_at ?? Date.now();
     try {
-      await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
-      } catch (e) {
+      if (await isWakuConfigured()) {
+        await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
+      }
+    } catch (e) {
       console.error('Failed to send Waku settings update:', e);
     }
   }
@@ -961,7 +974,9 @@ class DatabaseService {
     const createdAt = row?.created_at ?? Date.now();
     const updatedAt = row?.updated_at ?? Date.now();
     try {
-      await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
+      if (await isWakuConfigured()) {
+        await sendWakuSettingsUpdate(key, value, createdAt, updatedAt);
+      }
     } catch (e) {
       console.error('Failed to send Waku settings update:', e);
     }

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -3,6 +3,7 @@ import { Order, OrderStatus, OrderTrackingStep, CartItem, ShippingAddress } from
 import DatabaseService from './database';
 import { getTenant } from '../constants/tenant';
 import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
+import { isWakuConfigured } from '../lib/waku/isWakuConfigured';
 
 class OrderService {
   private static instance: OrderService;
@@ -153,7 +154,7 @@ class OrderService {
     this.simulateOrderProgress(orderId);
 
     try {
-      if (order) {
+      if (order && (await isWakuConfigured())) {
         await sendWakuOrderUpdate(order);
       }
     } catch (e) {
@@ -189,7 +190,7 @@ class OrderService {
     this.notifyListeners();
     try {
       const order = await this.getOrder(orderId);
-      if (order) {
+      if (order && (await isWakuConfigured())) {
         await sendWakuOrderUpdate(order);
       }
     } catch (e) {

--- a/tests/wakuSkipBroadcast.test.ts
+++ b/tests/wakuSkipBroadcast.test.ts
@@ -1,0 +1,32 @@
+import DatabaseService from '../services/database';
+import OrderService from '../services/orders';
+import { insertConfig } from './testUtils';
+import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
+import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
+
+jest.mock('../lib/waku/sendWakuUserUpdate');
+jest.mock('../lib/waku/sendWakuOrderUpdate');
+
+describe('Waku disabled behaviour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (DatabaseService as any).instance = undefined;
+    (OrderService as any).instance = undefined;
+  });
+
+  it('skips user update when Waku disabled', async () => {
+    await insertConfig({ EXPO_PUBLIC_USE_WAKU: 'false' });
+    const db = DatabaseService.getInstance();
+    jest.spyOn(db, 'getUserProfile').mockResolvedValue({ id: '1' } as any);
+    await db.updateUserRole('1', 'admin');
+    expect(sendWakuUserUpdate).not.toHaveBeenCalled();
+  });
+
+  it('skips order update when secret missing', async () => {
+    await insertConfig({ EXPO_PUBLIC_USE_WAKU: 'true', EXPO_PUBLIC_WAKU_SECRET: '' });
+    const svc = OrderService.getInstance();
+    jest.spyOn(svc, 'getOrder').mockResolvedValue({ id: '1' } as any);
+    await svc.updateOrderStatus('1', 'delivered');
+    expect(sendWakuOrderUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add helper `isWakuConfigured`
- skip Waku broadcasts in DatabaseService and OrderService when config is missing
- test that Waku updates are skipped without config

## Testing
- `yarn test --silent` *(fails: Config value EXPO_PUBLIC_WAKU_SECRET is required)*

------
https://chatgpt.com/codex/tasks/task_e_688955ae517483269d53cd35743b005f