### PR TITLE
Enable default Waku config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ export EXPO_PUBLIC_CHAT_SECRET=test_chat_secret
 
 Set them in your shell or enter them in the system settings screen after the app starts. You can modify them later from that screen at any time.
 
+If `EXPO_PUBLIC_USE_WAKU` or `EXPO_PUBLIC_WAKU_SECRET` are omitted, the app
+defaults to `EXPO_PUBLIC_USE_WAKU=true` with a `test_waku_secret` so that user
+profiles persist across refreshes.
+
 ### Onboarding
 
 Start the app once the dependencies are installed. The first screen prompts you

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -79,7 +79,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     const init = async () => {
       try {
-        await usersAgent.ready();
+        await usersAgent.whenReady();
         let token = await getToken();
         if (token && (await isTokenValid(token))) {
           const JWT_SECRET = await getJwtSecret();
@@ -87,7 +87,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
               const payload: any = JWT.decode(token, JWT_SECRET);
               setSession(token);
               if (payload?.sub) {
-                await usersAgent.ready();
+                await usersAgent.whenReady();
                 await loadProfile(payload.sub);
               }
             } else {

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -32,6 +32,17 @@ export async function initConfig(): Promise<void> {
       config[key] = value;
     }
   }
+
+  // Enable Waku by default using the test secret when no
+  // configuration was provided. This allows user data to
+  // persist between reloads without manual environment
+  // setup.
+  if (!config.EXPO_PUBLIC_WAKU_SECRET) {
+    config.EXPO_PUBLIC_WAKU_SECRET = 'test_waku_secret';
+  }
+  if (!config.EXPO_PUBLIC_USE_WAKU) {
+    config.EXPO_PUBLIC_USE_WAKU = 'true';
+  }
 }
 
 export async function persist(): Promise<void> {

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -26,6 +26,8 @@ export default class WakuAgent<T extends { id: string }> {
   private node: any | null = null;
   private decoder: any | null = null;
   private readyPromise: Promise<void> | null = null;
+  /** Exposed promise for external consumers */
+  public ready: Promise<void> | null = null;
   protected hashCache: Set<string> = new Set();
 
   constructor(
@@ -34,10 +36,11 @@ export default class WakuAgent<T extends { id: string }> {
   ) {
     if (this.options.topic) {
       this.readyPromise = this.init();
+      this.ready = this.readyPromise;
     }
   }
 
-  async ready(): Promise<void> {
+  async whenReady(): Promise<void> {
     if (this.readyPromise) {
       await this.readyPromise;
     }
@@ -71,9 +74,6 @@ export default class WakuAgent<T extends { id: string }> {
     this.hashCache.clear();
   }
 
-  ready(): Promise<void> {
-    return this.readyPromise || Promise.resolve();
-  }
 
   private async init() {
     if (!(await isWakuConfigured())) return;


### PR DESCRIPTION
## Summary
- default to running Waku using the test secret if no environment config is supplied
- expose a public `ready` promise from `WakuAgent` and provide `whenReady()` helper
- update `AuthContext` to use the new `whenReady()` function
- document the automatic Waku fallback in the README

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688cc457df6c8326a991d82175b235c4