### PR TITLE
feat: support custom Waku bootstrap peers

### DIFF
--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -12,7 +12,9 @@ import {
 import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
 import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
-const BOOTSTRAP =
+import { getWakuBootstrapNodes } from '../utils/appConfig';
+
+const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 
 export interface WakuClient {
@@ -42,8 +44,10 @@ export function useWakuClient(): WakuClient {
     (async () => {
       let node: LightNode | undefined;
       try {
+        const bootstrap = getWakuBootstrapNodes();
+        if (bootstrap.length === 0) bootstrap.push(DEFAULT_BOOTSTRAP);
         node = await createLightNode({
-          libp2p: { bootstrap: [BOOTSTRAP] },
+          libp2p: { bootstrap },
         });
         await node.start();
         await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);

--- a/lib/waku/nodeSingleton.ts
+++ b/lib/waku/nodeSingleton.ts
@@ -1,13 +1,18 @@
 import { createLightNode, waitForRemotePeer, Protocols, type LightNode } from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../../utils/appConfig';
 
 let nodePromise: Promise<LightNode> | null = null;
 
 export async function getNode(): Promise<LightNode> {
   if (!nodePromise) {
     nodePromise = (async () => {
+      const bootstrap = getWakuBootstrapNodes();
       const n = await createLightNode({
-        defaultBootstrap: true,
-        libp2p: { hideWebSocketInfo: true },
+        ...(bootstrap.length === 0 ? { defaultBootstrap: true } : {}),
+        libp2p: {
+          hideWebSocketInfo: true,
+          ...(bootstrap.length ? { bootstrap } : {}),
+        },
       });
       await n.start();
       await waitForRemotePeer(n, [Protocols.LightPush]);

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -15,6 +15,7 @@ const ENV_KEYS = [
   'EXPO_PUBLIC_JWT_SECRET',
   'EXPO_PUBLIC_CHAT_SECRET',
   'EXPO_PUBLIC_WAKU_SECRET',
+  'EXPO_PUBLIC_WAKU_BOOTSTRAP',
   'EXPO_PUBLIC_ADMIN_USERNAME',
   'EXPO_PUBLIC_PINATA_JWT',
   'EXPO_PUBLIC_PINATA_API_KEY',
@@ -74,6 +75,17 @@ export async function persist(): Promise<void> {
 export function setConfig(key: string, value: string): void {
   config[key] = value;
   // persistence handled externally
+}
+
+export function getWakuBootstrapNodes(): string[] {
+  const raw =
+    config.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
+    process.env.EXPO_PUBLIC_WAKU_BOOTSTRAP;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((addr) => addr.trim())
+    .filter(Boolean);
 }
 
 export default config;


### PR DESCRIPTION
## Summary
- allow bootstrap peers to be configured via EXPO_PUBLIC_WAKU_BOOTSTRAP
- use configured peers when initializing Waku clients

## Testing
- `yarn install` *(fails: @waku/sdk@0.0.33 requires node >=22; using 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_6897f4922e188326b305305e873e6e3c