### PR TITLE
Require login before onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ All state is held in memory and hydrated from the Waku message history on boot. 
 
 ### Onboarding
 
-Start the app once the dependencies are installed. On first launch you will be
-prompted for a few details:
+Start the app once the dependencies are installed. The first screen prompts you
+to sign up or log in. After authentication you'll be asked for a few setup
+details:
 
-- **App name and admin credentials** – required to set up your local identity
-  and admin user.
+- **App name** – required to configure your local instance.
 - **Pinata keys** – optional values that enable media uploads to IPFS via
   Pinata.
 - **MoonPay key** – optional value enabling credit card purchases through the
   MoonPay widget.
 - A JWT secret is generated automatically on first launch and stored locally.
 
-After saving the form your admin key pair is created locally and subsequent
+After saving the form the configuration is stored locally and subsequent
 launches skip this screen.
 
 If you provided Pinata credentials the `PinataService` will upload any product

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@
 // normal imports:
 import React, { useEffect, useState } from 'react';
 import { View, ActivityIndicator } from 'react-native';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useFrameworkReady } from '../hooks/useFrameworkReady';
@@ -105,15 +105,23 @@ export default function RootLayout() {
 
   return (
     <ConfigProvider>
-      <OnboardingProvider>
-        <RootLayoutInner />
-      </OnboardingProvider>
+      <AuthProvider>
+        <OnboardingProvider>
+          <RootLayoutInner />
+        </OnboardingProvider>
+      </AuthProvider>
     </ConfigProvider>
   );
 }
 
 function RootLayoutInner() {
   const { onboarded } = useOnboarding();
+  const { isLoggedIn } = useAuth();
+  useEffect(() => {
+    if (onboarded === false && !isLoggedIn) {
+      router.replace('/auth/signup');
+    }
+  }, [onboarded, isLoggedIn]);
 
   if (onboarded === null) {
     return (
@@ -131,13 +139,11 @@ function RootLayoutInner() {
     <AppInfoProvider>
       <ThemeProvider>
         <LanguageProvider>
-          <AuthProvider>
-            <CurrencyProvider>
-              <NotificationProvider>
-                <AppContent />
-              </NotificationProvider>
-            </CurrencyProvider>
-          </AuthProvider>
+          <CurrencyProvider>
+            <NotificationProvider>
+              <AppContent />
+            </NotificationProvider>
+          </CurrencyProvider>
         </LanguageProvider>
       </ThemeProvider>
     </AppInfoProvider>

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -13,14 +13,11 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import bcrypt from 'bcryptjs';
-import { savePrivateKey } from '../../utils/privateKeyStorage';
-import { getPublicKeyAsync, utils as edUtils, etc as edBytes } from '@noble/ed25519';
+import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useConfig } from '../../contexts/ConfigContext';
 import InfoModal from '../../components/InfoModal';
 import { useOnboarding } from '../../contexts/OnboardingContext';
-import { sendWakuUserUpdate } from '../../lib/waku/sendWakuUserUpdate';
 
 export default function OnboardingScreen() {
   const { colors } = useTheme();
@@ -35,8 +32,7 @@ export default function OnboardingScreen() {
   const [moonpayKey, setMoonpayKey] = useState('');
   const [chatSecret, setChatSecret] = useState('');
   const [wakuSecret, setWakuSecret] = useState('');
-  const [adminUser, setAdminUser] = useState('');
-  const [adminPass, setAdminPass] = useState('');
+  const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [info, setInfo] = useState({
     visible: false,
@@ -56,11 +52,11 @@ export default function OnboardingScreen() {
   }, []);
 
   const handleSubmit = async () => {
-    if (!appName || !adminUser || !adminPass) {
+    if (!appName) {
       setInfo({
         visible: true,
         title: 'Error',
-        message: 'App name, admin username and password are required',
+        message: 'App name is required',
         type: 'error',
       });
       return;
@@ -68,7 +64,9 @@ export default function OnboardingScreen() {
     setLoading(true);
     try {
       setValue('EXPO_PUBLIC_TENANT', tenant);
-      setValue('EXPO_PUBLIC_ADMIN_USERNAME', adminUser);
+      if (user?.username) {
+        setValue('EXPO_PUBLIC_ADMIN_USERNAME', user.username);
+      }
       setValue('APP_NAME', appName);
       setValue('PRIMARY_COLOR', primaryColor);
       if (logo) setValue('APP_LOGO', logo);
@@ -78,33 +76,6 @@ export default function OnboardingScreen() {
       if (moonpayKey) setValue('MOONPAY_KEY', moonpayKey);
       if (chatSecret) setValue('EXPO_PUBLIC_CHAT_SECRET', chatSecret);
       if (wakuSecret) setValue('EXPO_PUBLIC_WAKU_SECRET', wakuSecret);
-
-      const hash = await bcrypt.hash(adminPass, 10);
-      const id = `admin_${Date.now()}`;
-      const priv = edUtils.randomPrivateKey();
-      const pub = await getPublicKeyAsync(priv);
-      await savePrivateKey(edBytes.bytesToHex(priv));
-      setValue('ADMIN_ID', id);
-      setValue('ADMIN_USERNAME', adminUser);
-      setValue('ADMIN_HASH', hash);
-      setValue('ADMIN_PUBLIC_KEY', edBytes.bytesToHex(pub));
-
-      const user = {
-        id,
-        username: adminUser,
-        displayName: 'Admin',
-        tenant_id: tenant,
-        role: 'admin',
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      };
-
-      await sendWakuUserUpdate(user, {
-        id,
-        publicKey: edBytes.bytesToHex(pub),
-        role: 'admin',
-        privateKey: edBytes.bytesToHex(priv),
-      });
 
       setValue('ONBOARD_COMPLETE', 'true');
       await refreshOnboardingStatus();
@@ -192,12 +163,8 @@ export default function OnboardingScreen() {
             <TextInput style={[styles.input, { borderColor: colors.border.primary, color: colors.text.primary, backgroundColor: colors.surface.primary }]} value={wakuSecret} onChangeText={setWakuSecret} />
           </View>
           <View style={styles.formGroup}>
-            <Text style={[styles.label, { color: colors.text.primary }]}>Admin Username *</Text>
-            <TextInput style={[styles.input, { borderColor: colors.border.primary, color: colors.text.primary, backgroundColor: colors.surface.primary }]} value={adminUser} onChangeText={setAdminUser} autoCapitalize="none" />
-          </View>
-          <View style={styles.formGroup}>
-            <Text style={[styles.label, { color: colors.text.primary }]}>Admin Password *</Text>
-            <TextInput style={[styles.input, { borderColor: colors.border.primary, color: colors.text.primary, backgroundColor: colors.surface.primary }]} value={adminPass} onChangeText={setAdminPass} secureTextEntry autoCapitalize="none" />
+            <Text style={[styles.label, { color: colors.text.primary }]}>Admin</Text>
+            <Text style={{ color: colors.text.primary, textAlign: 'right' }}>{user?.username}</Text>
           </View>
           <TouchableOpacity
             style={[styles.button, { backgroundColor: colors.gold }, loading && { backgroundColor: colors.interactive.disabled }]}


### PR DESCRIPTION
## Summary
- wrap AuthProvider around OnboardingProvider
- redirect unauthenticated users to signup screen
- use logged in user info during onboarding
- simplify onboarding form
- document that authentication comes first

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b593358c88326b34bd66f3218dc2d