### PR TITLE
Add Apple Pay integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ yarn test
 
 Run `yarn install` before executing `yarn test` so Jest and other dependencies are present.
 
+## Apple Pay Integration
+
+The project uses MoonPay for purchasing crypto with a credit card. To accept Apple Pay directly in the app, install the Expo Stripe payments package and configure your merchant identifier.
+
+1. Install the library:
+```sh
+yarn add expo-payments-stripe
+```
+2. Add the plugin to **app.json**:
+```json
+{
+  "expo": {
+    "plugins": [["expo-payments-stripe", { "merchantIdentifier": "merchant.com.example" }]]
+  }
+}
+```
+3. Initialize Stripe when the app launches:
+```ts
+import { initStripe } from "expo-payments-stripe";
+
+initStripe({
+  publishableKey: "<your-stripe-key>",
+  merchantIdentifier: "merchant.com.example",
+});
+```
+4. Use `presentApplePay` from the library when the user checks out.
+
+Refer to the Expo Stripe documentation for full setup details.
+
 
 ## License
 


### PR DESCRIPTION
## Summary
- document how to integrate Apple Pay with Expo

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898636ee4483269d35f0075c696232