### PR TITLE
docs: add IPFS-safe web build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ deploying the static build, verify the manifest is accessible:
 curl https://<your-site>/tonconnect-manifest.json
 ```
 
+### Web (IPFS-safe) build
+
+- **Build:**
+
+  ```sh
+  npm run web:release
+  ```
+
+- **Local preview:**
+
+  ```sh
+  npm run web:preview
+  ```
+
+  Then open `http://localhost:4173/` and navigate within the app (no deep links).
+
+- **Upload:** Manually pin the `dist/` folder to Pinata.
+
+Deep links require additional rewrite support.
+
 ## Troubleshooting
 
 ### Content Security Policy


### PR DESCRIPTION
## Summary
- document how to build and preview an IPFS-safe web release
- add note on manually pinning the build to Pinata and deep link limitations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2664644c832691d241567869e0e4