### PR TITLE
Switch to async public key generation

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -14,7 +14,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import bcrypt from 'bcryptjs';
 import * as SecureStore from 'expo-secure-store';
-import { getPublicKey, utils as edUtils } from '@noble/ed25519';
+import { getPublicKeyAsync, utils as edUtils } from '@noble/ed25519';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useConfig } from '../../contexts/ConfigContext';
 import InfoModal from '../../components/InfoModal';
@@ -72,7 +72,7 @@ export default function OnboardingScreen() {
       const hash = await bcrypt.hash(adminPass, 10);
       const id = `admin_${Date.now()}`;
       const priv = edUtils.randomPrivateKey();
-      const pub = await getPublicKey(priv);
+      const pub = await getPublicKeyAsync(priv);
       await SecureStore.setItemAsync('ed25519_private_key', edUtils.bytesToHex(priv));
       setValue('ADMIN_ID', id);
       setValue('ADMIN_USERNAME', adminUser);

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -3,7 +3,7 @@ import usersAgent from '../agents/users-agent';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
 import * as SecureStore from 'expo-secure-store';
-import { getPublicKey, utils as edUtils } from '@noble/ed25519';
+import { getPublicKeyAsync, utils as edUtils } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 import config from '../utils/appConfig';
@@ -151,7 +151,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const isAdminUsername = (await getAdminUsernames()).includes(username);
       const role = isAdminUsername ? 'admin' : 'user';
       const priv = edUtils.randomPrivateKey();
-      const pub = await getPublicKey(priv);
+      const pub = await getPublicKeyAsync(priv);
       const privateKey = edUtils.bytesToHex(priv);
       const publicKey = edUtils.bytesToHex(pub);
       await SecureStore.setItemAsync(PRIVATE_KEY_KEY, privateKey);


### PR DESCRIPTION
## Summary
- use `getPublicKeyAsync` from `@noble/ed25519` during onboarding
- use `getPublicKeyAsync` in AuthContext signup

## Testing
- `CI=true yarn test`
- `yarn build:web`


------
https://chatgpt.com/codex/tasks/task_e_688a69cf144c83268d5a7390957e3bcd