### PR TITLE
feat: close auth modal before wallet connect

### DIFF
--- a/components/AuthTabsModal.tsx
+++ b/components/AuthTabsModal.tsx
@@ -20,7 +20,7 @@ export default function AuthTabsModal({ visible, onClose }: AuthTabsModalProps) 
           <TouchableOpacity style={styles.close} onPress={onClose}>
             <X size={24} color={colors.text.primary} />
           </TouchableOpacity>
-          <WalletConnectButton />
+          <WalletConnectButton onConnect={onClose} />
         </View>
       </View>
     </Modal>

--- a/components/WalletConnectButton.tsx
+++ b/components/WalletConnectButton.tsx
@@ -1,16 +1,36 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
-import { TonConnectButton, useTonWallet, useTonAddress } from '@tonconnect/ui-react';
+import {
+  TonConnectButton,
+  useTonWallet,
+  useTonAddress,
+  useTonConnectUI,
+} from '@tonconnect/ui-react';
 
-export default function WalletConnectButton() {
+interface WalletConnectButtonProps {
+  onConnect?: () => void;
+}
+
+export default function WalletConnectButton({ onConnect }: WalletConnectButtonProps) {
   const wallet = useTonWallet();
   const address = useTonAddress();
+  const { openModal } = useTonConnectUI();
+
+  const handleTonConnect = () => {
+    onConnect?.();
+    openModal();
+  };
+
+  const handleMetaMaskConnect = () => {
+    onConnect?.();
+    alert('MetaMaskConnect coming soon.');
+  };
 
   return (
     <View style={{ alignItems: 'center', gap: 12 }}>
-      <TonConnectButton />
+      <TonConnectButton onClick={handleTonConnect} />
       {wallet && <Text>{address}</Text>}
-      <Button title="Connect with MetaMask" onPress={() => alert('MetaMaskConnect coming soon.')} />
+      <Button title="Connect with MetaMask" onPress={handleMetaMaskConnect} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- close auth modal before opening wallet connect
- add optional callback on wallet connect button

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68916545811c8326b5b7fcb4e4f8e1a9