### PR TITLE
refactor: use shared Waku node

### DIFF
--- a/lib/waku/nodeSingleton.ts
+++ b/lib/waku/nodeSingleton.ts
@@ -1,7 +1,21 @@
-import { createLightNode, waitForRemotePeer, Protocols, type LightNode } from '@waku/sdk';
+import {
+  createLightNode,
+  waitForRemotePeer,
+  Protocols,
+  type LightNode,
+  type Decoder,
+} from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../../utils/appConfig';
 
 let nodePromise: Promise<LightNode> | null = null;
+
+type TopicSubscription = {
+  decoder: Decoder<any>;
+  handlers: Set<(msg: any) => void | Promise<void>>;
+  callback: (msg: any) => void | Promise<void>;
+};
+
+const subscriptions: Map<string, TopicSubscription> = new Map();
 
 export async function getNode(): Promise<LightNode> {
   if (!nodePromise) {
@@ -15,16 +29,66 @@ export async function getNode(): Promise<LightNode> {
         },
       });
       await n.start();
-      await waitForRemotePeer(n, [Protocols.LightPush]);
+      await waitForRemotePeer(n, [
+        Protocols.Filter,
+        Protocols.Store,
+        Protocols.LightPush,
+      ]);
       return n;
     })();
   }
   return nodePromise;
 }
 
+export async function subscribe(
+  topic: string,
+  handler: (msg: any) => void | Promise<void>,
+): Promise<Decoder<any>> {
+  const node = await getNode();
+  let sub = subscriptions.get(topic);
+  if (!sub) {
+    const decoder = node.createDecoder({ contentTopic: topic });
+    const handlers = new Set<(msg: any) => void | Promise<void>>();
+    const callback = async (msg: any) => {
+      for (const h of handlers) {
+        await h(msg);
+      }
+    };
+    await node.filter!.subscribe(decoder, callback);
+    sub = { decoder, handlers, callback };
+    subscriptions.set(topic, sub);
+  }
+  sub.handlers.add(handler);
+  return sub.decoder;
+}
+
+export async function unsubscribe(
+  topic: string,
+  handler: (msg: any) => void | Promise<void>,
+): Promise<void> {
+  const sub = subscriptions.get(topic);
+  if (!sub) return;
+  sub.handlers.delete(handler);
+  if (sub.handlers.size === 0) {
+    const node = await getNode();
+    try {
+      await node.filter?.unsubscribe(sub.decoder);
+    } catch {
+      // ignore unsubscribe errors
+    }
+    subscriptions.delete(topic);
+  }
+}
+
 export async function stopNode(): Promise<void> {
   if (nodePromise) {
     const n = await nodePromise;
+    for (const { decoder } of subscriptions.values()) {
+      try {
+        await n.filter?.unsubscribe(decoder);
+      } catch {}
+    }
+    subscriptions.clear();
     await n.stop();
     nodePromise = null;
   }

--- a/utils/wakuAgent.ts
+++ b/utils/wakuAgent.ts
@@ -1,11 +1,7 @@
 import { Buffer } from 'buffer';
-import {
-  createLightNode,
-  waitForRemotePeer,
-  Protocols,
-} from '@waku/sdk';
 import TonWeb from 'tonweb';
 import { decryptWakuPayload } from '../lib/waku/wakuCrypto';
+import { getNode, subscribe, unsubscribe } from '../lib/waku/nodeSingleton';
 
 const tonweb = new TonWeb();
 
@@ -32,6 +28,7 @@ export default class WakuAgent<T extends { id: string }> {
   protected store: Map<string, T> = new Map();
   private node: any | null = null;
   private decoder: any | null = null;
+  private handler: ((msg: any) => Promise<void>) | null = null;
   private readyPromise: Promise<void> | null = null;
   /** Exposed promise for external consumers */
   public ready: Promise<void> | null = null;
@@ -93,25 +90,23 @@ export default class WakuAgent<T extends { id: string }> {
 
   private async init() {
     try {
-      this.node = await createLightNode({
-        defaultBootstrap: true,
-        libp2p: { hideWebSocketInfo: true },
-      });
-      await this.node.start();
-      await waitForRemotePeer(this.node, [Protocols.Store, Protocols.LightPush]);
+      this.node = await getNode();
       if (!this.options.topic) return;
-      this.decoder = this.node.createDecoder({ contentTopic: this.options.topic });
-      const handler = async (msg: any) => {
+      this.handler = async (msg: any) => {
         if (!msg.payload) return;
         const decoded = new TextDecoder().decode(msg.payload);
         const plaintext = await decryptWakuPayload(decoded);
         await this.processPayload(plaintext);
       };
-      await this.node.filter!.subscribe(this.decoder, handler);
+      this.decoder = await subscribe(this.options.topic, this.handler);
 
       if (this.options.replayHistory) {
         try {
-          await this.node.store.queryWithOrderedCallback([this.decoder], handler, { pageSize: 100 });
+          await this.node.store.queryWithOrderedCallback(
+            [this.decoder],
+            this.handler,
+            { pageSize: 100 },
+          );
         } catch (e) {
           console.error('Failed to replay Waku history', e);
         }
@@ -182,14 +177,14 @@ export default class WakuAgent<T extends { id: string }> {
   }
 
   async stop() {
-    if (this.decoder && this.node?.filter) {
+    if (this.options.topic && this.handler) {
       try {
-        await this.node.filter.unsubscribe(this.decoder);
+        await unsubscribe(this.options.topic, this.handler);
       } catch {}
     }
-    await this.node?.stop();
-    this.node = null;
     this.decoder = null;
+    this.handler = null;
+    this.node = null;
   }
 }
 


### PR DESCRIPTION
## Summary
- use a singleton Waku node for agents
- enable multiple topic subscriptions on the shared node

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*
- `yarn lint` *(fails: expo: not found)*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898022ba020832691cb04947ab695b5