### PR TITLE
feat: auto-enable waku

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Expo project uses React Native with the Expo Router.
 
 ## Setup
 
-Run `yarn install` to populate `node_modules`. All data is ephemeral and can be synchronized between peers over Waku when enabled; no external services are required.
+Run `yarn install` to populate `node_modules`. All data is ephemeral and synchronized between peers over Waku; no external services are required.
 
 ```sh
 yarn install
@@ -16,7 +16,7 @@ All state is held in memory and hydrated from the Waku message history on boot. 
 
 The app reads several secrets from the environment to encrypt peer-to-peer messages and sign tokens:
 
-- `EXPO_PUBLIC_WAKU_SECRET` – AES key used for Waku message encryption.
+- `EXPO_PUBLIC_WAKU_SECRET` – AES key used for Waku message encryption. If not provided one is generated on first launch.
 - `EXPO_PUBLIC_JWT_SECRET` – secret for signing JWT tokens.
 - `EXPO_PUBLIC_CHAT_SECRET` – secret used by the chat service.
 
@@ -30,9 +30,7 @@ export EXPO_PUBLIC_CHAT_SECRET=test_chat_secret
 
 Set them in your shell or enter them in the system settings screen after the app starts. You can modify them later from that screen at any time.
 
-Waku synchronization is disabled until `EXPO_PUBLIC_WAKU_SECRET` is provided.
-Once a secret is set, you can enable peer-to-peer sync by setting
-`EXPO_PUBLIC_USE_WAKU=true`.
+A Waku secret is generated automatically on first launch and peer-to-peer sync is always enabled.
 
 ### Onboarding
 
@@ -64,7 +62,6 @@ recognized keys include:
 - `EXPO_PUBLIC_JWT_SECRET`
 - `EXPO_PUBLIC_CHAT_SECRET`
 - `EXPO_PUBLIC_WAKU_SECRET`
-- `EXPO_PUBLIC_USE_WAKU`
 - `EXPO_PUBLIC_ADMIN_USERNAME`
 - `EXPO_PUBLIC_PINATA_JWT`
 - `EXPO_PUBLIC_PINATA_API_KEY`
@@ -120,7 +117,7 @@ appropriate `sendWaku...Update` function to broadcast the update. Each agent
 listens for new messages on its topic and applies them automatically, so data
 can be rehydrated from history at any time.
 
-Agents only start when `EXPO_PUBLIC_USE_WAKU=true` and a secret is provided. Without a secret Waku remains disabled and data stays purely local.
+Agents start automatically once the Waku secret has been generated.
 
 ### Web Notes
 

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -12,11 +12,6 @@ import {
 import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
 import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
-import config from '../utils/appConfig';
-
-async function useWaku(): Promise<boolean> {
-  return config.EXPO_PUBLIC_USE_WAKU === 'true';
-}
 const BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 
@@ -45,7 +40,6 @@ export function useWakuClient(): WakuClient {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      if (!(await useWaku())) return;
       let node: LightNode | undefined;
       try {
         node = await createLightNode({
@@ -85,7 +79,7 @@ export function useWakuClient(): WakuClient {
     };
     await db.sendChatMessage(roomId, { ...full, message: encrypted });
 
-    if ((await useWaku()) && nodeRef.current) {
+    if (nodeRef.current) {
       const encoder = createEncoder({ contentTopic: topic(roomId) });
       await nodeRef.current.lightPush.push(encoder, {
         payload: utf8ToBytes(encrypted),
@@ -98,7 +92,7 @@ export function useWakuClient(): WakuClient {
     roomId: string,
     cb: (msg: ChatMessage) => void,
   ): Promise<() => void> => {
-    if (!(await useWaku()) || !nodeRef.current) return () => {};
+    if (!nodeRef.current) return () => {};
     const decoder = createDecoder(topic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
@@ -134,7 +128,7 @@ export function useWakuClient(): WakuClient {
     roomId: string,
     cb: (msg: ChatMessage) => void,
   ) => {
-    if (!(await useWaku()) || !nodeRef.current) return;
+    if (!nodeRef.current) return;
     const decoder = createDecoder(topic(roomId));
     for await (const msgs of nodeRef.current.store.queryGenerator({
       contentTopics: [topic(roomId)],

--- a/lib/waku/isWakuConfigured.ts
+++ b/lib/waku/isWakuConfigured.ts
@@ -1,6 +1,0 @@
-import config from '../../utils/appConfig';
-
-export async function isWakuConfigured(): Promise<boolean> {
-  return !!config.EXPO_PUBLIC_WAKU_SECRET;
-}
-

--- a/lib/waku/isWakuConfigured.ts
+++ b/lib/waku/isWakuConfigured.ts
@@ -1,8 +1,6 @@
 import config from '../../utils/appConfig';
 
 export async function isWakuConfigured(): Promise<boolean> {
-  const enabled = config.EXPO_PUBLIC_USE_WAKU || 'false';
-  const secret = config.EXPO_PUBLIC_WAKU_SECRET || '';
-  return enabled === 'true' && !!secret;
+  return !!config.EXPO_PUBLIC_WAKU_SECRET;
 }
 

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -15,7 +15,6 @@ beforeEach(async () => {
     EXPO_PUBLIC_JWT_SECRET: 'test_jwt_secret',
     EXPO_PUBLIC_CHAT_SECRET: 'test_chat_secret',
     EXPO_PUBLIC_WAKU_SECRET: 'test_waku_secret',
-    EXPO_PUBLIC_USE_WAKU: 'true',
   });
   await loadTenantSettings();
 });

--- a/tests/usersSignupWaku.test.ts
+++ b/tests/usersSignupWaku.test.ts
@@ -56,7 +56,7 @@ describe('Signup broadcasts over Waku', () => {
     (usersAgent as any).hashCache.clear();
     messages.length = 0;
     jest.clearAllMocks();
-    insertConfig({ EXPO_PUBLIC_USE_WAKU: 'true', EXPO_PUBLIC_WAKU_SECRET: 's' });
+    insertConfig({ EXPO_PUBLIC_WAKU_SECRET: 's' });
   });
 
   it('broadcasts and replays user update', async () => {

--- a/tests/wakuAutoEnable.test.ts
+++ b/tests/wakuAutoEnable.test.ts
@@ -1,32 +1,39 @@
 import DatabaseService from '../services/database';
 import OrderService from '../services/orders';
+import ordersAgent from '../agents/orders-agent';
 import { insertConfig } from './testUtils';
+import config, { initConfig } from '../utils/appConfig';
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
 
 jest.mock('../lib/waku/sendWakuUserUpdate');
 jest.mock('../lib/waku/sendWakuOrderUpdate');
 
-describe('Waku disabled behaviour', () => {
-  beforeEach(() => {
+describe('Waku auto enable', () => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     (DatabaseService as any).instance = undefined;
     (OrderService as any).instance = undefined;
+    for (const key of Object.keys(config)) {
+      delete (config as any)[key];
+    }
+    // ensure no secret is preset
+    insertConfig({});
+    await initConfig();
   });
 
-  it('skips user update when Waku disabled', async () => {
-    await insertConfig({ EXPO_PUBLIC_USE_WAKU: 'false' });
+  it('generates secret automatically and broadcasts user updates', async () => {
+    expect(config.EXPO_PUBLIC_WAKU_SECRET).toBeDefined();
     const db = DatabaseService.getInstance();
     jest.spyOn(db, 'getUserProfile').mockResolvedValue({ id: '1' } as any);
     await db.updateUserRole('1', 'admin');
-    expect(sendWakuUserUpdate).not.toHaveBeenCalled();
+    expect(sendWakuUserUpdate).toHaveBeenCalled();
   });
 
-  it('skips order update when secret missing', async () => {
-    await insertConfig({ EXPO_PUBLIC_USE_WAKU: 'true', EXPO_PUBLIC_WAKU_SECRET: '' });
+  it('broadcasts order update without manual secret', async () => {
     const svc = OrderService.getInstance();
-    jest.spyOn(svc as any, 'getOrder').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(ordersAgent as any, 'get').mockReturnValue({ id: '1', status: 'pending' });
     await svc.updateOrderStatus('1', 'delivered');
-    expect(sendWakuOrderUpdate).not.toHaveBeenCalled();
+    expect(sendWakuOrderUpdate).toHaveBeenCalled();
   });
 });

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { loadConfig as loadConfigFromStorage, saveConfig as persistConfig } from './configStorage';
 
 // Configuration values are stored locally but can be overridden by
@@ -10,7 +11,6 @@ const ENV_KEYS = [
   'EXPO_PUBLIC_JWT_SECRET',
   'EXPO_PUBLIC_CHAT_SECRET',
   'EXPO_PUBLIC_WAKU_SECRET',
-  'EXPO_PUBLIC_USE_WAKU',
   'EXPO_PUBLIC_ADMIN_USERNAME',
   'EXPO_PUBLIC_PINATA_JWT',
   'EXPO_PUBLIC_PINATA_API_KEY',
@@ -33,13 +33,15 @@ export async function initConfig(): Promise<void> {
     }
   }
 
-  // If no Waku secret was provided disable peer-to-peer sync and warn
+  let shouldPersist = false;
   if (!config.EXPO_PUBLIC_WAKU_SECRET) {
-    config.EXPO_PUBLIC_USE_WAKU = 'false';
-    console.warn('EXPO_PUBLIC_WAKU_SECRET missing; Waku disabled');
-  } else if (!config.EXPO_PUBLIC_USE_WAKU) {
-    // Enable Waku by default when a secret exists
-    config.EXPO_PUBLIC_USE_WAKU = 'true';
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    config.EXPO_PUBLIC_WAKU_SECRET = Buffer.from(bytes).toString('hex');
+    shouldPersist = true;
+  }
+  if (shouldPersist) {
+    await persistConfig(config);
   }
 }
 

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer';
-import { isWakuConfigured } from '../lib/waku/isWakuConfigured';
 import { decryptWakuPayload } from '../lib/waku/wakuCrypto';
 
 export interface WakuAgentOptions<T> {
@@ -42,13 +41,13 @@ export default class WakuAgent<T extends { id: string }> {
 
   async whenReady(): Promise<void> {
     if (!this.readyPromise) {
-      if (this.options.topic && (await isWakuConfigured())) {
+      if (this.options.topic) {
         this.readyPromise = this.init();
         this.ready = this.readyPromise;
       } else {
         return;
       }
-    } else if (!this.node && (await isWakuConfigured())) {
+    } else if (!this.node) {
       this.readyPromise = this.init();
       this.ready = this.readyPromise;
     }
@@ -85,7 +84,6 @@ export default class WakuAgent<T extends { id: string }> {
 
 
   private async init() {
-    if (!(await isWakuConfigured())) return;
     try {
       const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       this.node = await createLightNode({
@@ -148,9 +146,7 @@ export default class WakuAgent<T extends { id: string }> {
 
   protected async broadcast(item: T) {
     try {
-      if (await isWakuConfigured()) {
-        await this.sendFn(item);
-      }
+      await this.sendFn(item);
     } catch (e) {
       console.error('Failed to broadcast Waku message', e);
     }


### PR DESCRIPTION
## Summary
- generate Waku secret during config init and persist it
- always start Waku client without gating by config
- document automatic Waku secret and default sync

## Testing
- `yarn test tests/wakuAutoEnable.test.ts tests/usersSignupWaku.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6893b5d576988326a41f0f3e96c9e899