### PR TITLE
Add seller key registry and ECDH shipping encryption

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -9,9 +9,8 @@ import {
   refundPayment,
 } from '../services/tonContract';
 import productsAgent from './products-agent';
-import { getUser } from '../services/tonUsers';
-import * as nacl from 'tweetnacl';
-import * as ed2curve from 'ed2curve';
+import { getSellerPublicKey } from '../services/sellerRegistry';
+import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
@@ -87,25 +86,14 @@ class OrdersAgent {
     }
     if (enriched.shippingAddress && enriched.sellerAddress) {
       try {
-        const seller = await getUser(enriched.sellerAddress);
-        const sellerPub = seller?.publicKey;
+        const sellerPub = await getSellerPublicKey(enriched.sellerAddress);
         if (sellerPub) {
-          const sellerPubX = ed2curve.convertPublicKey(Buffer.from(sellerPub, 'hex'));
-          if (sellerPubX) {
-            const ephem = nacl.box.keyPair();
-            const nonce = nacl.randomBytes(nacl.box.nonceLength);
-            const msg = Buffer.from(JSON.stringify(enriched.shippingAddress));
-            const cipher = nacl.box(msg, nonce, sellerPubX, ephem.secretKey);
-            toStore = {
-              ...toStore,
-              shipAddrEnc: {
-                cipher: Buffer.from(cipher).toString('base64'),
-                nonce: Buffer.from(nonce).toString('base64'),
-                ephem: Buffer.from(ephem.publicKey).toString('base64'),
-              },
-            };
-            delete toStore.shippingAddress;
-          }
+          const shipAddrEnc = await encryptShippingInfo(
+            enriched.shippingAddress,
+            sellerPub,
+          );
+          toStore = { ...toStore, shipAddrEnc };
+          delete toStore.shippingAddress;
         }
       } catch (err) {
         console.warn('Failed to encrypt shipping address', err);

--- a/services/sellerRegistry.ts
+++ b/services/sellerRegistry.ts
@@ -1,0 +1,17 @@
+const sellerPubKeys: Record<string, string> = {};
+
+export function setSellerPublicKey(address: string, publicKey: string) {
+  sellerPubKeys[address] = publicKey;
+}
+
+export function getSellerPublicKey(address: string): string | undefined {
+  return sellerPubKeys[address];
+}
+
+export function removeSellerPublicKey(address: string) {
+  delete sellerPubKeys[address];
+}
+
+export function listSellerPublicKeys(): { address: string; publicKey: string }[] {
+  return Object.entries(sellerPubKeys).map(([address, publicKey]) => ({ address, publicKey }));
+}

--- a/services/sellerTools.ts
+++ b/services/sellerTools.ts
@@ -1,0 +1,9 @@
+import { Order, ShippingAddress } from '../types';
+import { decryptShippingInfo } from '../utils/shippingCrypto';
+
+export async function decryptOrderShipping(
+  order: Order,
+): Promise<ShippingAddress | null> {
+  if (!order.shipAddrEnc) return null;
+  return decryptShippingInfo(order.shipAddrEnc);
+}

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -1,11 +1,11 @@
 import * as nacl from 'tweetnacl';
-import * as ed2curve from 'ed2curve';
 import { sha256 } from '@noble/hashes/sha256';
 import { Order } from '../types';
+import { decryptOrderShipping } from '../services/sellerTools';
+import { getSellerPublicKey } from '../services/sellerRegistry';
+import { getPrivateKey } from '../services/localIdentity';
 
 const mockStore: Record<string, any> = {};
-const sellerKey = nacl.sign.keyPair();
-const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
 
 jest.mock('../services/tonOrders', () => ({
   setOrder: jest.fn(async (o: any) => {
@@ -25,9 +25,8 @@ jest.mock('../services/tonContract', () => ({
   refundPayment: jest.fn(),
 }));
 
-jest.mock('../services/tonUsers', () => ({
-  getUser: jest.fn().mockResolvedValue({ publicKey: sellerPubEd }),
-}));
+jest.mock('../services/sellerRegistry');
+jest.mock('../services/localIdentity');
 
 jest.mock('../services/tonAuth', () => ({
   getAddress: jest.fn().mockReturnValue('seller'),
@@ -35,7 +34,12 @@ jest.mock('../services/tonAuth', () => ({
   openModal: jest.fn(),
 }));
 
-import ordersAgent from '../agents/orders-agent';
+const sellerKey = nacl.sign.keyPair();
+const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
+(getSellerPublicKey as jest.Mock).mockResolvedValue(sellerPubEd);
+(getPrivateKey as jest.Mock).mockResolvedValue(sellerKey.secretKey);
+
+const ordersAgent = require('../agents/orders-agent').default;
 
 describe('ordersAgent.add', () => {
   it('encrypts shipping address and persists new fields', async () => {
@@ -87,15 +91,7 @@ describe('ordersAgent.add', () => {
     expect(stored.shipAddrEnc).toBeDefined();
     expect(stored.shippingAddress).toBeUndefined();
 
-    const privX = ed2curve.convertSecretKey(sellerKey.secretKey);
-    const decrypted = nacl.box.open(
-      Buffer.from(stored.shipAddrEnc.cipher, 'base64'),
-      Buffer.from(stored.shipAddrEnc.nonce, 'base64'),
-      Buffer.from(stored.shipAddrEnc.ephem, 'base64'),
-      privX,
-    );
-    expect(decrypted).not.toBeNull();
-    const addr = JSON.parse(Buffer.from(decrypted!).toString());
+    const addr = await decryptOrderShipping(stored);
     expect(addr).toEqual(order.shippingAddress);
 
     const persisted = await ordersAgent.get(order.id);

--- a/tests/shippingCrypto.test.ts
+++ b/tests/shippingCrypto.test.ts
@@ -1,0 +1,20 @@
+import * as nacl from 'tweetnacl';
+import { encryptShippingInfo, decryptShippingInfo } from '../utils/shippingCrypto';
+
+const seller = nacl.sign.keyPair();
+const sellerPub = Buffer.from(seller.publicKey).toString('hex');
+
+describe('shippingCrypto', () => {
+  it('performs ECDH round trip for shipping info', async () => {
+    const addr = {
+      name: 'Alice',
+      phone: '1',
+      street: 'st',
+      city: 'c',
+      postalCode: 'p',
+    };
+    const enc = await encryptShippingInfo(addr, sellerPub);
+    const dec = await decryptShippingInfo(enc, seller.secretKey);
+    expect(dec).toEqual(addr);
+  });
+});

--- a/utils/shippingCrypto.ts
+++ b/utils/shippingCrypto.ts
@@ -1,0 +1,44 @@
+import * as nacl from 'tweetnacl';
+import * as ed2curve from 'ed2curve';
+import { ShippingAddress } from '../types';
+import { getPrivateKey } from '../services/localIdentity';
+
+export interface EncryptedShipping {
+  cipher: string;
+  nonce: string;
+  ephem: string;
+}
+
+export async function encryptShippingInfo(
+  info: ShippingAddress,
+  sellerPublicKey: string,
+): Promise<EncryptedShipping> {
+  const sellerPubX = ed2curve.convertPublicKey(Buffer.from(sellerPublicKey, 'hex'));
+  if (!sellerPubX) throw new Error('invalid seller key');
+  const ephem = nacl.box.keyPair();
+  const nonce = nacl.randomBytes(nacl.box.nonceLength);
+  const msg = Buffer.from(JSON.stringify(info));
+  const cipher = nacl.box(msg, nonce, sellerPubX, ephem.secretKey);
+  return {
+    cipher: Buffer.from(cipher).toString('base64'),
+    nonce: Buffer.from(nonce).toString('base64'),
+    ephem: Buffer.from(ephem.publicKey).toString('base64'),
+  };
+}
+
+export async function decryptShippingInfo(
+  enc: EncryptedShipping,
+  privKey?: Uint8Array,
+): Promise<ShippingAddress | null> {
+  const secret = privKey ?? (await getPrivateKey());
+  const privX = ed2curve.convertSecretKey(secret);
+  if (!privX) return null;
+  const decrypted = nacl.box.open(
+    Buffer.from(enc.cipher, 'base64'),
+    Buffer.from(enc.nonce, 'base64'),
+    Buffer.from(enc.ephem, 'base64'),
+    privX,
+  );
+  if (!decrypted) return null;
+  return JSON.parse(Buffer.from(decrypted).toString());
+}


### PR DESCRIPTION
## Summary
- add in-memory seller public key registry
- provide ECDH-based utility for encrypting and decrypting shipping details
- wire orders agent and seller tools to use the new crypto helpers
- test shipping info encryption/decryption round trip

## Testing
- `npx jest tests/shippingCrypto.test.ts tests/ordersAgent.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a78ccb1308326a5c879dadfe1c481