### PR TITLE
Add dashboard metrics and public storefront

### DIFF
--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import productsAgent from '../../agents/products-agent';
+import reviewAgent from '../../agents/review-agent';
+import ProductCard from '../../components/ProductCard';
+import { Product } from '../../types';
+
+interface ReviewMap {
+  [productId: string]: { rating: number; count: number };
+}
+
+export default function StorefrontScreen() {
+  const { colors } = useTheme();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [reviews, setReviews] = useState<ReviewMap>({});
+
+  useEffect(() => {
+    const load = async () => {
+      const all = await productsAgent.getAll();
+      setProducts(all);
+      const entries = await Promise.all(
+        all.map(async (p) => {
+          const revs = await reviewAgent.getByProduct(p.id);
+          const count = revs.length;
+          const rating = count > 0 ? revs.reduce((a, r) => a + r.rating, 0) / count : 0;
+          return [p.id, { rating, count }] as [string, { rating: number; count: number }];
+        })
+      );
+      const map: ReviewMap = {};
+      entries.forEach(([id, data]) => {
+        map[id] = data;
+      });
+      setReviews(map);
+    };
+    load();
+  }, []);
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+    >
+      {products.map((p) => (
+        <View key={p.id} style={styles.product}>
+          <ProductCard product={p} style={{ marginBottom: 4 }} />
+          <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+            ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
+          </Text>
+        </View>
+      ))}
+      {products.length === 0 && (
+        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+          אין מוצרים זמינים
+        </Text>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16 },
+  product: { marginBottom: 12 },
+});

--- a/app/stores/[id]/dashboard.tsx
+++ b/app/stores/[id]/dashboard.tsx
@@ -3,31 +3,44 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { listProducts } from '../../../services/tonProducts';
-import { listOrdersBySeller } from '../../../services/tonOrders';
+import { getStore } from '../../../services/tonStores';
+import OrderRevenueMetrics from '../../../components/OrderRevenueMetrics';
+import { useAuth } from '../../../components/AuthContext';
 
 export default function StoreDashboardScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { colors } = useTheme();
+  const { user } = useAuth();
   const [productCount, setProductCount] = useState(0);
-  const [orderCount, setOrderCount] = useState(0);
 
   useEffect(() => {
-    const loadStats = async () => {
+    const checkOwner = async () => {
       if (!id) return;
+      const store = await getStore(id);
+      if (!store || store.owner !== user?.address) {
+        router.replace(`/stores/${id}`);
+        return false;
+      }
+      return true;
+    };
+
+    const loadStats = async () => {
+      const isOwner = await checkOwner();
+      if (!isOwner) return;
       const products = await listProducts();
       setProductCount(products.filter((p) => p.storeId === id).length);
-      const orders = await listOrdersBySeller(id);
-      setOrderCount(orders.length);
     };
+
     loadStats();
-  }, [id]);
+  }, [id, user?.address]);
+  
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <Text style={[styles.title, { color: colors.text.primary }]}>לוח חנות</Text>
       <View style={styles.stats}>
         <Text style={[styles.statText, { color: colors.text.primary }]}>מוצרים: {productCount}</Text>
-        <Text style={[styles.statText, { color: colors.text.primary }]}>הזמנות: {orderCount}</Text>
+        {id && <OrderRevenueMetrics sellerId={id} />}
       </View>
       <View style={styles.nav}>
         <TouchableOpacity

--- a/components/OrderRevenueMetrics.tsx
+++ b/components/OrderRevenueMetrics.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { listOrdersBySeller } from '../services/tonOrders';
+import { Order } from '../types';
+
+interface Props {
+  sellerId: string;
+}
+
+export default function OrderRevenueMetrics({ sellerId }: Props) {
+  const { colors } = useTheme();
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!sellerId) return;
+      const list = await listOrdersBySeller(sellerId);
+      setOrders(list);
+    };
+    load();
+  }, [sellerId]);
+
+  const totalOrders = orders.length;
+  const totalRevenue = orders.reduce((sum, o) => sum + (o.total || 0), 0);
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.stat, { color: colors.text.primary }]}>Orders: {totalOrders}</Text>
+      <Text style={[styles.stat, { color: colors.text.primary }]}>Revenue: {totalRevenue.toFixed(2)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'flex-end', gap: 4 },
+  stat: { fontSize: 16 },
+});

--- a/tests/__mocks__/react-native.js
+++ b/tests/__mocks__/react-native.js
@@ -1,1 +1,11 @@
-module.exports = { Platform: { OS: 'ios' } };
+const React = require('react');
+
+const View = ({ children, style }) => React.createElement('View', { style }, children);
+const Text = ({ children, style }) => React.createElement('Text', { style }, children);
+const ScrollView = ({ children, style, contentContainerStyle }) =>
+  React.createElement('ScrollView', { style, contentContainerStyle }, children);
+const TouchableOpacity = ({ children, onPress, style }) =>
+  React.createElement('TouchableOpacity', { onPress, style }, children);
+const StyleSheet = { create: (s) => s };
+
+module.exports = { Platform: { OS: 'ios' }, View, Text, ScrollView, TouchableOpacity, StyleSheet };

--- a/tests/orderRevenueMetrics.test.tsx
+++ b/tests/orderRevenueMetrics.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import OrderRevenueMetrics from '../components/OrderRevenueMetrics';
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: { text: { primary: '#000' } } }),
+}));
+
+jest.mock('../services/tonOrders', () => ({
+  listOrdersBySeller: jest.fn(async () => [
+    { id: '1', total: 10 } as any,
+    { id: '2', total: 5 } as any,
+  ]),
+}));
+
+describe('OrderRevenueMetrics', () => {
+  it('renders totals for orders and revenue', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<OrderRevenueMetrics sellerId="s1" />);
+    });
+    const tree = root!.toJSON();
+    expect(JSON.stringify(tree)).toContain('Orders: 2');
+    expect(JSON.stringify(tree)).toContain('Revenue: 15.00');
+  });
+});

--- a/tests/storefront.test.tsx
+++ b/tests/storefront.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import StorefrontScreen from '../app/storefront';
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: { background: '#fff', text: { primary: '#000', secondary: '#666' } } }),
+}));
+
+jest.mock('../agents/products-agent', () => ({
+  getAll: jest.fn(async () => [
+    {
+      id: 'p1',
+      name: 'Product 1',
+      storeId: 's1',
+      price: 1,
+      stock: 1,
+      description: '',
+      images: [],
+      categoryId: 'c1',
+      createdAt: '',
+      updatedAt: '',
+    } as any,
+  ]),
+}));
+
+jest.mock('../agents/review-agent', () => ({
+  getByProduct: jest.fn(async () => [
+    { id: 'r1', productId: 'p1', userId: 'u1', rating: 4, comment: '', createdAt: '' } as any,
+  ]),
+}));
+
+jest.mock('../components/ProductCard', () => ({
+  __esModule: true,
+  default: ({ product }: any) => React.createElement('ProductCard', null, product.name),
+}));
+
+describe('StorefrontScreen', () => {
+  it('shows products with review info', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StorefrontScreen />);
+    });
+    const tree = root!.toJSON();
+    const str = JSON.stringify(tree);
+    expect(str).toContain('Product 1');
+    expect(str).toContain('⭐ 4.0 (1)');
+  });
+});


### PR DESCRIPTION
## Summary
- add OrderRevenueMetrics component to compute orders and revenue
- restrict store dashboard to owners and show revenue stats
- introduce public storefront page listing products with reviews
- mock react-native for UI tests and add dashboard/storefront tests

## Testing
- `npm test` *(fails: Jest encountered an unexpected token; TonConnect not initialized; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689a78d1cda48326a956b2abe6a222ff