### PR TITLE
feat: generate default waku secret

### DIFF
--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -3,6 +3,11 @@ import { loadConfig as loadConfigFromStorage, saveConfig as persistConfig } from
 // Configuration values are stored locally but can be overridden by
 // environment variables. When a value exists in `process.env` it
 // takes precedence over the persisted config.
+//
+// `EXPO_PUBLIC_WAKU_SECRET` is used to encrypt/decrypt messages sent over
+// Waku. **All production peers must use the same secret** or messages will
+// not be readable between them. During development a random secret is
+// generated if one is not provided.
 
 const config: Record<string, string> = {};
 
@@ -33,10 +38,32 @@ export async function initConfig(): Promise<void> {
   }
 
   if (!config.EXPO_PUBLIC_WAKU_SECRET) {
-    const message =
-      'Missing EXPO_PUBLIC_WAKU_SECRET. Provide it via configuration or onboarding.';
-    console.error(message);
-    throw new Error(message);
+    if (process.env.NODE_ENV !== 'production') {
+      const buf = new Uint8Array(32);
+      const cryptoObj =
+        typeof globalThis.crypto !== 'undefined'
+          ? globalThis.crypto
+          : (await import('crypto')).webcrypto;
+      cryptoObj.getRandomValues(buf);
+      config.EXPO_PUBLIC_WAKU_SECRET = Buffer.from(buf).toString('hex');
+      await persistConfig(config);
+    } else {
+      let secret: string | null = null;
+      if (typeof (globalThis as any).prompt === 'function') {
+        secret = (globalThis as any).prompt(
+          'Enter shared Waku secret used for message decryption:',
+        );
+      }
+      if (secret) {
+        config.EXPO_PUBLIC_WAKU_SECRET = secret;
+        await persistConfig(config);
+      } else {
+        const message =
+          'Missing EXPO_PUBLIC_WAKU_SECRET. Provide it via configuration or onboarding.';
+        console.error(message);
+        throw new Error(message);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- generate and persist a random Waku secret in development if one is not configured
- prompt for the shared Waku secret in production and document that peers must share it

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d13298e08326bc7ff23e45b31978