### PR TITLE
fix: allow inline scripts in CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' https://tonapi.io https://raw.githubusercontent.com https://api.pinata.cloud https://gateway.pinata.cloud https://buy.moonpay.com https://blue-ocean.vercel.app; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://tonapi.io https://raw.githubusercontent.com https://api.pinata.cloud https://gateway.pinata.cloud https://buy.moonpay.com https://blue-ocean.vercel.app; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';"
     />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- allow inline scripts in CSP

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4".*)
- `node puppeteer check` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6893c65d1fac8326960403364d1b1d86