### PR TITLE
Ensure Waku agents can be awaited

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -71,13 +71,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         const token = await getToken();
         if (token && (await isTokenValid(token))) {
           const JWT_SECRET = await getJwtSecret();
-          if (JWT_SECRET) {
-            const payload: any = JWT.decode(token, JWT_SECRET);
-            setSession(token);
-            if (payload?.sub) {
-              await loadProfile(payload.sub);
-            }
-          } else {
+            if (JWT_SECRET) {
+              const payload: any = JWT.decode(token, JWT_SECRET);
+              setSession(token);
+              if (payload?.sub) {
+                await usersAgent.ready();
+                await loadProfile(payload.sub);
+              }
+            } else {
             await removeToken();
           }
         } else {

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -25,7 +25,7 @@ export default class WakuAgent<T extends { id: string }> {
   protected store: Map<string, T> = new Map();
   private node: any | null = null;
   private decoder: any | null = null;
-  private ready: Promise<void> | null = null;
+  private readyPromise: Promise<void> | null = null;
   protected hashCache: Set<string> = new Set();
 
   constructor(
@@ -33,7 +33,7 @@ export default class WakuAgent<T extends { id: string }> {
     private options: WakuAgentOptions<T> = {}
   ) {
     if (this.options.topic) {
-      this.ready = this.init();
+      this.readyPromise = this.init();
     }
   }
 
@@ -63,6 +63,10 @@ export default class WakuAgent<T extends { id: string }> {
 
   clearHashCache(): void {
     this.hashCache.clear();
+  }
+
+  ready(): Promise<void> {
+    return this.readyPromise || Promise.resolve();
   }
 
   private async init() {


### PR DESCRIPTION
## Summary
- expose a `ready()` method on `WakuAgent`
- wait for `usersAgent` initialization before loading profile data

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688bfb933bb08326a1a7a38abfb272ec