### PR TITLE
fix: anchor tab bar to bottom

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -31,6 +31,10 @@ export default function TabLayout() {
           tabBarActiveTintColor: colors.tabBar.active,
           tabBarInactiveTintColor: colors.tabBar.inactive,
           tabBarStyle: {
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
             backgroundColor: colors.tabBar.background,
             borderTopWidth: 1,
             borderTopColor: colors.tabBar.border,


### PR DESCRIPTION
## Summary
- absolutely position the tab bar so it stays pinned to bottom

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6893c65c877c8326960e465d51016785