### PR TITLE
feat: integrate ton connect auth

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,6 +1,7 @@
 import { User } from '../types';
 import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
 
 class UsersAgent extends WakuAgent<User> {
   constructor() {
@@ -9,6 +10,24 @@ class UsersAgent extends WakuAgent<User> {
       replayHistory: true,
       extractItem: (msg: any) => msg.user as User,
     });
+  }
+
+  async add(user: User): Promise<void> {
+    const enriched: User = {
+      ...user,
+      publicKey: tonAuth.getTonPublicKey() || user.publicKey,
+      address: tonAuth.getAddress(),
+    };
+    await super.add(enriched);
+  }
+
+  async update(user: User): Promise<void> {
+    const enriched: User = {
+      ...user,
+      publicKey: tonAuth.getTonPublicKey() || user.publicKey,
+      address: tonAuth.getAddress(),
+    };
+    await super.update(enriched);
   }
 }
 

--- a/lib/waku/sendWakuCartUpdate.ts
+++ b/lib/waku/sendWakuCartUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuCartUpdate = async (cartItem: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'cart.update', cartItem };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'cart.update', cartItem, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/cart/1' });

--- a/lib/waku/sendWakuCategoryUpdate.ts
+++ b/lib/waku/sendWakuCategoryUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuCategoryUpdate = async (category: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'category.update', category };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'category.update', category, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/categories/1' });

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuNotificationUpdate = async (notification: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'notification.update', notification };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'notification.update', notification, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/notifications/1' });

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuOrderUpdate = async (order: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'order.update', order };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'order.update', order, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1/proto' });

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuProductUpdate = async (product: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'product.update', product };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'product.update', product, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1/proto' });

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -1,5 +1,6 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuSettingsUpdate = async (
   key: string,
@@ -8,12 +9,17 @@ export const sendWakuSettingsUpdate = async (
   updatedAt: number
 ) => {
   const node = await getNode();
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
   const payloadObj = {
     type: 'settings.update',
     key,
     value,
     createdAt,
     updatedAt,
+    sender,
   };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -1,9 +1,14 @@
 import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
 
 export const sendWakuUserUpdate = async (user: any) => {
   const node = await getNode();
-  const payloadObj = { type: 'user.update', user };
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'user.update', user, sender };
   const message = JSON.stringify(payloadObj);
   const encrypted = await encryptWakuPayload(message);
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1/proto' });

--- a/services/tonAuth.ts
+++ b/services/tonAuth.ts
@@ -1,0 +1,58 @@
+class TonAuthService {
+  private static instance: TonAuthService;
+  private tonConnectUI: any = null;
+  private publicKey: string | null = null;
+  private address: string | null = null;
+
+  private constructor() {
+    if (typeof window !== 'undefined') {
+      this.init();
+    }
+  }
+
+  private async init() {
+    try {
+      const { TonConnectUI } = await import('@tonconnect/ui');
+      const manifestUrl = process.env.NODE_ENV === 'development'
+        ? new URL('/tonconnect-manifest.json', window.location.origin).href
+        : '/tonconnect-manifest.json';
+      this.tonConnectUI = new TonConnectUI({ manifestUrl });
+      this.tonConnectUI.onStatusChange((wallet: any | null) => {
+        this.publicKey = wallet?.account?.publicKey ?? null;
+        this.address = wallet?.account?.address ?? null;
+      });
+    } catch (e) {
+      console.error('Failed to initialize TonConnectUI', e);
+    }
+  }
+
+  public static getInstance(): TonAuthService {
+    if (!TonAuthService.instance) {
+      TonAuthService.instance = new TonAuthService();
+    }
+    return TonAuthService.instance;
+  }
+
+  public getTonPublicKey(): string | null {
+    return this.publicKey;
+  }
+
+  public getAddress(): string | null {
+    return this.address;
+  }
+
+  public async requestSignature(payload: any): Promise<string | null> {
+    if (!this.tonConnectUI) return null;
+    const result = await this.tonConnectUI.signData(payload);
+    return result.signature;
+  }
+
+  public async openModal(): Promise<void> {
+    if (!this.tonConnectUI) return;
+    await this.tonConnectUI.openModal();
+  }
+}
+
+const tonAuth = TonAuthService.getInstance();
+export const getTonPublicKey = () => tonAuth.getTonPublicKey();
+export default tonAuth;

--- a/types/index.ts
+++ b/types/index.ts
@@ -112,6 +112,7 @@ export interface User {
   email?: string;
   role?: string;
   publicKey?: string;
+  address?: string;
   createdAt?: string;
   updatedAt?: string;
   kycStatus?: KycStatus;


### PR DESCRIPTION
## Summary
- add Ton Auth service to manage TON Connect session and signatures
- enrich user agent with wallet address and public key
- attach TON sender keys to Waku update payloads

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_6897808ecf588326b7bcab7a00869d2f