### PR TITLE
Add payment release and refund workflow for TON orders

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -3,8 +3,8 @@ import tonAuth from '../services/tonAuth';
 import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
 import {
   deployOrderPayment,
-  releaseFunds,
-  refundOrder,
+  releasePayment,
+  refundPayment,
 } from '../services/tonContract';
 
 class OrdersAgent {
@@ -57,22 +57,38 @@ class OrdersAgent {
     return await listOrdersBySeller(address);
   }
 
-  async releaseFunds(orderId: string): Promise<string> {
+  async releasePayment(orderId: string): Promise<string> {
     await this.ensureWallet();
     const order = await this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
-    return await releaseFunds(order.paymentContractAddress);
+    const hash = await releasePayment(order.paymentContractAddress);
+    const updated: Order = {
+      ...order,
+      status: 'released',
+      updatedAt: new Date().toISOString(),
+    };
+    await setOrder(updated);
+    this.subscribers.forEach((cb) => cb(updated));
+    return hash;
   }
 
-  async refundOrder(orderId: string): Promise<string> {
+  async refundPayment(orderId: string): Promise<string> {
     await this.ensureWallet();
     const order = await this.get(orderId);
     if (!order?.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
-    return await refundOrder(order.paymentContractAddress);
+    const hash = await refundPayment(order.paymentContractAddress);
+    const updated: Order = {
+      ...order,
+      status: 'refunded',
+      updatedAt: new Date().toISOString(),
+    };
+    await setOrder(updated);
+    this.subscribers.forEach((cb) => cb(updated));
+    return hash;
   }
 
   subscribe(cb: (o: Order) => void) {

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -2,15 +2,17 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DatabaseService from '../../services/database';
-import { User } from '../../types';
+import { User, Order } from '../../types';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useAuth } from '../../components/AuthContext';
 import usersAgent from '../../agents/users-agent';
+import ordersAgent from '../../agents/orders-agent';
 
 export default function AdminDashboard() {
   const { user } = useAuth();
   const { colors } = useTheme();
   const [requests, setRequests] = useState<User[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
     load();
@@ -20,6 +22,15 @@ export default function AdminDashboard() {
     const db = DatabaseService.getInstance();
     const pending = await db.getPendingKycRequests();
     setRequests(pending);
+    const allOrders = await ordersAgent.getAll();
+    const pendingOrders = allOrders.filter(
+      o =>
+        o.paymentMethod === 'ton' &&
+        o.paymentContractAddress &&
+        o.status !== 'released' &&
+        o.status !== 'refunded',
+    );
+    setOrders(pendingOrders);
   };
 
   const approve = async (id: string) => {
@@ -36,6 +47,16 @@ export default function AdminDashboard() {
       payload: { userId: id, status: 'rejected', adminId: user?.id },
     });
     setRequests(req => req.filter(r => r.id !== id));
+  };
+
+  const release = async (id: string) => {
+    await ordersAgent.releasePayment(id);
+    setOrders(o => o.filter(ord => ord.id !== id));
+  };
+
+  const refund = async (id: string) => {
+    await ordersAgent.refundPayment(id);
+    setOrders(o => o.filter(ord => ord.id !== id));
   };
 
   return (
@@ -63,6 +84,31 @@ export default function AdminDashboard() {
         ))}
         {requests.length === 0 && (
           <Text style={[styles.empty, { color: colors.text.secondary }]}>No pending requests.</Text>
+        )}
+
+        <Text style={[styles.title, { color: colors.text.primary }]}>Pending Paid Orders</Text>
+        {orders.map(o => (
+          <View key={o.id} style={[styles.card, { borderColor: colors.border.primary }]}>
+            <Text style={[styles.name, { color: colors.text.primary }]}>Order #{o.id}</Text>
+            <Text style={[styles.name, { color: colors.text.secondary }]}>Total: {o.total}</Text>
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.button, { backgroundColor: colors.status.success }]}
+                onPress={() => release(o.id)}
+              >
+                <Text style={{ color: colors.text.inverse }}>Release</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.button, { backgroundColor: colors.status.error }]}
+                onPress={() => refund(o.id)}
+              >
+                <Text style={{ color: colors.text.inverse }}>Refund</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))}
+        {orders.length === 0 && (
+          <Text style={[styles.empty, { color: colors.text.secondary }]}>No pending orders.</Text>
         )}
       </ScrollView>
     </SafeAreaView>

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -61,7 +61,7 @@ export async function deployOrderPayment(
   }
 }
 
-export async function releaseFunds(contractAddress: string): Promise<string> {
+export async function releasePayment(contractAddress: string): Promise<string> {
   try {
     const payload = makeComment('Release');
     const payloadBoc = TonWeb.utils.bytesToBase64(
@@ -75,12 +75,12 @@ export async function releaseFunds(contractAddress: string): Promise<string> {
       },
     ]);
   } catch (e) {
-    console.error('Failed to release funds', e);
+    console.error('Failed to release payment', e);
     throw e;
   }
 }
 
-export async function refundOrder(contractAddress: string): Promise<string> {
+export async function refundPayment(contractAddress: string): Promise<string> {
   try {
     const payload = makeComment('Refund');
     const payloadBoc = TonWeb.utils.bytesToBase64(
@@ -94,7 +94,7 @@ export async function refundOrder(contractAddress: string): Promise<string> {
       },
     ]);
   } catch (e) {
-    console.error('Failed to refund order', e);
+    console.error('Failed to refund payment', e);
     throw e;
   }
 }

--- a/tests/tonAuthContract.test.ts
+++ b/tests/tonAuthContract.test.ts
@@ -2,8 +2,8 @@ import { createHash } from 'crypto';
 import * as tonAuth from '../services/tonAuth';
 import {
   deployOrderPayment,
-  releaseFunds,
-  refundOrder,
+  releasePayment,
+  refundPayment,
   ORDER_PAYMENT_FACTORY_ADDRESS,
 } from '../services/tonContract';
 
@@ -45,8 +45,8 @@ describe('Ton contract flows', () => {
     expect(result.txHash).toBe(expectedHash);
   });
 
-  it('releases funds through TonConnect', async () => {
-    const res = await releaseFunds('contract1');
+  it('releases payment through TonConnect', async () => {
+    const res = await releasePayment('contract1');
     expect(mockTonConnect.sendTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [
@@ -57,8 +57,8 @@ describe('Ton contract flows', () => {
     expect(res).toBe(expectedHash);
   });
 
-  it('refunds order through TonConnect', async () => {
-    const res = await refundOrder('contract1');
+  it('refunds payment through TonConnect', async () => {
+    const res = await refundPayment('contract1');
     expect(mockTonConnect.sendTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [

--- a/types/index.ts
+++ b/types/index.ts
@@ -223,12 +223,14 @@ export interface Order {
   paymentTxHash?: string;
 }
 
-export type OrderStatus = 
+export type OrderStatus =
   | 'order_received'      // הזמנה התקבלה
   | 'courier_found'       // נמצא שליח מתאים
   | 'courier_picked_up'   // שליח אסף את ההזמנה
   | 'courier_on_way'      // שליח בדרך אלייך
-  | 'delivered';          // הזמנה התקבלה
+  | 'delivered'           // הזמנה התקבלה
+  | 'released'            // תשלום שוחרר
+  | 'refunded';           // תשלום הוחזר
 
 export interface OrderTrackingStep {
   status: OrderStatus;


### PR DESCRIPTION
## Summary
- support releasing or refunding TON escrow payments
- show pending paid orders in admin panel with release and refund actions
- track finalized order status as released or refunded

## Testing
- `npm test` *(fails: TonConnect not initialized, sha256_sync missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a5f7d0cd08326b398ec9ded86791d