### PR TITLE
feat: accept ipfs cids

### DIFF
--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -17,7 +17,6 @@ import { useCurrency } from '../../contexts/CurrencyContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
-import MediaUploader from '../../components/MediaUploader';
 import { useAppInfo } from '../../contexts/AppInfoContext';
 import commonStyles from '../../constants/styles';
 import SettingsAgent from '../../agents/settings-agent';
@@ -28,7 +27,7 @@ export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
 
   const [name, setName] = useState('');
-  const [logoMedia, setLogoMedia] = useState<any[]>([]);
+  const [logoCidInput, setLogoCidInput] = useState('');
   const [themeColor, setThemeColorState] = useState('#B99C5A');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -69,11 +68,7 @@ export default function SettingsScreen() {
 
     setName(appName);
     setThemeColorState(contextThemeColor);
-    if (logoCid) {
-      setLogoMedia([{ id: 'logo', uri: logoCid, type: 'image' }]);
-    } else {
-      setLogoMedia([]);
-    }
+    setLogoCidInput(logoCid || '');
   }, [contextCurrencySymbol, appName, logoCid, contextThemeColor]);
 
   const loadSettings = async () => {
@@ -110,7 +105,7 @@ export default function SettingsScreen() {
 
       await setAppName(name);
       await setThemeColor(themeColor);
-      const logoUri = logoMedia[0]?.uri || '';
+      const logoUri = logoCidInput.trim();
       await setLogoCid(logoUri);
 
       setInfoModal({
@@ -202,12 +197,21 @@ export default function SettingsScreen() {
             </View>
 
             <View style={styles.inputContainer}>
-              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>לוגו</Text>
-              <MediaUploader
-                media={logoMedia}
-                onMediaChange={setLogoMedia}
-                maxFiles={1}
-                allowVideos={false}
+              <Text style={[styles.inputLabel, { color: colors.text.primary }]}>לוגו (CID או URL)</Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  {
+                    borderColor: colors.border.primary,
+                    backgroundColor: colors.surface.primary,
+                    color: colors.text.primary,
+                  },
+                ]}
+                value={logoCidInput}
+                onChangeText={setLogoCidInput}
+                placeholder="ipfs://..."
+                textAlign="right"
+                placeholderTextColor={colors.text.tertiary}
               />
             </View>
 

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -16,6 +16,7 @@ import { Product, Category, Subcategory, PricingTier } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useCurrency } from '../contexts/CurrencyContext';
 import DatabaseService from '../services/database';
+import PinataService from '../services/pinata';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
 import PricingTierFormModal from "./PricingTierFormModal";
@@ -155,6 +156,20 @@ export default function ProductFormModal({
     if (images.length === 0 && videos.length === 0) {
       setInfoModal({ visible: true, title: 'שגיאה', message: 'אנא ספק לפחות מדיה אחת', type: 'error' });
       return;
+    }
+
+    const pinata = PinataService.getInstance();
+    const allMedia = [...images, ...videos];
+    for (const uri of allMedia) {
+      if (!pinata.isCidOrUrl(uri)) {
+        setInfoModal({
+          visible: true,
+          title: 'שגיאה',
+          message: 'כל המדיה חייבת להיות CID או קישור תקין',
+          type: 'error',
+        });
+        return;
+      }
     }
 
     setLoading(true);

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -9,7 +9,6 @@ import React, {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert } from 'react-native';
 import SettingsAgent from '../agents/settings-agent';
-import MediaService from '../services/media';
 import { fetchSettings } from '../services/tonSettings';
 
 interface AppInfoContextType {
@@ -142,15 +141,10 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   };
 
   const setLogoCid = async (logo: string) => {
-    let finalLogo = logo;
     try {
-      if (logo && !logo.startsWith('http')) {
-        const mediaSvc = MediaService.getInstance();
-        finalLogo = await mediaSvc.uploadMedia(logo, 'tenant_logo');
-      }
       const LOGO_KEY = `app_logo_${tenantId}`;
-      setLogoCidState(finalLogo);
-      await AsyncStorage.setItem(LOGO_KEY, finalLogo);
+      setLogoCidState(logo);
+      await AsyncStorage.setItem(LOGO_KEY, logo);
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת לוגו נכשלה');
       console.error('Error setting platform logo:', e);
@@ -165,7 +159,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       throw e;
     }
     try {
-      await tenantSvc.updateSettingValue('brand.logoCid', finalLogo);
+      await tenantSvc.updateSettingValue('brand.logoCid', logo);
       scheduleLoadInfo();
     } catch (e) {
       Alert.alert('שגיאה', 'שמירת לוגו נכשלה');

--- a/scripts/pinata-upload.ts
+++ b/scripts/pinata-upload.ts
@@ -35,11 +35,16 @@ async function main() {
     console.error('Usage: ts-node scripts/pinata-upload.ts <file> [file...]');
     process.exit(1);
   }
+  const results = await Promise.all(
+    files.map(async (file) => {
+      const resolved = path.resolve(file);
+      const cid = await upload(resolved);
+      return { resolved, cid };
+    })
+  );
 
-  for (const file of files) {
-    const resolved = path.resolve(file);
-    const cid = await upload(resolved);
-    console.log(`${resolved}: ${cid}`);
+  for (const r of results) {
+    console.log(`${r.resolved}: ${r.cid}`);
   }
 }
 

--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -1,4 +1,5 @@
 import { debugLog } from '../utils/logger';
+import { CID } from 'multiformats/cid';
 
 /**
  * Minimal Pinata helper. Uploads are not supported inside the app.
@@ -17,13 +18,29 @@ class PinataService {
     return PinataService.instance;
   }
 
-  /** Check whether a string is already an IPFS CID or URL. */
-  public isCid(uri: string): boolean {
-    return (
-      uri.startsWith('ipfs://') ||
-      /ipfs\/[A-Za-z0-9]+/.test(uri) ||
-      /^[A-Za-z0-9]{46,}$/i.test(uri)
-    );
+  /**
+   * Check whether a string is already an IPFS CID or a regular HTTP(S) URL.
+   * This relies on multiformats to validate CIDs and the WHATWG URL parser for
+   * web links.
+   */
+  public isCidOrUrl(uri: string): boolean {
+    if (!uri) return false;
+
+    // Accept valid HTTP(S) URLs
+    try {
+      // eslint-disable-next-line no-new
+      new URL(uri);
+      return true;
+    } catch {}
+
+    // Strip ipfs:// prefix if present and attempt to parse as CID
+    const cleaned = uri.replace(/^ipfs:\/\//, '').split('/')[0];
+    try {
+      CID.parse(cleaned);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -35,7 +52,7 @@ class PinataService {
     _name: string,
     _onProgress?: (percent: number) => void
   ): Promise<string> {
-    if (this.isCid(uri) || uri.startsWith('http')) {
+    if (this.isCidOrUrl(uri)) {
       return uri;
     }
     debugLog('Pinata upload skipped; provide a CID or URL instead:', uri);

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,25 +1,19 @@
 import PinataService from '../services/pinata';
-import axios from 'axios';
-
-jest.mock('axios');
 
 describe('PinataService', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('skips upload when URI is already a URL', async () => {
+  it('returns URI unchanged when already CID or URL', async () => {
+    const svc = PinataService.getInstance();
+    const cid = 'ipfs://bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6';
     const url = 'https://example.com/file.png';
-    const service = PinataService.getInstance();
-    const result = await service.uploadFile(url, 'file');
-    expect(result).toBe(url);
-    expect(axios.post).not.toHaveBeenCalled();
+    await expect(svc.uploadFile(cid, 'file')).resolves.toBe(cid);
+    await expect(svc.uploadFile(url, 'file')).resolves.toBe(url);
   });
 
-  it('detects CID strings', () => {
-    const service = PinataService.getInstance();
-    expect(service.isCid('bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6')).toBe(true);
-    expect(service.isCid('ipfs://bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6')).toBe(true);
-    expect(service.isCid('https://example.com')).toBe(false);
+  it('validates CID and URL strings', () => {
+    const svc = PinataService.getInstance();
+    expect(svc.isCidOrUrl('bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6')).toBe(true);
+    expect(svc.isCidOrUrl('ipfs://bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6')).toBe(true);
+    expect(svc.isCidOrUrl('https://example.com')).toBe(true);
+    expect(svc.isCidOrUrl('not-a-cid')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- validate CIDs and URLs with multiformats in Pinata service
- allow product and settings forms to take IPFS CIDs or HTTP links without uploads
- provide a local CLI for pinning files with PINATA_JWT

## Testing
- `npm test` *(fails: jest not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" )*


------
https://chatgpt.com/codex/tasks/task_e_689a4d31d14c8326b0f049c8e33998d9