### PR TITLE
feat: support order fee distribution

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -11,7 +11,9 @@ type SettingKey =
   | 'appName'
   | 'theme.primary'
   | 'brand.logoCid'
-  | 'fiatKey';
+  | 'fiatKey'
+  | 'feeAddress'
+  | 'feePercent';
 
 class SettingsAgent {
   private static instance: SettingsAgent;

--- a/contracts/order-payment.tact
+++ b/contracts/order-payment.tact
@@ -13,13 +13,17 @@ contract OrderPayment {
     buyer: Address;
     amount: Int;
     paid: Bool;
+    feeAddress: Address;
+    feePercent: Int;
 
-    init(owner: Address, seller: Address, buyer: Address, amount: Int) {
+    init(owner: Address, seller: Address, buyer: Address, amount: Int, feeAddress: Address, feePercent: Int) {
         self.owner = owner;
         self.seller = seller;
         self.buyer = buyer;
         self.amount = amount;
         self.paid = false;
+        self.feeAddress = feeAddress;
+        self.feePercent = feePercent;
     }
 
     receive(msg: Pay) {
@@ -33,7 +37,9 @@ contract OrderPayment {
     receive(msg: Release) {
         require(sender() == self.owner, 104);
         require(self.paid, 105);
-        send(self.seller, self.amount);
+        let fee = (self.amount * self.feePercent) / 100;
+        send(self.feeAddress, fee);
+        send(self.seller, self.amount - fee);
     }
 
     receive(msg: Refund) {

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -1,7 +1,9 @@
 // @ts-nocheck
 import TonWeb from 'tonweb';
 import { Buffer } from 'buffer';
+import { createHash } from 'crypto';
 import { getTonConnect } from './tonAuth';
+import { fetchSettings } from './tonSettings';
 
 /**
  * Address of the OrderPayment factory contract.
@@ -33,7 +35,7 @@ async function sendTonConnect(messages: {
   });
 
   return TonWeb.utils.bytesToHex(
-    TonWeb.utils.sha256_sync(Buffer.from(result.boc, 'base64')),
+    createHash('sha256').update(Buffer.from(result.boc, 'base64')).digest(),
   );
 }
 
@@ -41,7 +43,12 @@ export async function deployOrderPayment(
   amount: number,
 ): Promise<{ contractAddress: string; txHash: string }> {
   try {
-    const payload = makeComment(`Pay:${amount}`);
+    const settings = await fetchSettings();
+    const feeAddress = settings.feeAddress ?? '';
+    const feePercent = settings.feePercent ?? 0;
+    const payload = makeComment(
+      `Pay:${amount}:${feeAddress}:${feePercent}`,
+    );
     const payloadBoc = TonWeb.utils.bytesToBase64(
       await payload.toBoc({ idx: false }),
     );

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -11,6 +11,8 @@ export interface TonSettings {
   theme: { primary: string };
   brand: { logoCid: string };
   fiatKey?: string;
+  feeAddress?: string;
+  feePercent?: number;
   admins: string[];
 }
 
@@ -38,6 +40,8 @@ export async function fetchSettings(): Promise<TonSettings> {
     theme: { primary: map['theme.primary'] ?? '#B99C5A' },
     brand: { logoCid: map['brand.logoCid'] ?? '' },
     fiatKey: map['fiatKey'],
+    feeAddress: map['feeAddress'] ?? '',
+    feePercent: map['feePercent'] ? parseInt(map['feePercent']) : 0,
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
   };
 }

--- a/tests/__mocks__/@react-native-async-storage/async-storage.js
+++ b/tests/__mocks__/@react-native-async-storage/async-storage.js
@@ -2,4 +2,6 @@ module.exports = {
   setItem: jest.fn(async () => {}),
   getItem: jest.fn(async () => null),
   removeItem: jest.fn(async () => {}),
+  multiGet: jest.fn(async () => []),
+  multiSet: jest.fn(async () => {}),
 };

--- a/tests/__mocks__/multiformats/cid.js
+++ b/tests/__mocks__/multiformats/cid.js
@@ -1,1 +1,5 @@
-module.exports = { CID: {} };
+module.exports = {
+  CID: {
+    parse: jest.fn(() => ({})),
+  },
+};

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -1,11 +1,13 @@
-import SettingsAgent from '../agents/settings-agent';
-
 jest.mock('../services/tonAuth', () => ({
   getAddress: () => 'addr_admin',
   getTonPublicKey: () => 'pub_admin',
   openModal: jest.fn(),
+  getTonConnect: () => ({
+    sendTransaction: jest.fn().mockResolvedValue({}),
+  }),
 }));
 
+import SettingsAgent from '../agents/settings-agent';
 jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 import { __clear } from './tonKvMock';
 
@@ -26,5 +28,12 @@ describe('SettingsAgent TON integration', () => {
     await agent.updateSettingValue('appName', 'Test');
     const val = await agent.getSettingValue('appName');
     expect(val).toBe('Test');
+  });
+
+  it('handles fee settings', async () => {
+    const agent = SettingsAgent.getInstance();
+    await agent.updateSettingValue('feePercent', '5');
+    const fee = await agent.getSettingValue('feePercent');
+    expect(fee).toBe('5');
   });
 });

--- a/tests/tonAuthContract.test.ts
+++ b/tests/tonAuthContract.test.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'crypto';
 import * as tonAuth from '../services/tonAuth';
+
+jest.mock('../services/tonSettings', () => ({
+  fetchSettings: jest.fn().mockResolvedValue({
+    feeAddress: 'feeAddr',
+    feePercent: 5,
+  }),
+}));
+
 import {
   deployOrderPayment,
   releasePayment,


### PR DESCRIPTION
## Summary
- add configurable fee distribution to `OrderPayment` contract
- include fee parameters in order-payment deployment
- expose fee settings through Ton settings and admin agent

## Testing
- `npm test` *(fails: tonweb_1.default.utils.sha256_sync is not a function, TonConnect not initialized, missing ed2curve types)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e278e6c83268f67dea11c58592a