### PR TITLE
Alias Waku SDK for browser build

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,18 +4,30 @@ const { getDefaultConfig } = require('@expo/metro-config');
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push('wasm', 'sql');
 
+// Resolve package roots to avoid Node's fallbacks to non-browser builds
+const nobleHashesPath = path.resolve(__dirname, 'node_modules/@noble/hashes');
+const multiformatsPath = path.resolve(__dirname, 'node_modules/multiformats');
+
 // Map the Expo HMR client to our local wrapper so Buffer and Web Crypto are polyfilled
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
   '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
-  '@expo/metro-runtime/src/HMRClient.ts': path.resolve(__dirname, 'HMRClient.ts'),
+  '@expo/metro-runtime/src/HMRClient.ts': path.resolve(
+    __dirname,
+    'HMRClient.ts'
+  ),
   'react-native/Libraries/Utilities/HMRClient': path.resolve(
     __dirname,
     'EmptyHMRClient.ts'
   ),
-  '@noble/hashes/crypto.js': require.resolve('@noble/hashes/lib/crypto.js'),
-  '@waku/sdk': require.resolve('@waku/sdk/bundle/index.js'),
-  multiformats: require.resolve('multiformats/dist/index.min.js'),
+  '@noble/hashes': path.join(nobleHashesPath, 'index.js'),
+  '@noble/hashes/crypto': path.join(nobleHashesPath, 'crypto.js'),
+  '@noble/hashes/crypto.js': path.join(nobleHashesPath, 'crypto.js'),
+  '@waku/sdk': path.resolve(
+    __dirname,
+    'node_modules/@waku/sdk/bundle/index.js'
+  ),
+  multiformats: path.join(multiformatsPath, 'dist/index.min.js'),
 };
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,11 @@ module.exports = async function (env, argv) {
   );
 
   // Match Metro alias for the custom HMR client
+  const nobleHashesPath = path.resolve(__dirname, 'node_modules/@noble/hashes');
+  const multiformatsPath = path.resolve(
+    __dirname,
+    'node_modules/multiformats'
+  );
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),
@@ -41,9 +46,14 @@ module.exports = async function (env, argv) {
       __dirname,
       'EmptyHMRClient.ts'
     ),
-    '@noble/hashes/crypto.js': require.resolve('@noble/hashes/lib/crypto.js'),
-    '@waku/sdk': require.resolve('@waku/sdk/bundle/index.js'),
-    multiformats: require.resolve('multiformats/dist/index.min.js'),
+    '@noble/hashes': path.join(nobleHashesPath, 'index.js'),
+    '@noble/hashes/crypto': path.join(nobleHashesPath, 'crypto.js'),
+    '@noble/hashes/crypto.js': path.join(nobleHashesPath, 'crypto.js'),
+    '@waku/sdk': path.resolve(
+      __dirname,
+      'node_modules/@waku/sdk/bundle/index.js'
+    ),
+    multiformats: path.join(multiformatsPath, 'dist/index.min.js'),
   };
 
   return config;


### PR DESCRIPTION
## Summary
- Resolve `@waku/sdk` to its pre-bundled browser build so Metro and Webpack avoid eval usage
- Pin `@noble/hashes` and `multiformats` to explicit browser-friendly entry points

## Testing
- `yarn test` *(fails: Type 'string | null' is not assignable to type 'string | undefined'; Cannot find module '@waku/sdk')*
- `yarn build:web`


------
https://chatgpt.com/codex/tasks/task_e_6897ccc6ab1c8326b320cc43f85296c7