### PR TITLE
Broadcast user when Waku config becomes available

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  ReactNode,
+} from 'react';
 import usersAgent from '../agents/users-agent';
 import bcrypt from 'bcryptjs';
 import JWT from 'expo-jwt';
@@ -7,6 +14,8 @@ import { getPublicKeyAsync, utils as edUtils, etc as edBytes } from '@noble/ed25
 import { saveToken, getToken, removeToken } from '../utils/tokenStorage';
 import { isTokenValid, refreshToken } from '../utils/jwtSession';
 import config from '../utils/appConfig';
+import { useConfig } from '../contexts/ConfigContext';
+import { isWakuConfigured } from '../lib/waku/isWakuConfigured';
 
 async function getAdminUsernames(): Promise<string[]> {
   const raw = config.EXPO_PUBLIC_ADMIN_USERNAME || '';
@@ -64,6 +73,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [session, setSession] = useState<any | null>(null);
   const [user, setUser] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
+  const { config: cfg } = useConfig();
+  const wakuReady = useRef(false);
 
   useEffect(() => {
     const init = async () => {
@@ -238,6 +249,22 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
     }
   };
+
+  useEffect(() => {
+    (async () => {
+      const ready = await isWakuConfigured();
+      if (ready && !wakuReady.current) {
+        wakuReady.current = true;
+        if (user) {
+          usersAgent.update(user).catch((e) => {
+            console.error('Failed broadcasting user via Waku', e);
+          });
+        }
+      } else if (!ready) {
+        wakuReady.current = false;
+      }
+    })();
+  }, [cfg.EXPO_PUBLIC_USE_WAKU, cfg.EXPO_PUBLIC_WAKU_SECRET, user]);
 
   const value: AuthContextType = {
     isLoggedIn: !!session,


### PR DESCRIPTION
## Summary
- watch Waku settings in `AuthContext`
- send current user over Waku when Waku config becomes usable

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688bfb906fd88326b3e190cbd120c496