### PR TITLE
refactor: statically import TonConnectUI

### DIFF
--- a/services/tonAuth.ts
+++ b/services/tonAuth.ts
@@ -1,28 +1,29 @@
+import { TonConnectUI } from '@tonconnect/ui';
+
 class TonAuthService {
   private static instance: TonAuthService;
-  private tonConnectUI: any = null;
+  private tonConnectUI: TonConnectUI | null = null;
   private publicKey: string | null = null;
   private address: string | null = null;
 
   private constructor() {
-    if (typeof window !== 'undefined') {
-      this.init();
-    }
+    this.init();
   }
 
-  private async init() {
-    try {
-      const { TonConnectUI } = await import('@tonconnect/ui');
-      const manifestUrl = process.env.NODE_ENV === 'development'
-        ? new URL('/tonconnect-manifest.json', window.location.origin).href
-        : '/tonconnect-manifest.json';
-      this.tonConnectUI = new TonConnectUI({ manifestUrl });
-      this.tonConnectUI.onStatusChange((wallet: any | null) => {
-        this.publicKey = wallet?.account?.publicKey ?? null;
-        this.address = wallet?.account?.address ?? null;
-      });
-    } catch (e) {
-      console.error('Failed to initialize TonConnectUI', e);
+  private init() {
+    if (typeof window !== 'undefined') {
+      try {
+        const manifestUrl = process.env.NODE_ENV === 'development'
+          ? new URL('/tonconnect-manifest.json', window.location.origin).href
+          : '/tonconnect-manifest.json';
+        this.tonConnectUI = new TonConnectUI({ manifestUrl });
+        this.tonConnectUI.onStatusChange((wallet: any | null) => {
+          this.publicKey = wallet?.account?.publicKey ?? null;
+          this.address = wallet?.account?.address ?? null;
+        });
+      } catch (e) {
+        console.error('Failed to initialize TonConnectUI', e);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- switch to top-level `TonConnectUI` import
- guard TonConnectUI init for browser environments

## Testing
- `yarn lint`
- `yarn test` *(fails: Type 'string | null' is not assignable to type 'string | undefined'; Cannot find module '@waku/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_6897aec59dd08326a5a51b61e6ac196d