### PR TITLE
Use tonconnect connection restoration hook

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, useContext, ReactNode } from 'react';
-import { useTonConnectUI, useTonWallet, useTonAddress } from '@tonconnect/ui-react';
+import {
+  useTonConnectUI,
+  useTonAddress,
+  useIsConnectionRestored,
+} from '@tonconnect/ui-react';
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -33,12 +37,8 @@ interface AuthProviderProps { children: ReactNode }
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const { openModal, tonConnectUI } = useTonConnectUI();
-  const wallet = useTonWallet();
   const address = useTonAddress();
-
-  React.useEffect(() => {
-    tonConnectUI.connectionRestore();
-  }, [tonConnectUI]);
+  const connectionRestored = useIsConnectionRestored();
 
   const login = async () => {
     openModal();
@@ -51,6 +51,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const user = address ? { id: address, address } : null;
+
+  if (!connectionRestored) {
+    return null;
+  }
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
## Summary
- replace invalid tonconnect `connectionRestore` call with `useIsConnectionRestored`
- render children only after wallet session restoration completes

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68914e0677008326b7c891ef1e651c03