### PR TITLE
feat: show rating summaries

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,9 +1,22 @@
 import { Product } from '../types';
 import tonAuth from '../services/tonAuth';
-import { setProduct, getProduct, listProducts, removeProduct } from '../services/tonProducts';
+import {
+  setProduct,
+  getProduct,
+  listProducts,
+  removeProduct,
+} from '../services/tonProducts';
 import { getStore } from '../services/tonStores';
 
+interface ProductSummary {
+  rating: number;
+  reviews: number;
+}
+
 class ProductsAgent {
+  private cache: Map<string, Product> = new Map();
+  private summaries: Map<string, ProductSummary> = new Map();
+
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -25,11 +38,15 @@ class ProductsAgent {
   async add(item: Product): Promise<void> {
     await this.assertStoreOwner(item.storeId);
     await setProduct(item);
+    this.cache.set(item.id, item);
+    this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
   }
 
   async update(item: Product): Promise<void> {
     await this.assertStoreOwner(item.storeId);
     await setProduct(item);
+    this.cache.set(item.id, item);
+    this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
   }
 
   async remove(id: string): Promise<void> {
@@ -37,14 +54,36 @@ class ProductsAgent {
     if (!prod) return;
     await this.assertStoreOwner(prod.storeId);
     await removeProduct(id);
+    this.cache.delete(id);
+    this.summaries.delete(id);
   }
 
   async get(id: string): Promise<Product | null> {
-    return await getProduct(id);
+    const cached = this.cache.get(id);
+    if (cached) return cached;
+    const prod = await getProduct(id);
+    if (prod) {
+      this.cache.set(id, prod);
+      this.summaries.set(id, { rating: prod.rating, reviews: prod.reviews });
+    }
+    return prod;
   }
 
   async getAll(): Promise<Product[]> {
-    return await listProducts();
+    if (this.cache.size > 0) return Array.from(this.cache.values());
+    const prods = await listProducts();
+    prods.forEach((p) => {
+      this.cache.set(p.id, p);
+      this.summaries.set(p.id, { rating: p.rating, reviews: p.reviews });
+    });
+    return prods;
+  }
+
+  async getSummary(id: string): Promise<ProductSummary> {
+    const cached = this.summaries.get(id);
+    if (cached) return cached;
+    const prod = await this.get(id);
+    return prod ? { rating: prod.rating, reviews: prod.reviews } : { rating: 0, reviews: 0 };
   }
 
   async decrementStock(productId: string, quantity: number): Promise<void> {

--- a/app/stores/[id]/index.tsx
+++ b/app/stores/[id]/index.tsx
@@ -3,22 +3,34 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { getStore } from '../../../services/tonStores';
-import { listProducts } from '../../../services/tonProducts';
 import ProductCard from '../../../components/ProductCard';
 import { Store, Product } from '../../../types';
+import productsAgent from '../../../agents/products-agent';
 
 export default function StoreProfileScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { colors } = useTheme();
   const [store, setStore] = useState<Store | null>(null);
   const [products, setProducts] = useState<Product[]>([]);
+  const [storeRating, setStoreRating] = useState({ avg: 0, count: 0 });
 
   useEffect(() => {
     const load = async () => {
       if (!id) return;
-      const [s, all] = await Promise.all([getStore(id), listProducts()]);
+      const [s, all] = await Promise.all([getStore(id), productsAgent.getAll()]);
       setStore(s);
-      setProducts(all.filter((p) => p.storeId === id));
+      const owned = all.filter((p) => p.storeId === id);
+      setProducts(owned);
+      const summaries = await Promise.all(
+        owned.map((p) => productsAgent.getSummary(p.id))
+      );
+      const count = summaries.reduce((acc, s) => acc + s.reviews, 0);
+      const total = summaries.reduce(
+        (acc, s) => acc + s.rating * s.reviews,
+        0
+      );
+      const avg = count > 0 ? total / count : 0;
+      setStoreRating({ avg, count });
     };
     load();
   }, [id]);
@@ -53,6 +65,10 @@ export default function StoreProfileScreen() {
         <Text style={[styles.storeOwner, { color: colors.text.secondary }]}>
           {store.owner}
         </Text>
+        <View style={styles.ratingRow}>
+          <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {storeRating.avg.toFixed(1)}</Text>
+          <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({storeRating.count})</Text>
+        </View>
       </View>
       {products.map((p) => (
         <ProductCard key={p.id} product={p} style={{ marginBottom: 12 }} />
@@ -72,5 +88,8 @@ const styles = StyleSheet.create({
   profile: { marginBottom: 16, alignItems: 'center' },
   storeName: { fontSize: 24, fontWeight: 'bold', marginBottom: 4 },
   storeOwner: { fontSize: 16 },
+  ratingRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
+  rating: { fontSize: 14, fontWeight: '500' },
+  reviews: { fontSize: 14, marginLeft: 4 },
 });
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -17,6 +17,7 @@ import CartService from '../services/cart';
 import DatabaseService from '../services/database';
 import MediaService from '../services/media';
 import { useTonAddress } from '../services/tonAuth';
+import productsAgent from '../agents/products-agent';
 
 interface ProductCardProps {
   product: Product;
@@ -43,6 +44,7 @@ export default function ProductCard({
   const [pricingTier, setPricingTier] = useState<PricingTier | null>(null);
   const [videoThumbnail, setVideoThumbnail] = useState<string | null>(null);
   const [selectedVariantIndex, setSelectedVariantIndex] = useState(0);
+  const [summary, setSummary] = useState({ rating: product.rating, reviews: product.reviews });
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const address = useTonAddress();
@@ -71,6 +73,16 @@ export default function ProductCard({
     
     return () => cartService.removeListener(handleUpdate);
   }, [product.id, product.pricingTier]);
+
+  useEffect(() => {
+    let active = true;
+    productsAgent.getSummary(product.id).then((s) => {
+      if (active) setSummary(s);
+    });
+    return () => {
+      active = false;
+    };
+  }, [product.id]);
 
   useEffect(() => {
     const loadThumb = async () => {
@@ -249,8 +261,8 @@ export default function ProductCard({
 
         {/* Rating */}
         <View style={styles.ratingContainer}>
-          <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {product.rating}</Text>
-          <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({product.reviews})</Text>
+          <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {summary.rating.toFixed(1)}</Text>
+          <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({summary.reviews})</Text>
         </View>
 
         {/* Variant Colors */}


### PR DESCRIPTION
## Summary
- cache product rating summaries for fast lookups
- show average rating and review count on product cards
- display aggregate store rating and review count on store profile

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a694ef0c08326b0dcda025bea04d3