### PR TITLE
force source-map devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,12 +6,14 @@ const webpack = require('webpack');
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
 
+  // Use source maps in all modes to avoid eval-based tooling which can violate CSP
+  config.devtool = 'source-map';
+
   // Optional: remove buggy plugin in production
   if (config.mode === 'production') {
     config.plugins = config.plugins.filter(
       (p) => p.constructor.name !== 'WebpackDeepScopeAnalysisPlugin'
     );
-    config.devtool = 'source-map';
   }
 
   // Polyfill Node.js core modules used by some dependencies


### PR DESCRIPTION
## Summary
- always use a non-eval `source-map` devtool in webpack config
## Testing
- `yarn build:web`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6894fa8773b883269fd2375bda490cda