### PR TITLE
Add web webpack config with IPFS public path

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,0 +1,7 @@
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+
+module.exports = async function (env, argv) {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+  config.output.publicPath = "./"; // Use relative URLs for IPFS
+  return config;
+};


### PR DESCRIPTION
## Summary
- add a web-specific webpack config
- ensure bundle uses relative URLs for IPFS hosting

## Testing
- `npm test` *(fails: TS errors in tonAuthContract and databaseService tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a1a3d98688326a05d22ab07025004