### PR TITLE
Add username to auth context and use in onboarding

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -65,9 +65,7 @@ export default function OnboardingScreen() {
     setLoading(true);
     try {
       setValue('EXPO_PUBLIC_TENANT', tenant);
-      if (user?.username) {
-        setValue('EXPO_PUBLIC_ADMIN_USERNAME', user.username);
-      }
+      setValue('EXPO_PUBLIC_ADMIN_USERNAME', user?.username ?? '');
       setValue('APP_NAME', appName);
       setValue('PRIMARY_COLOR', primaryColor);
       if (logo) setValue('APP_LOGO', logo);

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -5,11 +5,17 @@ import {
   useIsConnectionRestored,
 } from '@tonconnect/ui-react';
 
+interface User {
+  id: string;
+  address: string;
+  username: string;
+}
+
 interface AuthContextType {
   isLoggedIn: boolean;
   isAdmin: boolean;
   isDriver: boolean;
-  user: any | null;
+  user: User | null;
   loading: boolean;
   login: () => Promise<void>;
   signup: () => Promise<void>;
@@ -50,7 +56,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     await tonConnectUI.disconnect();
   };
 
-  const user = address ? { id: address, address } : null;
+  const user = address ? { id: address, address, username: address } : null;
 
   if (!connectionRestored) {
     return null;


### PR DESCRIPTION
## Summary
- add username field to auth user object defaulting to TON address
- use new username when saving onboarding admin config

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires Node >=22, current 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_6897f28008408326a7c43ed4db4c8861