### PR TITLE
refactor: move pointer event style to prop

### DIFF
--- a/components/MoonPayModal.tsx
+++ b/components/MoonPayModal.tsx
@@ -53,7 +53,7 @@ export default function MoonPayModal({
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>
         {loading && (
-          <View style={[styles.loading, { pointerEvents: 'none' }]}>
+          <View style={styles.loading} pointerEvents="none">
             <LoadingSpinner />
           </View>
         )}


### PR DESCRIPTION
## Summary
- move `pointerEvents` setting for the MoonPay modal overlay from an inline style to a prop
- ensure no other components pass `pointerEvents` as a prop

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6893c65fa10083268c3f26db696e2876