### PR TITLE
Fix JWT secret refresh

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -19,12 +19,8 @@ async function getAdminUsernames(): Promise<string[]> {
     .map((u) => u.trim())
     .filter(Boolean);
 }
-let jwtSecretPromise: Promise<string | null> | null = null;
 async function getJwtSecret(): Promise<string | null> {
-  if (!jwtSecretPromise) {
-    jwtSecretPromise = Promise.resolve(config.EXPO_PUBLIC_JWT_SECRET || null);
-  }
-  return jwtSecretPromise;
+  return config.EXPO_PUBLIC_JWT_SECRET || null;
 }
 
 export class UsernameTakenError extends Error {

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -5,12 +5,8 @@ import cartAgent from '../agents/cart-agent';
 import JWT from 'expo-jwt';
 import config from '../utils/appConfig';
 
-let jwtSecretPromise: Promise<string | null> | null = null;
 async function getJwtSecret(): Promise<string | null> {
-  if (!jwtSecretPromise) {
-    jwtSecretPromise = Promise.resolve(config.EXPO_PUBLIC_JWT_SECRET || null);
-  }
-  return jwtSecretPromise;
+  return config.EXPO_PUBLIC_JWT_SECRET || null;
 }
 import { getToken } from '../utils/tokenStorage';
 import { isTokenValid } from '../utils/jwtSession';

--- a/utils/jwtSession.ts
+++ b/utils/jwtSession.ts
@@ -1,12 +1,8 @@
 import JWT from 'expo-jwt';
 import config from './appConfig';
 
-let jwtSecretPromise: Promise<string | null> | null = null;
 async function getJwtSecret(): Promise<string | null> {
-  if (!jwtSecretPromise) {
-    jwtSecretPromise = Promise.resolve(config.EXPO_PUBLIC_JWT_SECRET || null);
-  }
-  return jwtSecretPromise;
+  return config.EXPO_PUBLIC_JWT_SECRET || null;
 }
 
 export async function isTokenValid(token: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- always read latest JWT secret from appConfig
- update AuthContext and CartService to use non-cached secret

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688beb05346883269ebb762c99b52117