### PR TITLE
feat: replace waku agents with ton contracts

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,20 +1,8 @@
 import { CartItem } from '../types';
-import { sendWakuCartUpdate } from '../lib/waku/sendWakuCartUpdate';
-import WakuAgent from '../utils/wakuAgent';
 import tonAuth from '../services/tonAuth';
+import { setCartItem, getCartItem, listCartItems, removeCartItem } from '../services/tonCart';
 
-// Publishes and replicates cart items via Waku
-
-class CartAgent extends WakuAgent<CartItem> {
-  constructor() {
-    super(sendWakuCartUpdate, {
-      topic: '/congress/cart/1',
-      replayHistory: true,
-      extractItem: (msg: any) =>
-        msg.type === 'cart.update' ? (msg.cartItem as CartItem) : undefined,
-    });
-  }
-
+class CartAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -26,12 +14,25 @@ class CartAgent extends WakuAgent<CartItem> {
 
   async add(item: CartItem): Promise<void> {
     await this.ensureWallet();
-    await super.add(item);
+    await setCartItem(item);
   }
 
   async update(item: CartItem): Promise<void> {
     await this.ensureWallet();
-    await super.update(item);
+    await setCartItem(item);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeCartItem(id);
+  }
+
+  async get(id: string): Promise<CartItem | null> {
+    return await getCartItem(id);
+  }
+
+  async getAll(): Promise<CartItem[]> {
+    return await listCartItems();
   }
 }
 

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -1,20 +1,8 @@
 import { Category } from '../types';
-import { sendWakuCategoryUpdate } from '../lib/waku/sendWakuCategoryUpdate';
-import WakuAgent from '../utils/wakuAgent';
 import tonAuth from '../services/tonAuth';
+import { setCategory, getCategory, listCategories, removeCategory } from '../services/tonCategories';
 
-// Publishes and replicates category records via Waku
-
-class CategoriesAgent extends WakuAgent<Category> {
-  constructor() {
-    super(sendWakuCategoryUpdate, {
-      topic: '/congress/categories/1',
-      replayHistory: true,
-      extractItem: (msg: any) =>
-        msg.type === 'category.update' ? (msg.category as Category) : undefined,
-    });
-  }
-
+class CategoriesAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -26,12 +14,25 @@ class CategoriesAgent extends WakuAgent<Category> {
 
   async add(item: Category): Promise<void> {
     await this.ensureWallet();
-    await super.add(item);
+    await setCategory(item);
   }
 
   async update(item: Category): Promise<void> {
     await this.ensureWallet();
-    await super.update(item);
+    await setCategory(item);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeCategory(id);
+  }
+
+  async get(id: string): Promise<Category | null> {
+    return await getCategory(id);
+  }
+
+  async getAll(): Promise<Category[]> {
+    return await listCategories();
   }
 }
 

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,21 +1,14 @@
 import { Notification } from '../types';
-import { sendWakuNotificationUpdate } from '../lib/waku/sendWakuNotificationUpdate';
-import WakuAgent from '../utils/wakuAgent';
 import tonAuth from '../services/tonAuth';
+import {
+  setNotification,
+  getNotification,
+  listNotifications,
+  removeNotification,
+} from '../services/tonNotifications';
 
-class NotificationsAgent extends WakuAgent<Notification> {
+class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
-
-  constructor() {
-    super(sendWakuNotificationUpdate, {
-      topic: '/congress/notifications/1',
-      replayHistory: true,
-      extractItem: (msg: any) => msg.notification as Notification,
-      onUpdate: (item: Notification) => {
-        this.subscribers.forEach((cb) => cb(item));
-      },
-    });
-  }
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -28,12 +21,27 @@ class NotificationsAgent extends WakuAgent<Notification> {
 
   async add(item: Notification): Promise<void> {
     await this.ensureWallet();
-    await super.add(item);
+    await setNotification(item);
+    this.subscribers.forEach((cb) => cb(item));
   }
 
   async update(item: Notification): Promise<void> {
     await this.ensureWallet();
-    await super.update(item);
+    await setNotification(item);
+    this.subscribers.forEach((cb) => cb(item));
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeNotification(id);
+  }
+
+  async get(id: string): Promise<Notification | null> {
+    return await getNotification(id);
+  }
+
+  async getAll(): Promise<Notification[]> {
+    return await listNotifications();
   }
 
   subscribe(cb: (n: Notification) => void) {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,26 +1,14 @@
 import { Order } from '../types';
-import { sendWakuOrderUpdate } from '../lib/waku/sendWakuOrderUpdate';
-import WakuAgent from '../utils/wakuAgent';
+import tonAuth from '../services/tonAuth';
+import { setOrder, getOrder, listOrders, removeOrder } from '../services/tonOrders';
 import {
   createOrderPayment,
   releaseFunds,
   refundOrder,
 } from '../services/tonContract';
-import tonAuth from '../services/tonAuth';
 
-class OrdersAgent extends WakuAgent<Order> {
+class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
-
-  constructor() {
-    super(sendWakuOrderUpdate, {
-      topic: '/congress/orders/1/proto',
-      replayHistory: true,
-      extractItem: (msg: any) => msg.order as Order,
-      onUpdate: (order: Order) => {
-        this.subscribers.forEach(cb => cb(order));
-      },
-    });
-  }
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -34,22 +22,37 @@ class OrdersAgent extends WakuAgent<Order> {
   async add(order: Order): Promise<void> {
     await this.ensureWallet();
     const { contractAddress, txHash } = await createOrderPayment(order);
-    const orderWithTx: Order = {
+    const enriched: Order = {
       ...order,
       paymentContractAddress: contractAddress,
       paymentTxHash: txHash,
     };
-    await super.add(orderWithTx);
+    await setOrder(enriched);
+    this.subscribers.forEach((cb) => cb(enriched));
   }
 
   async update(order: Order): Promise<void> {
     await this.ensureWallet();
-    await super.update(order);
+    await setOrder(order);
+    this.subscribers.forEach((cb) => cb(order));
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeOrder(id);
+  }
+
+  async get(id: string): Promise<Order | null> {
+    return await getOrder(id);
+  }
+
+  async getAll(): Promise<Order[]> {
+    return await listOrders();
   }
 
   async releaseFunds(orderId: string): Promise<string> {
     await this.ensureWallet();
-    const order = this.get(orderId);
+    const order = await this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
@@ -58,30 +61,11 @@ class OrdersAgent extends WakuAgent<Order> {
 
   async refundOrder(orderId: string): Promise<string> {
     await this.ensureWallet();
-    const order = this.get(orderId);
+    const order = await this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
     return await refundOrder(order.paymentContractAddress);
-  }
-
-  async processPayload(payload: string): Promise<void> {
-    try {
-      const parsed = JSON.parse(payload);
-      const order = parsed.order as Order | undefined;
-      const sender = parsed.sender?.address;
-      if (!order || !sender) return;
-      const existing = this.get(order.id) ?? order;
-      const allowed = [existing.buyerAddress, existing.sellerAddress].filter(Boolean);
-      if (!allowed.includes(sender)) {
-        console.error('Unauthorized order update sender');
-        return;
-      }
-    } catch (e) {
-      console.error('Invalid order payload', e);
-      return;
-    }
-    await super.processPayload(payload);
   }
 
   subscribe(cb: (o: Order) => void) {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,25 +1,9 @@
 import { Product } from '../types';
-import { sendWakuProductUpdate } from '../lib/waku/sendWakuProductUpdate';
-import WakuAgent from '../utils/wakuAgent';
-import storesAgent from './stores-agent';
 import tonAuth from '../services/tonAuth';
+import { setProduct, getProduct, listProducts, removeProduct } from '../services/tonProducts';
+import { getStore } from '../services/tonStores';
 
-class ProductsAgent extends WakuAgent<Product> {
-  constructor() {
-    super(sendWakuProductUpdate, {
-      topic: '/congress/products/1/proto',
-      replayHistory: true,
-      extractItem: (msg: any) => msg.product as Product,
-      validateMessage: async (msg: any) => {
-        const storeId = msg.product?.storeId;
-        const senderAddr = msg.sender?.address;
-        if (!storeId || !senderAddr) return false;
-        const store = storesAgent.get(storeId);
-        return store?.owner === senderAddr;
-      },
-    });
-  }
-
+class ProductsAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -30,23 +14,37 @@ class ProductsAgent extends WakuAgent<Product> {
     return { address };
   }
 
+  private async assertStoreOwner(storeId: string) {
+    const { address } = await this.ensureWallet();
+    const store = await getStore(storeId);
+    if (!store || store.owner !== address) {
+      throw new Error('Only the store owner can manage products');
+    }
+  }
+
   async add(item: Product): Promise<void> {
-    await this.ensureWallet();
-    await super.add(item);
+    await this.assertStoreOwner(item.storeId);
+    await setProduct(item);
   }
 
   async update(item: Product): Promise<void> {
-    await this.ensureWallet();
-    await super.update(item);
+    await this.assertStoreOwner(item.storeId);
+    await setProduct(item);
   }
 
-  protected async broadcast(item: Product) {
-    const { address } = await this.ensureWallet();
-    const store = storesAgent.get(item.storeId);
-    if (!store || store.owner !== address) {
-      throw new Error('Only the store owner can broadcast product updates');
-    }
-    await super.broadcast(item);
+  async remove(id: string): Promise<void> {
+    const prod = await getProduct(id);
+    if (!prod) return;
+    await this.assertStoreOwner(prod.storeId);
+    await removeProduct(id);
+  }
+
+  async get(id: string): Promise<Product | null> {
+    return await getProduct(id);
+  }
+
+  async getAll(): Promise<Product[]> {
+    return await listProducts();
   }
 }
 

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -1,30 +1,12 @@
-import WakuAgent from '../utils/wakuAgent';
-import { sendWakuSettingsUpdate } from '../lib/waku/sendWakuSettingsUpdate';
-import { store } from '../lib/memoryStore';
-import type { TenantSettings } from '../types';
 import tonAuth from '../services/tonAuth';
+import { getSetting, setSetting } from '../services/tonSettings';
 
 interface SettingItem { id: string; value: string }
 
-class SettingsAgent extends WakuAgent<SettingItem> {
+class SettingsAgent {
   private static instance: SettingsAgent;
 
-  private constructor() {
-    super(
-      async ({ id, value }) => {
-        const now = Date.now();
-        await sendWakuSettingsUpdate(id, value, now, now);
-      },
-      {
-        topic: '/congress/settings/1/proto',
-        replayHistory: true,
-        extractItem: (msg: any) =>
-          msg.type === 'settings.update'
-            ? { id: msg.key as string, value: msg.value as string }
-            : undefined,
-      }
-    );
-  }
+  private constructor() {}
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -35,52 +17,28 @@ class SettingsAgent extends WakuAgent<SettingItem> {
     }
   }
 
-  async add(item: SettingItem): Promise<void> {
-    await this.ensureWallet();
-    await super.add(item);
-  }
-
-  async update(item: SettingItem): Promise<void> {
-    await this.ensureWallet();
-    await super.update(item);
-  }
-
   async set(key: string, value: string): Promise<void> {
-    if (this.store.has(key)) {
-      await this.update({ id: key, value });
-    } else {
-      await this.add({ id: key, value });
-    }
+    await this.ensureWallet();
+    await setSetting(key, value);
   }
 
-  protected async broadcast(item: SettingItem) {
-    try {
-      await sendWakuSettingsUpdate(item.id, item.value, Date.now(), Date.now());
-    } catch (e) {
-      console.error('Failed to broadcast settings update', e);
-      throw e;
-    }
+  async get(key: string): Promise<string | null> {
+    return await getSetting(key);
   }
 
   async getTenantSetting(
     tenant: string,
-    key: 'platform_name' | 'platform_logo' | 'theme_color'
+    key: 'platform_name' | 'platform_logo' | 'theme_color',
   ): Promise<string | null> {
-    const obj = store.tenantSettings[tenant];
-    if (!obj) return null;
-    return (obj as any)[key] ?? null;
+    return await getSetting(`${tenant}:${key}`);
   }
 
   async updateTenantSetting(
     tenant: string,
     key: 'platform_name' | 'platform_logo' | 'theme_color',
-    value: string
+    value: string,
   ): Promise<void> {
-    if (!store.tenantSettings[tenant]) {
-      store.tenantSettings[tenant] = { tenant_id: tenant } as TenantSettings;
-    }
-    (store.tenantSettings[tenant] as any)[key] = value;
-    await this.set(key, value);
+    await this.set(`${tenant}:${key}`, value);
   }
 
   static getInstance(): SettingsAgent {

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,17 +1,8 @@
 import { Store } from '../types';
-import { sendWakuStoreUpdate } from '../lib/waku/sendWakuStoreUpdate';
-import WakuAgent from '../utils/wakuAgent';
 import tonAuth from '../services/tonAuth';
+import { setStore, getStore, listStores, removeStore } from '../services/tonStores';
 
-class StoresAgent extends WakuAgent<Store> {
-  constructor() {
-    super(sendWakuStoreUpdate, {
-      topic: '/congress/stores/1/proto',
-      replayHistory: true,
-      extractItem: (msg: any) => msg.store as Store,
-    });
-  }
-
+class StoresAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -23,12 +14,25 @@ class StoresAgent extends WakuAgent<Store> {
 
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
-    await super.add(item);
+    await setStore(item);
   }
 
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
-    await super.update(item);
+    await setStore(item);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeStore(id);
+  }
+
+  async get(id: string): Promise<Store | null> {
+    return await getStore(id);
+  }
+
+  async getAll(): Promise<Store[]> {
+    return await listStores();
   }
 }
 

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,17 +1,8 @@
 import { User } from '../types';
-import { sendWakuUserUpdate } from '../lib/waku/sendWakuUserUpdate';
-import WakuAgent from '../utils/wakuAgent';
 import tonAuth from '../services/tonAuth';
+import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 
-class UsersAgent extends WakuAgent<User> {
-  constructor() {
-    super(sendWakuUserUpdate, {
-      topic: '/congress/users/1/proto',
-      replayHistory: true,
-      extractItem: (msg: any) => msg.user as User,
-    });
-  }
-
+class UsersAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -24,22 +15,27 @@ class UsersAgent extends WakuAgent<User> {
 
   async add(user: User): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
-    const enriched: User = {
-      ...user,
-      publicKey,
-      address,
-    };
-    await super.add(enriched);
+    const enriched: User = { ...user, publicKey, address };
+    await setUser(enriched);
   }
 
   async update(user: User): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
-    const enriched: User = {
-      ...user,
-      publicKey,
-      address,
-    };
-    await super.update(enriched);
+    const enriched: User = { ...user, publicKey, address };
+    await setUser(enriched);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.ensureWallet();
+    await removeUser(id);
+  }
+
+  async get(id: string): Promise<User | null> {
+    return await getUser(id);
+  }
+
+  async getAll(): Promise<User[]> {
+    return await listUsers();
   }
 }
 

--- a/contracts/ton/cart.tact
+++ b/contracts/ton/cart.tact
@@ -1,0 +1,17 @@
+contract Cart {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/categories.tact
+++ b/contracts/ton/categories.tact
@@ -1,0 +1,17 @@
+contract Categories {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/deploy.ts
+++ b/contracts/ton/deploy.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import TonWeb from 'tonweb';
+import { getTonConnect } from '../../services/tonAuth';
+
+const provider = new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC');
+const tonweb = new TonWeb(provider);
+
+export async function compile(contract: string) {
+  const file = path.resolve(__dirname, `${contract}.tact`);
+  execSync(`npx tact ${file}`, { stdio: 'inherit' });
+}
+
+export async function deploy(contract: string, init: string) {
+  await compile(contract);
+  const tonConnect = getTonConnect();
+  if (!tonConnect) throw new Error('TonConnect not initialized');
+  await tonConnect.sendTransaction({
+    validUntil: Math.floor(Date.now() / 1000) + 60,
+    messages: [
+      {
+        address: init,
+        amount: '0',
+      },
+    ],
+  });
+}

--- a/contracts/ton/notifications.tact
+++ b/contracts/ton/notifications.tact
@@ -1,0 +1,17 @@
+contract Notifications {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/orders.tact
+++ b/contracts/ton/orders.tact
@@ -1,0 +1,17 @@
+contract Orders {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/products.tact
+++ b/contracts/ton/products.tact
@@ -1,0 +1,17 @@
+contract Products {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/settings.tact
+++ b/contracts/ton/settings.tact
@@ -1,0 +1,17 @@
+contract Settings {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/stores.tact
+++ b/contracts/ton/stores.tact
@@ -1,0 +1,17 @@
+contract Stores {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/contracts/ton/users.tact
+++ b/contracts/ton/users.tact
@@ -1,0 +1,17 @@
+contract Users {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    self.data.set(key, value);
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+}

--- a/services/tonCart.ts
+++ b/services/tonCart.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { CartItem } from '../types';
+
+const ADDRESS = process.env.TON_CART_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getCartItem(id: string): Promise<CartItem | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as CartItem) : null;
+}
+
+export async function setCartItem(item: CartItem) {
+  await setValue(ADDRESS, item.id, JSON.stringify(item));
+}
+
+export async function removeCartItem(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listCartItems(): Promise<CartItem[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as CartItem);
+}

--- a/services/tonCategories.ts
+++ b/services/tonCategories.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { Category } from '../types';
+
+const ADDRESS = process.env.TON_CATEGORIES_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getCategory(id: string): Promise<Category | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as Category) : null;
+}
+
+export async function setCategory(category: Category) {
+  await setValue(ADDRESS, category.id, JSON.stringify(category));
+}
+
+export async function removeCategory(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listCategories(): Promise<Category[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as Category);
+}

--- a/services/tonKvStore.ts
+++ b/services/tonKvStore.ts
@@ -1,0 +1,63 @@
+import TonWeb from 'tonweb';
+import { Buffer } from 'buffer';
+import { getTonConnect } from './tonAuth';
+
+const provider = new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC');
+const tonweb = new TonWeb(provider);
+
+function makeSetPayload(key: string, value: string): TonWeb.boc.Cell {
+  const cell = new TonWeb.boc.Cell();
+  (cell.bits as any).writeUint(0, 32);
+  const body = JSON.stringify({ key, value });
+  (cell.bits as any).writeBytes(Buffer.from(body, 'utf8'));
+  return cell;
+}
+
+export async function setValue(address: string, key: string, value: string) {
+  const tonConnect = getTonConnect();
+  if (!tonConnect) throw new Error('TonConnect not initialized');
+  const cell = makeSetPayload(key, value);
+  const payload = TonWeb.utils.bytesToBase64(await cell.toBoc({ idx: false }));
+  return await tonConnect.sendTransaction({
+    validUntil: Math.floor(Date.now() / 1000) + 60,
+    messages: [
+      { address, amount: '0', payload },
+    ],
+  });
+}
+
+export async function removeValue(address: string, key: string) {
+  return await setValue(address, key, '');
+}
+
+export async function getValue(address: string, key: string): Promise<string | null> {
+  try {
+    const result = await tonweb.provider.call(address, 'get', [
+      { type: 'int', value: TonWeb.utils.bytesToHex(Buffer.from(key, 'utf8')) },
+    ]);
+    const cellBoc = result.stack?.[0]?.[1]?.bytes;
+    if (!cellBoc) return null;
+    const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(cellBoc, 'base64'))[0];
+    const bytes = (cell.bits as any).array.slice(0, cell.bits.cursor);
+    return Buffer.from(bytes).toString('utf8');
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function listValues(address: string): Promise<{ key: string; value: string }[]> {
+  try {
+    const result = await tonweb.provider.call(address, 'list', []);
+    const dictBoc = result.stack?.[0]?.[1]?.bytes;
+    if (!dictBoc) return [];
+    const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(dictBoc, 'base64'))[0];
+    const dict = cell.beginParse().readDict(256, (c: any) => c.readRemaining());
+    const items: { key: string; value: string }[] = [];
+    for (const [k, v] of dict.entries()) {
+      items.push({ key: k.toString(), value: Buffer.from(v).toString('utf8') });
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}

--- a/services/tonNotifications.ts
+++ b/services/tonNotifications.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { Notification } from '../types';
+
+const ADDRESS = process.env.TON_NOTIFICATIONS_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getNotification(id: string): Promise<Notification | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as Notification) : null;
+}
+
+export async function setNotification(notification: Notification) {
+  await setValue(ADDRESS, notification.id, JSON.stringify(notification));
+}
+
+export async function removeNotification(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listNotifications(): Promise<Notification[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as Notification);
+}

--- a/services/tonOrders.ts
+++ b/services/tonOrders.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { Order } from '../types';
+
+const ADDRESS = process.env.TON_ORDERS_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getOrder(id: string): Promise<Order | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as Order) : null;
+}
+
+export async function setOrder(order: Order) {
+  await setValue(ADDRESS, order.id, JSON.stringify(order));
+}
+
+export async function removeOrder(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listOrders(): Promise<Order[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as Order);
+}

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { Product } from '../types';
+
+const ADDRESS = process.env.TON_PRODUCTS_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getProduct(id: string): Promise<Product | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as Product) : null;
+}
+
+export async function setProduct(product: Product) {
+  await setValue(ADDRESS, product.id, JSON.stringify(product));
+}
+
+export async function removeProduct(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listProducts(): Promise<Product[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as Product);
+}

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -1,0 +1,15 @@
+import { getValue, setValue, listValues } from './tonKvStore';
+
+const ADDRESS = process.env.TON_SETTINGS_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getSetting(key: string): Promise<string | null> {
+  return await getValue(ADDRESS, key);
+}
+
+export async function setSetting(key: string, value: string) {
+  return await setValue(ADDRESS, key, value);
+}
+
+export async function listSettings(): Promise<{ key: string; value: string }[]> {
+  return await listValues(ADDRESS);
+}

--- a/services/tonStores.ts
+++ b/services/tonStores.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { Store } from '../types';
+
+const ADDRESS = process.env.TON_STORES_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getStore(id: string): Promise<Store | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as Store) : null;
+}
+
+export async function setStore(store: Store) {
+  await setValue(ADDRESS, store.id, JSON.stringify(store));
+}
+
+export async function removeStore(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listStores(): Promise<Store[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as Store);
+}

--- a/services/tonUsers.ts
+++ b/services/tonUsers.ts
@@ -1,0 +1,22 @@
+import { getValue, setValue, listValues, removeValue } from './tonKvStore';
+import { User } from '../types';
+
+const ADDRESS = process.env.TON_USERS_ADDRESS ?? 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+
+export async function getUser(id: string): Promise<User | null> {
+  const res = await getValue(ADDRESS, id);
+  return res ? (JSON.parse(res) as User) : null;
+}
+
+export async function setUser(user: User) {
+  await setValue(ADDRESS, user.id, JSON.stringify(user));
+}
+
+export async function removeUser(id: string) {
+  await removeValue(ADDRESS, id);
+}
+
+export async function listUsers(): Promise<User[]> {
+  const items = await listValues(ADDRESS);
+  return items.map((i) => JSON.parse(i.value) as User);
+}

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -1,15 +1,15 @@
-/// <reference types="node" />
 import SettingsAgent from '../agents/settings-agent';
-import { store } from '../lib/memoryStore';
 
-jest.mock('../lib/waku/sendWakuSettingsUpdate', () => ({
-  sendWakuSettingsUpdate: jest.fn(),
+jest.mock('../services/tonSettings', () => ({
+  getSetting: jest.fn().mockResolvedValue(null),
+  setSetting: jest.fn().mockResolvedValue(undefined),
 }));
+
+const { getSetting, setSetting } = require('../services/tonSettings');
 
 describe('SettingsAgent', () => {
   beforeEach(() => {
     (SettingsAgent as any).instance = undefined;
-    store.tenantSettings = {} as any;
     jest.clearAllMocks();
   });
 
@@ -17,13 +17,12 @@ describe('SettingsAgent', () => {
     const agent = SettingsAgent.getInstance();
     const val = await agent.getTenantSetting('foo', 'platform_name');
     expect(val).toBeNull();
+    expect(getSetting).toHaveBeenCalled();
   });
 
-  it('updates local store and broadcasts', async () => {
-    const { sendWakuSettingsUpdate } = require('../lib/waku/sendWakuSettingsUpdate');
+  it('updates via TON service', async () => {
     const agent = SettingsAgent.getInstance();
     await agent.updateTenantSetting('foo', 'platform_name', 'Test');
-    expect(store.tenantSettings.foo.platform_name).toBe('Test');
-    expect(sendWakuSettingsUpdate).toHaveBeenCalled();
+    expect(setSetting).toHaveBeenCalledWith('foo:platform_name', 'Test');
   });
 });


### PR DESCRIPTION
## Summary
- add TON key-value contracts for settings, users, products, stores, orders, categories, cart, and notifications
- wrap contracts with new TypeScript services and refactor agents to use them
- update settings agent tests for TON service

## Testing
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899dae508ac8326924b5b60f3ee4e02