### PR TITLE
Store admin username config

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -55,6 +55,7 @@ export default function OnboardingScreen() {
     setLoading(true);
     try {
       await saveConfigValue('EXPO_PUBLIC_TENANT', tenant);
+      await saveConfigValue('EXPO_PUBLIC_ADMIN_USERNAME', adminUser);
       await saveConfigValue('APP_NAME', appName);
       await saveConfigValue('PRIMARY_COLOR', primaryColor);
       if (logo) await saveConfigValue('APP_LOGO', logo);


### PR DESCRIPTION
## Summary
- persist EXPO_PUBLIC_ADMIN_USERNAME when saving onboarding info

## Testing
- `yarn test` *(fails: Attempting to open a second database handle)*

------
https://chatgpt.com/codex/tasks/task_e_68895aed26f08326933c977a6d40be7f