### PR TITLE
Add product variant color previews and tier persistence

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -255,31 +255,38 @@ export default function ProductCard({
 
         {/* Variant Colors */}
         {variants.length > 0 && (
-          <View style={styles.variantContainer}>
-            {variants.map((v, idx) => (
-              <TouchableOpacity
-                key={idx}
-                onPress={(e) => {
-                  e.stopPropagation();
-                  setSelectedVariantIndex(idx);
-                }}
-                style={[
-                  styles.variantDot,
-                  { backgroundColor: v.color, borderColor: colors.border.primary },
-                  idx === selectedVariantIndex && { borderColor: colors.gold, borderWidth: 2 },
-                ]}
-              />
-            ))}
-          </View>
+          <>
+            <View style={styles.variantContainer}>
+              {variants.map((v, idx) => (
+                <TouchableOpacity
+                  key={idx}
+                  onPress={(e) => {
+                    e.stopPropagation();
+                    setSelectedVariantIndex(idx);
+                  }}
+                  style={[
+                    styles.variantDot,
+                    { backgroundColor: v.color, borderColor: colors.border.primary },
+                    idx === selectedVariantIndex && { borderColor: colors.gold, borderWidth: 2 },
+                  ]}
+                />
+              ))}
+            </View>
+            {selectedVariant && (
+              <Text style={[styles.selectedVariantText, { color: colors.text.secondary }]}>צבע: {selectedVariant.color}</Text>
+            )}
+          </>
         )}
 
         {/* Stock Status */}
         <View style={styles.stockContainer}>
-          <View style={[
-            styles.stockIndicator,
-            { backgroundColor: stock > 0 ? colors.status.success : colors.status.error }
-          ]} />
-          <Text style={[styles.stockText, { color: colors.text.secondary }]}>
+          <View
+            style={[
+              styles.stockIndicator,
+              { backgroundColor: stock > 0 ? colors.status.success : colors.status.error },
+            ]}
+          />
+          <Text style={[styles.stockText, { color: colors.text.secondary }]}> 
             {stock > 0 ? `במלאי (${stock})` : 'אזל מהמלאי'}
           </Text>
         </View>
@@ -430,6 +437,11 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginLeft: 6,
     borderWidth: 1,
+  },
+  selectedVariantText: {
+    fontSize: 12,
+    marginBottom: 4,
+    textAlign: 'right',
   },
   stockContainer: {
     flexDirection: 'row',

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -376,25 +376,37 @@ export default function ProductFormModal({
               <Text style={[styles.formLabel, { color: colors.text.primary }]}>וריאציות צבע</Text>
               {variants.map((variant, index) => (
                 <View key={index} style={styles.variantRow}>
+                  <View
+                    style={[
+                      styles.colorPreview,
+                      { backgroundColor: variant.color || 'transparent', borderColor: colors.border.primary },
+                    ]}
+                  />
                   <TextInput
-                    style={[styles.variantColorInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
+                    style={[
+                      styles.variantColorInput,
+                      {
+                        borderColor: colors.border.primary,
+                        backgroundColor: colors.surface.primary,
+                        color: colors.text.primary,
+                      },
+                    ]}
                     value={variant.color}
-                    onChangeText={text => updateVariant(index, 'color', text)}
+                    onChangeText={(text) => updateVariant(index, 'color', text)}
                     placeholder="צבע"
                     textAlign="right"
                   />
                   <TextInput
-                    style={[styles.variantStockInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
+                    style={[
+                      styles.variantStockInput,
+                      {
+                        borderColor: colors.border.primary,
+                        backgroundColor: colors.surface.primary,
+                        color: colors.text.primary,
+                      },
+                    ]}
                     value={variant.stock?.toString()}
-                    onChangeText={text => updateVariant(index, 'stock', parseInt(text) || 0)}
+                    onChangeText={(text) => updateVariant(index, 'stock', parseInt(text) || 0)}
                     placeholder="מלאי"
                     keyboardType="numeric"
                     textAlign="right"
@@ -643,6 +655,7 @@ const styles = StyleSheet.create({
   pricingTierDiscount: { fontSize: 14, fontWeight: 'bold' },
   pricingTierDescription: { fontSize: 12, textAlign: 'right' },
   variantRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  colorPreview: { width: 24, height: 24, borderRadius: 12, marginRight: 8, borderWidth: 1 },
   variantColorInput: { flex: 1, borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
   variantStockInput: { width: 80, borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16, marginLeft: 8 },
   removeVariantButton: { marginLeft: 8 },

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -10,7 +10,12 @@ export async function getProduct(id: string): Promise<Product | null> {
   const res = await getValue(ADDRESS, id);
   if (!res) return null;
   const parsed = JSON.parse(res) as Product;
-  return { ...parsed, pricingTier: parsed.pricingTier, variants: parsed.variants || [] };
+  return {
+    ...parsed,
+    pricingTier: parsed.pricingTier,
+    variants: parsed.variants || [],
+    colors: parsed.colors || [],
+  };
 }
 
 export async function setProduct(product: Product) {
@@ -21,6 +26,7 @@ export async function setProduct(product: Product) {
       ...product,
       pricingTier: product.pricingTier,
       variants: product.variants || [],
+      colors: product.colors || [],
     })
   );
 }
@@ -33,6 +39,11 @@ export async function listProducts(): Promise<Product[]> {
   const items = await listValues(ADDRESS);
   return items.map((i) => {
     const parsed = JSON.parse(i.value) as Product;
-    return { ...parsed, pricingTier: parsed.pricingTier, variants: parsed.variants || [] };
+    return {
+      ...parsed,
+      pricingTier: parsed.pricingTier,
+      variants: parsed.variants || [],
+      colors: parsed.colors || [],
+    };
   });
 }


### PR DESCRIPTION
## Summary
- show color swatches and per-variant stock in product form
- persist variant colors and pricing tier details in TON product service
- display selected variant color on product card

## Testing
- `npm test` *(fails: Cannot access 'TonWeb.boc' because 'TonWeb' is a type, but not a namespace)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f339cf083269dbe6b007ddfc085