### PR TITLE
Add private key storage helper

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -13,7 +13,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import bcrypt from 'bcryptjs';
-import * as SecureStore from 'expo-secure-store';
+import { savePrivateKey } from '../../utils/privateKeyStorage';
 import { getPublicKeyAsync, utils as edUtils, etc as edBytes } from '@noble/ed25519';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useConfig } from '../../contexts/ConfigContext';
@@ -73,7 +73,7 @@ export default function OnboardingScreen() {
       const id = `admin_${Date.now()}`;
       const priv = edUtils.randomPrivateKey();
       const pub = await getPublicKeyAsync(priv);
-      await SecureStore.setItemAsync('ed25519_private_key', edBytes.bytesToHex(priv));
+      await savePrivateKey(edBytes.bytesToHex(priv));
       setValue('ADMIN_ID', id);
       setValue('ADMIN_USERNAME', adminUser);
       setValue('ADMIN_HASH', hash);

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState, ReactNode } from
 import usersAgent from '../agents/users-agent';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
-import * as SecureStore from 'expo-secure-store';
+import { savePrivateKey } from '../utils/privateKeyStorage';
 import { getPublicKeyAsync, utils as edUtils, etc as edBytes } from '@noble/ed25519';
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
@@ -26,7 +26,6 @@ async function getJwtSecret(): Promise<string | null> {
   }
   return jwtSecretPromise;
 }
-const PRIVATE_KEY_KEY = 'ed25519_private_key';
 
 export class UsernameTakenError extends Error {
   constructor() {
@@ -154,7 +153,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const pub = await getPublicKeyAsync(priv);
       const privateKey = edBytes.bytesToHex(priv);
       const publicKey = edBytes.bytesToHex(pub);
-      await SecureStore.setItemAsync(PRIVATE_KEY_KEY, privateKey);
+      await savePrivateKey(privateKey);
       const existing = usersAgent.getAll().find((u) => u.username === username);
       if (existing) {
         throw new UsernameTakenError();

--- a/tests/__mocks__/@react-native-async-storage/async-storage.js
+++ b/tests/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,0 +1,5 @@
+module.exports = {
+  setItem: jest.fn(async () => {}),
+  getItem: jest.fn(async () => null),
+  removeItem: jest.fn(async () => {}),
+};

--- a/tests/privateKeyStorage.test.ts
+++ b/tests/privateKeyStorage.test.ts
@@ -1,0 +1,41 @@
+import { savePrivateKey, getPrivateKey, removePrivateKey } from '../utils/privateKeyStorage';
+import SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+jest.mock('expo-secure-store');
+jest.mock('@react-native-async-storage/async-storage');
+
+describe('privateKeyStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses SecureStore on native platforms', async () => {
+    (Platform as any).OS = 'ios';
+    await savePrivateKey('priv');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('ed25519_private_key', 'priv');
+
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('priv');
+    expect(await getPrivateKey()).toBe('priv');
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith('ed25519_private_key');
+
+    await removePrivateKey();
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('ed25519_private_key');
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('uses AsyncStorage on web', async () => {
+    (Platform as any).OS = 'web';
+    await savePrivateKey('priv');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('ed25519_private_key', 'priv');
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('priv');
+    expect(await getPrivateKey()).toBe('priv');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('ed25519_private_key');
+
+    await removePrivateKey();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('ed25519_private_key');
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+});

--- a/utils/privateKeyStorage.ts
+++ b/utils/privateKeyStorage.ts
@@ -1,0 +1,28 @@
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+const PRIVATE_KEY_KEY = 'ed25519_private_key';
+
+export async function savePrivateKey(key: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(PRIVATE_KEY_KEY, key);
+  } else {
+    await SecureStore.setItemAsync(PRIVATE_KEY_KEY, key);
+  }
+}
+
+export async function getPrivateKey(): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    return await AsyncStorage.getItem(PRIVATE_KEY_KEY);
+  }
+  return await SecureStore.getItemAsync(PRIVATE_KEY_KEY);
+}
+
+export async function removePrivateKey(): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(PRIVATE_KEY_KEY);
+  } else {
+    await SecureStore.deleteItemAsync(PRIVATE_KEY_KEY);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `privateKeyStorage` helper mirroring token storage
- store admin private key using the helper in onboarding and auth contexts
- add unit tests for new helper and mocks for AsyncStorage

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688a8f7f5d5c8326ac2f841ffe854fd9