### PR TITLE
Ensure TonConnect manifest in web build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ expo-env.d.ts
 # @end expo-cli
 node_modules/
 .expo/
+dist/
 
 
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Export the web build using Expo once onboarding is complete:
 yarn build:web
 ```
 
+The export step copies `public/tonconnect-manifest.json` into the `dist` folder
+so wallets can load it from `/tonconnect-manifest.json` in production. After
+deploying the static build, verify the manifest is accessible:
+
+```sh
+curl https://<your-site>/tonconnect-manifest.json
+```
+
 ## Docker
 
 Use Docker to run the project in a reproducible environment. Build the image

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "cross-env EXPO_NO_TELEMETRY=1 expo start",
     "lint": "expo lint",
     "seed": "node scripts/seed.js",
-    "build:web": "expo export --platform web --output-dir dist",
+    "build:web": "expo export --platform web --output-dir dist && node scripts/copy-tonconnect-manifest.js",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/copy-tonconnect-manifest.js
+++ b/scripts/copy-tonconnect-manifest.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = path.join(__dirname, '..', 'public', 'tonconnect-manifest.json');
+const destDir = path.join(__dirname, '..', 'dist');
+const dest = path.join(destDir, 'tonconnect-manifest.json');
+
+if (!fs.existsSync(src)) {
+  console.error(`Source manifest not found at ${src}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(destDir)) {
+  fs.mkdirSync(destDir, { recursive: true });
+}
+
+fs.copyFileSync(src, dest);
+console.log(`Copied TonConnect manifest to ${dest}`);
+


### PR DESCRIPTION
## Summary
- copy `public/tonconnect-manifest.json` to `dist` after static export
- document verifying `/tonconnect-manifest.json` after deployment
- ignore `dist/` build artifacts

## Testing
- `yarn build:web` *(fails: expo: not found)*
- `yarn test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893a918c07083269e385c26a001b017