### PR TITLE
Avoid repeated Waku secret warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,17 +166,18 @@ curl https://<your-site>/tonconnect-manifest.json
 ## Docker
 
 Use Docker to run the project in a reproducible environment. Build the image
-and start the Expo server with:
+and start the Expo server with a Waku secret provided via the environment:
 
 ```sh
 docker build -t blue-ocean .
-docker run -p 19000-19002:19000-19002 blue-ocean
+docker run -e EXPO_PUBLIC_WAKU_SECRET=$(openssl rand -hex 32) \
+  -p 19000-19002:19000-19002 blue-ocean
 ```
 
 For hot reloading and easier development you can also use Docker Compose:
 
 ```sh
-docker compose up
+EXPO_PUBLIC_WAKU_SECRET=$(openssl rand -hex 32) docker compose up
 ```
 
 ## Tests

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -6,6 +6,9 @@ import { loadConfig as loadConfigFromStorage, saveConfig as persistConfig } from
 
 const config: Record<string, string> = {};
 
+// Track whether a missing Waku secret has already been reported
+let warnedMissingWakuSecret = false;
+
 const ENV_KEYS = [
   'EXPO_PUBLIC_JWT_SECRET',
   'EXPO_PUBLIC_CHAT_SECRET',
@@ -36,7 +39,10 @@ export async function initConfig(): Promise<void> {
   // If no Waku secret was provided disable peer-to-peer sync and warn
   if (!config.EXPO_PUBLIC_WAKU_SECRET) {
     config.EXPO_PUBLIC_USE_WAKU = 'false';
-    console.warn('EXPO_PUBLIC_WAKU_SECRET missing; Waku disabled');
+    if (!warnedMissingWakuSecret) {
+      console.warn('EXPO_PUBLIC_WAKU_SECRET missing; Waku disabled');
+      warnedMissingWakuSecret = true;
+    }
   } else if (!config.EXPO_PUBLIC_USE_WAKU) {
     // Enable Waku by default when a secret exists
     config.EXPO_PUBLIC_USE_WAKU = 'true';


### PR DESCRIPTION
## Summary
- prevent repeated warnings when `EXPO_PUBLIC_WAKU_SECRET` is missing
- document how to set `EXPO_PUBLIC_WAKU_SECRET` for Docker deployments

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6893ba65040c832685952a6836378b4b