### PR TITLE
Fix tenant-based loading in AppInfoContext

### DIFF
--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -48,7 +48,6 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   useEffect(() => {
     const t = config.EXPO_PUBLIC_TENANT;
     setTenant(t || 'default');
-    loadInfo();
   }, []);
 
   const loadInfo = async () => {
@@ -88,6 +87,12 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       console.error('Error loading app info:', e);
     }
   };
+
+  useEffect(() => {
+    if (tenant) {
+      loadInfo();
+    }
+  }, [tenant]);
 
   const scheduleLoadInfo = () => {
     if (reloadTimeout.current) {


### PR DESCRIPTION
## Summary
- defer loading app info until tenant is known
- trigger app info load whenever tenant changes

## Testing
- `yarn install --ignore-engines`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688bca84e5648326bd96a3dbd812dbe1