### PR TITLE
feat: track seller performance

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -2,6 +2,7 @@ import { Order, OrderStatus, Notification } from '../types';
 import tonAuth from '../services/tonAuth';
 import notificationsAgent from './notifications-agent';
 import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
+import storesAgent from './stores-agent';
 import {
   deployOrderPayment,
   releasePayment,
@@ -24,6 +25,26 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
 
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
+  private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};
+
+  private recordSellerMetric(seller?: string, type?: 'completed' | 'refunded') {
+    if (!seller) return;
+    if (!this.sellerMetrics[seller]) {
+      this.sellerMetrics[seller] = { completed: 0, refunds: 0 };
+    }
+    if (type === 'completed') {
+      this.sellerMetrics[seller].completed += 1;
+    } else if (type === 'refunded') {
+      this.sellerMetrics[seller].refunds += 1;
+    }
+    const { completed, refunds } = this.sellerMetrics[seller];
+    const score = completed + refunds > 0 ? completed / (completed + refunds) : 0;
+    storesAgent.updateReputationByOwner(seller, score);
+  }
+
+  getSellerMetrics(address: string) {
+    return this.sellerMetrics[address] || { completed: 0, refunds: 0 };
+  }
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -93,6 +114,11 @@ class OrdersAgent {
     this.subscribers.forEach((cb) => cb(order));
     if (statusChanged) {
       await this.notifyStatusChange(order);
+      if (order.status === 'released') {
+        this.recordSellerMetric(order.sellerAddress, 'completed');
+      } else if (order.status === 'refunded') {
+        this.recordSellerMetric(order.sellerAddress, 'refunded');
+      }
     }
   }
 
@@ -144,6 +170,7 @@ class OrdersAgent {
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
     await this.notifyPaymentReceived(updated);
+    this.recordSellerMetric(order.sellerAddress, 'completed');
     return hash;
   }
 
@@ -169,6 +196,7 @@ class OrdersAgent {
     await setOrder(updated);
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
+    this.recordSellerMetric(order.sellerAddress, 'refunded');
     return hash;
   }
 

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -13,8 +13,8 @@ class StoresAgent {
   }
 
   private toRecord(item: Store) {
-    const { id, name, owner, nftId } = item;
-    return { id, name, owner, nftId };
+    const { id, name, owner, nftId, reputation = 0 } = item;
+    return { id, name, owner, nftId, reputation };
   }
 
   async add(item: Store): Promise<void> {
@@ -25,6 +25,14 @@ class StoresAgent {
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
     await setStore(this.toRecord(item));
+  }
+
+  async updateReputationByOwner(owner: string, reputation: number): Promise<void> {
+    const stores = await listStores();
+    const store = stores.find((s) => s.owner === owner);
+    if (store) {
+      await setStore(this.toRecord({ ...store, reputation }));
+    }
   }
 
   async remove(id: string): Promise<void> {

--- a/app/stores/[id]/index.tsx
+++ b/app/stores/[id]/index.tsx
@@ -69,6 +69,7 @@ export default function StoreProfileScreen() {
           <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {storeRating.avg.toFixed(1)}</Text>
           <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({storeRating.count})</Text>
         </View>
+        <Text style={[styles.reputation, { color: colors.text.primary }]}>Reputation: {Math.round((store.reputation ?? 0) * 100)}%</Text>
       </View>
       {products.map((p) => (
         <ProductCard key={p.id} product={p} style={{ marginBottom: 12 }} />
@@ -91,5 +92,6 @@ const styles = StyleSheet.create({
   ratingRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
   rating: { fontSize: 14, fontWeight: '500' },
   reviews: { fontSize: 14, marginLeft: 4 },
+  reputation: { fontSize: 14, marginTop: 4 },
 });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -36,6 +36,7 @@ export interface Store {
   name: string;
   owner: string;
   nftId: string;
+  reputation?: number;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- track per-seller completed and refunded orders and update store reputation
- persist reputation on stores and show it in store profile pages

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e24493c832681edf5f7cb80ad10