### PR TITLE
chore: use relative publicPath for web

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = async function (env, argv) {
 
   // Use source maps in all modes to avoid eval-based tooling which can violate CSP
   config.devtool = 'source-map';
+  // Ensure assets are served relative to index.html for IPFS/URL subpaths
+  config.output.publicPath = './';
 
   // Optional: remove buggy plugin in production
   if (config.mode === 'production') {


### PR DESCRIPTION
## Summary
- serve built web assets relative to `index.html` for IPFS/URL subpaths

## Testing
- `npm test` *(fails: jest: not found)*
- `yarn install --frozen-lockfile` *(fails: engine node >=22 required)*
- `yarn lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3001d2e88326a6a73c426ee3c394