### PR TITLE
feat: broadcast order events via notifications

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -7,6 +7,11 @@ import {
   removeNotification,
 } from '../services/tonNotifications';
 
+type NotificationEvent =
+  | 'order.created'
+  | 'payment.received'
+  | 'status.updated';
+
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
 
@@ -42,6 +47,12 @@ class NotificationsAgent {
 
   async getAll(): Promise<Notification[]> {
     return await listNotifications();
+  }
+
+  async broadcast(event: NotificationEvent, item: Notification): Promise<void> {
+    await this.ensureWallet();
+    await setNotification(item);
+    this.subscribers.forEach((cb) => cb(item));
   }
 
   subscribe(cb: (n: Notification) => void) {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -44,6 +44,7 @@ class OrdersAgent {
     }
     await setOrder(enriched);
     this.subscribers.forEach((cb) => cb(enriched));
+    await this.notifyOrderCreated(enriched);
   }
 
   async update(order: Order): Promise<void> {
@@ -114,6 +115,7 @@ class OrdersAgent {
     );
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
+    await this.notifyPaymentReceived(updated);
     return hash;
   }
 
@@ -161,7 +163,41 @@ class OrdersAgent {
       timestamp: Date.now(),
     };
     try {
-      await notificationsAgent.add(notification);
+      await notificationsAgent.broadcast('status.updated', notification);
+    } catch (err) {
+      console.error('Failed to send notification', err);
+    }
+  }
+
+  private async notifyOrderCreated(order: Order) {
+    const notification: Notification = {
+      id: `ntf_${Date.now()}`,
+      userId: order.userId,
+      title: 'Order created',
+      message: `Order ${order.id} has been created`,
+      type: 'order',
+      read: false,
+      timestamp: Date.now(),
+    };
+    try {
+      await notificationsAgent.broadcast('order.created', notification);
+    } catch (err) {
+      console.error('Failed to send notification', err);
+    }
+  }
+
+  private async notifyPaymentReceived(order: Order) {
+    const notification: Notification = {
+      id: `ntf_${Date.now()}`,
+      userId: order.userId,
+      title: 'Payment received',
+      message: `Payment for order ${order.id} has been released`,
+      type: 'order',
+      read: false,
+      timestamp: Date.now(),
+    };
+    try {
+      await notificationsAgent.broadcast('payment.received', notification);
     } catch (err) {
       console.error('Failed to send notification', err);
     }


### PR DESCRIPTION
## Summary
- add event-based broadcast helper for notifications
- send notifications for order creation, status changes, and payment release

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_689a67b241cc83268b42647f43834cf8