### PR TITLE
Enable cart and category replication

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -2,6 +2,8 @@ import { CartItem } from '../types';
 import { sendWakuCartUpdate } from '../lib/waku/sendWakuCartUpdate';
 import WakuAgent from '../utils/wakuAgent';
 
+// Publishes and replicates cart items via Waku
+
 class CartAgent extends WakuAgent<CartItem> {
   constructor() {
     super(sendWakuCartUpdate, {

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -2,6 +2,8 @@ import { Category } from '../types';
 import { sendWakuCategoryUpdate } from '../lib/waku/sendWakuCategoryUpdate';
 import WakuAgent from '../utils/wakuAgent';
 
+// Publishes and replicates category records via Waku
+
 class CategoriesAgent extends WakuAgent<Category> {
   constructor() {
     super(sendWakuCategoryUpdate, {


### PR DESCRIPTION
## Summary
- update `categories-agent` and `cart-agent` with comments clarifying Waku replication
- agents continue to use history replay, topic configuration and extract callbacks

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688a6f56e2788326b967969fac72a67a