### PR TITLE
Decrement product stock on payment and enforce stock limits

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -6,6 +6,7 @@ import {
   releasePayment,
   refundPayment,
 } from '../services/tonContract';
+import productsAgent from './products-agent';
 
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
@@ -73,6 +74,14 @@ class OrdersAgent {
       updatedAt: new Date().toISOString(),
     };
     await setOrder(updated);
+    await Promise.all(
+      order.items.map((item) =>
+        productsAgent.decrementStock(
+          item.productId,
+          item.effectiveQty ?? item.quantity
+        )
+      )
+    );
     this.subscribers.forEach((cb) => cb(updated));
     return hash;
   }

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -46,6 +46,14 @@ class ProductsAgent {
   async getAll(): Promise<Product[]> {
     return await listProducts();
   }
+
+  async decrementStock(productId: string, quantity: number): Promise<void> {
+    const prod = await getProduct(productId);
+    if (!prod) return;
+    await this.assertStoreOwner(prod.storeId);
+    const newStock = Math.max((prod.stock || 0) - quantity, 0);
+    await setProduct({ ...prod, stock: newStock });
+  }
 }
 
 export default new ProductsAgent();

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -188,6 +188,19 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       return;
     }
 
+    const overstock = cartItems.find(
+      (i) => (i.effectiveQty ?? i.quantity) > (i.product.stock ?? Infinity)
+    );
+    if (overstock) {
+      setInfoModal({
+        visible: true,
+        title: 'חוסר במלאי',
+        message: 'כמות מבוקשת עולה על המלאי הזמין',
+        type: 'warning',
+      });
+      return;
+    }
+
     // KYC gate
     if (user && user.kycStatus !== 'verified') {
       let message = '';


### PR DESCRIPTION
## Summary
- Deduct product stock through ProductsAgent when an order's payment is released
- Prevent checkout if cart quantities exceed available stock

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a657a09048326b851b4efc9767ea8