### PR TITLE
feat: add voice synthesis and onboarding visualizer

### DIFF
--- a/components/AuroraSphere.tsx
+++ b/components/AuroraSphere.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+interface AuroraSphereProps {
+  amplitude: number; // 0..1
+  size?: number;
+  colors?: string[];
+}
+
+export default function AuroraSphere({
+  amplitude,
+  size = 160,
+  colors = ['#00f0ff', '#6f00ff'],
+}: AuroraSphereProps) {
+  const scale = useRef(new Animated.Value(0.8)).current;
+
+  useEffect(() => {
+    Animated.timing(scale, {
+      toValue: 0.8 + amplitude * 0.4,
+      duration: 100,
+      useNativeDriver: true,
+    }).start();
+  }, [amplitude]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.wrapper,
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          transform: [{ scale }],
+        },
+      ]}
+    >
+      <LinearGradient
+        colors={colors}
+        style={StyleSheet.absoluteFillObject}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+      />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    overflow: 'hidden',
+  },
+});

--- a/components/OnboardingFlow.tsx
+++ b/components/OnboardingFlow.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import AuroraSphere from './AuroraSphere';
+import VoiceService from '../services/voice';
+
+interface Message {
+  id: string;
+  role: 'ai' | 'user';
+  text: string;
+}
+
+interface OnboardingFlowProps {
+  messages: Message[];
+}
+
+export default function OnboardingFlow({ messages }: OnboardingFlowProps) {
+  const [amplitude, setAmplitude] = useState(0);
+  const [spokenIndex, setSpokenIndex] = useState(-1);
+  const voice = VoiceService.getInstance();
+
+  useEffect(() => {
+    const nextIndex = messages.findIndex(
+      (m, i) => i > spokenIndex && m.role === 'ai'
+    );
+    if (nextIndex !== -1) {
+      voice.speak(messages[nextIndex].text, {
+        onAmplitude: setAmplitude,
+        onDone: () => {
+          setAmplitude(0);
+          setSpokenIndex(nextIndex);
+        },
+      });
+    }
+  }, [messages, spokenIndex]);
+
+  useEffect(() => {
+    return () => {
+      voice.stop();
+    };
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <AuroraSphere amplitude={amplitude} />
+      <View style={styles.messages}>
+        {messages.map((m) => (
+          <Text key={m.id} style={styles.messageText}>
+            {m.text}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  messages: {
+    marginTop: 24,
+    paddingHorizontal: 20,
+  },
+  messageText: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+});

--- a/services/voice.ts
+++ b/services/voice.ts
@@ -1,0 +1,110 @@
+import { Platform } from 'react-native';
+
+export interface SpeakOptions {
+  onStart?: () => void;
+  onDone?: () => void;
+  onAmplitude?: (value: number) => void;
+}
+
+class VoiceService {
+  private static instance: VoiceService;
+  private amplitudeInterval?: NodeJS.Timeout;
+
+  private constructor() {}
+
+  static getInstance(): VoiceService {
+    if (!VoiceService.instance) {
+      VoiceService.instance = new VoiceService();
+    }
+    return VoiceService.instance;
+  }
+
+  private clearAmplitude(onAmplitude?: (value: number) => void) {
+    if (this.amplitudeInterval) {
+      clearInterval(this.amplitudeInterval);
+      this.amplitudeInterval = undefined;
+    }
+    if (onAmplitude) {
+      onAmplitude(0);
+    }
+  }
+
+  async speak(text: string, options: SpeakOptions = {}): Promise<void> {
+    const { onStart, onDone, onAmplitude } = options;
+
+    if (!text) {
+      return;
+    }
+
+    return new Promise<void>(async (resolve) => {
+      const startAmplitude = () => {
+        if (onAmplitude) {
+          this.clearAmplitude();
+          this.amplitudeInterval = setInterval(() => {
+            onAmplitude(Math.random());
+          }, 100);
+        }
+      };
+
+      const finish = () => {
+        this.clearAmplitude(onAmplitude);
+        onDone && onDone();
+        resolve();
+      };
+
+      try {
+        if (Platform.OS === 'web' && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+          const utter = new SpeechSynthesisUtterance(text);
+          utter.onstart = () => {
+            onStart && onStart();
+            startAmplitude();
+          };
+          utter.onend = finish;
+          utter.onerror = finish;
+          window.speechSynthesis.speak(utter);
+        } else {
+          let Speech: any;
+          try {
+            Speech = require('expo-speech');
+          } catch {
+            Speech = null;
+          }
+
+          if (Speech && Speech.speak) {
+            onStart && onStart();
+            startAmplitude();
+            Speech.speak(text, {
+              onDone: finish,
+              onStopped: finish,
+              onError: finish,
+            });
+          } else {
+            console.warn('Speech synthesis not available');
+            finish();
+          }
+        }
+      } catch (e) {
+        console.warn('Speech synthesis error', e);
+        finish();
+      }
+    });
+  }
+
+  stop() {
+    try {
+      if (Platform.OS === 'web' && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+        window.speechSynthesis.cancel();
+      } else {
+        const Speech = require('expo-speech');
+        Speech.stop();
+      }
+    } catch {
+      // ignore
+    } finally {
+      this.clearAmplitude();
+    }
+  }
+}
+
+export default VoiceService;
+


### PR DESCRIPTION
## Summary
- add cross-platform voice synthesis service with graceful fallbacks
- create AuroraSphere component driven by amplitude
- integrate onboarding flow to speak AI messages and animate sphere

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install --ignore-scripts --non-interactive` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_689a2d736ec0832683f0d6957e67c541