### PR TITLE
refactor: centralize polyfill imports

### DIFF
--- a/HMRClient.ts
+++ b/HMRClient.ts
@@ -1,9 +1,3 @@
-import 'react-native-get-random-values';
-import { Buffer } from 'buffer';
-// Ensure Buffer is available globally for any modules that expect it
-(global as any).Buffer = Buffer;
-import 'expo-standard-web-crypto';
-
 const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 export default MetroHMRClient;
 export * from 'metro-runtime/src/modules/HMRClient';

--- a/README.md
+++ b/README.md
@@ -80,21 +80,25 @@ purchases. Pass the wallet address, coin and USD amount to display the widget in
 a modal and pre-fill the fiat amount.
 
 
-Some dependencies rely on Node.js globals like `Buffer` and `URL`. The project
-includes a `polyfills.js` file to provide these when running on React Native or
-the web. The polyfill is automatically imported from `index.ts`.
-The project also uses `expo-standard-web-crypto` to polyfill the Web Crypto API,
-so ensure it's installed as a dependency.
-The polyfill additionally provides a synchronous SHA-512 implementation for
-`@noble/ed25519` so key generation works in every environment.
+Some dependencies rely on Node.js globals like `Buffer`, `process`, and
+`crypto.subtle`. The `polyfills.js` file provides these shims for React Native
+and web environments and **must only be imported once** from the app entry
+point (`index.ts`). Importing polyfills elsewhere can lead to inconsistent
+execution environments.
+
+The polyfill also pulls in `react-native-get-random-values` and
+`expo-standard-web-crypto` so `crypto.getRandomValues` and `crypto.subtle` are
+available globally. It additionally exposes a synchronous SHA-512
+implementation for `@noble/ed25519` so key generation works in every
+environment.
 
 ### Hot Reloading
 
 Metro resolves both `@expo/metro-runtime/src/HMRClient` and
 `@expo/metro-runtime/src/HMRClient.ts` to the local `HMRClient.ts` wrapper.
 TypeScript and webpack use the same aliases so all tools reference the wrapper
-consistently. This module applies the necessary polyfills before loading
-Metro's runtime so hot reloading works reliably on every platform.
+consistently. Polyfills are initialized at the app entry point, so the HMR
+runtime runs within the already-prepared environment.
 
 Metro also maps `react-native/Libraries/Utilities/HMRClient` to a stub
 `EmptyHMRClient.ts` with no-op methods so bundling succeeds even when the native

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,7 +8,7 @@ config.resolver.assetExts.push('wasm', 'sql');
 const nobleHashesPath = path.resolve(__dirname, 'node_modules/@noble/hashes');
 const multiformatsPath = path.resolve(__dirname, 'node_modules/multiformats');
 
-// Map the Expo HMR client to our local wrapper so Buffer and Web Crypto are polyfilled
+// Map the Expo HMR client to our local wrapper; polyfills are applied at app entry
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
   '@expo/metro-runtime/src/HMRClient': path.resolve(__dirname, 'HMRClient.ts'),

--- a/polyfills.js
+++ b/polyfills.js
@@ -6,7 +6,9 @@ import { etc as edUtils } from '@noble/ed25519';
 
 try {
   require('react-native-get-random-values'); // correct: must use require()
-  require('expo-standard-web-crypto'); // correct
+  if (typeof global.crypto === 'undefined' || !global.crypto.subtle) {
+    require('expo-standard-web-crypto'); // provides global.crypto.subtle
+  }
 } catch (err) {
   console.warn('❌ Polyfill load failed:', err);
 }


### PR DESCRIPTION
## Summary
- load crypto, Buffer, and related shims once from `index.ts`
- simplify `HMRClient` and update Metro config to rely on entry polyfills
- document polyfills and HMR setup for developers

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4".)*


------
https://chatgpt.com/codex/tasks/task_e_6897ec139adc8326ac1cdd2588f0c14d