### PR TITLE
Use AsyncStorage for session tokens

### DIFF
--- a/tests/tokenStorage.test.ts
+++ b/tests/tokenStorage.test.ts
@@ -1,0 +1,47 @@
+import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+jest.mock('@react-native-async-storage/async-storage');
+
+describe('tokenStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global as any).window = {};
+  });
+
+  it('uses AsyncStorage on native platforms', async () => {
+    (Platform as any).OS = 'ios';
+
+    await saveToken('tok');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('auth_token', 'tok');
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('tok');
+    expect(await getToken()).toBe('tok');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('auth_token');
+
+    await removeToken();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('auth_token');
+  });
+
+  it('uses localStorage on web', async () => {
+    (Platform as any).OS = 'web';
+    const storage = {
+      setItem: jest.fn(),
+      getItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+    (global as any).window = { localStorage: storage };
+
+    await saveToken('tok');
+    expect(storage.setItem).toHaveBeenCalledWith('auth_token', 'tok');
+
+    storage.getItem.mockReturnValue('tok');
+    expect(await getToken()).toBe('tok');
+    expect(storage.getItem).toHaveBeenCalledWith('auth_token');
+
+    await removeToken();
+    expect(storage.removeItem).toHaveBeenCalledWith('auth_token');
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});

--- a/utils/tokenStorage.ts
+++ b/utils/tokenStorage.ts
@@ -1,28 +1,33 @@
-import * as SecureStore from 'expo-secure-store';
-import Cookies from 'js-cookie';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
 const TOKEN_KEY = 'auth_token';
 
 export async function saveToken(token: string): Promise<void> {
   if (Platform.OS === 'web') {
-    Cookies.set(TOKEN_KEY, token);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(TOKEN_KEY, token);
+    }
   } else {
-    await SecureStore.setItemAsync(TOKEN_KEY, token);
+    await AsyncStorage.setItem(TOKEN_KEY, token);
   }
 }
 
 export async function getToken(): Promise<string | null> {
   if (Platform.OS === 'web') {
-    return Cookies.get(TOKEN_KEY) || null;
+    return typeof window !== 'undefined'
+      ? window.localStorage.getItem(TOKEN_KEY)
+      : null;
   }
-  return await SecureStore.getItemAsync(TOKEN_KEY);
+  return await AsyncStorage.getItem(TOKEN_KEY);
 }
 
 export async function removeToken(): Promise<void> {
   if (Platform.OS === 'web') {
-    Cookies.remove(TOKEN_KEY);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(TOKEN_KEY);
+    }
   } else {
-    await SecureStore.deleteItemAsync(TOKEN_KEY);
+    await AsyncStorage.removeItem(TOKEN_KEY);
   }
 }


### PR DESCRIPTION
## Summary
- swap cookie storage for AsyncStorage with localStorage fallback
- add tests for tokenStorage

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: incompatible Node engine)*

------
https://chatgpt.com/codex/tasks/task_e_688beb0548b88326ac3a3227ca06b987