### PR TITLE
Enforce valid order status transitions and notify updates

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,11 +1,22 @@
-import { Order } from '../types';
+import { Order, OrderStatus, Notification } from '../types';
 import tonAuth from '../services/tonAuth';
+import notificationsAgent from './notifications-agent';
 import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
 import {
   deployOrderPayment,
   releasePayment,
   refundPayment,
 } from '../services/tonContract';
+
+export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  order_received: ['courier_found'],
+  courier_found: ['courier_picked_up'],
+  courier_picked_up: ['courier_on_way'],
+  courier_on_way: ['delivered'],
+  delivered: ['released', 'refunded'],
+  released: [],
+  refunded: [],
+};
 
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
@@ -36,8 +47,23 @@ class OrdersAgent {
 
   async update(order: Order): Promise<void> {
     await this.ensureWallet();
+    const current = await this.get(order.id);
+    if (!current) {
+      throw new Error('Order not found');
+    }
+    let statusChanged = false;
+    if (order.status !== current.status) {
+      const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
+      if (!allowed.includes(order.status)) {
+        throw new Error(`Invalid status transition from ${current.status} to ${order.status}`);
+      }
+      statusChanged = true;
+    }
     await setOrder(order);
     this.subscribers.forEach((cb) => cb(order));
+    if (statusChanged) {
+      await this.notifyStatusChange(order);
+    }
   }
 
   async remove(id: string): Promise<void> {
@@ -66,6 +92,10 @@ class OrdersAgent {
     if (!order.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
+    const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
+    if (!allowed.includes('released')) {
+      throw new Error(`Invalid status transition from ${order.status} to released`);
+    }
     const hash = await releasePayment(order.paymentContractAddress);
     const updated: Order = {
       ...order,
@@ -74,6 +104,7 @@ class OrdersAgent {
     };
     await setOrder(updated);
     this.subscribers.forEach((cb) => cb(updated));
+    await this.notifyStatusChange(updated);
     return hash;
   }
 
@@ -86,6 +117,10 @@ class OrdersAgent {
     if (!order.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
+    const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
+    if (!allowed.includes('refunded')) {
+      throw new Error(`Invalid status transition from ${order.status} to refunded`);
+    }
     const hash = await refundPayment(order.paymentContractAddress);
     const updated: Order = {
       ...order,
@@ -94,6 +129,7 @@ class OrdersAgent {
     };
     await setOrder(updated);
     this.subscribers.forEach((cb) => cb(updated));
+    await this.notifyStatusChange(updated);
     return hash;
   }
 
@@ -103,6 +139,23 @@ class OrdersAgent {
 
   unsubscribe(cb: (o: Order) => void) {
     this.subscribers.delete(cb);
+  }
+
+  private async notifyStatusChange(order: Order) {
+    const notification: Notification = {
+      id: `ntf_${Date.now()}`,
+      userId: order.userId,
+      title: 'Order status updated',
+      message: `Order ${order.id} status changed to ${order.status}`,
+      type: 'order',
+      read: false,
+      timestamp: Date.now(),
+    };
+    try {
+      await notificationsAgent.add(notification);
+    } catch (err) {
+      console.error('Failed to send notification', err);
+    }
   }
 }
 

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useAuth } from '../../components/AuthContext';
+import GlobalHeader from '../../components/GlobalHeader';
+import InfoModal from '../../components/InfoModal';
+import OrderService from '../../services/orders';
+import { Order, OrderStatus } from '../../types';
+import { ALLOWED_STATUS_TRANSITIONS } from '../../agents/orders-agent';
+
+export default function OrderDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors } = useTheme();
+  const { user, isDriver } = useAuth();
+  const [order, setOrder] = useState<Order | null>(null);
+  const [infoModal, setInfoModal] = useState({
+    visible: false,
+    title: '',
+    message: '',
+    type: 'info' as 'success' | 'error' | 'info' | 'warning',
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      if (!id) return;
+      const svc = OrderService.getInstance();
+      const o = await svc.getOrder(id);
+      setOrder(o);
+    };
+    load();
+  }, [id]);
+
+  const address = user?.address;
+  const isSeller = !!address && order?.sellerAddress === address;
+  const canUpdate = !!order && (isSeller || isDriver);
+  const nextStatuses: OrderStatus[] = order ? ALLOWED_STATUS_TRANSITIONS[order.status] || [] : [];
+
+  const statusLabel = (status: OrderStatus) => {
+    switch (status) {
+      case 'order_received':
+        return 'הזמנה התקבלה';
+      case 'courier_found':
+        return 'נמצא שליח';
+      case 'courier_picked_up':
+        return 'שליח אסף';
+      case 'courier_on_way':
+        return 'שליח בדרך';
+      case 'delivered':
+        return 'הזמנה נמסרה';
+      case 'released':
+        return 'תשלום שוחרר';
+      case 'refunded':
+        return 'תשלום הוחזר';
+      default:
+        return status;
+    }
+  };
+
+  const handleUpdate = async (status: OrderStatus) => {
+    if (!order) return;
+    try {
+      const svc = OrderService.getInstance();
+      await svc.updateOrderStatus(order.id, status);
+      const updated = await svc.getOrder(order.id);
+      setOrder(updated);
+      setInfoModal({ visible: true, title: 'עודכן', message: 'סטטוס ההזמנה עודכן', type: 'success' });
+    } catch (e) {
+      setInfoModal({ visible: true, title: 'שגיאה', message: 'עדכון הסטטוס נכשל', type: 'error' });
+    }
+  };
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.background }]}> 
+      <GlobalHeader title={`הזמנה #${id}`} showBackButton />
+      {order && (
+        <View style={styles.content}>
+          <Text style={[styles.status, { color: colors.text.primary }]}>סטטוס נוכחי: {statusLabel(order.status)}</Text>
+          {canUpdate && nextStatuses.length > 0 && (
+            <View style={styles.actions}>
+              {nextStatuses.map((s) => (
+                <TouchableOpacity
+                  key={s}
+                  style={[styles.button, { backgroundColor: colors.interactive.primary }]}
+                  onPress={() => handleUpdate(s)}
+                >
+                  <Text style={[styles.buttonText, { color: colors.text.contrast }]}>{statusLabel(s)}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
+      {!order && (
+        <Text style={{ color: colors.text.primary, textAlign: 'center' }}>הזמנה לא נמצאה</Text>
+      )}
+      <InfoModal
+        visible={infoModal.visible}
+        title={infoModal.title}
+        message={infoModal.message}
+        type={infoModal.type}
+        onClose={() => setInfoModal({ ...infoModal, visible: false })}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16 },
+  status: { fontSize: 18, fontWeight: '600', textAlign: 'right', marginBottom: 24 },
+  actions: { gap: 12 },
+  button: { paddingVertical: 12, borderRadius: 8 },
+  buttonText: { fontSize: 16, textAlign: 'center', fontWeight: '600' },
+});
+


### PR DESCRIPTION
## Summary
- enforce explicit order status transitions and emit notifications on every change
- add seller/driver order detail screen for updating statuses

## Testing
- `npm test` *(fails: Error loading tenant settings)*
- `npm run lint` *(fails: ProductCard conditional hook errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a65466e988326abaad581aafc5c32