### PR TITLE
refactor: static import for waku sdk

### DIFF
--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -1,4 +1,9 @@
 import { Buffer } from 'buffer';
+import {
+  createLightNode,
+  waitForRemotePeer,
+  Protocols,
+} from '@waku/sdk';
 import { decryptWakuPayload } from '../lib/waku/wakuCrypto';
 
 export interface WakuAgentOptions<T> {
@@ -85,7 +90,6 @@ export default class WakuAgent<T extends { id: string }> {
 
   private async init() {
     try {
-      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       this.node = await createLightNode({
         defaultBootstrap: true,
         libp2p: { hideWebSocketInfo: true },


### PR DESCRIPTION
## Summary
- replace dynamic `@waku/sdk` import with static top-level import
- rely on statically imported Waku SDK for node initialization

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install --frozen-lockfile` *(fails: @waku/sdk requires Node >=22)*
- `yarn build:web` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950051cc048326bfc41e33a02ecc2b