### PR TITLE
Load config from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ If you provided Pinata credentials the `PinataService` will upload any product
 images or videos to IPFS automatically. Without these keys the app simply keeps
 the local file URIs.
 
+### Environment Variables
+
+The app also checks `process.env` for known configuration keys when it starts.
+If a variable is defined it **overrides** the value stored locally. This allows
+secrets to be injected at runtime without editing the on-device config. The
+recognized keys include:
+
+- `EXPO_PUBLIC_JWT_SECRET`
+- `EXPO_PUBLIC_CHAT_SECRET`
+- `EXPO_PUBLIC_WAKU_SECRET`
+- `EXPO_PUBLIC_USE_WAKU`
+- `EXPO_PUBLIC_ADMIN_USERNAME`
+- `EXPO_PUBLIC_PINATA_JWT`
+- `EXPO_PUBLIC_PINATA_API_KEY`
+- `EXPO_PUBLIC_PINATA_SECRET_API_KEY`
+- `EXPO_PUBLIC_TENANT`
+- `EXPO_PUBLIC_DEBUG_LOGS`
+- `MOONPAY_KEY`
+- `APP_NAME`
+- `PRIMARY_COLOR`
+- `APP_LOGO`
+
 ### Credit Card Checkout
 
 Providing a MoonPay key enables the `MoonPayModal` component for credit card

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,10 +1,37 @@
 import { loadConfig as loadConfigFromStorage, saveConfig as persistConfig } from './configStorage';
 
+// Configuration values are stored locally but can be overridden by
+// environment variables. When a value exists in `process.env` it
+// takes precedence over the persisted config.
+
 const config: Record<string, string> = {};
+
+const ENV_KEYS = [
+  'EXPO_PUBLIC_JWT_SECRET',
+  'EXPO_PUBLIC_CHAT_SECRET',
+  'EXPO_PUBLIC_WAKU_SECRET',
+  'EXPO_PUBLIC_USE_WAKU',
+  'EXPO_PUBLIC_ADMIN_USERNAME',
+  'EXPO_PUBLIC_PINATA_JWT',
+  'EXPO_PUBLIC_PINATA_API_KEY',
+  'EXPO_PUBLIC_PINATA_SECRET_API_KEY',
+  'EXPO_PUBLIC_TENANT',
+  'EXPO_PUBLIC_DEBUG_LOGS',
+  'MOONPAY_KEY',
+  'APP_NAME',
+  'PRIMARY_COLOR',
+  'APP_LOGO',
+];
 
 export async function initConfig(): Promise<void> {
   const stored = await loadConfigFromStorage();
   Object.assign(config, stored);
+  for (const key of ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
 }
 
 export async function persist(): Promise<void> {


### PR DESCRIPTION
## Summary
- allow `initConfig` to pull known config keys from `process.env`
- document the behaviour and precedence in README

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*
- `yarn test` *(fails: jest not found due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_688bf3c6dfb8832696c71d166020a414