### PR TITLE
chore: use lightPush.send in Waku client

### DIFF
--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -85,7 +85,7 @@ export function useWakuClient(): WakuClient {
 
     if (nodeRef.current) {
       const encoder = createEncoder({ contentTopic: topic(roomId) });
-      await nodeRef.current.lightPush.push(encoder, {
+      await nodeRef.current.lightPush.send(encoder, {
         payload: utf8ToBytes(encrypted),
       });
     }


### PR DESCRIPTION
## Summary
- use `lightPush.send` when sending chat messages

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install --frozen-lockfile` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_6897ff390d7c83268fa9381edf486ad7