### PR TITLE
Add Waku message validation

### DIFF
--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -9,6 +9,7 @@ class CategoriesAgent extends WakuAgent<Category> {
       replayHistory: true,
       extractItem: (msg: any) =>
         msg.type === 'category.update' ? (msg.category as Category) : undefined,
+      allowedRoles: ['admin'],
     });
   }
 }

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -8,6 +8,9 @@ class OrdersAgent extends WakuAgent<Order> {
       topic: '/congress/orders/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.order as Order,
+      allowedRoles: ['admin', 'user', 'driver'],
+      validateMessage: (msg: any) =>
+        msg.sender.role === 'admin' || msg.order?.userId === msg.sender.id,
     });
   }
 }

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -8,6 +8,7 @@ class ProductsAgent extends WakuAgent<Product> {
       topic: '/congress/products/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.product as Product,
+      allowedRoles: ['admin'],
     });
   }
 }

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -21,6 +21,7 @@ class SettingsAgent extends WakuAgent<SettingItem> {
           msg.type === 'settings.update'
             ? { id: msg.key as string, value: msg.value as string }
             : undefined,
+        allowedRoles: ['admin'],
       }
     );
   }

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -8,6 +8,7 @@ class UsersAgent extends WakuAgent<User> {
       topic: '/congress/users/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.user as User,
+      allowedRoles: ['admin', 'user', 'driver'],
     });
   }
 }

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { isWakuConfigured } from '../lib/waku/isWakuConfigured';
 import { decryptWakuPayload } from '../lib/waku/wakuCrypto';
 
@@ -10,6 +11,10 @@ export interface WakuAgentOptions<T> {
   extractItem?: (msg: any) => T | undefined;
   /** Called whenever an item is stored */
   onUpdate?: (item: T) => void;
+  /** Allowed sender roles */
+  allowedRoles?: string[];
+  /** Additional validation */
+  validateMessage?: (msg: any) => boolean | Promise<boolean>;
 }
 
 /**
@@ -21,6 +26,7 @@ export default class WakuAgent<T extends { id: string }> {
   private node: any | null = null;
   private decoder: any | null = null;
   private ready: Promise<void> | null = null;
+  private hashCache: Set<string> = new Set();
 
   constructor(
     private sendFn: (item: T) => Promise<void>,
@@ -68,16 +74,7 @@ export default class WakuAgent<T extends { id: string }> {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
         const plaintext = await decryptWakuPayload(decoded);
-        try {
-          const parsed = JSON.parse(plaintext);
-          const item = this.options.extractItem ? this.options.extractItem(parsed) : (parsed as T);
-          if (item && item.id) {
-            this.store.set(item.id, item);
-            this.options.onUpdate?.(item);
-          }
-        } catch (e) {
-          console.error('Invalid Waku message:', e);
-        }
+        await this.processPayload(plaintext);
       };
       await this.node.filter!.subscribe(this.decoder, handler);
 
@@ -90,6 +87,36 @@ export default class WakuAgent<T extends { id: string }> {
       }
     } catch (e) {
       console.error('Failed initializing WakuAgent', e);
+    }
+  }
+
+  async processPayload(payload: string): Promise<void> {
+    try {
+      const parsed = JSON.parse(payload);
+      if (!parsed.sender?.publicKey || !parsed.signature || !parsed.sender?.role) return;
+
+      if (this.options.allowedRoles && !this.options.allowedRoles.includes(parsed.sender.role)) return;
+
+      const { verify, etc: edBytes } = await import('@noble/ed25519');
+      const { sha256 } = await import('@noble/hashes/sha256');
+      const verifyObj = { ...parsed } as any;
+      delete (verifyObj as any).signature;
+      const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
+      const hashHex = Buffer.from(hash).toString('hex');
+      if (this.hashCache.has(hashHex)) return;
+      const ok = await verify(edBytes.hexToBytes(parsed.signature), hash, edBytes.hexToBytes(parsed.sender.publicKey));
+      if (!ok) return;
+
+      if (this.options.validateMessage && !(await this.options.validateMessage(parsed))) return;
+
+      const item = this.options.extractItem ? this.options.extractItem(parsed) : (parsed as T);
+      if (item && item.id) {
+        this.store.set(item.id, item);
+        this.hashCache.add(hashHex);
+        this.options.onUpdate?.(item);
+      }
+    } catch (e) {
+      console.error('Invalid Waku message:', e);
     }
   }
 


### PR DESCRIPTION
## Summary
- extend `WakuAgent` with message hash cache and validation helpers
- require admin role for products, categories and settings updates
- allow orders and users to validate sender role and id
- update agents to configure allowed roles

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688a1ecaf8848326b0facde390d0dcae