### PR TITLE
feat: add Buy TON option in cart

### DIFF
--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -37,6 +37,8 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { router } from 'expo-router';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
+import MoonPayModal from './MoonPayModal';
+import tonAuth, { useTonAddress } from '../services/tonAuth';
 
 interface CartModalProps {
   visible: boolean;
@@ -66,6 +68,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const { showNotification } = useNotifications();
   const { t } = useLanguage();
   const scrollViewRef = useRef<ScrollView>(null);
+  const walletAddress = useTonAddress();
 
   // Info/confirm modals
   const [infoModal, setInfoModal] = useState({
@@ -82,6 +85,9 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     cancelText: '',
     action: () => {},
   });
+
+  const [moonPayVisible, setMoonPayVisible] = useState(false);
+  const [moonPayAmount, setMoonPayAmount] = useState(0);
 
   useEffect(() => {
     if (visible) {
@@ -230,6 +236,27 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   };
 
   const goToConfirmation = () => setCheckoutStep('confirmation');
+
+  const handleBuyTon = async () => {
+    if (!walletAddress) {
+      await tonAuth.openModal();
+      return;
+    }
+    try {
+      const res = await fetch(
+        'https://api.coingecko.com/api/v3/simple/price?ids=the-open-network&vs_currencies=usd',
+      );
+      const data = await res.json();
+      const tonPrice = data['the-open-network']?.usd;
+      if (tonPrice) {
+        const amount = getTotal() / tonPrice;
+        setMoonPayAmount(Number(amount.toFixed(2)));
+        setMoonPayVisible(true);
+      }
+    } catch (err) {
+      console.error('Error fetching TON price:', err);
+    }
+  };
 
   const goBack = () => {
     switch (checkoutStep) {
@@ -767,6 +794,13 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
             </View>
           </TouchableOpacity>
         </View>
+
+        <TouchableOpacity
+          style={[styles.buyTonButton, { backgroundColor: colors.gold }]}
+          onPress={handleBuyTon}
+        >
+          <Text style={[styles.buyTonButtonText, { color: colors.text.inverse }]}>Buy TON</Text>
+        </TouchableOpacity>
 
         <View
           style={[
@@ -1308,6 +1342,13 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         }}
         onCancel={() => setConfirmModal({ ...confirmModal, visible: false })}
       />
+      <MoonPayModal
+        visible={moonPayVisible}
+        onClose={() => setMoonPayVisible(false)}
+        walletAddress={walletAddress || ''}
+        coin="ton"
+        amountTON={moonPayAmount}
+      />
     </>
   );
 }
@@ -1443,6 +1484,13 @@ const styles = StyleSheet.create({
   paymentOptionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 4, textAlign: 'right' },
   paymentOptionDescription: { fontSize: 12, textAlign: 'right' },
   paymentOptionCheck: { marginLeft: 12 },
+  buyTonButton: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  buyTonButtonText: { fontSize: 16, fontWeight: '600' },
   shippingAddressSummary: { borderRadius: 12, padding: 16, marginBottom: 16, borderWidth: 1 },
   summaryHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 },
   editLink: { fontSize: 14, fontWeight: '500' },

--- a/components/MoonPayModal.tsx
+++ b/components/MoonPayModal.tsx
@@ -9,8 +9,9 @@ interface MoonPayModalProps {
   visible: boolean;
   onClose: () => void;
   walletAddress: string;
-  coin: 'eth' | 'usdt' | 'usdc';
-  amountUSD: number;
+  coin: 'eth' | 'usdt' | 'usdc' | 'ton';
+  amountUSD?: number;
+  amountTON?: number;
 }
 
 export default function MoonPayModal({
@@ -19,6 +20,7 @@ export default function MoonPayModal({
   walletAddress,
   coin,
   amountUSD,
+  amountTON,
 }: MoonPayModalProps) {
   const { colors } = useTheme();
   const [loading, setLoading] = useState(true);
@@ -27,8 +29,22 @@ export default function MoonPayModal({
 
   const url = `https://buy.moonpay.com?apiKey=${config.fiatKey}&currencyCode=${coin}&walletAddress=${walletAddress}&baseCurrencyCode=usd`;
 
-  // Inject JavaScript to pre-fill the fiat amount once the widget has loaded
-  const injectedJavaScript = `
+  let injectedJavaScript: string | undefined;
+  if (typeof amountTON === 'number') {
+    injectedJavaScript = `
+    setTimeout(function() {
+      var input = document.querySelector('input[name="quote-amount-input"], input[name="quoteAmount"], input[name="digital-amount-input"]');
+      if (input) {
+        var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        nativeInputValueSetter.call(input, '${amountTON}');
+        var ev = new Event('input', { bubbles: true });
+        input.dispatchEvent(ev);
+      }
+    }, 2500);
+    true;
+  `;
+  } else if (typeof amountUSD === 'number') {
+    injectedJavaScript = `
     setTimeout(function() {
       var input = document.querySelector('input[name="base-amount-input"], input[name="baseAmount"]');
       if (input) {
@@ -40,6 +56,7 @@ export default function MoonPayModal({
     }, 2500);
     true;
   `;
+  }
 
   const handleNavigationChange = (event: any) => {
     if (event.url.includes('success') || event.url.includes('complete')) {


### PR DESCRIPTION
## Summary
- add Buy TON button to cart payment step
- open MoonPay modal with wallet and TON amount from cart total
- support TON currency in MoonPayModal

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn add --dev jest@29.7.0` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689a628846708326a0658d71906f0a0b