### PR TITLE
Generate persistent JWT secret during onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ prompted for a few details:
   Pinata.
 - **MoonPay key** – optional value enabling credit card purchases through the
   MoonPay widget.
+- A JWT secret is generated automatically on first launch and stored locally.
 
 After saving the form your admin key pair is created locally and subsequent
 launches skip this screen.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,7 @@ import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
 import { ConfigProvider } from '../contexts/ConfigContext';
 import { loadTenantSettings } from '../constants/tenant';
+import { initConfig } from '../utils/appConfig';
 import OnboardingScreen from './onboarding';
 import { OnboardingProvider, useOnboarding } from '../contexts/OnboardingContext';
 
@@ -88,6 +89,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     (async () => {
+      await initConfig();
       await loadTenantSettings();
       setReady(true);
     })();

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Buffer } from 'buffer';
 import {
   View,
   Text,
@@ -23,7 +24,7 @@ import { sendWakuUserUpdate } from '../../lib/waku/sendWakuUserUpdate';
 
 export default function OnboardingScreen() {
   const { colors } = useTheme();
-  const { setValue } = useConfig();
+  const { config, setValue } = useConfig();
   const [tenant, setTenant] = useState('thecongress');
   const [appName, setAppName] = useState('');
   const [primaryColor, setPrimaryColor] = useState('');
@@ -44,6 +45,15 @@ export default function OnboardingScreen() {
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
   const { refreshOnboardingStatus } = useOnboarding();
+
+  useEffect(() => {
+    if (!config.EXPO_PUBLIC_JWT_SECRET) {
+      const bytes = new Uint8Array(32);
+      crypto.getRandomValues(bytes);
+      const secret = Buffer.from(bytes).toString('hex');
+      setValue('EXPO_PUBLIC_JWT_SECRET', secret);
+    }
+  }, []);
 
   const handleSubmit = async () => {
     if (!appName || !adminUser || !adminPass) {

--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
-import appConfig, { setConfig } from '../utils/appConfig';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import appConfig, { setConfig, initConfig, persist } from '../utils/appConfig';
 
 interface ConfigContextValue {
   config: Record<string, string>;
@@ -16,9 +16,16 @@ export const useConfig = () => useContext(ConfigContext);
 export function ConfigProvider({ children }: { children: React.ReactNode }) {
   const [, forceUpdate] = useState({});
 
+  useEffect(() => {
+    (async () => {
+      await initConfig();
+      forceUpdate({});
+    })();
+  }, []);
+
   const setValue = (key: string, value: string) => {
     setConfig(key, value);
-    // Trigger re-render for consumers
+    persist().catch(() => {});
     forceUpdate({});
   };
 

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,7 +1,19 @@
+import { loadConfig as loadConfigFromStorage, saveConfig as persistConfig } from './configStorage';
+
 const config: Record<string, string> = {};
+
+export async function initConfig(): Promise<void> {
+  const stored = await loadConfigFromStorage();
+  Object.assign(config, stored);
+}
+
+export async function persist(): Promise<void> {
+  await persistConfig(config);
+}
 
 export function setConfig(key: string, value: string): void {
   config[key] = value;
+  // persistence handled externally
 }
 
 export default config;

--- a/utils/configStorage.ts
+++ b/utils/configStorage.ts
@@ -1,0 +1,33 @@
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+const CONFIG_KEY = 'app_config';
+
+export async function loadConfig(): Promise<Record<string, string>> {
+  try {
+    const raw =
+      Platform.OS === 'web'
+        ? await AsyncStorage.getItem(CONFIG_KEY)
+        : await SecureStore.getItemAsync(CONFIG_KEY);
+    if (raw) {
+      return JSON.parse(raw);
+    }
+  } catch (err) {
+    console.warn('Failed to load config', err);
+  }
+  return {};
+}
+
+export async function saveConfig(config: Record<string, string>): Promise<void> {
+  try {
+    const data = JSON.stringify(config);
+    if (Platform.OS === 'web') {
+      await AsyncStorage.setItem(CONFIG_KEY, data);
+    } else {
+      await SecureStore.setItemAsync(CONFIG_KEY, data);
+    }
+  } catch (err) {
+    console.warn('Failed to save config', err);
+  }
+}


### PR DESCRIPTION
## Summary
- persist config values using new storage helper
- load saved config before tenant settings initialize
- generate a JWT secret automatically if one isn't set
- document JWT secret generation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688ac1fefc7c83268578c546323224dd