### PR TITLE
Add store NFT management and store-linked products

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ All SQL migration files have been removed.
 | `/congress/settings/1` | Store name, color, app config       |
 | `/congress/users/1`    | Registered users + roles + keys     |
 | `/congress/products/1` | Product catalog                     |
+| `/congress/stores/1`   | Store registry + metadata           |
 | `/congress/orders/1`   | Orders placed by users              |
 
 All topics are encrypted (optionally) and signed.

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,6 +1,8 @@
 import { Product } from '../types';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import storesAgent from './stores-agent';
+import tonAuth from '../services/tonAuth';
 
 class ProductsAgent extends WakuAgent<Product> {
   constructor() {
@@ -8,7 +10,23 @@ class ProductsAgent extends WakuAgent<Product> {
       topic: '/congress/products/1/proto',
       replayHistory: true,
       extractItem: (msg: any) => msg.product as Product,
+      validateMessage: async (msg: any) => {
+        const storeId = msg.product?.storeId;
+        const senderAddr = msg.sender?.address;
+        if (!storeId || !senderAddr) return false;
+        const store = storesAgent.get(storeId);
+        return store?.owner === senderAddr;
+      },
     });
+  }
+
+  protected async broadcast(item: Product) {
+    const store = storesAgent.get(item.storeId);
+    const addr = tonAuth.getAddress();
+    if (!store || store.owner !== addr) {
+      throw new Error('Only the store owner can broadcast product updates');
+    }
+    await super.broadcast(item);
   }
 }
 

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,0 +1,15 @@
+import { Store } from '../types';
+import { sendWakuStoreUpdate } from '../lib/waku/sendWakuStoreUpdate';
+import WakuAgent from '../utils/wakuAgent';
+
+class StoresAgent extends WakuAgent<Store> {
+  constructor() {
+    super(sendWakuStoreUpdate, {
+      topic: '/congress/stores/1/proto',
+      replayHistory: true,
+      extractItem: (msg: any) => msg.store as Store,
+    });
+  }
+}
+
+export default new StoresAgent();

--- a/app/stores/index.tsx
+++ b/app/stores/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import StoreCreation from '../../components/StoreCreation';
+
+export default function StoresScreen() {
+  return (
+    <View style={styles.container}>
+      <StoreCreation />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+});

--- a/components/StoreCreation.tsx
+++ b/components/StoreCreation.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import storesAgent from '../agents/stores-agent';
+import tonAuth from '../services/tonAuth';
+
+const StoreCreation: React.FC = () => {
+  const [name, setName] = useState('');
+
+  const mintStore = async () => {
+    if (!name) return;
+    const id = Date.now().toString();
+    const owner = tonAuth.getAddress() || '';
+    await storesAgent.add({ id, name, owner });
+    setName('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Store Name</Text>
+      <TextInput style={styles.input} value={name} onChangeText={setName} />
+      <Button title="Mint Store" onPress={mintStore} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { gap: 16 },
+  label: { fontSize: 16, fontWeight: '600', textAlign: 'right' },
+  input: { borderWidth: 1, borderRadius: 8, padding: 8, textAlign: 'right' },
+});
+
+export default StoreCreation;

--- a/contracts/store-nft.tact
+++ b/contracts/store-nft.tact
@@ -1,0 +1,28 @@
+import "@tact-lang/core";
+
+message Transfer {
+    to: Address;
+}
+
+contract StoreNFT {
+    owner: Address;
+    name: String;
+
+    init(owner: Address, name: String) {
+        self.owner = owner;
+        self.name = name;
+    }
+
+    receive(msg: Transfer) {
+        require(sender() == self.owner, 101);
+        self.owner = msg.to;
+    }
+
+    getOwner(): Address {
+        return self.owner;
+    }
+
+    getMetadata(): (String, Address) {
+        return (self.name, self.owner);
+    }
+}

--- a/lib/memoryStore.ts
+++ b/lib/memoryStore.ts
@@ -1,8 +1,9 @@
-import type { User, Product, Order, TenantSettings, Notification } from '../types';
+import type { User, Product, Order, TenantSettings, Notification, Store } from '../types';
 
 export interface MemoryStore {
   users: User[];
   products: Product[];
+  stores: Store[];
   orders: Order[];
   notifications: Notification[];
   tenantSettings: Record<string, TenantSettings>;
@@ -11,6 +12,7 @@ export interface MemoryStore {
 export const store: MemoryStore = {
   users: [],
   products: [],
+  stores: [],
   orders: [],
   notifications: [],
   tenantSettings: {},

--- a/lib/waku/sendWakuStoreUpdate.ts
+++ b/lib/waku/sendWakuStoreUpdate.ts
@@ -1,0 +1,18 @@
+import { encryptWakuPayload } from './wakuCrypto';
+import { getNode } from './nodeSingleton';
+import tonAuth from '../../services/tonAuth';
+
+export const sendWakuStoreUpdate = async (store: any) => {
+  const node = await getNode();
+  const sender = {
+    address: tonAuth.getAddress(),
+    publicKey: tonAuth.getTonPublicKey(),
+  };
+  const payloadObj = { type: 'store.update', store, sender };
+  const message = JSON.stringify(payloadObj);
+  const signature = await tonAuth.requestSignature(message);
+  const signed = { ...payloadObj, signature };
+  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const encoder = node.createEncoder({ contentTopic: '/congress/stores/1/proto' });
+  await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
+};

--- a/tests/databaseService.test.ts
+++ b/tests/databaseService.test.ts
@@ -1,16 +1,23 @@
 import DatabaseService from '../services/database';
 import productsAgent from '../agents/products-agent';
 import categoriesAgent from '../agents/categories-agent';
+import storesAgent from '../agents/stores-agent';
+import tonAuth from '../services/tonAuth';
 
 beforeEach(() => {
   (DatabaseService as any).instance = undefined;
   (productsAgent as any).store.clear();
   (categoriesAgent as any).store.clear();
+  (storesAgent as any).store.clear();
+  (tonAuth as any).getAddress = () => 'owner1';
+  (productsAgent as any).sendFn = async () => {};
+  (productsAgent as any).clearHashCache();
 });
 
 describe('DatabaseService basic operations', () => {
   it('handles product lifecycle', async () => {
     const db = DatabaseService.getInstance();
+    await storesAgent.add({ id: 'store1', name: 'Store', owner: 'owner1' });
     const prodId = await db.addProduct({
       name: 'Test',
       price: 1,
@@ -20,6 +27,7 @@ describe('DatabaseService basic operations', () => {
       rating: 0,
       reviews: 0,
       stock: 1,
+      storeId: 'store1',
     });
     const product = await db.getProduct(prodId);
     expect(product?.name).toBe('Test');
@@ -42,6 +50,7 @@ describe('DatabaseService basic operations', () => {
 
   it('stores wishlist items per user', async () => {
     const db = DatabaseService.getInstance();
+    await storesAgent.add({ id: 'store1', name: 'Store', owner: 'owner1' });
     const id = await db.addProduct({
       name: 'Wish',
       price: 5,
@@ -51,6 +60,7 @@ describe('DatabaseService basic operations', () => {
       rating: 0,
       reviews: 0,
       stock: 1,
+      storeId: 'store1',
     });
     await db.addWishlistItem('u1', id);
     expect((await db.getWishlistItems('u1')).length).toBe(1);

--- a/tests/wakuUpdates.test.ts
+++ b/tests/wakuUpdates.test.ts
@@ -2,6 +2,7 @@ import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
 import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
 import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
 import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpdate';
+import { sendWakuStoreUpdate } from '../lib/waku/sendWakuStoreUpdate';
 
 jest.mock('../lib/waku/wakuCrypto', () => ({
   encryptWakuPayload: jest.fn(async (p: string) => p),
@@ -44,6 +45,12 @@ describe('Waku send updates', () => {
 
   it('notification update uses shared node', async () => {
     await sendWakuNotificationUpdate({});
+    expect(getNode).toHaveBeenCalled();
+    expect(node.lightPush.send).toHaveBeenCalled();
+  });
+
+  it('store update uses shared node', async () => {
+    await sendWakuStoreUpdate({});
     expect(getNode).toHaveBeenCalled();
     expect(node.lightPush.send).toHaveBeenCalled();
   });

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,9 +19,16 @@ export interface Product {
   badges?: string[];
   pricingTier?: string;
   mixGroupId?: string;
+  storeId: string;
   stock: number;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface Store {
+  id: string;
+  name: string;
+  owner: string;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- add `/congress/stores/1` topic and store agent for Waku replication
- introduce `store-nft.tact` to mint store NFTs with name and owner
- enforce store ownership on product updates and link products to `storeId`
- add basic UI and route for creating and managing store NFTs

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires Node >=22; current 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68978ada48b883268c8ed943bc94286f