### PR TITLE
feat: add roadmap progression

### DIFF
--- a/app/control/LiveFocusView.tsx
+++ b/app/control/LiveFocusView.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import { RoadmapProvider, useRoadmap } from '../../contexts/RoadmapContext';
+import RoadmapService from '../../services/roadmap';
+import type { RoadmapTask } from '../../types';
+
+function LiveFocusInner() {
+  const { activeRoadmap, tasks, completeTask, progress } = useRoadmap();
+  const [currentTask, setCurrentTask] = useState<RoadmapTask | null>(null);
+
+  useEffect(() => {
+    if (activeRoadmap) {
+      const next = RoadmapService.getNextPendingTask(activeRoadmap.id);
+      setCurrentTask(next);
+    } else {
+      setCurrentTask(null);
+    }
+  }, [activeRoadmap, tasks]);
+
+  const handleComplete = async () => {
+    if (!activeRoadmap || !currentTask) return;
+    await completeTask(currentTask.id);
+    // simulate Supabase query for next pending task
+    const next = RoadmapService.getNextPendingTask(activeRoadmap.id);
+    setCurrentTask(next);
+  };
+
+  return (
+    <View style={{ padding: 16 }}>
+      <Text style={{ fontWeight: 'bold', marginBottom: 8 }}>
+        {activeRoadmap?.title || 'No Active Roadmap'}
+      </Text>
+      <Text style={{ marginBottom: 16 }}>Progress: {Math.round(progress)}%</Text>
+      {currentTask ? (
+        <View style={{ marginBottom: 16 }}>
+          <Text style={{ marginBottom: 8 }}>{currentTask.title}</Text>
+          <Button title="Complete" onPress={handleComplete} />
+        </View>
+      ) : (
+        <Text style={{ marginBottom: 16 }}>All tasks complete!</Text>
+      )}
+      <FlatList
+        data={tasks}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <Text
+            style={{
+              textDecorationLine: item.completed ? 'line-through' : 'none',
+              marginBottom: 4,
+            }}
+          >
+            {item.title}
+          </Text>
+        )}
+      />
+    </View>
+  );
+}
+
+export default function LiveFocusView() {
+  return (
+    <RoadmapProvider>
+      <LiveFocusInner />
+    </RoadmapProvider>
+  );
+}

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -12,6 +12,7 @@ import { router } from 'expo-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAppInfo } from '../contexts/AppInfoContext';
+import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from './WishlistModal';
 import CartService from '../services/cart';
@@ -30,6 +31,7 @@ export default function GlobalHeader({
   const { t } = useLanguage();
   const { colors } = useTheme();
   const { platformName, platformLogo } = useAppInfo();
+  const { progress } = useRoadmap();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
 
@@ -101,6 +103,18 @@ export default function GlobalHeader({
                 </View>
               )}
             </TouchableOpacity>
+            <View
+              style={[
+                styles.progressContainer,
+                { backgroundColor: colors.surface.primary },
+              ]}
+            >
+              <Text
+                style={[styles.progressText, { color: colors.text.primary }]}
+              >
+                {Math.round(progress)}%
+              </Text>
+            </View>
             <UserAvatar />
           </View>
         </View>
@@ -195,6 +209,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
   },
   badgeText: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  progressContainer: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  progressText: {
     fontSize: 12,
     fontWeight: 'bold',
   },

--- a/contexts/RoadmapContext.tsx
+++ b/contexts/RoadmapContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { Roadmap, RoadmapTask } from '../types';
+import RoadmapService from '../services/roadmap';
+
+interface RoadmapContextValue {
+  activeRoadmap: Roadmap | null;
+  tasks: RoadmapTask[];
+  progress: number;
+  setActiveRoadmap: (id: string) => void;
+  completeTask: (taskId: string) => Promise<void>;
+}
+
+const RoadmapContext = createContext<RoadmapContextValue>({
+  activeRoadmap: null,
+  tasks: [],
+  progress: 0,
+  setActiveRoadmap: () => {},
+  completeTask: async () => {},
+});
+
+export const RoadmapProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [activeRoadmap, setActiveRoadmapState] = useState<Roadmap | null>(
+    RoadmapService.getActiveRoadmap()
+  );
+  const [tasks, setTasks] = useState<RoadmapTask[]>(
+    activeRoadmap ? RoadmapService.getTasks(activeRoadmap.id) : []
+  );
+
+  const setActiveRoadmap = (id: string) => {
+    RoadmapService.setActiveRoadmap(id);
+    const rm = RoadmapService.getActiveRoadmap();
+    setActiveRoadmapState(rm);
+    setTasks(rm ? RoadmapService.getTasks(rm.id) : []);
+  };
+
+  const completeTask = async (taskId: string) => {
+    if (!activeRoadmap) return;
+    RoadmapService.completeTask(activeRoadmap.id, taskId);
+    setTasks([...RoadmapService.getTasks(activeRoadmap.id)]);
+  };
+
+  useEffect(() => {
+    const rm = RoadmapService.getActiveRoadmap();
+    setActiveRoadmapState(rm);
+    setTasks(rm ? RoadmapService.getTasks(rm.id) : []);
+  }, []);
+
+  const progress = activeRoadmap
+    ? RoadmapService.getProgress(activeRoadmap.id)
+    : 0;
+
+  return (
+    <RoadmapContext.Provider
+      value={{ activeRoadmap, tasks, progress, setActiveRoadmap, completeTask }}
+    >
+      {children}
+    </RoadmapContext.Provider>
+  );
+};
+
+export const useRoadmap = () => useContext(RoadmapContext);

--- a/services/roadmap.ts
+++ b/services/roadmap.ts
@@ -1,0 +1,73 @@
+import { Roadmap, RoadmapTask } from '../types';
+
+class RoadmapService {
+  private static instance: RoadmapService;
+  private roadmaps: Map<string, Roadmap> = new Map();
+  private activeRoadmapId: string | null = null;
+
+  public static getInstance(): RoadmapService {
+    if (!RoadmapService.instance) {
+      RoadmapService.instance = new RoadmapService();
+    }
+    return RoadmapService.instance;
+  }
+
+  addRoadmap(roadmap: Roadmap): void {
+    this.roadmaps.set(roadmap.id, roadmap);
+    if (roadmap.active) {
+      this.setActiveRoadmap(roadmap.id);
+    }
+  }
+
+  setActiveRoadmap(id: string): void {
+    this.activeRoadmapId = id;
+    // ensure exactly one active roadmap
+    for (const [rid, rm] of this.roadmaps.entries()) {
+      rm.active = rid === id;
+      this.roadmaps.set(rid, rm);
+    }
+  }
+
+  getActiveRoadmap(): Roadmap | null {
+    if (!this.activeRoadmapId) return null;
+    return this.roadmaps.get(this.activeRoadmapId) || null;
+  }
+
+  getRoadmap(id: string): Roadmap | null {
+    return this.roadmaps.get(id) || null;
+  }
+
+  addTask(roadmapId: string, task: RoadmapTask): void {
+    const rm = this.roadmaps.get(roadmapId);
+    if (!rm) return;
+    rm.tasks.push(task);
+    this.roadmaps.set(roadmapId, rm);
+  }
+
+  completeTask(roadmapId: string, taskId: string): void {
+    const rm = this.roadmaps.get(roadmapId);
+    if (!rm) return;
+    const t = rm.tasks.find(task => task.id === taskId);
+    if (t) t.completed = true;
+  }
+
+  getTasks(roadmapId: string): RoadmapTask[] {
+    return this.roadmaps.get(roadmapId)?.tasks || [];
+  }
+
+  getNextPendingTask(roadmapId: string): RoadmapTask | null {
+    const rm = this.roadmaps.get(roadmapId);
+    if (!rm) return null;
+    const sorted = [...rm.tasks].sort((a, b) => a.order - b.order);
+    return sorted.find(t => !t.completed) || null;
+  }
+
+  getProgress(roadmapId: string): number {
+    const rm = this.roadmaps.get(roadmapId);
+    if (!rm || rm.tasks.length === 0) return 0;
+    const completed = rm.tasks.filter(t => t.completed).length;
+    return (completed / rm.tasks.length) * 100;
+  }
+}
+
+export default RoadmapService.getInstance();

--- a/types/index.ts
+++ b/types/index.ts
@@ -261,3 +261,18 @@ export interface TenantSettings {
   platform_logo?: string | null;
   theme_color?: string | null;
 }
+
+export interface RoadmapTask {
+  id: string;
+  roadmapId: string;
+  title: string;
+  order: number;
+  completed: boolean;
+}
+
+export interface Roadmap {
+  id: string;
+  title: string;
+  tasks: RoadmapTask[];
+  active?: boolean;
+}


### PR DESCRIPTION
## Summary
- add in-memory roadmap service supporting single active roadmap and progress tracking
- expose roadmap context and LiveFocusView that steps through tasks sequentially
- surface roadmap progress in global header HUD

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: @waku/sdk requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68987b8b91cc83269ff660a59434b7f0