### PR TITLE
Add escrow smart contracts and simulation tests

### DIFF
--- a/contracts/Escrow.tact
+++ b/contracts/Escrow.tact
@@ -1,0 +1,65 @@
+import "@tact-lang/core";
+
+message Release {}
+message Refund {}
+message AdminResolve {
+    toSeller: Bool;
+}
+
+contract Escrow {
+    buyer: Address;
+    seller: Address;
+    admin: Address;
+    amount: Int;
+    disputeWindow: Int;
+    createdAt: Int;
+    status: Int; // 0 pending, 1 released, 2 refunded
+
+    init(buyer: Address, seller: Address, amount: Int, disputeWindow: Int) {
+        self.buyer = buyer;
+        self.seller = seller;
+        self.amount = amount;
+        self.disputeWindow = disputeWindow;
+        self.admin = sender();
+        self.createdAt = now();
+        self.status = 0;
+    }
+
+    private isExpired(): Bool {
+        return now() >= self.createdAt + self.disputeWindow;
+    }
+
+    receive(msg: Release) {
+        require(self.status == 0, 100);
+        if (!self.isExpired()) {
+            require(sender() == self.buyer, 101);
+        } else {
+            require(sender() == self.buyer || sender() == self.seller, 102);
+        }
+        send(self.seller, self.amount);
+        self.status = 1;
+    }
+
+    receive(msg: Refund) {
+        require(self.status == 0, 103);
+        if (!self.isExpired()) {
+            require(sender() == self.seller, 104);
+        } else {
+            require(sender() == self.buyer || sender() == self.seller, 105);
+        }
+        send(self.buyer, balance());
+        self.status = 2;
+    }
+
+    receive(msg: AdminResolve) {
+        require(self.status == 0, 106);
+        require(sender() == self.admin, 107);
+        if (msg.toSeller) {
+            send(self.seller, self.amount);
+            self.status = 1;
+        } else {
+            send(self.buyer, balance());
+            self.status = 2;
+        }
+    }
+}

--- a/contracts/EscrowFactory.tact
+++ b/contracts/EscrowFactory.tact
@@ -1,0 +1,17 @@
+import "@tact-lang/core";
+import "./Escrow.tact";
+
+message CreateEscrow {
+    buyer: Address;
+    seller: Address;
+    amount: Int;
+    disputeWindow: Int;
+}
+
+contract EscrowFactory {
+    receive(msg: CreateEscrow) {
+        let init = initOf Escrow(msg.buyer, msg.seller, msg.amount, msg.disputeWindow);
+        let addr = contractAddress(init);
+        send(addr, msg.amount, null, 0, init);
+    }
+}

--- a/tests/escrowContract.test.ts
+++ b/tests/escrowContract.test.ts
@@ -1,0 +1,121 @@
+class EscrowSim {
+  buyer: string;
+  seller: string;
+  admin: string;
+  amount: number;
+  disputeWindow: number;
+  start: number;
+  now: number;
+  status: number; // 0 pending, 1 released, 2 refunded
+  lastRecipient: string | null;
+
+  constructor(buyer: string, seller: string, admin: string, amount: number, disputeWindow: number) {
+    this.buyer = buyer;
+    this.seller = seller;
+    this.admin = admin;
+    this.amount = amount;
+    this.disputeWindow = disputeWindow;
+    this.start = 0;
+    this.now = 0;
+    this.status = 0;
+    this.lastRecipient = null;
+  }
+
+  private expired() {
+    return this.now >= this.start + this.disputeWindow;
+  }
+
+  advance(seconds: number) {
+    this.now += seconds;
+  }
+
+  release(sender: string) {
+    if (this.status !== 0) throw new Error('finalized');
+    if (!this.expired()) {
+      if (sender !== this.buyer) throw new Error('not allowed');
+    } else {
+      if (sender !== this.buyer && sender !== this.seller) throw new Error('not allowed');
+    }
+    this.status = 1;
+    this.lastRecipient = this.seller;
+  }
+
+  refund(sender: string) {
+    if (this.status !== 0) throw new Error('finalized');
+    if (!this.expired()) {
+      if (sender !== this.seller) throw new Error('not allowed');
+    } else {
+      if (sender !== this.buyer && sender !== this.seller) throw new Error('not allowed');
+    }
+    this.status = 2;
+    this.lastRecipient = this.buyer;
+  }
+
+  adminResolve(sender: string, toSeller: boolean) {
+    if (this.status !== 0) throw new Error('finalized');
+    if (sender !== this.admin) throw new Error('not admin');
+    this.status = toSeller ? 1 : 2;
+    this.lastRecipient = toSeller ? this.seller : this.buyer;
+  }
+}
+
+describe('EscrowSim', () => {
+  const buyer = 'buyer';
+  const seller = 'seller';
+  const admin = 'admin';
+  const amount = 100;
+  const dispute = 10;
+
+  test('buyer releases before timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    e.release(buyer);
+    expect(e.status).toBe(1);
+    expect(e.lastRecipient).toBe(seller);
+  });
+
+  test('seller cannot release before timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    expect(() => e.release(seller)).toThrow();
+    expect(e.status).toBe(0);
+  });
+
+  test('seller refunds before timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    e.refund(seller);
+    expect(e.status).toBe(2);
+    expect(e.lastRecipient).toBe(buyer);
+  });
+
+  test('buyer cannot refund before timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    expect(() => e.refund(buyer)).toThrow();
+  });
+
+  test('seller releases after timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    e.advance(dispute + 1);
+    e.release(seller);
+    expect(e.status).toBe(1);
+    expect(e.lastRecipient).toBe(seller);
+  });
+
+  test('buyer refunds after timeout', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    e.advance(dispute + 1);
+    e.refund(buyer);
+    expect(e.status).toBe(2);
+    expect(e.lastRecipient).toBe(buyer);
+  });
+
+  test('admin resolves to seller', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    e.adminResolve(admin, true);
+    expect(e.status).toBe(1);
+    expect(e.lastRecipient).toBe(seller);
+  });
+
+  test('unauthorized admin resolve rejected', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    expect(() => e.adminResolve('other', true)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add EscrowFactory to create Escrow instances with buyer, seller, amount, dispute window
- implement Escrow contract state machine with time-lock and admin resolution
- include simulation tests covering release, refund, and admin resolve paths

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a702dddb083269f3e66c56b117afc