### PR TITLE
feat: add kyc message handling

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -3,6 +3,16 @@ import tonAuth from '../services/tonAuth';
 import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 import { getPublicKeyHex } from '../services/localIdentity';
 
+export type UsersAgentMessage =
+  | { type: 'user.add'; payload: User }
+  | { type: 'user.update'; payload: User }
+  | { type: 'user.remove'; payload: { id: string } }
+  | { type: 'kyc.request'; payload: { userId: string; documentUri: string } }
+  | {
+      type: 'kyc.update';
+      payload: { userId: string; status: 'verified' | 'rejected'; adminId?: string };
+    };
+
 class UsersAgent {
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -75,6 +85,30 @@ class UsersAgent {
 
   async getAll(): Promise<User[]> {
     return await listUsers();
+  }
+
+  async handleMessage(msg: UsersAgentMessage): Promise<void> {
+    switch (msg.type) {
+      case 'user.add':
+        await this.add(msg.payload);
+        break;
+      case 'user.update':
+        await this.update(msg.payload);
+        break;
+      case 'user.remove':
+        await this.remove(msg.payload.id);
+        break;
+      case 'kyc.request':
+        await this.requestKyc(msg.payload.userId, msg.payload.documentUri);
+        break;
+      case 'kyc.update':
+        await this.updateKyc(
+          msg.payload.userId,
+          msg.payload.status,
+          msg.payload.adminId,
+        );
+        break;
+    }
   }
 }
 

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -23,12 +23,18 @@ export default function AdminDashboard() {
   };
 
   const approve = async (id: string) => {
-    await usersAgent.updateKyc(id, 'verified', user?.id);
+    await usersAgent.handleMessage({
+      type: 'kyc.update',
+      payload: { userId: id, status: 'verified', adminId: user?.id },
+    });
     setRequests(req => req.filter(r => r.id !== id));
   };
 
   const reject = async (id: string) => {
-    await usersAgent.updateKyc(id, 'rejected', user?.id);
+    await usersAgent.handleMessage({
+      type: 'kyc.update',
+      payload: { userId: id, status: 'rejected', adminId: user?.id },
+    });
     setRequests(req => req.filter(r => r.id !== id));
   };
 

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -14,7 +14,10 @@ export default function KycScreen() {
 
   const submit = async () => {
     if (!user || !docUri) return;
-    await usersAgent.requestKyc(user.id, docUri);
+    await usersAgent.handleMessage({
+      type: 'kyc.request',
+      payload: { userId: user.id, documentUri: docUri },
+    });
     router.back();
   };
 


### PR DESCRIPTION
## Summary
- handle kyc.request and kyc.update messages in users agent
- allow users to submit document uploads through KYC screen
- enable admins to approve or reject pending KYC requests

## Testing
- `yarn test tests/usersAgent.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a55f86b648326837ad79f81234f93