### PR TITLE
feat: add chat agent and message seller

### DIFF
--- a/agents/chat-agent.ts
+++ b/agents/chat-agent.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'events';
+import DatabaseService from '../services/database';
+import { ChatRoom } from '../types';
+
+class ChatAgent {
+  private emitter = new EventEmitter();
+
+  private getRoomId(buyerAddress: string, sellerAddress: string) {
+    return `${buyerAddress}-${sellerAddress}`;
+  }
+
+  async openChat(
+    buyerAddress: string,
+    sellerAddress: string,
+    sellerName: string,
+    sellerPublicKey?: string,
+  ) {
+    const roomId = this.getRoomId(buyerAddress, sellerAddress);
+    const db = DatabaseService.getInstance();
+    await db.getOrCreateChatRoom(
+      sellerAddress,
+      sellerName,
+      sellerPublicKey,
+      roomId,
+    );
+    const room: ChatRoom = {
+      id: roomId,
+      userId: sellerAddress,
+      userName: sellerName,
+      userPublicKey: sellerPublicKey,
+      lastMessage: '',
+      lastMessageTime: Date.now(),
+      unreadCount: 0,
+    };
+    this.emitter.emit('open', room);
+  }
+
+  onOpen(cb: (room: ChatRoom) => void) {
+    this.emitter.on('open', cb);
+    return () => this.emitter.off('open', cb);
+  }
+}
+
+export default new ChatAgent();

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -26,6 +26,7 @@ import {
   Pencil,
   X,
   Image as ImageIcon,
+  MessageCircle,
 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import CartService from '../../services/cart';
@@ -39,6 +40,7 @@ import ProductFormModal from '../../components/ProductFormModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import MediaService from '../../services/media';
 import { useTonAddress } from '../../services/tonAuth';
+import chatAgent from '../../agents/chat-agent';
 import commonStyles from '../../constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '../../components/FloatingCartWidget';
@@ -272,6 +274,12 @@ export default function ProductDetailScreen() {
       pathname: '/(tabs)',
       params: { showCart: 'true' },
     });
+  };
+
+  const handleMessageSeller = async () => {
+    if (!product) return;
+    const buyer = address || 'guest_user';
+    await chatAgent.openChat(buyer, product.storeId, product.storeId);
   };
 
   const openEditModal = () => {
@@ -752,6 +760,18 @@ export default function ProductDetailScreen() {
               </View>
             </View>
           )}
+
+          <TouchableOpacity
+            style={[styles.messageSellerButton, { backgroundColor: colors.gold }]}
+            onPress={handleMessageSeller}
+          >
+            <MessageCircle size={20} color={colors.text.inverse} />
+            <Text
+              style={[styles.messageSellerText, { color: colors.text.inverse }]}
+            >
+              Message Seller
+            </Text>
+          </TouchableOpacity>
         </View>
       </ScrollView>
 
@@ -987,6 +1007,20 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
     marginHorizontal: 20,
+  },
+  messageSellerButton: {
+    marginTop: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+  },
+  messageSellerText: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
   },
   tieredPricingInfo: {
     borderRadius: 12,

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -41,6 +41,7 @@ import { isChatConfigured } from '../services/chatConfig';
 import InfoModal from './InfoModal';
 import UserProfileModal from './UserProfileModal';
 import SettingsAgent from '../agents/settings-agent';
+import chatAgent from '../agents/chat-agent';
 
 const EMOJI_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '😡'];
 const CHAT_ONBOARDED_KEY = 'chatOnboarded';
@@ -347,6 +348,14 @@ const loadOrCreateDefaultRoom = async () => {
     await loadMessages(room.id, room.userPublicKey || '');
     await maybeSendOnboardMessage(room.id, room.userPublicKey || '');
   };
+
+  useEffect(() => {
+    const unsubscribe = chatAgent.onOpen(async (room) => {
+      setIsOpen(true);
+      await openChat(room);
+    });
+    return unsubscribe;
+  }, []);
 
   useEffect(() => {
     if (!selectedRoom) return;

--- a/services/database.ts
+++ b/services/database.ts
@@ -250,14 +250,15 @@ class DatabaseService {
     userId: string,
     userName: string,
     userPublicKey?: string,
+    roomId?: string,
   ): Promise<string> {
     for (const room of this.chatRooms.values()) {
-      if (room.userId === userId) {
+      if ((roomId && room.id === roomId) || (!roomId && room.userId === userId)) {
         if (userPublicKey) room.userPublicKey = userPublicKey;
         return room.id;
       }
     }
-    const id = `room_${Date.now()}`;
+    const id = roomId || `room_${Date.now()}`;
     this.chatRooms.set(id, {
       id,
       userId,


### PR DESCRIPTION
## Summary
- support chat rooms keyed by buyer and seller addresses
- open chat from product detail via new "Message Seller" button
- allow database chat rooms to be created with explicit ids

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689a65e695ac832698545e540c9e2881