### PR TITLE
Hide WebSocket info banner

### DIFF
--- a/lib/waku/sendWakuCartUpdate.ts
+++ b/lib/waku/sendWakuCartUpdate.ts
@@ -10,7 +10,10 @@ export const sendWakuCartUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuCategoryUpdate.ts
+++ b/lib/waku/sendWakuCategoryUpdate.ts
@@ -10,7 +10,10 @@ export const sendWakuCategoryUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -10,7 +10,10 @@ export const sendWakuNotificationUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -10,7 +10,10 @@ export const sendWakuOrderUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -11,7 +11,10 @@ export const sendWakuProductUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -14,7 +14,10 @@ export const sendWakuSettingsUpdate = async (
   const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -32,7 +32,10 @@ export const sendWakuUserUpdate = async (
     if (stored) privateKey = stored;
   }
 
-  const node = await createLightNode({ defaultBootstrap: true });
+  const node = await createLightNode({
+    defaultBootstrap: true,
+    libp2p: { hideWebSocketInfo: true },
+  });
   try {
     await node.start();
     await waitForRemotePeer(node, [Protocols.LightPush]);

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -88,7 +88,10 @@ export default class WakuAgent<T extends { id: string }> {
     if (!(await isWakuConfigured())) return;
     try {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
-      this.node = await createLightNode({ defaultBootstrap: true });
+      this.node = await createLightNode({
+        defaultBootstrap: true,
+        libp2p: { hideWebSocketInfo: true },
+      });
       await this.node.start();
       await waitForRemotePeer(this.node, [Protocols.Store, Protocols.LightPush]);
       if (!this.options.topic) return;


### PR DESCRIPTION
## Summary
- suppress WebSocket info in Waku light nodes
- apply option across all send helpers

## Testing
- `yarn test`
- `yarn start` (checked output for lack of banner)


------
https://chatgpt.com/codex/tasks/task_e_688cd645a2f88326b0d5d4bc507b10b5