### PR TITLE
test: cover waku and ton connect flows

### DIFF
--- a/tests/tonAuthContract.test.ts
+++ b/tests/tonAuthContract.test.ts
@@ -1,0 +1,73 @@
+import TonWeb from 'tonweb';
+import * as tonAuth from '../services/tonAuth';
+import {
+  createOrderPayment,
+  releaseFunds,
+  refundOrder,
+  ORDER_PAYMENT_FACTORY_ADDRESS,
+} from '../services/tonContract';
+
+describe('tonAuth.requestSignature', () => {
+  it('uses TonConnect signData', async () => {
+    const mockTonConnect = {
+      signData: jest.fn().mockResolvedValue({ signature: 'abc' }),
+    };
+    (tonAuth as any).tonConnect = mockTonConnect;
+    const payload = { hello: 'world' };
+    const result = await tonAuth.requestSignature(payload);
+    expect(mockTonConnect.signData).toHaveBeenCalledWith(payload);
+    expect(result).toBe('abc');
+    (tonAuth as any).tonConnect = null;
+  });
+});
+
+describe('Ton contract flows', () => {
+  const bocBytes = Buffer.from([1, 2, 3]);
+  const boc = bocBytes.toString('base64');
+  const expectedHash = TonWeb.utils.bytesToHex(
+    TonWeb.utils.sha256_sync(Buffer.from(boc, 'base64')),
+  );
+  const mockTonConnect = {
+    sendTransaction: jest.fn().mockResolvedValue({ boc }),
+  } as any;
+
+  beforeEach(() => {
+    jest.spyOn(tonAuth, 'getTonConnect').mockReturnValue(mockTonConnect);
+    jest.clearAllMocks();
+  });
+
+  it('creates order payment via TonConnect', async () => {
+    const order = { total: 5 } as any;
+    const result = await createOrderPayment(order);
+    expect(mockTonConnect.sendTransaction).toHaveBeenCalled();
+    const sent = mockTonConnect.sendTransaction.mock.calls[0][0];
+    expect(sent.messages[0].address).toBe(ORDER_PAYMENT_FACTORY_ADDRESS);
+    expect(result.contractAddress).toBe(ORDER_PAYMENT_FACTORY_ADDRESS);
+    expect(result.txHash).toBe(expectedHash);
+  });
+
+  it('releases funds through TonConnect', async () => {
+    const res = await releaseFunds('contract1');
+    expect(mockTonConnect.sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({ address: 'contract1', amount: '0' }),
+        ],
+      }),
+    );
+    expect(res).toBe(expectedHash);
+  });
+
+  it('refunds order through TonConnect', async () => {
+    const res = await refundOrder('contract1');
+    expect(mockTonConnect.sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({ address: 'contract1', amount: '0' }),
+        ],
+      }),
+    );
+    expect(res).toBe(expectedHash);
+  });
+});
+

--- a/tests/wakuAgentBroadcast.test.ts
+++ b/tests/wakuAgentBroadcast.test.ts
@@ -1,0 +1,15 @@
+import WakuAgent from '../utils/wakuAgent';
+
+interface TestItem {
+  id: string;
+  value: string;
+}
+
+test('broadcasts messages using provided send function', async () => {
+  const sendFn = jest.fn().mockResolvedValue(undefined);
+  const agent = new WakuAgent<TestItem>(sendFn, { requireSignature: false });
+  const item = { id: 'b1', value: 'hello' };
+  await agent.add(item);
+  expect(sendFn).toHaveBeenCalledWith(item, false);
+});
+

--- a/tests/wakuAgentValidation.test.ts
+++ b/tests/wakuAgentValidation.test.ts
@@ -32,3 +32,49 @@ test('skips duplicate messages using hash cache', async () => {
   expect(all).toHaveLength(1);
   expect(all[0]).toEqual(item);
 });
+
+test('processes valid signed message when signature required', async () => {
+  const TonWeb = (await import('tonweb')).default as any;
+  const tonweb = new TonWeb();
+  const keyPair = TonWeb.utils.nacl.sign.keyPair();
+  const WalletClass = tonweb.wallet.all[tonweb.wallet.defaultVersion];
+  const wallet = new WalletClass(tonweb.provider, {
+    publicKey: keyPair.publicKey,
+    wc: 0,
+  });
+  const address = (await wallet.getAddress()).toString(true, true, true);
+
+  const item = { id: 's1', value: 'signed' };
+  const unsigned = {
+    type: 'item.update',
+    item,
+    sender: {
+      publicKey: Buffer.from(keyPair.publicKey).toString('hex'),
+      address,
+    },
+  };
+  const msgBytes = Buffer.from(JSON.stringify(unsigned), 'utf8');
+  const signature = Buffer.from(
+    TonWeb.utils.nacl.sign.detached(msgBytes, keyPair.secretKey),
+  ).toString('base64');
+  const payload = JSON.stringify({ ...unsigned, signature });
+
+  const agent = new WakuAgent<TestItem>(async () => {}, {
+    extractItem: (msg: any) => msg.item as TestItem,
+  });
+
+  await agent.processPayload(payload);
+  expect(agent.getAll()).toEqual([item]);
+});
+
+test('rejects unsigned message when signature required', async () => {
+  const agent = new WakuAgent<TestItem>(async () => {}, {
+    extractItem: (msg: any) => msg.item as TestItem,
+  });
+
+  const item = { id: 'u1', value: 'unsigned' };
+  const payload = JSON.stringify({ type: 'item.update', item });
+
+  await agent.processPayload(payload);
+  expect(agent.getAll()).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- add signed and unsigned payload tests for WakuAgent
- mock TonConnect to test requestSignature and contract flows
- verify WakuAgent broadcasting via mocked send interface

## Testing
- `yarn test` *(fails: utils/appConfig.ts:47:17 - error TS2349: This expression is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6897ef3157dc8326b16b478961eb9841