### PR TITLE
Add install reminder before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Run the test suite with:
 yarn test
 ```
 
-Ensure all dependencies are installed using `yarn install` before running the tests.
+Run `yarn install` before executing `yarn test` so Jest and other dependencies are present.
 
 
 ## License


### PR DESCRIPTION
## Summary
- clarify test instructions in README

## Testing
- `yarn install --ignore-engines`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6889803545248326b4e4d22d03154e2e