### PR TITLE
feat: load config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ All data is ephemeral and synchronized between peers over Waku; no external serv
 
 ### Environment Variables
 
-The application loads configuration from a `.env` file. At minimum, define:
+The project reads all configuration from a `.env` file using Expo's env
+support for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests.
+Copy `.env.example` to `.env` and set at minimum:
 
 - `EXPO_PUBLIC_ADMIN_USERNAME`
 - `EXPO_PUBLIC_WAKU_SECRET`
+- `EXPO_PUBLIC_WAKU_BOOTSTRAP`
 - `EXPO_PUBLIC_JWT_SECRET`
 - `EXPO_PUBLIC_CHAT_SECRET`
 - `TON_NOTIFICATIONS_ADDRESS`

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,7 +26,6 @@ import CartModal from '../components/CartModal';
 import ChatWidget from '../components/ChatWidget';
 import { ConfigProvider } from '../contexts/ConfigContext';
 import { loadTenantSettings } from '../constants/tenant';
-import { initConfig } from '../utils/appConfig';
 
 function AppContent() {
   const [showCartModal, setShowCartModal] = useState(false);
@@ -86,7 +85,6 @@ export default function RootLayout() {
 
   useEffect(() => {
     (async () => {
-      await initConfig();
       await loadTenantSettings();
       setReady(true);
     })();

--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import appConfig, { initConfig } from '../utils/appConfig';
+import React, { createContext, useContext } from 'react';
+import appConfig from '../utils/appConfig';
 
 interface ConfigContextValue {
   config: Record<string, string>;
@@ -12,15 +12,6 @@ const ConfigContext = createContext<ConfigContextValue>({
 export const useConfig = () => useContext(ConfigContext);
 
 export function ConfigProvider({ children }: { children: React.ReactNode }) {
-  const [, forceUpdate] = useState({});
-
-  useEffect(() => {
-    (async () => {
-      await initConfig();
-      forceUpdate({});
-    })();
-  }, []);
-
   return (
     <ConfigContext.Provider value={{ config: appConfig }}>
       {children}

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import config from '../utils/appConfig';
 import { insertConfig } from './testUtils';
 import { loadTenantSettings } from '../constants/tenant';
 
@@ -9,9 +8,6 @@ var __DEV__ = false;
 
 
 beforeEach(async () => {
-  for (const key of Object.keys(config)) {
-    delete (config as any)[key];
-  }
   insertConfig({
     EXPO_PUBLIC_JWT_SECRET: 'test_jwt_secret',
     EXPO_PUBLIC_CHAT_SECRET: 'test_chat_secret',

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,7 +1,12 @@
-import { setConfig } from '../utils/appConfig';
+import { reloadConfig } from '../utils/appConfig';
 
 export function insertConfig(values: Record<string, string>): void {
   for (const [key, value] of Object.entries(values)) {
-    setConfig(key, value);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
+  reloadConfig();
 }

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -3,8 +3,6 @@
 // Waku. **All production peers must use the same secret** or messages will
 // not be readable between them.
 
-const config: Record<string, string> = {};
-
 const ENV_KEYS = [
   'EXPO_PUBLIC_JWT_SECRET',
   'EXPO_PUBLIC_CHAT_SECRET',
@@ -20,19 +18,35 @@ const ENV_KEYS = [
   'APP_NAME',
   'PRIMARY_COLOR',
   'APP_LOGO',
+  'TON_NOTIFICATIONS_ADDRESS',
+  'TON_STORES_ADDRESS',
+  'TON_ORDERS_ADDRESS',
+  'TON_SETTINGS_ADDRESS',
+  'TON_CART_ADDRESS',
+  'TON_USERS_ADDRESS',
+  'TON_PRODUCTS_ADDRESS',
+  'TON_CATEGORIES_ADDRESS',
 ];
 
-export async function initConfig(): Promise<void> {
+function loadConfig(): Record<string, string> {
+  const cfg: Record<string, string> = {};
   for (const key of ENV_KEYS) {
     const value = process.env[key];
     if (value !== undefined) {
-      config[key] = value;
+      cfg[key] = value;
     }
   }
+  return cfg;
 }
 
-export function setConfig(key: string, value: string): void {
-  config[key] = value;
+const config: Record<string, string> = loadConfig();
+
+export function reloadConfig(): void {
+  const fresh = loadConfig();
+  for (const key of Object.keys(config)) {
+    delete config[key];
+  }
+  Object.assign(config, fresh);
 }
 
 export function getWakuBootstrapNodes(): string[] {


### PR DESCRIPTION
## Summary
- load runtime configuration exclusively from environment variables
- simplify config context and remove init side effects
- document required `.env` keys

## Testing
- `yarn lint`
- `yarn test` *(fails: Type 'Decoder' is not generic)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed6e6f808326bc253f15d3a7c4c2