### PR TITLE
fix: allow tonapi domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Blue Ocean</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://tonapi.io;" />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://yourdomain.com",
+  "url": "https://tonapi.io",
   "name": "The Congress",
   "iconUrl": "https://red-definite-wolf-677.mypinata.cloud/ipfs/bafybeicl42ot7h3itsvxrzp4qv6t7t2f4n657jxilei65ni3nemv7ykony",
-  "termsOfUseUrl": "https://yourdomain.com/terms",
-  "privacyPolicyUrl": "https://yourdomain.com/privacy"
+  "termsOfUseUrl": "https://tonapi.io/terms",
+  "privacyPolicyUrl": "https://tonapi.io/privacy"
 }


### PR DESCRIPTION
## Summary
- point tonconnect manifest at https://tonapi.io
- allow tonapi in web Content Security Policy

## Testing
- `yarn build:web` *(fails: expo: not found)*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a91e564c8326bff0a88cf25b4f97