### PR TITLE
fix: configure tonconnect manifest

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -117,8 +117,13 @@ export default function RootLayout() {
     );
   }
 
+  const manifestUrl =
+    typeof window !== 'undefined'
+      ? new URL('/tonconnect-manifest.json', window.location.origin).href
+      : '/tonconnect-manifest.json';
+
   return (
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl={manifestUrl}>
       <ConfigProvider>
         <AuthProvider>
           <OnboardingProvider>

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://yourapp.com",
-  "name": "Your App Name",
-  "iconUrl": "https://yourapp.com/icon.png",
-  "termsOfUseUrl": "https://yourapp.com/terms",
-  "privacyPolicyUrl": "https://yourapp.com/privacy"
+  "url": "https://blue-ocean.vercel.app",
+  "name": "The Congress",
+  "iconUrl": "https://blue-ocean.vercel.app/assets/images/icon.png",
+  "termsOfUseUrl": "https://blue-ocean.vercel.app/terms",
+  "privacyPolicyUrl": "https://blue-ocean.vercel.app/privacy"
 }


### PR DESCRIPTION
## Summary
- remove duplicate public icon and reference Expo icon in TonConnect manifest
- maintain absolute TonConnect manifest URL for consistent wallet loading

## Testing
- `CI=1 yarn test`
- `yarn build:web`


------
https://chatgpt.com/codex/tasks/task_e_6891654d47b8832685df7db11147b517