### PR TITLE
Add Waku LightNode singleton

### DIFF
--- a/lib/waku/nodeSingleton.ts
+++ b/lib/waku/nodeSingleton.ts
@@ -1,0 +1,27 @@
+import type { LightNode } from '@waku/sdk';
+
+let nodePromise: Promise<LightNode> | null = null;
+
+export async function getNode(): Promise<LightNode> {
+  if (!nodePromise) {
+    nodePromise = (async () => {
+      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+      const n = await createLightNode({
+        defaultBootstrap: true,
+        libp2p: { hideWebSocketInfo: true },
+      });
+      await n.start();
+      await waitForRemotePeer(n, [Protocols.LightPush]);
+      return n;
+    })();
+  }
+  return nodePromise;
+}
+
+export async function stopNode(): Promise<void> {
+  if (nodePromise) {
+    const n = await nodePromise;
+    await n.stop();
+    nodePromise = null;
+  }
+}

--- a/lib/waku/sendWakuCartUpdate.ts
+++ b/lib/waku/sendWakuCartUpdate.ts
@@ -1,22 +1,16 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { getNode } from './nodeSingleton';
 
 export const sendWakuCartUpdate = async (
   cartItem: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
     const payloadObj = {
       type: 'cart.update',
@@ -42,7 +36,4 @@ export const sendWakuCartUpdate = async (
 
     const encoder = node.createEncoder({ contentTopic: '/congress/cart/1' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/lib/waku/sendWakuCategoryUpdate.ts
+++ b/lib/waku/sendWakuCategoryUpdate.ts
@@ -1,22 +1,16 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { getNode } from './nodeSingleton';
 
 export const sendWakuCategoryUpdate = async (
   category: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
     const payloadObj = {
       type: 'category.update',
@@ -42,7 +36,4 @@ export const sendWakuCategoryUpdate = async (
 
     const encoder = node.createEncoder({ contentTopic: '/congress/categories/1' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -1,22 +1,16 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { getNode } from './nodeSingleton';
 
 export const sendWakuNotificationUpdate = async (
   notification: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
     const payloadObj = {
       type: 'notification.update',
@@ -42,7 +36,4 @@ export const sendWakuNotificationUpdate = async (
 
     const encoder = node.createEncoder({ contentTopic: '/congress/notifications/1' });
     await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,22 +1,16 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { getNode } from './nodeSingleton';
 
 export const sendWakuOrderUpdate = async (
   order: any,
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
   const payloadObj = {
     type: 'order.update',
@@ -42,7 +36,4 @@ export const sendWakuOrderUpdate = async (
 
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,6 +1,7 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { getNode } from './nodeSingleton';
 
 
 export const sendWakuProductUpdate = async (
@@ -8,16 +9,9 @@ export const sendWakuProductUpdate = async (
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
   const payloadObj = {
     type: 'product.update',
@@ -43,7 +37,4 @@ export const sendWakuProductUpdate = async (
 
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,7 +1,7 @@
 import type { WakuSender } from './sendWakuUserUpdate';
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
-
+import { getNode } from './nodeSingleton';
 
 export const sendWakuSettingsUpdate = async (
   key: string,
@@ -11,47 +11,35 @@ export const sendWakuSettingsUpdate = async (
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
-    const payloadObj = {
-      type: 'settings.update',
-      key,
-      value,
-      createdAt,
-      updatedAt,
-      sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
-    };
-    const payload = JSON.stringify(payloadObj);
+  const payloadObj = {
+    type: 'settings.update',
+    key,
+    value,
+    createdAt,
+    updatedAt,
+    sender: { id: sender.id, publicKey: sender.publicKey, role: sender.role },
+  };
+  const payload = JSON.stringify(payloadObj);
 
-    let signature = '';
-    if (sender.privateKey) {
-      try {
-        const hash = sha256(new TextEncoder().encode(payload));
-        const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
-        signature = edBytes.bytesToHex(sig);
-      } catch (e) {
-        console.error('Failed to sign Waku message', e);
-      }
+  let signature = '';
+  if (sender.privateKey) {
+    try {
+      const hash = sha256(new TextEncoder().encode(payload));
+      const sig = await sign(hash, edBytes.hexToBytes(sender.privateKey));
+      signature = edBytes.bytesToHex(sig);
+    } catch (e) {
+      console.error('Failed to sign Waku message', e);
     }
-
-    const message = JSON.stringify({ ...payloadObj, signature });
-
-    const encrypted = await encryptWakuPayload(message);
-
-    const encoder = node.createEncoder({ contentTopic: '/congress/settings/1/proto' });
-    await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-
-  } finally {
-    await node.stop();
   }
 
+  const message = JSON.stringify({ ...payloadObj, signature });
+
+  const encrypted = await encryptWakuPayload(message);
+
+  const encoder = node.createEncoder({ contentTopic: '/congress/settings/1/proto' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,6 +1,7 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { getPrivateKey } from '../../utils/privateKeyStorage';
+import { getNode } from './nodeSingleton';
 
 
 export interface WakuSender {
@@ -16,7 +17,6 @@ export const sendWakuUserUpdate = async (
   sender: WakuSender = { id: '', publicKey: '', role: '' },
   privateKey = ''
 ) => {
-  const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
   const { sign, etc: edBytes } = await import('@noble/ed25519');
 
   // populate missing sender fields from the user record
@@ -32,13 +32,7 @@ export const sendWakuUserUpdate = async (
     if (stored) privateKey = stored;
   }
 
-  const node = await createLightNode({
-    defaultBootstrap: true,
-    libp2p: { hideWebSocketInfo: true },
-  });
-  try {
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.LightPush]);
+  const node = await getNode();
 
   const payloadObj = {
     type: 'user.update',
@@ -65,7 +59,4 @@ export const sendWakuUserUpdate = async (
 
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
-  } finally {
-    await node.stop();
-  }
 };

--- a/tests/wakuUpdates.test.ts
+++ b/tests/wakuUpdates.test.ts
@@ -6,25 +6,15 @@ import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpda
 jest.mock('../lib/waku/wakuCrypto', () => ({
   encryptWakuPayload: jest.fn(async (p: string) => p),
 }));
-
-const start = jest.fn();
-const stop = jest.fn();
 const node = {
-  start,
-  stop,
   createEncoder: jest.fn(() => ({})),
   lightPush: { send: jest.fn() },
 };
 
-jest.mock(
-  '@waku/sdk',
-  () => ({
-    createLightNode: jest.fn(async () => node),
-    waitForRemotePeer: jest.fn(async () => undefined),
-    Protocols: { LightPush: 'lightpush' },
-  }),
-  { virtual: true }
-);
+jest.mock('../lib/waku/nodeSingleton', () => ({
+  getNode: jest.fn(async () => node),
+  stopNode: jest.fn(),
+}));
 
 jest.mock('@noble/ed25519', () => ({
   sign: jest.fn(),
@@ -32,35 +22,33 @@ jest.mock('@noble/ed25519', () => ({
 }));
 
 describe('Waku send updates', () => {
+  const { getNode } = require('../lib/waku/nodeSingleton');
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('user update creates and stops node', async () => {
+  it('user update uses shared node', async () => {
     await sendWakuUserUpdate({});
-    const { createLightNode } = await import('@waku/sdk');
-    expect(createLightNode).toHaveBeenCalled();
-    expect(stop).toHaveBeenCalled();
+    expect(getNode).toHaveBeenCalled();
+    expect(node.lightPush.send).toHaveBeenCalled();
   });
 
-  it('product update creates and stops node', async () => {
+  it('product update uses shared node', async () => {
     await sendWakuProductUpdate({});
-    const { createLightNode } = await import('@waku/sdk');
-    expect(createLightNode).toHaveBeenCalled();
-    expect(stop).toHaveBeenCalled();
+    expect(getNode).toHaveBeenCalled();
+    expect(node.lightPush.send).toHaveBeenCalled();
   });
 
-  it('order update creates and stops node', async () => {
+  it('order update uses shared node', async () => {
     await sendWakuOrderUpdate({});
-    const { createLightNode } = await import('@waku/sdk');
-    expect(createLightNode).toHaveBeenCalled();
-    expect(stop).toHaveBeenCalled();
+    expect(getNode).toHaveBeenCalled();
+    expect(node.lightPush.send).toHaveBeenCalled();
   });
 
-  it('notification update creates and stops node', async () => {
+  it('notification update uses shared node', async () => {
     await sendWakuNotificationUpdate({});
-    const { createLightNode } = await import('@waku/sdk');
-    expect(createLightNode).toHaveBeenCalled();
-    expect(stop).toHaveBeenCalled();
+    expect(getNode).toHaveBeenCalled();
+    expect(node.lightPush.send).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- implement `getNode`/`stopNode` helper managing a single `LightNode`
- refactor all `sendWaku*` modules to reuse this node
- update tests to mock the new singleton

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce20ecff88326971ac3d31be89f6a