### PR TITLE
Add store creation flow and seller link

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -12,14 +12,19 @@ class StoresAgent {
     }
   }
 
+  private toRecord(item: Store) {
+    const { id, name, owner, nftId } = item;
+    return { id, name, owner, nftId };
+  }
+
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore({ id: item.id, name: item.name, owner: item.owner, nftId: item.nftId });
+    await setStore(this.toRecord(item));
   }
 
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore({ id: item.id, name: item.name, owner: item.owner, nftId: item.nftId });
+    await setStore(this.toRecord(item));
   }
 
   async remove(id: string): Promise<void> {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -460,6 +460,7 @@ export default function HomeScreen() {
         <TouchableOpacity
           style={[styles.becomeSellerButton, { backgroundColor: colors.gold }]}
           onPress={() => router.push('/stores/create')}
+          accessibilityRole="link"
         >
           <Text style={[styles.becomeSellerText, { color: colors.text.inverse }]}>Become a Seller</Text>
         </TouchableOpacity>

--- a/components/StoreCreation.tsx
+++ b/components/StoreCreation.tsx
@@ -12,7 +12,7 @@ const provider = new TonWeb.HttpProvider('https://testnet.toncenter.com/api/v2/j
 const StoreCreation: React.FC = () => {
   const [name, setName] = useState('');
 
-  const deployStoreNFT = async (_storeName: string, owner: string) => {
+  const deployStoreNFT = async () => {
     const code = TonWeb.boc.Cell.fromBoc(Buffer.from(codeBoc, 'base64'))[0];
     const data = TonWeb.boc.Cell.fromBoc(Buffer.from(dataBoc, 'base64'))[0];
     const contract = new (TonWeb as any).Contract(provider, { code, data });
@@ -50,7 +50,7 @@ const StoreCreation: React.FC = () => {
       return;
     }
     try {
-      const nftId = await deployStoreNFT(name, owner);
+      const nftId = await deployStoreNFT();
       const id = Date.now().toString();
       await storesAgent.add({ id, name, owner, nftId });
       setName('');


### PR DESCRIPTION
## Summary
- allow minting store NFTs via new StoreCreation component
- store agent records id, name, owner and nftId for each store
- add a "Become a Seller" link from the home tab to the store creation page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5f25965c8326a7d949b77f97b38f