### PR TITLE
feat: enforce order wallet authorization

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -34,8 +34,17 @@ class OrdersAgent {
     }
   }
 
-  async add(order: Order): Promise<void> {
+  private async ensureAuthorized(order: Order) {
     await this.ensureWallet();
+    const address = tonAuth.getAddress();
+    const allowed = [order.buyerAddress, order.sellerAddress, order.driverAddress].filter(Boolean);
+    if (!address || !allowed.includes(address)) {
+      throw new Error('Unauthorized order update');
+    }
+  }
+
+  async add(order: Order): Promise<void> {
+    await this.ensureAuthorized(order);
     let enriched = order;
     if (!order.paymentContractAddress || !order.paymentTxHash) {
       const { contractAddress, txHash } = await deployOrderPayment(order.total);
@@ -76,11 +85,11 @@ class OrdersAgent {
   }
 
   async update(order: Order): Promise<void> {
-    await this.ensureWallet();
     const current = await this.get(order.id);
     if (!current) {
       throw new Error('Order not found');
     }
+    await this.ensureAuthorized(current);
     let statusChanged = false;
     if (order.status !== current.status) {
       const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
@@ -97,7 +106,11 @@ class OrdersAgent {
   }
 
   async remove(id: string): Promise<void> {
-    await this.ensureWallet();
+    const order = await this.get(id);
+    if (!order) {
+      throw new Error('Order not found');
+    }
+    await this.ensureAuthorized(order);
     await removeOrder(id);
   }
 
@@ -114,11 +127,11 @@ class OrdersAgent {
   }
 
   async releasePayment(orderId: string): Promise<string> {
-    await this.ensureWallet();
     const order = await this.get(orderId);
     if (!order) {
       throw new Error('Order not found');
     }
+    await this.ensureAuthorized(order);
     if (!order.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }
@@ -148,11 +161,11 @@ class OrdersAgent {
   }
 
   async refundPayment(orderId: string): Promise<string> {
-    await this.ensureWallet();
     const order = await this.get(orderId);
     if (!order) {
       throw new Error('Order not found');
     }
+    await this.ensureAuthorized(order);
     if (!order.paymentContractAddress) {
       throw new Error('Order payment contract not found');
     }

--- a/types/index.ts
+++ b/types/index.ts
@@ -222,6 +222,7 @@ export interface Order {
   paymentMethod: 'cash_on_delivery' | 'ton';
   buyerAddress?: string;
   sellerAddress?: string;
+  driverAddress?: string;
   paymentContractAddress?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- ensure orders can only be modified by buyer, seller, or driver wallet
- add driverAddress field to Order type for authorization

## Testing
- `yarn test` *(fails: Error loading tenant settings: async_storage_1.default.multiGet is not a function; PinataService CID validation expected true received false)*

------
https://chatgpt.com/codex/tasks/task_e_689a6bab01148326ba61fc70666380df