### PR TITLE
Add tests for notification agent

### DIFF
--- a/tests/__mocks__/expo-secure-store.js
+++ b/tests/__mocks__/expo-secure-store.js
@@ -1,0 +1,5 @@
+module.exports = {
+  setItemAsync: jest.fn(async () => {}),
+  getItemAsync: jest.fn(async () => null),
+  deleteItemAsync: jest.fn(async () => {}),
+};

--- a/tests/notificationService.test.ts
+++ b/tests/notificationService.test.ts
@@ -1,0 +1,37 @@
+import NotificationService from '../services/notification';
+import notificationsAgent from '../agents/notifications-agent';
+
+jest.mock('../lib/waku/sendWakuNotificationUpdate', () => ({
+  sendWakuNotificationUpdate: jest.fn(),
+}));
+
+describe('NotificationService with Waku agent', () => {
+  beforeEach(() => {
+    (NotificationService as any).instance = undefined;
+    (notificationsAgent as any).store.clear();
+  });
+
+  it('adds notifications to agent store', async () => {
+    const svc = NotificationService.getInstance();
+    const n = await svc.addNotification({
+      userId: 'u1',
+      title: 'Hello',
+      message: 'World',
+      type: 'system',
+    });
+    expect(n).toBeTruthy();
+    expect(notificationsAgent.get(n!.id)).toEqual(n);
+  });
+
+  it('updates read status via agent', async () => {
+    const svc = NotificationService.getInstance();
+    const n = await svc.addNotification({
+      userId: 'u1',
+      title: 'Test',
+      message: 'Msg',
+      type: 'system',
+    });
+    await svc.markAsRead(n!.id);
+    expect(notificationsAgent.get(n!.id)?.read).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add mock for expo-secure-store
- test NotificationService integration with notifications agent

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688a65fbfe688326bb7b5b55cfeaa52d