### PR TITLE
feat: clean and sync web build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "web:clean": "node scripts/web-clean.js",
     "web:build": "expo export --platform web --output-dir dist",
     "web:ipfs-sanitize": "node scripts/ipfs-sanitize.js",
-    "web:release": "npm run web:clean && npm run web:build && npm run web:ipfs-sanitize",
+    "web:release": "npm run web:clean && npm run web:build && node scripts/web-clean.js copy && npm run web:ipfs-sanitize",
     "web:preview": "npx serve dist -p 4173 -s",
     "test": "jest",
     "build:ton": "ts-node scripts/build-ton.ts",

--- a/scripts/web-clean.js
+++ b/scripts/web-clean.js
@@ -1,11 +1,28 @@
 const fs = require('fs-extra');
 const path = require('path');
 
+const dist = path.join(__dirname, '..', 'dist');
+const publicDir = path.join(__dirname, '..', 'public');
+
+async function removeDist() {
+  if (await fs.pathExists(dist)) {
+    await fs.remove(dist);
+    console.log(`Removed ${dist}`);
+  }
+}
+
+async function copyPublic() {
+  await fs.copy(publicDir, dist, { overwrite: true });
+  console.log(`Copied ${publicDir} to ${dist}`);
+}
+
 async function main() {
-  const dist = path.join(__dirname, '..', 'dist');
-  await fs.remove(dist);
-  await fs.ensureDir(dist);
-  console.log(`Cleaned ${dist}`);
+  const mode = process.argv[2];
+  if (mode === 'copy') {
+    await copyPublic();
+  } else {
+    await removeDist();
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- add flexible `web-clean` script to wipe previous web builds or copy `public/` assets into `dist/`
- ensure `web:release` cleans dist, builds, then copies public files before IPFS sanitation

## Testing
- `node scripts/web-clean.js copy`
- `npm test` *(fails: Property 'sha256_sync' does not exist, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689a1e344f8483269e2f441a1f9ab9ab