### PR TITLE
Disable Waku if secret missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Expo project uses React Native with the Expo Router.
 
 ## Setup
 
-Run `yarn install` to populate `node_modules`. All data is ephemeral and synchronized between peers over Waku; no external services are required.
+Run `yarn install` to populate `node_modules`. All data is ephemeral and can be synchronized between peers over Waku when enabled; no external services are required.
 
 ```sh
 yarn install
@@ -30,9 +30,9 @@ export EXPO_PUBLIC_CHAT_SECRET=test_chat_secret
 
 Set them in your shell or enter them in the system settings screen after the app starts. You can modify them later from that screen at any time.
 
-If `EXPO_PUBLIC_USE_WAKU` or `EXPO_PUBLIC_WAKU_SECRET` are omitted, the app
-defaults to `EXPO_PUBLIC_USE_WAKU=true` with a `test_waku_secret` so that user
-profiles persist across refreshes.
+Waku synchronization is disabled until `EXPO_PUBLIC_WAKU_SECRET` is provided.
+Once a secret is set, you can enable peer-to-peer sync by setting
+`EXPO_PUBLIC_USE_WAKU=true`.
 
 ### Onboarding
 
@@ -120,7 +120,7 @@ appropriate `sendWaku...Update` function to broadcast the update. Each agent
 listens for new messages on its topic and applies them automatically, so data
 can be rehydrated from history at any time.
 
-Agents only start when `EXPO_PUBLIC_USE_WAKU=true`. Disable Waku to keep data purely local.
+Agents only start when `EXPO_PUBLIC_USE_WAKU=true` and a secret is provided. Without a secret Waku remains disabled and data stays purely local.
 
 ### Web Notes
 

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -33,14 +33,12 @@ export async function initConfig(): Promise<void> {
     }
   }
 
-  // Enable Waku by default using the test secret when no
-  // configuration was provided. This allows user data to
-  // persist between reloads without manual environment
-  // setup.
+  // If no Waku secret was provided disable peer-to-peer sync and warn
   if (!config.EXPO_PUBLIC_WAKU_SECRET) {
-    config.EXPO_PUBLIC_WAKU_SECRET = 'test_waku_secret';
-  }
-  if (!config.EXPO_PUBLIC_USE_WAKU) {
+    config.EXPO_PUBLIC_USE_WAKU = 'false';
+    console.warn('EXPO_PUBLIC_WAKU_SECRET missing; Waku disabled');
+  } else if (!config.EXPO_PUBLIC_USE_WAKU) {
+    // Enable Waku by default when a secret exists
     config.EXPO_PUBLIC_USE_WAKU = 'true';
   }
 }


### PR DESCRIPTION
## Summary
- disable Waku when `EXPO_PUBLIC_WAKU_SECRET` isn't provided
- warn when no secret is set
- clarify in README that Waku is disabled until a secret is configured

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce208bb3883268f75203b1ac171ba