### PR TITLE
feat: make waku signatures optional

### DIFF
--- a/lib/waku/sendWakuCartUpdate.ts
+++ b/lib/waku/sendWakuCartUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuCartUpdate = async (cartItem: any) => {
+export const sendWakuCartUpdate = async (
+  cartItem: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'cart.update', cartItem, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'cart.update', cartItem };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/cart/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuCategoryUpdate.ts
+++ b/lib/waku/sendWakuCategoryUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuCategoryUpdate = async (category: any) => {
+export const sendWakuCategoryUpdate = async (
+  category: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'category.update', category, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'category.update', category };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/categories/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuNotificationUpdate = async (notification: any) => {
+export const sendWakuNotificationUpdate = async (
+  notification: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'notification.update', notification, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'notification.update', notification };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/notifications/1' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuOrderUpdate = async (order: any) => {
+export const sendWakuOrderUpdate = async (
+  order: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'order.update', order, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'order.update', order };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/orders/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuProductUpdate = async (product: any) => {
+export const sendWakuProductUpdate = async (
+  product: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'product.update', product, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'product.update', product };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/products/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -6,25 +6,28 @@ export const sendWakuSettingsUpdate = async (
   key: string,
   value: string,
   createdAt: number,
-  updatedAt: number
+  updatedAt: number,
+  requireSignature = true,
 ) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = {
+  const payloadObj: any = {
     type: 'settings.update',
     key,
     value,
     createdAt,
     updatedAt,
-    sender,
   };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/settings/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuStoreUpdate.ts
+++ b/lib/waku/sendWakuStoreUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuStoreUpdate = async (store: any) => {
+export const sendWakuStoreUpdate = async (
+  store: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'store.update', store, nftId: store.nftId, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'store.update', store, nftId: store.nftId };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/stores/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -2,17 +2,23 @@ import { encryptWakuPayload } from './wakuCrypto';
 import { getNode } from './nodeSingleton';
 import tonAuth from '../../services/tonAuth';
 
-export const sendWakuUserUpdate = async (user: any) => {
+export const sendWakuUserUpdate = async (
+  user: any,
+  requireSignature = true,
+) => {
   const node = await getNode();
-  const sender = {
-    address: tonAuth.getAddress(),
-    publicKey: tonAuth.getTonPublicKey(),
-  };
-  const payloadObj = { type: 'user.update', user, sender };
-  const message = JSON.stringify(payloadObj);
-  const signature = await tonAuth.requestSignature(message);
-  const signed = { ...payloadObj, signature };
-  const encrypted = await encryptWakuPayload(JSON.stringify(signed));
+  const payloadObj: any = { type: 'user.update', user };
+  if (requireSignature) {
+    const sender = {
+      address: tonAuth.getAddress(),
+      publicKey: tonAuth.getTonPublicKey(),
+    };
+    payloadObj.sender = sender;
+    const message = JSON.stringify(payloadObj);
+    const signature = await tonAuth.requestSignature(message);
+    payloadObj.signature = signature;
+  }
+  const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));
   const encoder = node.createEncoder({ contentTopic: '/congress/users/1/proto' });
   await node.lightPush!.send(encoder, { payload: new TextEncoder().encode(encrypted) });
 };

--- a/tests/wakuAgentValidation.test.ts
+++ b/tests/wakuAgentValidation.test.ts
@@ -5,6 +5,7 @@ interface TestItem { id: string; value: string }
 test('accepts messages without sender or signature', async () => {
   const agent = new WakuAgent<TestItem>(async () => {}, {
     extractItem: (msg: any) => msg.item as TestItem,
+    requireSignature: false,
   });
 
   const item = { id: 'x', value: '1' };
@@ -18,6 +19,7 @@ test('accepts messages without sender or signature', async () => {
 test('skips duplicate messages using hash cache', async () => {
   const agent = new WakuAgent<TestItem>(async () => {}, {
     extractItem: (msg: any) => msg.item as TestItem,
+    requireSignature: false,
   });
 
   const item = { id: 'd', value: 'dup' };

--- a/tests/wakuUpdates.test.ts
+++ b/tests/wakuUpdates.test.ts
@@ -37,6 +37,15 @@ describe('Waku send updates', () => {
     expect(node.lightPush.send).toHaveBeenCalled();
   });
 
+  it('omits sender and signature when disabled', async () => {
+    await sendWakuProductUpdate({}, false);
+    const payload = node.lightPush.send.mock.calls[0][1].payload;
+    const decoded = new TextDecoder().decode(payload);
+    const parsed = JSON.parse(decoded);
+    expect(parsed.sender).toBeUndefined();
+    expect(parsed.signature).toBeUndefined();
+  });
+
   it('order update uses shared node', async () => {
     await sendWakuOrderUpdate({});
     expect(getNode).toHaveBeenCalled();

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -20,6 +20,8 @@ export interface WakuAgentOptions<T> {
   onUpdate?: (item: T) => void;
   /** Additional validation */
   validateMessage?: (msg: any) => boolean | Promise<boolean>;
+  /** Require TON signatures on incoming messages */
+  requireSignature?: boolean;
 }
 
 /**
@@ -36,7 +38,7 @@ export default class WakuAgent<T extends { id: string }> {
   protected hashCache: Set<string> = new Set();
 
   constructor(
-    private sendFn: (item: T) => Promise<void>,
+    private sendFn: (item: T, requireSignature?: boolean) => Promise<void>,
     private options: WakuAgentOptions<T> = {}
   ) {
     if (this.options.topic) {
@@ -124,31 +126,33 @@ export default class WakuAgent<T extends { id: string }> {
     try {
       if (this.hashCache.has(payload)) return;
       const parsed = JSON.parse(payload);
-
       const { signature, sender, ...unsigned } = parsed as any;
-      if (!signature || !sender?.publicKey || !sender?.address) return;
 
-      const message = JSON.stringify(unsigned);
-      const msgBytes = Buffer.from(message, 'utf8');
-      const sigBytes = Buffer.from(signature, 'base64');
-      const pubKeyBytes = Buffer.from(sender.publicKey, 'hex');
+      if (this.options.requireSignature !== false) {
+        if (!signature || !sender?.publicKey || !sender?.address) return;
 
-      const isValid = TonWeb.utils.nacl.sign.detached.verify(
-        msgBytes,
-        sigBytes,
-        pubKeyBytes,
-      );
-      if (!isValid) {
-        console.error('Invalid TON signature');
-        return;
-      }
+        const message = JSON.stringify(unsigned);
+        const msgBytes = Buffer.from(message, 'utf8');
+        const sigBytes = Buffer.from(signature, 'base64');
+        const pubKeyBytes = Buffer.from(sender.publicKey, 'hex');
 
-      const WalletClass = tonweb.wallet.all[tonweb.wallet.defaultVersion];
-      const wallet = new WalletClass(tonweb.provider, { publicKey: pubKeyBytes, wc: 0 });
-      const derived = (await wallet.getAddress()).toString(true, true, true);
-      if (derived !== sender.address) {
-        console.error('Signature address mismatch');
-        return;
+        const isValid = TonWeb.utils.nacl.sign.detached.verify(
+          msgBytes,
+          sigBytes,
+          pubKeyBytes,
+        );
+        if (!isValid) {
+          console.error('Invalid TON signature');
+          return;
+        }
+
+        const WalletClass = tonweb.wallet.all[tonweb.wallet.defaultVersion];
+        const wallet = new WalletClass(tonweb.provider, { publicKey: pubKeyBytes, wc: 0 });
+        const derived = (await wallet.getAddress()).toString(true, true, true);
+        if (derived !== sender.address) {
+          console.error('Signature address mismatch');
+          return;
+        }
       }
 
       if (this.options.validateMessage && !(await this.options.validateMessage(parsed))) return;
@@ -170,7 +174,7 @@ export default class WakuAgent<T extends { id: string }> {
 
   protected async broadcast(item: T) {
     try {
-      await this.sendFn(item);
+      await this.sendFn(item, this.options.requireSignature !== false);
     } catch (e) {
       console.error('Failed to broadcast Waku message', e);
     }


### PR DESCRIPTION
## Summary
- allow disabling TON signature validation with `requireSignature`
- omit `sender` and `signature` fields from Waku helpers when signatures off
- add tests for unsigned Waku messages

## Testing
- `npm test` *(fails: utils/appConfig.ts:47:17 - error TS2349: This expression is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6897d40564e08326ae00029c2735701e