### PR TITLE
Add escrow metadata and encrypted shipping to orders

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -12,6 +12,7 @@ import productsAgent from './products-agent';
 import { getUser } from '../services/tonUsers';
 import * as nacl from 'tweetnacl';
 import * as ed2curve from 'ed2curve';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -72,10 +73,18 @@ class OrdersAgent {
       enriched = {
         ...order,
         paymentContractAddress: contractAddress,
+        escrowAddr: contractAddress,
         paymentTxHash: txHash,
       };
+    } else if (!order.escrowAddr && order.paymentContractAddress) {
+      enriched = { ...order, escrowAddr: order.paymentContractAddress };
     }
     let toStore: any = { ...enriched };
+    if (!toStore.itemsHash) {
+      toStore.itemsHash = Buffer.from(
+        sha256(Buffer.from(JSON.stringify(enriched.items)))
+      ).toString('hex');
+    }
     if (enriched.shippingAddress && enriched.sellerAddress) {
       try {
         const seller = await getUser(enriched.sellerAddress);
@@ -89,9 +98,11 @@ class OrdersAgent {
             const cipher = nacl.box(msg, nonce, sellerPubX, ephem.secretKey);
             toStore = {
               ...toStore,
-              shippingAddressCipher: Buffer.from(cipher).toString('base64'),
-              shippingAddressNonce: Buffer.from(nonce).toString('base64'),
-              shippingAddressEphemeralPublicKey: Buffer.from(ephem.publicKey).toString('base64'),
+              shipAddrEnc: {
+                cipher: Buffer.from(cipher).toString('base64'),
+                nonce: Buffer.from(nonce).toString('base64'),
+                ephem: Buffer.from(ephem.publicKey).toString('base64'),
+              },
             };
             delete toStore.shippingAddress;
           }
@@ -158,14 +169,14 @@ class OrdersAgent {
       throw new Error('Order not found');
     }
     await this.ensureAuthorized(order);
-    if (!order.paymentContractAddress) {
-      throw new Error('Order payment contract not found');
+    if (!order.escrowAddr) {
+      throw new Error('Order escrow address not found');
     }
     const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
     if (!allowed.includes('released')) {
       throw new Error(`Invalid status transition from ${order.status} to released`);
     }
-    const hash = await releasePayment(order.paymentContractAddress);
+    const hash = await releasePayment(order.escrowAddr);
     const updated: Order = {
       ...order,
       status: 'released',
@@ -193,14 +204,14 @@ class OrdersAgent {
       throw new Error('Order not found');
     }
     await this.ensureAuthorized(order);
-    if (!order.paymentContractAddress) {
-      throw new Error('Order payment contract not found');
+    if (!order.escrowAddr) {
+      throw new Error('Order escrow address not found');
     }
     const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
     if (!allowed.includes('refunded')) {
       throw new Error(`Invalid status transition from ${order.status} to refunded`);
     }
-    const hash = await refundPayment(order.paymentContractAddress);
+    const hash = await refundPayment(order.escrowAddr);
     const updated: Order = {
       ...order,
       status: 'refunded',

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -26,7 +26,7 @@ export default function AdminDashboard() {
     const pendingOrders = allOrders.filter(
       o =>
         o.paymentMethod === 'ton' &&
-        o.paymentContractAddress &&
+        (o.escrowAddr || o.paymentContractAddress) &&
         o.status !== 'released' &&
         o.status !== 'refunded',
     );

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -30,15 +30,18 @@ export default function OrderDetailScreen() {
       const svc = OrderService.getInstance();
       const raw: any = await svc.getOrder(id);
       let decrypted = raw as Order | null;
-      if (raw && raw.shippingAddressCipher && isSeller) {
+      if (raw && raw.shipAddrEnc && isSeller) {
         const priv = tonAuth.getTonPrivateKey();
         if (priv) {
           try {
             const privX = ed2curve.convertSecretKey(Buffer.from(priv, 'hex'));
-            const nonce = Buffer.from(raw.shippingAddressNonce, 'base64');
-            const cipher = Buffer.from(raw.shippingAddressCipher, 'base64');
-            const ephemPub = Buffer.from(raw.shippingAddressEphemeralPublicKey, 'base64');
-            const msg = nacl.box.open(cipher, nonce, ephemPub, privX);
+            const { cipher, nonce, ephem } = raw.shipAddrEnc;
+            const msg = nacl.box.open(
+              Buffer.from(cipher, 'base64'),
+              Buffer.from(nonce, 'base64'),
+              Buffer.from(ephem, 'base64'),
+              privX,
+            );
             if (msg) {
               raw.shippingAddress = JSON.parse(Buffer.from(msg).toString());
               decrypted = raw as Order;

--- a/contracts/ton/orders.tact
+++ b/contracts/ton/orders.tact
@@ -1,17 +1,23 @@
+struct OrderData {
+  address escrowAddr;
+  slice itemsHash;
+  cell shipAddrEnc;
+}
+
 contract Orders {
   address owner;
-  map<int, cell> data;
+  map<int, OrderData> data;
 
   init(owner: address) {
     self.owner = owner;
   }
 
-  receive("set", key: int, value: cell) {
+  receive("set", key: int, value: OrderData) {
     require(sender == self.owner, "only owner");
     self.data.set(key, value);
   }
 
-  get fun get(key: int): cell? {
+  get fun get(key: int): OrderData? {
     return self.data.get(key);
   }
 }

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,5 +1,6 @@
 import ordersAgent from '../agents/orders-agent';
 import { Order, OrderStatus, CartItem, ShippingAddress, OrderTrackingStep } from '../types';
+import { sha256 } from '@noble/hashes/sha256';
 
 class OrderService {
   private static instance: OrderService;
@@ -76,6 +77,9 @@ class OrderService {
 
     const orderId = `order_${Date.now()}`;
     const timestamp = new Date().toISOString();
+    const itemsHash = Buffer.from(
+      sha256(Buffer.from(JSON.stringify(items)))
+    ).toString('hex');
     const order: Order = {
       id: orderId,
       userId,
@@ -83,10 +87,12 @@ class OrderService {
       total,
       status: 'order_received',
       shippingAddress,
+       itemsHash,
       paymentMethod: payment?.method ?? 'cash_on_delivery',
       buyerAddress: payment?.buyerAddress,
       sellerAddress: payment?.sellerAddress,
       paymentContractAddress: payment?.contractAddress,
+      escrowAddr: payment?.contractAddress,
       paymentTxHash: payment?.txHash,
       createdAt: timestamp,
       updatedAt: timestamp,

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -1,0 +1,108 @@
+import * as nacl from 'tweetnacl';
+import * as ed2curve from 'ed2curve';
+import { sha256 } from '@noble/hashes/sha256';
+import { Order } from '../types';
+
+const mockStore: Record<string, any> = {};
+const sellerKey = nacl.sign.keyPair();
+const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
+
+jest.mock('../services/tonOrders', () => ({
+  setOrder: jest.fn(async (o: any) => {
+    mockStore[o.id] = o;
+  }),
+  getOrder: jest.fn(async (id: string) => mockStore[id] || null),
+  listOrders: jest.fn().mockResolvedValue([]),
+  removeOrder: jest.fn(),
+  listOrdersBySeller: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../agents/notifications-agent', () => ({ broadcast: jest.fn() }));
+
+jest.mock('../services/tonContract', () => ({
+  deployOrderPayment: jest.fn().mockResolvedValue({ contractAddress: 'escrow1', txHash: 'tx1' }),
+  releasePayment: jest.fn(),
+  refundPayment: jest.fn(),
+}));
+
+jest.mock('../services/tonUsers', () => ({
+  getUser: jest.fn().mockResolvedValue({ publicKey: sellerPubEd }),
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  getAddress: jest.fn().mockReturnValue('seller'),
+  getTonPublicKey: jest.fn().mockReturnValue('pub'),
+  openModal: jest.fn(),
+}));
+
+import ordersAgent from '../agents/orders-agent';
+
+describe('ordersAgent.add', () => {
+  it('encrypts shipping address and persists new fields', async () => {
+    const items = [{
+      id: 'i1',
+      productId: 'p1',
+      product: {
+        id: 'p1',
+        name: 'p1',
+        price: 5,
+        description: 'd',
+        category: 'c',
+        images: [],
+        rating: 0,
+        reviews: 0,
+        storeId: 's',
+        stock: 1,
+      },
+      quantity: 1,
+      addedAt: '',
+    }];
+    const itemsHash = Buffer.from(sha256(Buffer.from(JSON.stringify(items)))).toString('hex');
+    const order: Order = {
+      id: 'order1',
+      userId: 'u1',
+      items,
+      total: 5,
+      status: 'order_received',
+      shippingAddress: {
+        name: 'A',
+        phone: '1',
+        street: 'st',
+        city: 'c',
+        postalCode: 'p',
+      },
+      itemsHash,
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      trackingSteps: [],
+    };
+
+    await ordersAgent.add(order);
+    const stored = mockStore[order.id];
+    expect(stored.escrowAddr).toBe('escrow1');
+    expect(stored.itemsHash).toBe(itemsHash);
+    expect(stored.shipAddrEnc).toBeDefined();
+    expect(stored.shippingAddress).toBeUndefined();
+
+    const privX = ed2curve.convertSecretKey(sellerKey.secretKey);
+    const decrypted = nacl.box.open(
+      Buffer.from(stored.shipAddrEnc.cipher, 'base64'),
+      Buffer.from(stored.shipAddrEnc.nonce, 'base64'),
+      Buffer.from(stored.shipAddrEnc.ephem, 'base64'),
+      privX,
+    );
+    expect(decrypted).not.toBeNull();
+    const addr = JSON.parse(Buffer.from(decrypted!).toString());
+    expect(addr).toEqual(order.shippingAddress);
+
+    const persisted = await ordersAgent.get(order.id);
+    expect(persisted?.escrowAddr).toBe('escrow1');
+  });
+});
+
+afterAll(() => {
+  jest.resetModules();
+});

--- a/types/ed2curve.d.ts
+++ b/types/ed2curve.d.ts
@@ -1,0 +1,1 @@
+declare module 'ed2curve';

--- a/types/index.ts
+++ b/types/index.ts
@@ -223,17 +223,18 @@ export interface Order {
   total: number;
   status: OrderStatus;
   shippingAddress: ShippingAddress;
-  /** Encrypted shipping address data (base64) */
-  shippingAddressCipher?: string;
-  /** Nonce used for shipping address encryption (base64) */
-  shippingAddressNonce?: string;
-  /** Ephemeral public key used for shipping address encryption (base64) */
-  shippingAddressEphemeralPublicKey?: string;
+  shipAddrEnc?: {
+    cipher: string;
+    nonce: string;
+    ephem: string;
+  };
   paymentMethod: 'cash_on_delivery' | 'ton';
   buyerAddress?: string;
   sellerAddress?: string;
   driverAddress?: string;
   paymentContractAddress?: string;
+  escrowAddr?: string;
+  itemsHash: string;
   createdAt: string;
   updatedAt: string;
   trackingSteps: OrderTrackingStep[];


### PR DESCRIPTION
## Summary
- extend on-chain Orders schema with escrow address, item hash and encrypted shipping blob
- compute item hashes and escrow address during order creation
- secure shipping address with NaCl box and store as `shipAddrEnc`
- test order encryption and field persistence

## Testing
- `npm test tests/ordersAgent.test.ts`
- `npm test` *(fails: TonConnect not initialized; PinataService CID validation; tonAuth requestSignature; DatabaseService product store)*

------
https://chatgpt.com/codex/tasks/task_e_689a72ddc7b4832682e87ed2108aa94c