### PR TITLE
refactor: statically import Waku SDK

### DIFF
--- a/lib/waku/nodeSingleton.ts
+++ b/lib/waku/nodeSingleton.ts
@@ -1,11 +1,10 @@
-import type { LightNode } from '@waku/sdk';
+import { createLightNode, waitForRemotePeer, Protocols, type LightNode } from '@waku/sdk';
 
 let nodePromise: Promise<LightNode> | null = null;
 
 export async function getNode(): Promise<LightNode> {
   if (!nodePromise) {
     nodePromise = (async () => {
-      const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
       const n = await createLightNode({
         defaultBootstrap: true,
         libp2p: { hideWebSocketInfo: true },


### PR DESCRIPTION
## Summary
- use static imports for Waku SDK in nodeSingleton to avoid runtime evaluation

## Testing
- `EXPO_NO_TELEMETRY=1 yarn build:web`

------
https://chatgpt.com/codex/tasks/task_e_689500567974832686f7a3cc5ab45583