### PR TITLE
Propagate Waku agent init failures to callers

### DIFF
--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -64,6 +64,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
 
       const tenantSvc = SettingsAgent.getInstance();
       try {
+        await tenantSvc.whenReady();
         const t = tenant;
         const dbName = await tenantSvc.getTenantSetting(t, 'platform_name');
         const dbLogo = await tenantSvc.getTenantSetting(t, 'platform_logo');
@@ -81,6 +82,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
           await AsyncStorage.setItem(COLOR_KEY, dbColor);
         }
       } catch (err) {
+        Alert.alert('שגיאה', 'טעינת הגדרות מהשרת נכשלה');
         console.error('Failed fetching branding from server:', err);
       }
     } catch (e) {
@@ -109,6 +111,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
     await AsyncStorage.setItem(NAME_KEY, name);
     const tenantSvc = SettingsAgent.getInstance();
     try {
+      await tenantSvc.whenReady();
       await tenantSvc.updateTenantSetting(tenant, 'platform_name', name);
       scheduleLoadInfo();
     } catch (e) {
@@ -130,6 +133,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       setPlatformLogoState(finalLogo);
       await AsyncStorage.setItem(LOGO_KEY, finalLogo);
       const tenantSvc = SettingsAgent.getInstance();
+      await tenantSvc.whenReady();
       await tenantSvc.updateTenantSetting(tenant, 'platform_logo', finalLogo);
       scheduleLoadInfo();
     } catch (e) {
@@ -145,6 +149,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       setThemeColorState(color);
       await AsyncStorage.setItem(COLOR_KEY, color);
       const tenantSvc = SettingsAgent.getInstance();
+      await tenantSvc.whenReady();
       await tenantSvc.updateTenantSetting(tenant, 'theme_color', color);
       scheduleLoadInfo();
     } catch (e) {

--- a/tests/usersSignupWaku.test.ts
+++ b/tests/usersSignupWaku.test.ts
@@ -74,7 +74,14 @@ describe('Signup broadcasts over Waku', () => {
 
     const AgentClass = (usersAgent as any).constructor;
     const newAgent: any = new AgentClass();
-    await (newAgent.ready || Promise.resolve());
+    if (newAgent.ready) {
+      try {
+        await newAgent.ready;
+      } catch (e) {
+        console.error('Failed to initialize UsersAgent', e);
+        throw e;
+      }
+    }
     const stored = newAgent.get(user.id);
     expect(stored).toEqual(user);
     await newAgent.stop();

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -111,6 +111,7 @@ export default class WakuAgent<T extends { id: string }> {
       }
     } catch (e) {
       console.error('Failed initializing WakuAgent', e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Summary
- Rethrow Waku agent initialization errors so callers can detect failures
- Await SettingsAgent readiness before using it and alert on init failures
- Handle UsersAgent readiness rejection in unit test

## Testing
- `yarn install` *(fails: @waku/sdk requires Node >=22)*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950054cf2c8326808e44143c4a49eb