### PR TITLE
feat: add ton contract tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ and loaded automatically; no `.env` entries are required for them.
 
 ### TON Smart Contracts
 
-Smart contracts written in Tact live in `contracts/ton`.
+Smart contracts written in Tact live in `contracts/ton`. The helper scripts in
+`scripts/` use `@tact-lang/compiler` for compiling contracts and `ton-core` for
+deployment.
 
 Compile all contracts with:
 
 ```sh
 yarn build:ton
+# or
+yarn ton:build
 ```
 
 Compiled `.boc` files are written to `contracts/ton/build`.
@@ -62,6 +66,8 @@ Then run:
 
 ```sh
 yarn deploy:ton <contract-name>
+# or
+yarn ton:deploy <contract-name>
 ```
 
 Replace `<contract-name>` with the name of the Tact file (without extension).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build:web": "expo export --platform web --output-dir dist && node scripts/copy-tonconnect-manifest.js",
     "test": "jest",
     "build:ton": "ts-node scripts/build-ton.ts",
-    "deploy:ton": "ts-node scripts/deploy-ton.ts"
+    "deploy:ton": "ts-node scripts/deploy-ton.ts",
+    "ton:build": "yarn build:ton",
+    "ton:deploy": "yarn deploy:ton"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",

--- a/scripts/build-ton.ts
+++ b/scripts/build-ton.ts
@@ -1,3 +1,4 @@
+// Compile all Tact contracts in `contracts/ton` into BOC artifacts.
 import { compile } from '@tact-lang/compiler';
 import fs from 'fs';
 import path from 'path';

--- a/scripts/deploy-ton.ts
+++ b/scripts/deploy-ton.ts
@@ -1,3 +1,4 @@
+// Deploy a compiled contract to the TON blockchain using ton-core utilities.
 import {
   TonClient,
   WalletContractV4,


### PR DESCRIPTION
## Summary
- document contract deployment and environment variables for TON
- expose TON build and deploy scripts in package.json
- add helper comments for compile and deploy scripts

## Testing
- `yarn build:ton` *(fails: Object literal may only specify known properties, and 'path' does not exist in type 'Instr[]')*
- `yarn test` *(fails: Property 'sha256_sync' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_6899ffb9268c8326804232a14b801801