### PR TITLE
Add color variants and pricing tier persistence

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -42,9 +42,13 @@ export default function ProductCard({
   const [isInWishlist, setIsInWishlist] = useState(false);
   const [pricingTier, setPricingTier] = useState<PricingTier | null>(null);
   const [videoThumbnail, setVideoThumbnail] = useState<string | null>(null);
+  const [selectedVariantIndex, setSelectedVariantIndex] = useState(0);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const address = useTonAddress();
+  const variants = product.variants || [];
+  const selectedVariant = variants[selectedVariantIndex];
+  const stock = selectedVariant ? selectedVariant.stock : product.stock;
 
   if (address && product.storeId !== address) {
     return null;
@@ -122,8 +126,8 @@ export default function ProductCard({
 
   const addToCart = async (e: any) => {
     e.stopPropagation();
-    if (product.stock === 0) return;
-    
+    if (stock === 0) return;
+
     const cartService = CartService.getInstance();
     await cartService.addToCart(product, 1);
     Alert.alert('נוסף לעגלה', `${product.name} נוסף לעגלה`);
@@ -179,14 +183,14 @@ export default function ProductCard({
         </TouchableOpacity>
 
         {/* Quick Add to Cart */}
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[
             styles.cartButton,
             { backgroundColor: colors.gold },
-            product.stock === 0 && { backgroundColor: colors.interactive.disabled }
-          ]} 
+            stock === 0 && { backgroundColor: colors.interactive.disabled }
+          ]}
           onPress={addToCart}
-          disabled={product.stock === 0}
+          disabled={stock === 0}
         >
           <ShoppingCart size={16} color={colors.text.inverse} />
         </TouchableOpacity>
@@ -249,14 +253,34 @@ export default function ProductCard({
           <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({product.reviews})</Text>
         </View>
 
+        {/* Variant Colors */}
+        {variants.length > 0 && (
+          <View style={styles.variantContainer}>
+            {variants.map((v, idx) => (
+              <TouchableOpacity
+                key={idx}
+                onPress={(e) => {
+                  e.stopPropagation();
+                  setSelectedVariantIndex(idx);
+                }}
+                style={[
+                  styles.variantDot,
+                  { backgroundColor: v.color, borderColor: colors.border.primary },
+                  idx === selectedVariantIndex && { borderColor: colors.gold, borderWidth: 2 },
+                ]}
+              />
+            ))}
+          </View>
+        )}
+
         {/* Stock Status */}
         <View style={styles.stockContainer}>
           <View style={[
             styles.stockIndicator,
-            { backgroundColor: product.stock > 0 ? colors.status.success : colors.status.error }
+            { backgroundColor: stock > 0 ? colors.status.success : colors.status.error }
           ]} />
           <Text style={[styles.stockText, { color: colors.text.secondary }]}>
-            {product.stock > 0 ? `במלאי (${product.stock})` : 'אזל מהמלאי'}
+            {stock > 0 ? `במלאי (${stock})` : 'אזל מהמלאי'}
           </Text>
         </View>
       </View>
@@ -393,6 +417,19 @@ const styles = StyleSheet.create({
   reviews: {
     fontSize: 12,
     marginLeft: 4,
+  },
+  variantContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    marginBottom: 6,
+  },
+  variantDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    marginLeft: 6,
+    borderWidth: 1,
   },
   stockContainer: {
     flexDirection: 'row',

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -51,6 +51,7 @@ export default function ProductFormModal({
   const [productMedia, setProductMedia] = useState<MediaItem[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [pricingTiers, setPricingTiers] = useState<PricingTier[]>([]);
+  const [variants, setVariants] = useState<{ color: string; stock: number }[]>([]);
   const [showCategorySelector, setShowCategorySelector] = useState(false);
   const [showSubcategorySelector, setShowSubcategorySelector] = useState(false);
   const [availableSubcategories, setAvailableSubcategories] = useState<Subcategory[]>([]);
@@ -94,6 +95,7 @@ export default function ProductFormModal({
       media.push({ id: `video_${index}`, uri, type: 'video', name: `Video ${index + 1}` });
     });
     setProductMedia(media);
+    setVariants(product?.variants || []);
   };
 
   const loadCategories = async () => {
@@ -137,6 +139,20 @@ export default function ProductFormModal({
     setShowPricingTierSelector(false);
   };
 
+  const addVariant = () => {
+    setVariants([...variants, { color: '', stock: 0 }]);
+  };
+
+  const updateVariant = (index: number, field: 'color' | 'stock', value: any) => {
+    const updated = [...variants];
+    updated[index] = { ...updated[index], [field]: value };
+    setVariants(updated);
+  };
+
+  const removeVariant = (index: number) => {
+    setVariants(variants.filter((_, i) => i !== index));
+  };
+
   const saveProduct = async () => {
     if (!editingProduct.name || !editingProduct.description || !editingProduct.price || editingProduct.price <= 0) {
       setInfoModal({ visible: true, title: 'שגיאה', message: 'אנא מלא את כל השדות הנדרשים', type: 'error' });
@@ -150,10 +166,14 @@ export default function ProductFormModal({
     setLoading(true);
     try {
       const db = DatabaseService.getInstance();
+      const totalVariantStock = variants.reduce((sum, v) => sum + (v.stock || 0), 0);
       const data = {
         ...editingProduct,
         images: productMedia.filter(m => m.type === 'image').map(m => m.uri),
         videos: productMedia.filter(m => m.type === 'video').map(m => m.uri),
+        colors: variants.map(v => v.color),
+        variants,
+        stock: variants.length > 0 ? totalVariantStock : editingProduct.stock,
       };
 
       let saved: Product;
@@ -323,6 +343,47 @@ export default function ProductFormModal({
                   </Text>
                 </TouchableOpacity>
               </View>
+
+            <View style={styles.formGroup}>
+              <Text style={[styles.formLabel, { color: colors.text.primary }]}>וריאציות צבע</Text>
+              {variants.map((variant, index) => (
+                <View key={index} style={styles.variantRow}>
+                  <TextInput
+                    style={[styles.variantColorInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={variant.color}
+                    onChangeText={text => updateVariant(index, 'color', text)}
+                    placeholder="צבע"
+                    textAlign="right"
+                  />
+                  <TextInput
+                    style={[styles.variantStockInput, {
+                      borderColor: colors.border.primary,
+                      backgroundColor: colors.surface.primary,
+                      color: colors.text.primary,
+                    }]}
+                    value={variant.stock?.toString()}
+                    onChangeText={text => updateVariant(index, 'stock', parseInt(text) || 0)}
+                    placeholder="מלאי"
+                    keyboardType="numeric"
+                    textAlign="right"
+                  />
+                  <TouchableOpacity onPress={() => removeVariant(index)} style={styles.removeVariantButton}>
+                    <Trash2 size={20} color={colors.status.error} />
+                  </TouchableOpacity>
+                </View>
+              ))}
+              <TouchableOpacity
+                style={[styles.addVariantButton, { borderColor: colors.border.primary, backgroundColor: colors.interactive.secondary }]}
+                onPress={addVariant}
+              >
+                <Plus size={20} color={colors.gold} />
+                <Text style={[styles.addVariantText, { color: colors.gold }]}>הוסף וריאציה</Text>
+              </TouchableOpacity>
+            </View>
 
             <View style={styles.formGroup}>
               <Text style={[styles.formLabel, { color: colors.text.primary }]}>מלאי *</Text>
@@ -553,4 +614,10 @@ const styles = StyleSheet.create({
   pricingTierInfo: { marginLeft: 12, flex: 1, alignItems: 'flex-end' },
   pricingTierDiscount: { fontSize: 14, fontWeight: 'bold' },
   pricingTierDescription: { fontSize: 12, textAlign: 'right' },
+  variantRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  variantColorInput: { flex: 1, borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
+  variantStockInput: { width: 80, borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16, marginLeft: 8 },
+  removeVariantButton: { marginLeft: 8 },
+  addVariantButton: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderRadius: 12, paddingVertical: 12, marginTop: 8 },
+  addVariantText: { fontSize: 16, fontWeight: '500', marginLeft: 8 },
 });

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -8,11 +8,21 @@ const ADDRESS =
 
 export async function getProduct(id: string): Promise<Product | null> {
   const res = await getValue(ADDRESS, id);
-  return res ? (JSON.parse(res) as Product) : null;
+  if (!res) return null;
+  const parsed = JSON.parse(res) as Product;
+  return { ...parsed, pricingTier: parsed.pricingTier, variants: parsed.variants || [] };
 }
 
 export async function setProduct(product: Product) {
-  await setValue(ADDRESS, product.id, JSON.stringify(product));
+  await setValue(
+    ADDRESS,
+    product.id,
+    JSON.stringify({
+      ...product,
+      pricingTier: product.pricingTier,
+      variants: product.variants || [],
+    })
+  );
 }
 
 export async function removeProduct(id: string) {
@@ -21,5 +31,8 @@ export async function removeProduct(id: string) {
 
 export async function listProducts(): Promise<Product[]> {
   const items = await listValues(ADDRESS);
-  return items.map((i) => JSON.parse(i.value) as Product);
+  return items.map((i) => {
+    const parsed = JSON.parse(i.value) as Product;
+    return { ...parsed, pricingTier: parsed.pricingTier, variants: parsed.variants || [] };
+  });
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,8 @@
+export interface ProductVariant {
+  color: string;
+  stock: number;
+}
+
 export interface Product {
   id: string;
   tenant_id?: string;
@@ -14,6 +19,7 @@ export interface Product {
   images: string[];
   videos?: string[];
   colors?: string[];
+  variants?: ProductVariant[];
   rating: number;
   reviews: number;
   badges?: string[];


### PR DESCRIPTION
## Summary
- add variant color and stock management in product form
- persist pricing tier and variant arrays in tonProducts service
- display selected variant details on product cards

## Testing
- `npm test` *(fails: Cannot access 'TonWeb.boc' because 'TonWeb' is a type, but not a namespace)*

------
https://chatgpt.com/codex/tasks/task_e_689a3801bd808326921081b1bfc19cd3