### PR TITLE
Add store dashboard and wallet-based product/order filtering

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,6 +1,6 @@
 import { Order } from '../types';
 import tonAuth from '../services/tonAuth';
-import { setOrder, getOrder, listOrders, removeOrder } from '../services/tonOrders';
+import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
 import {
   createOrderPayment,
   releaseFunds,
@@ -48,6 +48,10 @@ class OrdersAgent {
 
   async getAll(): Promise<Order[]> {
     return await listOrders();
+  }
+
+  async getBySeller(address: string): Promise<Order[]> {
+    return await listOrdersBySeller(address);
   }
 
   async releaseFunds(orderId: string): Promise<string> {

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -38,6 +38,7 @@ import InfoModal from '../../components/InfoModal';
 import ProductFormModal from '../../components/ProductFormModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import MediaService from '../../services/media';
+import { useTonAddress } from '../../services/tonAuth';
 import commonStyles from '../../constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '../../components/FloatingCartWidget';
@@ -69,6 +70,7 @@ export default function ProductDetailScreen() {
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const [videoThumbnails, setVideoThumbnails] = useState<Record<string, string>>({});
+  const address = useTonAddress();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -82,7 +84,7 @@ export default function ProductDetailScreen() {
     loadProduct();
     loadCategories();
     loadPricingTiers();
-  }, [id]);
+  }, [id, address]);
 
   useEffect(() => {
     if (product) {
@@ -124,6 +126,15 @@ export default function ProductDetailScreen() {
     try {
       const db = DatabaseService.getInstance();
       const fetched = await db.getProduct(id);
+      if (address && fetched && fetched.storeId !== address) {
+        setInfoModal({
+          visible: true,
+          title: 'שגיאה',
+          message: 'מוצר לא נמצא',
+          type: 'error',
+        });
+        return;
+      }
       setProduct(fetched);
     } catch (error) {
       console.error('Error loading product:', error);

--- a/app/stores/[id]/dashboard.tsx
+++ b/app/stores/[id]/dashboard.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useTheme } from '../../../contexts/ThemeContext';
+import { listProducts } from '../../../services/tonProducts';
+import { listOrdersBySeller } from '../../../services/tonOrders';
+
+export default function StoreDashboardScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors } = useTheme();
+  const [productCount, setProductCount] = useState(0);
+  const [orderCount, setOrderCount] = useState(0);
+
+  useEffect(() => {
+    const loadStats = async () => {
+      if (!id) return;
+      const products = await listProducts();
+      setProductCount(products.filter((p) => p.storeId === id).length);
+      const orders = await listOrdersBySeller(id);
+      setOrderCount(orders.length);
+    };
+    loadStats();
+  }, [id]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.title, { color: colors.text.primary }]}>לוח חנות</Text>
+      <View style={styles.stats}>
+        <Text style={[styles.statText, { color: colors.text.primary }]}>מוצרים: {productCount}</Text>
+        <Text style={[styles.statText, { color: colors.text.primary }]}>הזמנות: {orderCount}</Text>
+      </View>
+      <View style={styles.nav}>
+        <TouchableOpacity
+          style={[styles.navButton, { borderColor: colors.border.primary }]}
+          onPress={() => router.push(`/stores/${id}/products`)}
+        >
+          <Text style={{ color: colors.text.primary }}>ניהול מוצרים</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.navButton, { borderColor: colors.border.primary }]}
+          onPress={() => router.push(`/stores/${id}/orders`)}
+        >
+          <Text style={{ color: colors.text.primary }}>צפייה בהזמנות</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  title: { fontSize: 20, fontWeight: '600', marginBottom: 24, textAlign: 'right' },
+  stats: { marginBottom: 24, gap: 8, alignItems: 'flex-end' },
+  statText: { fontSize: 16 },
+  nav: { gap: 12 },
+  navButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+});
+

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -16,6 +16,7 @@ import { useCurrency } from '../contexts/CurrencyContext';
 import CartService from '../services/cart';
 import DatabaseService from '../services/database';
 import MediaService from '../services/media';
+import { useTonAddress } from '../services/tonAuth';
 
 interface ProductCardProps {
   product: Product;
@@ -43,6 +44,11 @@ export default function ProductCard({
   const [videoThumbnail, setVideoThumbnail] = useState<string | null>(null);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const address = useTonAddress();
+
+  if (address && product.storeId !== address) {
+    return null;
+  }
 
   useEffect(() => {
     const cartService = CartService.getInstance();

--- a/services/tonOrders.ts
+++ b/services/tonOrders.ts
@@ -23,3 +23,10 @@ export async function listOrders(): Promise<Order[]> {
   const items = await listValues(ADDRESS);
   return items.map((i) => JSON.parse(i.value) as Order);
 }
+
+export async function listOrdersBySeller(sellerAddress: string): Promise<Order[]> {
+  const items = await listValues(ADDRESS);
+  return items
+    .map((i) => JSON.parse(i.value) as Order)
+    .filter((o) => o.sellerAddress === sellerAddress);
+}


### PR DESCRIPTION
## Summary
- add `/stores/[id]/dashboard` screen showing product and order counts with navigation links
- hide products and routes not owned by connected wallet
- add seller-filtered order lookup and expose via orders agent

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a341f22c48326a78fe0d1e23a2367