### PR TITLE
Switch auth and notifications to Waku agents

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,0 +1,28 @@
+import { Notification } from '../types';
+import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpdate';
+import WakuAgent from '../utils/wakuAgent';
+
+class NotificationsAgent extends WakuAgent<Notification> {
+  private subscribers: Set<(n: Notification) => void> = new Set();
+
+  constructor() {
+    super(sendWakuNotificationUpdate, {
+      topic: '/congress/notifications/1/proto',
+      replayHistory: true,
+      extractItem: (msg: any) => msg.notification as Notification,
+      onUpdate: (item: Notification) => {
+        this.subscribers.forEach((cb) => cb(item));
+      },
+    });
+  }
+
+  subscribe(cb: (n: Notification) => void) {
+    this.subscribers.add(cb);
+  }
+
+  unsubscribe(cb: (n: Notification) => void) {
+    this.subscribers.delete(cb);
+  }
+}
+
+export default new NotificationsAgent();

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { executeSql } from '../lib/sqlite';
+import usersAgent from '../agents/users-agent';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
 import * as SecureStore from 'expo-secure-store';
@@ -7,7 +7,6 @@ import { getPublicKey, utils as edUtils } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 import config from '../utils/appConfig';
-import { getTenant } from '../constants/tenant';
 
 async function getAdminUsernames(): Promise<string[]> {
   const raw = config.EXPO_PUBLIC_ADMIN_USERNAME || '';
@@ -97,31 +96,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const loadProfile = async (uid: string) => {
-    const result = await executeSql('SELECT * FROM users WHERE id = ?', [uid]);
-    const data = (result.rows as any)._array?.[0];
+    const data = usersAgent.get(uid);
     if (data) {
-      setUser({
-        id: data.id,
-        username: data.username,
-        displayName: data.display_name,
-        role: data.role,
-        publicKey: data.public_key,
-      });
+      setUser(data);
     } else {
-      setUser({ id: uid, role: 'user', username: '', displayName: '' });
+      setUser({ id: uid, role: 'user', username: '', displayName: '', isAdmin: false });
     }
   };
 
   const login = async (username: string, password: string): Promise<boolean> => {
     setLoading(true);
     try {
-      const res = await executeSql('SELECT * FROM users WHERE username = ?', [username]);
-      const row = (res.rows as any)._array?.[0];
+      const row = usersAgent.getAll().find((u) => u.username === username);
       if (!row) {
         setLoading(false);
         return false;
       }
-      const match = await bcrypt.compare(password, row.password_hash);
+      const match = await bcrypt.compare(password, row.passwordHash || '');
       if (!match) {
         setLoading(false);
         return false;
@@ -164,15 +155,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const privateKey = edUtils.bytesToHex(priv);
       const publicKey = edUtils.bytesToHex(pub);
       await SecureStore.setItemAsync(PRIVATE_KEY_KEY, privateKey);
-      await executeSql(
-        'INSERT INTO users (id, username, password_hash, display_name, role, public_key) VALUES (?,?,?,?,?,?)',
-        [id, username, hash, displayName, role, publicKey],
-      );
-      const tenant = await getTenant();
-      await executeSql(
-        'INSERT INTO user_profiles (id, tenant_id, matrix_user_id, app_username, email, display_name, role) VALUES (?,?,?,?,?,?,?)',
-        [id, tenant, id, username, null, displayName, role],
-      );
+      const existing = usersAgent.getAll().find((u) => u.username === username);
+      if (existing) {
+        throw new UsernameTakenError();
+      }
+      await usersAgent.add({
+        id,
+        username,
+        displayName,
+        role,
+        publicKey,
+        isAdmin: role === 'admin',
+        isDriver: role === 'driver',
+        passwordHash: hash,
+      });
       const JWT_SECRET = await getJwtSecret();
       if (!JWT_SECRET) {
         console.error('JWT secret missing; cannot signup');

--- a/lib/memoryStore.ts
+++ b/lib/memoryStore.ts
@@ -1,9 +1,10 @@
-import type { User, Product, Order, TenantSettings } from '../types';
+import type { User, Product, Order, TenantSettings, Notification } from '../types';
 
 export interface MemoryStore {
   users: User[];
   products: Product[];
   orders: Order[];
+  notifications: Notification[];
   tenantSettings: Record<string, TenantSettings>;
 }
 
@@ -11,5 +12,6 @@ export const store: MemoryStore = {
   users: [],
   products: [],
   orders: [],
+  notifications: [],
   tenantSettings: {},
 };

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -1,0 +1,45 @@
+import type { WakuSender } from './sendWakuUserUpdate';
+import { encryptWakuPayload } from './wakuCrypto';
+import { sha256 } from '@noble/hashes/sha256';
+
+export const sendWakuNotificationUpdate = async (
+  notification: any,
+  sender: WakuSender = { id: '', publicKey: '', role: '' },
+  privateKey = ''
+) => {
+  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+  const { sign, etc: edBytes } = await import('@noble/ed25519');
+
+  const node = await createLightNode({ defaultBootstrap: true });
+  try {
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.LightPush]);
+
+    const payloadObj = {
+      type: 'notification.update',
+      notification,
+      sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+    };
+    const payload = JSON.stringify(payloadObj);
+
+    let signature = '';
+    if (sender.privateKey) {
+      try {
+        const hash = sha256(new TextEncoder().encode(payload));
+        const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+        signature = edBytes.bytesToHex(sig);
+      } catch (e) {
+        console.error('Failed to sign Waku message', e);
+      }
+    }
+
+    const message = JSON.stringify({ ...payloadObj, signature });
+
+    const encrypted = await encryptWakuPayload(message);
+
+    const encoder = node.createEncoder({ contentTopic: '/congress/notifications/1/proto' });
+    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+  } finally {
+    await node.stop();
+  }
+};

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -82,6 +82,18 @@ async function seed() {
   }
   store.orders.push(...orders);
 
+  // Notifications
+  const notifications = Array.from({ length: 5 }).map(() => ({
+    id: `ntf_${Date.now()}_${faker.number.int()}`,
+    userId: faker.helpers.arrayElement(store.users).id,
+    title: faker.lorem.words({ min: 2, max: 5 }),
+    message: faker.lorem.sentence(),
+    type: 'system',
+    read: false,
+    timestamp: Date.now(),
+  }));
+  store.notifications.push(...notifications);
+
   // Tenant settings
   for (const tenant of tenants) {
     store.tenantSettings[tenant] = {

--- a/services/notification.ts
+++ b/services/notification.ts
@@ -1,5 +1,5 @@
 import { Notification } from '../types';
-import { executeSql } from '../lib/sqlite';
+import notificationsAgent from '../agents/notifications-agent';
 
 class NotificationService {
   private static instance: NotificationService;
@@ -19,19 +19,10 @@ class NotificationService {
         console.warn('No user ID provided for getNotifications');
         return [];
       }
-      const result = await executeSql(
-        'SELECT * FROM notifications WHERE user_id = ? ORDER BY timestamp DESC',
-        [userId],
-      );
-      const rows = (result.rows as any)._array || [];
-      return rows.map((notification: any) => ({
-        id: notification.id,
-        title: notification.title,
-        message: notification.message,
-        type: notification.type,
-        read: notification.read,
-        timestamp: notification.timestamp,
-      }));
+      return notificationsAgent
+        .getAll()
+        .filter((n) => n.userId === userId)
+        .sort((a, b) => b.timestamp - a.timestamp);
     } catch (error) {
       console.error('Error in getNotifications:', error);
       return [];
@@ -40,7 +31,10 @@ class NotificationService {
 
   async markAsRead(id: string): Promise<boolean> {
     try {
-      await executeSql('UPDATE notifications SET read = 1 WHERE id = ?', [id]);
+      const n = notificationsAgent.get(id);
+      if (!n) return false;
+      n.read = true;
+      await notificationsAgent.update(n);
       return true;
     } catch (error) {
       console.error('Error in markAsRead:', error);
@@ -50,7 +44,13 @@ class NotificationService {
 
   async markAllAsRead(userId: string): Promise<boolean> {
     try {
-      await executeSql('UPDATE notifications SET read = 1 WHERE user_id = ?', [userId]);
+      const list = notificationsAgent
+        .getAll()
+        .filter((n) => n.userId === userId && !n.read);
+      for (const n of list) {
+        n.read = true;
+        await notificationsAgent.update(n);
+      }
       return true;
     } catch (error) {
       console.error('Error in markAllAsRead:', error);
@@ -60,7 +60,7 @@ class NotificationService {
 
   async deleteNotification(id: string): Promise<boolean> {
     try {
-      await executeSql('DELETE FROM notifications WHERE id = ?', [id]);
+      await notificationsAgent.remove(id);
       return true;
     } catch (error) {
       console.error('Error in deleteNotification:', error);
@@ -75,38 +75,17 @@ class NotificationService {
     type: 'order' | 'promo' | 'message' | 'system';
   }): Promise<Notification | null> {
     try {
-      const newNotification = {
-        user_id: notification.userId,
+      const newNotification: Notification = {
+        id: `ntf_${Date.now()}`,
+        userId: notification.userId,
         title: notification.title,
         message: notification.message,
         type: notification.type,
         read: false,
         timestamp: Date.now(),
       };
-
-      const id = `ntf_${Date.now()}`;
-      await executeSql(
-        `INSERT INTO notifications (id, user_id, title, message, type, read, timestamp)
-         VALUES (?,?,?,?,?,?,?)`,
-        [
-          id,
-          newNotification.user_id,
-          newNotification.title,
-          newNotification.message,
-          newNotification.type,
-          0,
-          newNotification.timestamp,
-        ],
-      );
-
-      return {
-        id,
-        title: newNotification.title,
-        message: newNotification.message,
-        type: newNotification.type,
-        read: false,
-        timestamp: newNotification.timestamp,
-      };
+      await notificationsAgent.add(newNotification);
+      return newNotification;
     } catch (error) {
       console.error('Error in addNotification:', error);
       return null;
@@ -116,17 +95,12 @@ class NotificationService {
   async getUnreadCount(userId?: string): Promise<number> {
     try {
       if (!userId) {
-        // Handle the case where userId is undefined
         console.warn('No user ID provided for getUnreadCount');
         return 0;
       }
-
-      const result = await executeSql(
-        'SELECT COUNT(*) as cnt FROM notifications WHERE user_id = ? AND read = 0',
-        [userId],
-      );
-      const item = (result.rows as any)._array?.[0];
-      return item ? item.cnt : 0;
+      return notificationsAgent
+        .getAll()
+        .filter((n) => n.userId === userId && !n.read).length;
     } catch (error) {
       console.error('Error in getUnreadCount:', error);
       return 0;
@@ -134,14 +108,17 @@ class NotificationService {
   }
 
   // Subscribe to real-time notifications for a specific user
-  subscribeToUserNotifications(_userId: string, _callback: (n: Notification) => void) {
-    console.warn('Realtime notifications not implemented with SQLite');
-    return null;
+  subscribeToUserNotifications(userId: string, callback: (n: Notification) => void) {
+    const handler = (n: Notification) => {
+      if (n.userId === userId) callback(n);
+    };
+    notificationsAgent.subscribe(handler);
+    return handler;
   }
 
   // Unsubscribe from real-time notifications
-  unsubscribeFromNotifications(_subscription: any) {
-    // no-op
+  unsubscribeFromNotifications(subscription: any) {
+    notificationsAgent.unsubscribe(subscription);
   }
 }
 

--- a/tests/wakuUpdates.test.ts
+++ b/tests/wakuUpdates.test.ts
@@ -1,6 +1,7 @@
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
 import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
+import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpdate';
 
 jest.mock('../lib/waku/wakuCrypto', () => ({
   encryptWakuPayload: jest.fn(async (p: string) => p),
@@ -51,6 +52,13 @@ describe('Waku send updates', () => {
 
   it('order update creates and stops node', async () => {
     await sendWakuOrderUpdate({});
+    const { createLightNode } = await import('@waku/sdk');
+    expect(createLightNode).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('notification update creates and stops node', async () => {
+    await sendWakuNotificationUpdate({});
     const { createLightNode } = await import('@waku/sdk');
     expect(createLightNode).toHaveBeenCalled();
     expect(stop).toHaveBeenCalled();

--- a/types/index.ts
+++ b/types/index.ts
@@ -107,6 +107,7 @@ export interface User {
   isAdmin: boolean;
   isDriver?: boolean;
   displayName: string;
+  passwordHash?: string;
   avatar?: string;
   email?: string;
   role?: string;
@@ -123,6 +124,7 @@ export interface User {
 
 export interface Notification {
   id: string;
+  userId: string;
   title: string;
   message: string;
   type: 'order' | 'promo' | 'message' | 'system';


### PR DESCRIPTION
## Summary
- drop SQLite from AuthContext and notification service
- track notifications in-memory with `notificationsAgent`
- support Waku notifications with `sendWakuNotificationUpdate`
- persist extra fields in memory store and user records
- adjust tests for new notification update

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6889f01dd3608326b48000d6742dee58