### PR TITLE
Allow Waku websocket in CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://tonapi.io https://raw.githubusercontent.com https://api.pinata.cloud https://gateway.pinata.cloud https://buy.moonpay.com https://blue-ocean.vercel.app; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://tonapi.io https://raw.githubusercontent.com https://api.pinata.cloud https://gateway.pinata.cloud https://buy.moonpay.com https://blue-ocean.vercel.app wss://node.waku.nodes.status.im; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';"
     />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- permit wss://node.waku.nodes.status.im in `connect-src` so the app can open Waku websockets

## Testing
- `yarn lint`
- `yarn test` *(fails: utils/appConfig.ts:48:17 - error TS2349: This expression is not callable)*
- headless Puppeteer check: WebSocket attempted to `wss://node.waku.nodes.status.im` with no CSP violations (certificate error only)


------
https://chatgpt.com/codex/tasks/task_e_68982c4cb1e88326a25dacab22e46d34