### PR TITLE
Enable history replay for cart and categories agents

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -4,7 +4,12 @@ import WakuAgent from '../utils/wakuAgent';
 
 class CartAgent extends WakuAgent<CartItem> {
   constructor() {
-    super(sendWakuCartUpdate);
+    super(sendWakuCartUpdate, {
+      topic: '/congress/cart/1',
+      replayHistory: true,
+      extractItem: (msg: any) =>
+        msg.type === 'cart.update' ? (msg.cartItem as CartItem) : undefined,
+    });
   }
 }
 

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -4,7 +4,12 @@ import WakuAgent from '../utils/wakuAgent';
 
 class CategoriesAgent extends WakuAgent<Category> {
   constructor() {
-    super(sendWakuCategoryUpdate);
+    super(sendWakuCategoryUpdate, {
+      topic: '/congress/categories/1',
+      replayHistory: true,
+      extractItem: (msg: any) =>
+        msg.type === 'category.update' ? (msg.category as Category) : undefined,
+    });
   }
 }
 

--- a/tests/categoriesAgent.test.ts
+++ b/tests/categoriesAgent.test.ts
@@ -1,0 +1,22 @@
+import categoriesAgent from '../agents/categories-agent';
+import DatabaseService from '../services/database';
+
+jest.mock('../lib/waku/sendWakuCategoryUpdate', () => ({
+  sendWakuCategoryUpdate: jest.fn(),
+}));
+
+describe('CategoriesAgent integration', () => {
+  beforeEach(() => {
+    (categoriesAgent as any).store.clear();
+    (DatabaseService as any).instance = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('DatabaseService returns replicated categories', async () => {
+    const category = { id: '1', name: 'Test', subcategories: [] } as any;
+    await categoriesAgent.add(category);
+    const db = DatabaseService.getInstance();
+    const categories = await db.getCategories();
+    expect(categories).toEqual([category]);
+  });
+});


### PR DESCRIPTION
## Summary
- configure categories and cart agents with topics and history replay
- add basic integration test for categories agent with database service

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6889f029c09c8326b37371a727e36a40