### PR TITLE
Enable dynamic onboarding refresh

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,8 +21,8 @@ import ChatWidget from '../components/ChatWidget';
 import { ensureDatabase, executeSql, closeDatabase } from '../lib/sqlite';
 import { ensureSettingsTable } from '../lib/sqlite/initSettingsTable';
 import { loadTenantSettings } from '../constants/tenant';
-import { checkOnboarding } from '../utils/config';
 import OnboardingScreen from './onboarding';
+import { OnboardingProvider, useOnboarding } from '../contexts/OnboardingContext';
 import { useWakuSettingsSync } from '../lib/waku/useWakuSettingsSync';
 import { useWakuUserSync } from '../lib/waku/useWakuUserSync';
 import { useWakuProductSync } from '../lib/waku/useWakuProductSync';
@@ -94,15 +94,12 @@ export default function RootLayout() {
   useFrameworkReady();
 
   const [dbReady, setDbReady] = useState(false);
-  const [onboarded, setOnboarded] = useState<boolean | null>(null);
 
   useEffect(() => {
     (async () => {
       await ensureDatabase();
       await ensureSettingsTable(executeSql);
       await loadTenantSettings();
-      const done = await checkOnboarding();
-      setOnboarded(done);
       setDbReady(true);
     })();
     return () => {
@@ -112,7 +109,25 @@ export default function RootLayout() {
     };
   }, []);
 
-  if (!dbReady || onboarded === null) {
+  if (!dbReady) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <OnboardingProvider>
+      <RootLayoutInner />
+    </OnboardingProvider>
+  );
+}
+
+function RootLayoutInner() {
+  const { onboarded } = useOnboarding();
+
+  if (onboarded === null) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <ActivityIndicator size="large" />

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { saveConfigValue } from '../../utils/config';
 import { executeSql } from '../../lib/sqlite';
 import InfoModal from '../../components/InfoModal';
+import { useOnboarding } from '../../contexts/OnboardingContext';
 
 export default function OnboardingScreen() {
   const { colors } = useTheme();
@@ -41,6 +42,7 @@ export default function OnboardingScreen() {
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
+  const { refreshOnboardingStatus } = useOnboarding();
 
   const handleSubmit = async () => {
     if (!appName || !adminUser || !adminPass) {
@@ -80,6 +82,7 @@ export default function OnboardingScreen() {
       );
 
       await saveConfigValue('ONBOARD_COMPLETE', 'true');
+      await refreshOnboardingStatus();
       setInfo({
         visible: true,
         title: 'Success',

--- a/contexts/OnboardingContext.tsx
+++ b/contexts/OnboardingContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { checkOnboarding } from '../utils/config';
+
+interface OnboardingContextType {
+  onboarded: boolean | null;
+  refreshOnboardingStatus: () => Promise<void>;
+}
+
+const OnboardingContext = createContext<OnboardingContextType>({
+  onboarded: null,
+  refreshOnboardingStatus: async () => {},
+});
+
+export const useOnboarding = () => useContext(OnboardingContext);
+
+interface OnboardingProviderProps {
+  children: React.ReactNode;
+}
+
+export function OnboardingProvider({ children }: OnboardingProviderProps) {
+  const [onboarded, setOnboarded] = useState<boolean | null>(null);
+
+  const refreshOnboardingStatus = async () => {
+    const done = await checkOnboarding();
+    setOnboarded(done);
+  };
+
+  useEffect(() => {
+    refreshOnboardingStatus();
+  }, []);
+
+  return (
+    <OnboardingContext.Provider value={{ onboarded, refreshOnboardingStatus }}>
+      {children}
+    </OnboardingContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add an `OnboardingContext` that can refresh onboarding status
- have `RootLayout` use the provider and read onboarding state from it
- refresh onboarding status after successful setup in `OnboardingScreen`

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: engine \"node\" incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_68895af34adc8326b06e1e6481d57139