### PR TITLE
Add TON-based product reviews

### DIFF
--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -1,6 +1,7 @@
 import { Review } from '../types';
 import tonAuth from '../services/tonAuth';
 import { addReview, getReviews } from '../services/tonReviews';
+import ordersAgent from './orders-agent';
 
 const TOPIC = '/congress/reviews/1';
 
@@ -18,6 +19,26 @@ class ReviewAgent {
 
   async add(review: Review): Promise<void> {
     await this.ensureWallet();
+
+    if (!review.orderId) {
+      throw new Error('Order reference required');
+    }
+
+    const order = await ordersAgent.get(review.orderId);
+    const validOrder =
+      order &&
+      order.userId === review.userId &&
+      order.status === 'delivered' &&
+      order.items.some((i) => i.productId === review.productId);
+    if (!validOrder) {
+      throw new Error('Only completed orders can be reviewed');
+    }
+
+    const existing = await getReviews(review.productId);
+    if (existing.some((r) => r.userId === review.userId)) {
+      throw new Error('Duplicate review');
+    }
+
     await addReview(review);
     this.subscribers.forEach((cb) => cb(review));
   }

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -31,7 +31,7 @@ import {
 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import CartService from '../../services/cart';
-import { Product, Category, PricingTier } from '../../types';
+import { Product, Category, PricingTier, Review } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
@@ -43,6 +43,7 @@ import MediaService from '../../services/media';
 import { useTonAddress } from '../../services/tonAuth';
 import chatAgent from '../../agents/chat-agent';
 import moderationAgent from '../../agents/moderation-agent';
+import reviewAgent from '../../agents/review-agent';
 import commonStyles from '../../constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '../../components/FloatingCartWidget';
@@ -75,6 +76,7 @@ export default function ProductDetailScreen() {
   const { currencySymbol } = useCurrency();
   const [videoThumbnails, setVideoThumbnails] = useState<Record<string, string>>({});
   const address = useTonAddress();
+  const [reviews, setReviews] = useState<Review[]>([]);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -84,11 +86,27 @@ export default function ProductDetailScreen() {
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
 
+  const averageRating =
+    reviews.length > 0
+      ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
+      : 0;
+
   useEffect(() => {
     loadProduct();
     loadCategories();
     loadPricingTiers();
+    loadReviews();
   }, [id, address]);
+
+  useEffect(() => {
+    const sub = (rev: Review) => {
+      if (rev.productId === id) {
+        setReviews((prev) => [rev, ...prev]);
+      }
+    };
+    reviewAgent.subscribe(sub);
+    return () => reviewAgent.unsubscribe(sub);
+  }, [id]);
 
   useEffect(() => {
     if (product) {
@@ -168,6 +186,15 @@ export default function ProductDetailScreen() {
       setPricingTiers(tiersData);
     } catch (error) {
       console.error('Error loading pricing tiers:', error);
+    }
+  };
+
+  const loadReviews = async () => {
+    try {
+      const list = await reviewAgent.getByProduct(id);
+      setReviews(list);
+    } catch (err) {
+      console.error('Error loading reviews:', err);
     }
   };
 
@@ -569,12 +596,12 @@ export default function ProductDetailScreen() {
                   key={star}
                   size={16}
                   color={
-                    star <= Math.floor(product.rating)
+                    star <= Math.floor(averageRating)
                       ? colors.gold
                       : colors.interactive.disabled
                   }
                   fill={
-                    star <= Math.floor(product.rating)
+                    star <= Math.floor(averageRating)
                       ? colors.gold
                       : 'transparent'
                   }
@@ -583,7 +610,7 @@ export default function ProductDetailScreen() {
               <Text
                 style={[styles.ratingText, { color: colors.text.secondary }]}
               >
-                {product.rating} ({product.reviews} ביקורות)
+                {averageRating.toFixed(1)} ({reviews.length} ביקורות)
               </Text>
             </View>
           </View>
@@ -814,6 +841,54 @@ export default function ProductDetailScreen() {
             </Text>
           </TouchableOpacity>
         </View>
+
+        {/* Reviews */}
+        {reviews.length > 0 && (
+          <View style={styles.reviewsSection}>
+            <Text
+              style={[styles.sectionTitle, { color: colors.text.primary }]}
+            >
+              ביקורות
+            </Text>
+            {reviews.map((rev) => (
+              <View key={rev.id} style={styles.reviewItem}>
+                <View style={styles.reviewHeader}>
+                  <Text
+                    style={[styles.reviewAuthor, { color: colors.text.primary }]}
+                  >
+                    {rev.userName}
+                  </Text>
+                  <View style={styles.reviewStars}>
+                    {[1, 2, 3, 4, 5].map((s) => (
+                      <Star
+                        key={s}
+                        size={14}
+                        color={
+                          s <= rev.rating
+                            ? colors.gold
+                            : colors.interactive.disabled
+                        }
+                        fill={
+                          s <= rev.rating ? colors.gold : 'transparent'
+                        }
+                      />
+                    ))}
+                  </View>
+                </View>
+                {rev.comment && (
+                  <Text
+                    style={[
+                      styles.reviewComment,
+                      { color: colors.text.secondary },
+                    ]}
+                  >
+                    {rev.comment}
+                  </Text>
+                )}
+              </View>
+            ))}
+          </View>
+        )}
       </ScrollView>
 
       <FloatingCartWidget />
@@ -1240,6 +1315,28 @@ const styles = StyleSheet.create({
   },
   pricingTierDescription: {
     fontSize: 12,
+    textAlign: 'right',
+  },
+  reviewsSection: {
+    marginTop: 24,
+  },
+  reviewItem: {
+    marginBottom: 16,
+    alignItems: 'flex-end',
+  },
+  reviewHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  reviewAuthor: {
+    fontWeight: '600',
+  },
+  reviewStars: {
+    flexDirection: 'row',
+  },
+  reviewComment: {
     textAlign: 'right',
   },
 });

--- a/contracts/ton/reviews.tact
+++ b/contracts/ton/reviews.tact
@@ -1,0 +1,25 @@
+contract Reviews {
+  address owner;
+  map<int, cell> data;
+
+  init(owner: address) {
+    self.owner = owner;
+  }
+
+  receive("set", key: int, value: cell) {
+    require(sender == self.owner, "only owner");
+    if (value.slice_bits() == 0) {
+      self.data.del(key);
+    } else {
+      self.data.set(key, value);
+    }
+  }
+
+  get fun get(key: int): cell? {
+    return self.data.get(key);
+  }
+
+  get fun list(): map<int, cell> {
+    return self.data;
+  }
+}

--- a/services/database.ts
+++ b/services/database.ts
@@ -5,6 +5,8 @@ import productsAgent from '../agents/products-agent';
 import ordersAgent from '../agents/orders-agent';
 import cartAgent from '../agents/cart-agent';
 import SettingsAgent from '../agents/settings-agent';
+import reviewAgent from '../agents/review-agent';
+import { listAllReviews } from '../services/tonReviews';
 import {
   User,
   Category,
@@ -189,10 +191,15 @@ class DatabaseService {
 
   // Reviews
   async getReviews(): Promise<Review[]> {
+    if (this.reviews.size === 0) {
+      const all = await listAllReviews();
+      all.forEach((r) => this.reviews.set(r.id, r));
+    }
     return Array.from(this.reviews.values());
   }
 
   async addReview(review: Review): Promise<void> {
+    await reviewAgent.add(review);
     this.reviews.set(review.id, review);
   }
 

--- a/tests/reviewAgent.test.ts
+++ b/tests/reviewAgent.test.ts
@@ -1,0 +1,78 @@
+import { Review } from '../types';
+
+const store: Record<string, Review[]> = {};
+
+jest.mock('../services/tonReviews', () => ({
+  getReviews: jest.fn(async (productId: string) => store[productId] || []),
+  addReview: jest.fn(async (review: Review) => {
+    const arr = store[review.productId] || [];
+    arr.push(review);
+    store[review.productId] = arr;
+  }),
+}));
+
+const orders: Record<string, any> = {
+  o1: {
+    id: 'o1',
+    userId: 'u1',
+    status: 'delivered',
+    items: [{ productId: 'p1', product: { id: 'p1', name: 'p1', price: 1, description: '', category: '', images: [], rating: 0, reviews: 0, storeId: 's1', stock: 1 } }],
+  },
+};
+
+jest.mock('../agents/orders-agent', () => ({
+  get: jest.fn(async (id: string) => orders[id] || null),
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  getAddress: jest.fn().mockReturnValue('user1'),
+  getTonPublicKey: jest.fn().mockReturnValue('pub'),
+  openModal: jest.fn(),
+}));
+
+import reviewAgent from '../agents/review-agent';
+
+describe('reviewAgent', () => {
+  const base: Review = {
+    id: 'r1',
+    productId: 'p1',
+    productName: 'Prod',
+    productImage: 'img',
+    orderId: 'o1',
+    userId: 'u1',
+    userName: 'Alice',
+    userAvatar: 'a',
+    rating: 5,
+    title: 'Great',
+    comment: 'Nice',
+    date: new Date().toISOString(),
+    helpful: 0,
+    verified: true,
+  };
+
+  it('adds a review when order is delivered', async () => {
+    await reviewAgent.add(base);
+    const res = await reviewAgent.getByProduct('p1');
+    expect(res).toHaveLength(1);
+    expect(res[0].rating).toBe(5);
+  });
+
+  it('prevents duplicate reviews from same user', async () => {
+    await expect(reviewAgent.add({ ...base, id: 'r2' })).rejects.toThrow(
+      'Duplicate review',
+    );
+  });
+
+  it('rejects review if order not delivered', async () => {
+    orders.o2 = {
+      id: 'o2',
+      userId: 'u1',
+      status: 'courier_on_way',
+      items: orders.o1.items,
+    };
+    await expect(
+      reviewAgent.add({ ...base, id: 'r3', orderId: 'o2' }),
+    ).rejects.toThrow('Only completed orders can be reviewed');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add simple Reviews contract to store reviews on-chain
- verify completed orders and prevent duplicates before adding reviews
- display product reviews and aggregate rating on product page

## Testing
- `npm test tests/reviewAgent.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a78d2f3488326bb079521d5436a6f