### PR TITLE
Ensure TON wallet before Waku updates

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,6 +1,7 @@
 import { CartItem } from '../types';
 import { sendWakuCartUpdate } from '../lib/waku/sendWakuCartUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
 
 // Publishes and replicates cart items via Waku
 
@@ -12,6 +13,25 @@ class CartAgent extends WakuAgent<CartItem> {
       extractItem: (msg: any) =>
         msg.type === 'cart.update' ? (msg.cartItem as CartItem) : undefined,
     });
+  }
+
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage your cart.');
+    }
+  }
+
+  async add(item: CartItem): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: CartItem): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
   }
 }
 

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -1,6 +1,7 @@
 import { Category } from '../types';
 import { sendWakuCategoryUpdate } from '../lib/waku/sendWakuCategoryUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
 
 // Publishes and replicates category records via Waku
 
@@ -12,6 +13,25 @@ class CategoriesAgent extends WakuAgent<Category> {
       extractItem: (msg: any) =>
         msg.type === 'category.update' ? (msg.category as Category) : undefined,
     });
+  }
+
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage categories.');
+    }
+  }
+
+  async add(item: Category): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: Category): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
   }
 }
 

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,6 +1,7 @@
 import { Notification } from '../types';
 import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
 
 class NotificationsAgent extends WakuAgent<Notification> {
   private subscribers: Set<(n: Notification) => void> = new Set();
@@ -14,6 +15,25 @@ class NotificationsAgent extends WakuAgent<Notification> {
         this.subscribers.forEach((cb) => cb(item));
       },
     });
+  }
+
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to send notifications.');
+    }
+  }
+
+  async add(item: Notification): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: Notification): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
   }
 
   subscribe(cb: (n: Notification) => void) {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -6,6 +6,7 @@ import {
   releaseFunds,
   refundOrder,
 } from '../services/tonContract';
+import tonAuth from '../services/tonAuth';
 
 class OrdersAgent extends WakuAgent<Order> {
   private subscribers: Set<(o: Order) => void> = new Set();
@@ -21,7 +22,17 @@ class OrdersAgent extends WakuAgent<Order> {
     });
   }
 
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage orders.');
+    }
+  }
+
   async add(order: Order): Promise<void> {
+    await this.ensureWallet();
     const { contractAddress, txHash } = await createOrderPayment(order);
     const orderWithTx: Order = {
       ...order,
@@ -31,7 +42,13 @@ class OrdersAgent extends WakuAgent<Order> {
     await super.add(orderWithTx);
   }
 
+  async update(order: Order): Promise<void> {
+    await this.ensureWallet();
+    await super.update(order);
+  }
+
   async releaseFunds(orderId: string): Promise<string> {
+    await this.ensureWallet();
     const order = this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');
@@ -40,6 +57,7 @@ class OrdersAgent extends WakuAgent<Order> {
   }
 
   async refundOrder(orderId: string): Promise<string> {
+    await this.ensureWallet();
     const order = this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -20,10 +20,30 @@ class ProductsAgent extends WakuAgent<Product> {
     });
   }
 
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage products.');
+    }
+    return { address };
+  }
+
+  async add(item: Product): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: Product): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
+  }
+
   protected async broadcast(item: Product) {
+    const { address } = await this.ensureWallet();
     const store = storesAgent.get(item.storeId);
-    const addr = tonAuth.getAddress();
-    if (!store || store.owner !== addr) {
+    if (!store || store.owner !== address) {
       throw new Error('Only the store owner can broadcast product updates');
     }
     await super.broadcast(item);

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -2,6 +2,7 @@ import WakuAgent from '../utils/wakuAgent';
 import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
 import { store } from '../lib/memoryStore';
 import type { TenantSettings } from '../types';
+import tonAuth from '../services/tonAuth';
 
 interface SettingItem { id: string; value: string }
 
@@ -25,6 +26,25 @@ class SettingsAgent extends WakuAgent<SettingItem> {
     );
   }
 
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage settings.');
+    }
+  }
+
+  async add(item: SettingItem): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: SettingItem): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
+  }
+
   async set(key: string, value: string): Promise<void> {
     if (this.store.has(key)) {
       await this.update({ id: key, value });
@@ -38,6 +58,7 @@ class SettingsAgent extends WakuAgent<SettingItem> {
       await sendWakuSettingsUpdate(item.id, item.value, Date.now(), Date.now());
     } catch (e) {
       console.error('Failed to broadcast settings update', e);
+      throw e;
     }
   }
 

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,6 +1,7 @@
 import { Store } from '../types';
 import { sendWakuStoreUpdate } from '../lib/waku/sendWakuStoreUpdate';
 import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
 
 class StoresAgent extends WakuAgent<Store> {
   constructor() {
@@ -9,6 +10,25 @@ class StoresAgent extends WakuAgent<Store> {
       replayHistory: true,
       extractItem: (msg: any) => msg.store as Store,
     });
+  }
+
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage stores.');
+    }
+  }
+
+  async add(item: Store): Promise<void> {
+    await this.ensureWallet();
+    await super.add(item);
+  }
+
+  async update(item: Store): Promise<void> {
+    await this.ensureWallet();
+    await super.update(item);
   }
 }
 

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -12,20 +12,32 @@ class UsersAgent extends WakuAgent<User> {
     });
   }
 
+  private async ensureWallet() {
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to manage users.');
+    }
+    return { address, publicKey };
+  }
+
   async add(user: User): Promise<void> {
+    const { address, publicKey } = await this.ensureWallet();
     const enriched: User = {
       ...user,
-      publicKey: tonAuth.getTonPublicKey() || user.publicKey,
-      address: tonAuth.getAddress(),
+      publicKey,
+      address,
     };
     await super.add(enriched);
   }
 
   async update(user: User): Promise<void> {
+    const { address, publicKey } = await this.ensureWallet();
     const enriched: User = {
       ...user,
-      publicKey: tonAuth.getTonPublicKey() || user.publicKey,
-      address: tonAuth.getAddress(),
+      publicKey,
+      address,
     };
     await super.update(enriched);
   }

--- a/lib/waku/sendWakuCartUpdate.ts
+++ b/lib/waku/sendWakuCartUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuCartUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'cart.update', cartItem };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuCategoryUpdate.ts
+++ b/lib/waku/sendWakuCategoryUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuCategoryUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'category.update', category };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuNotificationUpdate.ts
+++ b/lib/waku/sendWakuNotificationUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuNotificationUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'notification.update', notification };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuOrderUpdate.ts
+++ b/lib/waku/sendWakuOrderUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuOrderUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'order.update', order };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuProductUpdate.ts
+++ b/lib/waku/sendWakuProductUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuProductUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'product.update', product };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuSettingsUpdate.ts
+++ b/lib/waku/sendWakuSettingsUpdate.ts
@@ -18,13 +18,19 @@ export const sendWakuSettingsUpdate = async (
     updatedAt,
   };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuStoreUpdate.ts
+++ b/lib/waku/sendWakuStoreUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuStoreUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'store.update', store, nftId: store.nftId };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/lib/waku/sendWakuUserUpdate.ts
+++ b/lib/waku/sendWakuUserUpdate.ts
@@ -9,13 +9,19 @@ export const sendWakuUserUpdate = async (
   const node = await getNode();
   const payloadObj: any = { type: 'user.update', user };
   if (requireSignature) {
-    const sender = {
-      address: tonAuth.getAddress(),
-      publicKey: tonAuth.getTonPublicKey(),
-    };
+    const address = tonAuth.getAddress();
+    const publicKey = tonAuth.getTonPublicKey();
+    if (!address || !publicKey) {
+      await tonAuth.openModal();
+      throw new Error('Please connect your TON wallet to continue.');
+    }
+    const sender = { address, publicKey };
     payloadObj.sender = sender;
     const message = JSON.stringify(payloadObj);
     const signature = await tonAuth.requestSignature(message);
+    if (!signature) {
+      throw new Error('Signature request was rejected by the wallet.');
+    }
     payloadObj.signature = signature;
   }
   const encrypted = await encryptWakuPayload(JSON.stringify(payloadObj));

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -177,6 +177,7 @@ export default class WakuAgent<T extends { id: string }> {
       await this.sendFn(item, this.options.requireSignature !== false);
     } catch (e) {
       console.error('Failed to broadcast Waku message', e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Summary
- verify wallet address and public key before signing Waku messages
- prompt users to connect wallet across all agents
- rethrow broadcast errors for better surfacing

## Testing
- `yarn test` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_6897ee0b4f708326948dbaab59cc8f39