### PR TITLE
feat: add onboarding flow state machine

### DIFF
--- a/components/OnboardingFlow.tsx
+++ b/components/OnboardingFlow.tsx
@@ -1,0 +1,111 @@
+import React, { useRef, useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useOnboarding } from '../hooks/useOnboardingMachine';
+
+export default function OnboardingFlow() {
+  const { history, send, step, loading } = useOnboarding();
+  const [input, setInput] = useState('');
+  const scrollRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [history]);
+
+  if (loading) return null;
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    send(input.trim());
+    setInput('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.messages} ref={scrollRef}>
+        {history.map((msg) => (
+          <View
+            key={msg.id}
+            style={[
+              styles.message,
+              msg.sender === 'aurora' ? styles.aurora : styles.user,
+            ]}
+          >
+            <Text style={styles.text}>{msg.text}</Text>
+          </View>
+        ))}
+      </ScrollView>
+      {step !== 'complete' && (
+        <View style={styles.inputRow}>
+          <TextInput
+            style={styles.input}
+            value={input}
+            onChangeText={setInput}
+            placeholder="Type your response"
+          />
+          <TouchableOpacity style={styles.sendBtn} onPress={handleSend}>
+            <Text style={styles.sendText}>Send</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  messages: {
+    flex: 1,
+    padding: 16,
+  },
+  message: {
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 8,
+    maxWidth: '80%',
+  },
+  aurora: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#eee',
+  },
+  user: {
+    alignSelf: 'flex-end',
+    backgroundColor: '#007aff',
+  },
+  text: {
+    color: '#000',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    padding: 8,
+    borderTopWidth: 1,
+    borderColor: '#ccc',
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginRight: 8,
+  },
+  sendBtn: {
+    backgroundColor: '#007aff',
+    borderRadius: 4,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+  },
+  sendText: {
+    color: '#fff',
+  },
+});
+

--- a/hooks/useOnboardingMachine.tsx
+++ b/hooks/useOnboardingMachine.tsx
@@ -1,0 +1,167 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type OnboardingStep =
+  | 'intro'
+  | 'askName'
+  | 'askGoals'
+  | 'confirm'
+  | 'complete';
+
+export interface OnboardingMessage {
+  id: string;
+  sender: 'aurora' | 'user';
+  text: string;
+}
+
+interface OnboardingState {
+  step: OnboardingStep;
+  name?: string;
+  goals?: string;
+  history: OnboardingMessage[];
+}
+
+interface OnboardingContextValue extends OnboardingState {
+  loading: boolean;
+  send: (input: string) => void;
+  reset: () => void;
+}
+
+const STORAGE_KEY = 'onboarding.state';
+
+function getPrompt(step: OnboardingStep, state: OnboardingState): string {
+  switch (step) {
+    case 'intro':
+      return "Hi, I'm Aurora. Let's get started.";
+    case 'askName':
+      return 'What\'s your name?';
+    case 'askGoals':
+      return `Nice to meet you, ${state.name}. What are your goals?`;
+    case 'confirm':
+      return `Got it. You want to ${state.goals}. Ready to begin?`;
+    case 'complete':
+      return 'You\'re all set!';
+    default:
+      return '';
+  }
+}
+
+function createInitialState(): OnboardingState {
+  const base: OnboardingState = { step: 'intro', history: [] };
+  base.history.push({
+    id: Date.now().toString(),
+    sender: 'aurora',
+    text: getPrompt('intro', base),
+  });
+  return base;
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | undefined>(
+  undefined,
+);
+
+function useProvideOnboarding(): OnboardingContextValue {
+  const [state, setState] = useState<OnboardingState>(createInitialState());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const saved = await AsyncStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          setState(JSON.parse(saved));
+        }
+      } catch (err) {
+        console.error('Failed to load onboarding state', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (loading) return;
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state, loading]);
+
+  const send = useCallback((input: string) => {
+    setState((prev) => {
+      const history = [
+        ...prev.history,
+        { id: Date.now().toString(), sender: 'user', text: input },
+      ];
+      let step = prev.step;
+      let name = prev.name;
+      let goals = prev.goals;
+      switch (prev.step) {
+        case 'intro':
+          step = 'askName';
+          history.push({
+            id: Date.now().toString(),
+            sender: 'aurora',
+            text: getPrompt('askName', prev),
+          });
+          break;
+        case 'askName':
+          name = input;
+          step = 'askGoals';
+          history.push({
+            id: Date.now().toString(),
+            sender: 'aurora',
+            text: getPrompt('askGoals', { ...prev, name }),
+          });
+          break;
+        case 'askGoals':
+          goals = input;
+          step = 'confirm';
+          history.push({
+            id: Date.now().toString(),
+            sender: 'aurora',
+            text: getPrompt('confirm', { ...prev, name, goals }),
+          });
+          break;
+        case 'confirm':
+          step = 'complete';
+          history.push({
+            id: Date.now().toString(),
+            sender: 'aurora',
+            text: getPrompt('complete', prev),
+          });
+          break;
+        case 'complete':
+          break;
+      }
+      return { step, name, goals, history };
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    const init = createInitialState();
+    setState(init);
+  }, []);
+
+  return { ...state, loading, send, reset };
+}
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const value = useProvideOnboarding();
+  return (
+    <OnboardingContext.Provider value={value}>
+      {children}
+    </OnboardingContext.Provider>
+  );
+}
+
+export function useOnboarding() {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) throw new Error('useOnboarding must be used within OnboardingProvider');
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- add `useOnboardingMachine` hook with state machine and AsyncStorage persistence
- create `OnboardingFlow` component to drive conversational onboarding
- expose onboarding context to allow other modules to access user goals

## Testing
- `npm test` *(fails: Property 'sha256_sync' does not exist on type... and TypeScript errors in services/database.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bde41288326b8817a1c8d020a35