### PR TITLE
Use TonConnectButton for wallet connection

### DIFF
--- a/components/WalletConnectButton.tsx
+++ b/components/WalletConnectButton.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
-import { useTonConnectUI, useTonWallet, useTonAddress } from '@tonconnect/ui-react';
+import { TonConnectButton, useTonWallet, useTonAddress } from '@tonconnect/ui-react';
 
 export default function WalletConnectButton() {
-  const { openModal } = useTonConnectUI();
   const wallet = useTonWallet();
   const address = useTonAddress();
 
   return (
     <View style={{ alignItems: 'center', gap: 12 }}>
-      {!wallet ? (
-        <Button title="Connect Wallet" onPress={openModal} />
-      ) : (
-        <Text>{address}</Text>
-      )}
+      <TonConnectButton />
+      {wallet && <Text>{address}</Text>}
       <Button title="Connect with MetaMask" onPress={() => alert('MetaMaskConnect coming soon.')} />
     </View>
   );


### PR DESCRIPTION
## Summary
- replace manual TON wallet connection logic with `TonConnectButton`
- display connected wallet address when available
- keep MetaMask placeholder connect button

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891513897648326bcc846e1521df04c