### PR TITLE
refactor: drop WakuAgent allowedRoles option

### DIFF
--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -11,7 +11,7 @@ class CategoriesAgent extends WakuAgent<Category> {
       replayHistory: true,
       extractItem: (msg: any) =>
         msg.type === 'category.update' ? (msg.category as Category) : undefined,
-      allowedRoles: ['admin'],
+      validateMessage: (msg: any) => msg.sender.role === 'admin',
     });
   }
 }

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -10,9 +10,9 @@ class OrdersAgent extends WakuAgent<Order> {
       topic: '/congress/orders/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.order as Order,
-      allowedRoles: ['admin', 'user', 'driver'],
       validateMessage: (msg: any) =>
-        msg.sender.role === 'admin' || msg.order?.userId === msg.sender.id,
+        ['admin', 'user', 'driver'].includes(msg.sender.role) &&
+        (msg.sender.role === 'admin' || msg.order?.userId === msg.sender.id),
       onUpdate: (order: Order) => {
         this.subscribers.forEach(cb => cb(order));
       },

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -8,7 +8,7 @@ class ProductsAgent extends WakuAgent<Product> {
       topic: '/congress/products/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.product as Product,
-      allowedRoles: ['admin'],
+      validateMessage: (msg: any) => msg.sender.role === 'admin',
     });
   }
 }

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -21,7 +21,7 @@ class SettingsAgent extends WakuAgent<SettingItem> {
           msg.type === 'settings.update'
             ? { id: msg.key as string, value: msg.value as string }
             : undefined,
-        allowedRoles: ['admin'],
+        validateMessage: (msg: any) => msg.sender.role === 'admin',
       }
     );
   }

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -8,7 +8,8 @@ class UsersAgent extends WakuAgent<User> {
       topic: '/congress/users/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.user as User,
-      allowedRoles: ['admin', 'user', 'driver'],
+      validateMessage: (msg: any) =>
+        ['admin', 'user', 'driver'].includes(msg.sender.role),
     });
   }
 }

--- a/tests/wakuAgentValidation.test.ts
+++ b/tests/wakuAgentValidation.test.ts
@@ -17,8 +17,8 @@ test('rejects messages with invalid signature or role', async () => {
   const pubHex = ed.etc.bytesToHex(pub);
 
   const agent = new WakuAgent<TestItem>(async () => {}, {
-    allowedRoles: ['admin'],
     extractItem: (msg: any) => msg.item as TestItem,
+    validateMessage: (msg: any) => msg.sender.role === 'admin',
   });
 
   const sender = { id: '1', publicKey: pubHex, role: 'admin' };
@@ -53,8 +53,8 @@ test('skips duplicate messages using hash cache', async () => {
   const pubHex = ed.etc.bytesToHex(pub);
 
   const agent = new WakuAgent<TestItem>(async () => {}, {
-    allowedRoles: ['admin'],
     extractItem: (msg: any) => msg.item as TestItem,
+    validateMessage: (msg: any) => msg.sender.role === 'admin',
   });
 
   const sender = { id: '1', publicKey: pubHex, role: 'admin' };

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -10,8 +10,6 @@ export interface WakuAgentOptions<T> {
   extractItem?: (msg: any) => T | undefined;
   /** Called whenever an item is stored */
   onUpdate?: (item: T) => void;
-  /** Allowed sender roles */
-  allowedRoles?: string[];
   /** Additional validation */
   validateMessage?: (msg: any) => boolean | Promise<boolean>;
 }
@@ -118,8 +116,6 @@ export default class WakuAgent<T extends { id: string }> {
     try {
       const parsed = JSON.parse(payload);
       if (!parsed.sender?.publicKey || !parsed.signature || !parsed.sender?.role) return;
-
-      if (this.options.allowedRoles && !this.options.allowedRoles.includes(parsed.sender.role)) return;
 
       const { verify, etc: edBytes } = await import('@noble/ed25519');
       const { sha256 } = await import('@noble/hashes/sha256');


### PR DESCRIPTION
## Summary
- remove allowedRoles option from WakuAgent
- handle role restrictions via validateMessage in agents and tests

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895005903408326b09c031a8484f718