### PR TITLE
refactor: simplify Waku agent validation

### DIFF
--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -11,7 +11,6 @@ class CategoriesAgent extends WakuAgent<Category> {
       replayHistory: true,
       extractItem: (msg: any) =>
         msg.type === 'category.update' ? (msg.category as Category) : undefined,
-      allowedRoles: ['admin'],
     });
   }
 }

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -10,9 +10,6 @@ class OrdersAgent extends WakuAgent<Order> {
       topic: '/congress/orders/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.order as Order,
-      allowedRoles: ['admin', 'user', 'driver'],
-      validateMessage: (msg: any) =>
-        msg.sender.role === 'admin' || msg.order?.userId === msg.sender.id,
       onUpdate: (order: Order) => {
         this.subscribers.forEach(cb => cb(order));
       },

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -8,7 +8,6 @@ class ProductsAgent extends WakuAgent<Product> {
       topic: '/congress/products/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.product as Product,
-      allowedRoles: ['admin'],
     });
   }
 }

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -21,7 +21,6 @@ class SettingsAgent extends WakuAgent<SettingItem> {
           msg.type === 'settings.update'
             ? { id: msg.key as string, value: msg.value as string }
             : undefined,
-        allowedRoles: ['admin'],
       }
     );
   }

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -8,7 +8,6 @@ class UsersAgent extends WakuAgent<User> {
       topic: '/congress/users/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.user as User,
-      allowedRoles: ['admin', 'user', 'driver'],
     });
   }
 }

--- a/tests/wakuAgentValidation.test.ts
+++ b/tests/wakuAgentValidation.test.ts
@@ -1,68 +1,27 @@
 import WakuAgent from '../utils/wakuAgent';
-import { sha256 } from '@noble/hashes/sha256';
-import { sha512 } from '@noble/hashes/sha512';
 
 interface TestItem { id: string; value: string }
 
-let ed: any;
-
-beforeAll(async () => {
-  ed = await import('@noble/ed25519');
-  ed.etc.sha512Sync = sha512;
-});
-
-test('rejects messages with invalid signature or role', async () => {
-  const priv = ed.utils.randomPrivateKey();
-  const pub = await ed.getPublicKeyAsync(priv);
-  const pubHex = ed.etc.bytesToHex(pub);
-
+test('accepts messages without sender or signature', async () => {
   const agent = new WakuAgent<TestItem>(async () => {}, {
-    allowedRoles: ['admin'],
     extractItem: (msg: any) => msg.item as TestItem,
   });
 
-  const sender = { id: '1', publicKey: pubHex, role: 'admin' };
   const item = { id: 'x', value: '1' };
-  const msg = { type: 'item.update', item, sender };
-  const hash = sha256(new TextEncoder().encode(JSON.stringify(msg)));
-  const signature = ed.etc.bytesToHex(await ed.signAsync(hash, priv));
-  await agent.processPayload(JSON.stringify({ ...msg, signature }));
-
-  // invalid role
-  const badRole = { ...sender, role: 'user' };
-  const badRoleMsg = { type: 'item.update', item: { id: 'y', value: '2' }, sender: badRole };
-  const badRoleHash = sha256(new TextEncoder().encode(JSON.stringify(badRoleMsg)));
-  const badRoleSig = ed.etc.bytesToHex(await ed.signAsync(badRoleHash, priv));
-  await agent.processPayload(JSON.stringify({ ...badRoleMsg, signature: badRoleSig }));
-
-  // invalid signature
-  const badSigMsg = { type: 'item.update', item: { id: 'z', value: '3' }, sender };
-  const badSigHash = sha256(new TextEncoder().encode(JSON.stringify(badSigMsg)));
-  // sign with different key
-  const otherPriv = ed.utils.randomPrivateKey();
-  const badSig = ed.etc.bytesToHex(await ed.signAsync(badSigHash, otherPriv));
-  await agent.processPayload(JSON.stringify({ ...badSigMsg, signature: badSig }));
+  const msg = { type: 'item.update', item };
+  await agent.processPayload(JSON.stringify(msg));
 
   const all = agent.getAll();
   expect(all).toEqual([item]);
 });
 
 test('skips duplicate messages using hash cache', async () => {
-  const priv = ed.utils.randomPrivateKey();
-  const pub = await ed.getPublicKeyAsync(priv);
-  const pubHex = ed.etc.bytesToHex(pub);
-
   const agent = new WakuAgent<TestItem>(async () => {}, {
-    allowedRoles: ['admin'],
     extractItem: (msg: any) => msg.item as TestItem,
   });
 
-  const sender = { id: '1', publicKey: pubHex, role: 'admin' };
   const item = { id: 'd', value: 'dup' };
-  const msg = { type: 'item.update', item, sender };
-  const hash = sha256(new TextEncoder().encode(JSON.stringify(msg)));
-  const signature = ed.etc.bytesToHex(await ed.signAsync(hash, priv));
-  const payload = JSON.stringify({ ...msg, signature });
+  const payload = JSON.stringify({ type: 'item.update', item });
 
   await agent.processPayload(payload);
   await agent.processPayload(payload); // duplicate

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { decryptWakuPayload } from '../lib/waku/wakuCrypto';
 
 export interface WakuAgentOptions<T> {
@@ -10,8 +9,6 @@ export interface WakuAgentOptions<T> {
   extractItem?: (msg: any) => T | undefined;
   /** Called whenever an item is stored */
   onUpdate?: (item: T) => void;
-  /** Allowed sender roles */
-  allowedRoles?: string[];
   /** Additional validation */
   validateMessage?: (msg: any) => boolean | Promise<boolean>;
 }
@@ -117,26 +114,16 @@ export default class WakuAgent<T extends { id: string }> {
   async processPayload(payload: string): Promise<void> {
     try {
       const parsed = JSON.parse(payload);
-      if (!parsed.sender?.publicKey || !parsed.signature || !parsed.sender?.role) return;
-
-      if (this.options.allowedRoles && !this.options.allowedRoles.includes(parsed.sender.role)) return;
-
-      const { verify, etc: edBytes } = await import('@noble/ed25519');
-      const { sha256 } = await import('@noble/hashes/sha256');
-      const verifyObj = { ...parsed } as any;
-      delete (verifyObj as any).signature;
-      const hash = sha256(new TextEncoder().encode(JSON.stringify(verifyObj)));
-      const hashHex = Buffer.from(hash).toString('hex');
-      if (this.hashCache.has(hashHex)) return;
-      const ok = await verify(edBytes.hexToBytes(parsed.signature), hash, edBytes.hexToBytes(parsed.sender.publicKey));
-      if (!ok) return;
 
       if (this.options.validateMessage && !(await this.options.validateMessage(parsed))) return;
+
+      const hashKey = payload;
+      if (this.hashCache.has(hashKey)) return;
 
       const item = this.options.extractItem ? this.options.extractItem(parsed) : (parsed as T);
       if (item && item.id) {
         this.store.set(item.id, item);
-        this.hashCache.add(hashHex);
+        this.hashCache.add(hashKey);
         this.options.onUpdate?.(item);
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- drop signature and role checks from WakuAgent
- remove allowedRoles usage from downstream agents
- update validation tests for unsigned payloads

## Testing
- `yarn lint`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6895004e03a48326addb1009d39f0223