### PR TITLE
feat: add waku encryption and order notifications

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -6,6 +6,15 @@ import {
   listNotifications,
   removeNotification,
 } from '../services/tonNotifications';
+import {
+  LightNode,
+  createLightNode,
+  waitForRemotePeer,
+  createEncoder,
+  Protocols,
+  utf8ToBytes,
+} from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../utils/appConfig';
 
 type NotificationEvent =
   | 'order.created'
@@ -14,6 +23,7 @@ type NotificationEvent =
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
+  private node: LightNode | null = null;
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -28,12 +38,14 @@ class NotificationsAgent {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
+    await this.broadcastWaku(item);
   }
 
   async update(item: Notification): Promise<void> {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
+    await this.broadcastWaku(item);
   }
 
   async remove(id: string): Promise<void> {
@@ -53,6 +65,7 @@ class NotificationsAgent {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
+    await this.broadcastWaku(item);
   }
 
   subscribe(cb: (n: Notification) => void) {
@@ -62,6 +75,39 @@ class NotificationsAgent {
   unsubscribe(cb: (n: Notification) => void) {
     this.subscribers.delete(cb);
   }
+
+  private async ensureNode(): Promise<LightNode | null> {
+    if (this.node) return this.node;
+    try {
+      const bootstrap = getWakuBootstrapNodes();
+      if (bootstrap.length === 0) bootstrap.push(DEFAULT_BOOTSTRAP);
+      this.node = await createLightNode({ libp2p: { bootstrap } });
+      await this.node.start();
+      await waitForRemotePeer(this.node, [Protocols.Relay]);
+      return this.node;
+    } catch (err) {
+      console.error('Failed to start Waku node', err);
+      this.node = null;
+      return null;
+    }
+  }
+
+  private async broadcastWaku(item: Notification) {
+    const node = await this.ensureNode();
+    if (!node) return;
+    try {
+      const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
+      await node.lightPush.send(encoder, {
+        payload: utf8ToBytes(JSON.stringify(item)),
+      });
+    } catch (err) {
+      console.error('Failed to broadcast notification', err);
+    }
+  }
 }
+
+const DEFAULT_BOOTSTRAP =
+  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
+const ORDER_TOPIC = '/congress/orders/1';
 
 export default new NotificationsAgent();

--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -3,6 +3,7 @@ import NotificationService from '../services/notification';
 import { Notification } from '../types';
 import NotificationPopup from './NotificationPopup';
 import { useAuth } from './AuthContext';
+import { useWakuClient } from '../hooks/useWakuClient';
 
 interface NotificationContextType {
   unreadCount: number;
@@ -31,18 +32,23 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   } | null>(null);
   const { isLoggedIn, user } = useAuth();
   const notificationSubscription = useRef<any>(null);
+  const waku = useWakuClient();
+  const wakuUnsub = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (isLoggedIn && user) {
       refreshNotifications();
       setupRealtimeSubscription();
+      setupWakuSubscription();
     } else {
       setUnreadCount(0);
       cleanupSubscription();
+      cleanupWakuSubscription();
     }
-    
+
     return () => {
       cleanupSubscription();
+      cleanupWakuSubscription();
     };
   }, [isLoggedIn, user]);
 
@@ -79,6 +85,39 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
       const notificationService = NotificationService.getInstance();
       notificationService.unsubscribeFromNotifications(notificationSubscription.current);
       notificationSubscription.current = null;
+    }
+  };
+
+  const setupWakuSubscription = async () => {
+    if (!user) return;
+    if (wakuUnsub.current) {
+      wakuUnsub.current();
+      wakuUnsub.current = null;
+    }
+    wakuUnsub.current = await waku.subscribeOrders((message) => {
+      try {
+        const n: Notification = JSON.parse(message);
+        if (n.userId !== user.id) return;
+        setUnreadCount((prev) => prev + 1);
+        showNotification(
+          n.title,
+          n.message,
+          n.type === 'order'
+            ? 'success'
+            : n.type === 'promo' || n.type === 'message'
+              ? 'info'
+              : 'info',
+        );
+      } catch (err) {
+        console.error('Failed to parse notification', err);
+      }
+    });
+  };
+
+  const cleanupWakuSubscription = () => {
+    if (wakuUnsub.current) {
+      wakuUnsub.current();
+      wakuUnsub.current = null;
     }
   };
 

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -35,13 +35,16 @@ export interface WakuClient {
   ) => Promise<void>;
   broadcastSystem: (message: string) => Promise<void>;
   subscribeSystem: (cb: (msg: string) => void) => Promise<() => void>;
+  broadcastOrder: (message: string) => Promise<void>;
+  subscribeOrders: (cb: (msg: string) => void) => Promise<() => void>;
 }
 
-function topic(roomId: string) {
-  return `/blue-ocean/1/chat/${roomId}/proto`;
+function chatTopic(roomId: string) {
+  return `/congress/chat/1/${roomId}`;
 }
 
-const SYSTEM_TOPIC = '/blue-ocean/1/notifications/1/proto';
+const SYSTEM_TOPIC = '/congress/notifications/1';
+const ORDER_TOPIC = '/congress/orders/1';
 
 export function useWakuClient(): WakuClient {
   const nodeRef = useRef<LightNode>();
@@ -92,7 +95,7 @@ export function useWakuClient(): WakuClient {
     await db.sendChatMessage(roomId, { ...full, message: encrypted });
 
     if (nodeRef.current) {
-      const encoder = createEncoder({ contentTopic: topic(roomId) });
+      const encoder = createEncoder({ contentTopic: chatTopic(roomId) });
       await nodeRef.current.lightPush.send(encoder, {
         payload: utf8ToBytes(encrypted),
       });
@@ -106,7 +109,7 @@ export function useWakuClient(): WakuClient {
     cb: (msg: ChatMessage) => void,
   ): Promise<() => void> => {
     if (!nodeRef.current) return () => {};
-    const decoder = createDecoder(topic(roomId));
+    const decoder = createDecoder(chatTopic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       const encrypted = bytesToUtf8(wakuMsg.payload);
@@ -143,9 +146,9 @@ export function useWakuClient(): WakuClient {
     cb: (msg: ChatMessage) => void,
   ) => {
     if (!nodeRef.current) return;
-    const decoder = createDecoder(topic(roomId));
+    const decoder = createDecoder(chatTopic(roomId));
     for await (const msgs of nodeRef.current.store.queryGenerator({
-      contentTopics: [topic(roomId)],
+      contentTopics: [chatTopic(roomId)],
     })) {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
@@ -172,6 +175,12 @@ export function useWakuClient(): WakuClient {
     await nodeRef.current.lightPush.send(encoder, { payload: utf8ToBytes(message) });
   };
 
+  const broadcastOrder = async (message: string) => {
+    if (!nodeRef.current) return;
+    const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
+    await nodeRef.current.lightPush.send(encoder, { payload: utf8ToBytes(message) });
+  };
+
   const subscribeSystem = async (cb: (msg: string) => void) => {
     if (!nodeRef.current) return () => {};
     const decoder = createDecoder(SYSTEM_TOPIC);
@@ -192,5 +201,33 @@ export function useWakuClient(): WakuClient {
     };
   };
 
-  return { send, subscribe, fetchHistory, broadcastSystem, subscribeSystem };
+  const subscribeOrders = async (cb: (msg: string) => void) => {
+    if (!nodeRef.current) return () => {};
+    const decoder = createDecoder(ORDER_TOPIC);
+    const handler = (wakuMsg: any) => {
+      if (!wakuMsg.payload) return;
+      cb(bytesToUtf8(wakuMsg.payload));
+    };
+    const maybeUnsub = (nodeRef.current.relay as any).addObserver(
+      handler,
+      [decoder],
+    ) as (() => void) | void;
+    return () => {
+      if (typeof maybeUnsub === 'function') {
+        maybeUnsub();
+      } else {
+        (nodeRef.current?.relay as any)?.deleteObserver?.(handler);
+      }
+    };
+  };
+
+  return {
+    send,
+    subscribe,
+    fetchHistory,
+    broadcastSystem,
+    subscribeSystem,
+    broadcastOrder,
+    subscribeOrders,
+  };
 }

--- a/hooks/useWakuClient.web.ts
+++ b/hooks/useWakuClient.web.ts
@@ -32,5 +32,7 @@ export function useWakuClient() {
     ) => {},
     broadcastSystem: async (_msg: string) => {},
     subscribeSystem: async (_cb: (msg: string) => void) => () => {},
+    broadcastOrder: async (_msg: string) => {},
+    subscribeOrders: async (_cb: (msg: string) => void) => () => {},
   };
 }

--- a/tests/encryption.test.ts
+++ b/tests/encryption.test.ts
@@ -1,0 +1,19 @@
+import * as nacl from 'tweetnacl';
+import { deriveSharedKey, aesEncrypt, aesDecrypt } from '../utils/encryption';
+
+describe('ECDH + AES utilities', () => {
+  it('allow buyer and seller to exchange encrypted messages', async () => {
+    const buyerSeed = nacl.randomBytes(32);
+    const sellerSeed = nacl.randomBytes(32);
+    const buyer = nacl.sign.keyPair.fromSeed(buyerSeed);
+    const seller = nacl.sign.keyPair.fromSeed(sellerSeed);
+
+    const buyerKey = await deriveSharedKey(buyerSeed, Buffer.from(seller.publicKey).toString('hex'), 'room1');
+    const sellerKey = await deriveSharedKey(sellerSeed, Buffer.from(buyer.publicKey).toString('hex'), 'room1');
+
+    const message = 'hello seller';
+    const cipher = await aesEncrypt(message, buyerKey);
+    const plain = await aesDecrypt(cipher, sellerKey);
+    expect(plain).toBe(message);
+  });
+});

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -1,8 +1,5 @@
-import * as nacl from 'tweetnacl';
-import * as ed2curve from 'ed2curve';
-import { hkdf } from '@noble/hashes/hkdf';
-import { sha256 } from '@noble/hashes/sha256';
 import { getPrivateKey } from '../services/localIdentity';
+import { deriveSharedKey, aesEncrypt, aesDecrypt } from './encryption';
 
 const roomKeys: Record<string, CryptoKey | null> = {};
 
@@ -13,19 +10,7 @@ export async function getRoomKey(
   if (roomKeys.hasOwnProperty(roomId)) return roomKeys[roomId];
   try {
     const myPrivEd = await getPrivateKey();
-    const peerEd = Buffer.from(peerPublicKey, 'hex');
-    const myPrivX = ed2curve.convertSecretKey(myPrivEd);
-    const peerPubX = ed2curve.convertPublicKey(peerEd);
-    if (!myPrivX || !peerPubX) throw new Error('conversion failed');
-    const shared = nacl.scalarMult(myPrivX, peerPubX);
-    const derived = hkdf(sha256, shared, undefined, roomId, 32);
-    const key = await crypto.subtle.importKey(
-      'raw',
-      derived,
-      { name: 'AES-GCM' },
-      false,
-      ['encrypt', 'decrypt'],
-    );
+    const key = await deriveSharedKey(myPrivEd, peerPublicKey, roomId);
     roomKeys[roomId] = key;
     return key;
   } catch (err) {
@@ -42,12 +27,7 @@ export async function encryptMessage(
 ): Promise<string> {
   const key = await getRoomKey(roomId, peerPublicKey);
   if (!key) return msg;
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const enc = new TextEncoder().encode(msg);
-  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc);
-  const ivStr = Buffer.from(iv).toString('base64');
-  const dataStr = Buffer.from(new Uint8Array(cipher)).toString('base64');
-  return ivStr + ':' + dataStr;
+  return aesEncrypt(msg, key);
 }
 
 export async function decryptMessage(
@@ -56,14 +36,9 @@ export async function decryptMessage(
   peerPublicKey: string,
 ): Promise<string> {
   try {
-    const [ivStr, dataStr] = msg.split(':');
-    if (!ivStr || !dataStr) return msg;
     const key = await getRoomKey(roomId, peerPublicKey);
     if (!key) return msg;
-    const iv = Uint8Array.from(Buffer.from(ivStr, 'base64'));
-    const data = Uint8Array.from(Buffer.from(dataStr, 'base64'));
-    const dec = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
-    return new TextDecoder().decode(dec);
+    return await aesDecrypt(msg, key);
   } catch {
     return msg;
   }

--- a/utils/encryption.ts
+++ b/utils/encryption.ts
@@ -1,0 +1,59 @@
+import * as nacl from 'tweetnacl';
+import * as ed2curve from 'ed2curve';
+import { hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha256';
+
+/**
+ * Derive a shared AES-GCM key using ECDH over ed25519 keys.
+ * @param myPrivateEd25519 Your private ed25519 key bytes
+ * @param peerPublicEd25519Hex Peer public key as hex string
+ * @param info Context or room identifier used in HKDF
+ */
+export async function deriveSharedKey(
+  myPrivateEd25519: Uint8Array,
+  peerPublicEd25519Hex: string,
+  info: string,
+): Promise<CryptoKey> {
+  const myX = ed2curve.convertSecretKey(myPrivateEd25519);
+  const peerX = ed2curve.convertPublicKey(Buffer.from(peerPublicEd25519Hex, 'hex'));
+  if (!myX || !peerX) throw new Error('key conversion failed');
+  const shared = nacl.scalarMult(myX, peerX);
+  const derived = hkdf(sha256, shared, undefined, info, 32);
+  return crypto.subtle.importKey(
+    'raw',
+    derived,
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/**
+ * Encrypt a UTF-8 message using AES-GCM.
+ * Returns base64(iv) + ':' + base64(ciphertext)
+ */
+export async function aesEncrypt(
+  msg: string,
+  key: CryptoKey,
+): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const enc = new TextEncoder().encode(msg);
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc);
+  const ivStr = Buffer.from(iv).toString('base64');
+  const dataStr = Buffer.from(new Uint8Array(cipher)).toString('base64');
+  return `${ivStr}:${dataStr}`;
+}
+
+/**
+ * Decrypt a string produced by {@link aesEncrypt}
+ */
+export async function aesDecrypt(
+  payload: string,
+  key: CryptoKey,
+): Promise<string> {
+  const [ivStr, dataStr] = payload.split(':');
+  const iv = Uint8Array.from(Buffer.from(ivStr, 'base64'));
+  const data = Uint8Array.from(Buffer.from(dataStr, 'base64'));
+  const dec = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+  return new TextDecoder().decode(dec);
+}


### PR DESCRIPTION
## Summary
- add reusable ECDH/AES crypto helpers
- use Waku topics for chats and order notifications
- surface incoming order notifications in UI

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689a7bec39ec832681b9c46c84cbd703