### PR TITLE
feat: add MoonPay button using settings key

### DIFF
--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -37,8 +37,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { router } from 'expo-router';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
-import MoonPayModal from './MoonPayModal';
-import tonAuth, { useTonAddress } from '../services/tonAuth';
+import MoonPayButton from './MoonPayButton';
 
 interface CartModalProps {
   visible: boolean;
@@ -68,7 +67,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const { showNotification } = useNotifications();
   const { t } = useLanguage();
   const scrollViewRef = useRef<ScrollView>(null);
-  const walletAddress = useTonAddress();
 
   // Info/confirm modals
   const [infoModal, setInfoModal] = useState({
@@ -86,8 +84,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     action: () => {},
   });
 
-  const [moonPayVisible, setMoonPayVisible] = useState(false);
-  const [moonPayAmount, setMoonPayAmount] = useState(0);
 
   useEffect(() => {
     if (visible) {
@@ -249,27 +245,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   };
 
   const goToConfirmation = () => setCheckoutStep('confirmation');
-
-  const handleBuyTon = async () => {
-    if (!walletAddress) {
-      await tonAuth.openModal();
-      return;
-    }
-    try {
-      const res = await fetch(
-        'https://api.coingecko.com/api/v3/simple/price?ids=the-open-network&vs_currencies=usd',
-      );
-      const data = await res.json();
-      const tonPrice = data['the-open-network']?.usd;
-      if (tonPrice) {
-        const amount = getTotal() / tonPrice;
-        setMoonPayAmount(Number(amount.toFixed(2)));
-        setMoonPayVisible(true);
-      }
-    } catch (err) {
-      console.error('Error fetching TON price:', err);
-    }
-  };
 
   const goBack = () => {
     switch (checkoutStep) {
@@ -760,12 +735,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           </TouchableOpacity>
         </View>
 
-        <TouchableOpacity
-          style={[styles.buyTonButton, { backgroundColor: colors.gold }]}
-          onPress={handleBuyTon}
-        >
-          <Text style={[styles.buyTonButtonText, { color: colors.text.inverse }]}>Buy TON</Text>
-        </TouchableOpacity>
+        <MoonPayButton usdAmount={getTotal()} />
 
         <View
           style={[
@@ -1307,13 +1277,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         }}
         onCancel={() => setConfirmModal({ ...confirmModal, visible: false })}
       />
-      <MoonPayModal
-        visible={moonPayVisible}
-        onClose={() => setMoonPayVisible(false)}
-        walletAddress={walletAddress || ''}
-        coin="ton"
-        amountTON={moonPayAmount}
-      />
     </>
   );
 }
@@ -1449,13 +1412,6 @@ const styles = StyleSheet.create({
   paymentOptionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 4, textAlign: 'right' },
   paymentOptionDescription: { fontSize: 12, textAlign: 'right' },
   paymentOptionCheck: { marginLeft: 12 },
-  buyTonButton: {
-    borderRadius: 12,
-    paddingVertical: 12,
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  buyTonButtonText: { fontSize: 16, fontWeight: '600' },
   shippingAddressSummary: { borderRadius: 12, padding: 16, marginBottom: 16, borderWidth: 1 },
   summaryHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 },
   editLink: { fontSize: 14, fontWeight: '500' },

--- a/components/MoonPayButton.tsx
+++ b/components/MoonPayButton.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { useAppInfo } from '../contexts/AppInfoContext';
+import tonAuth, { useTonAddress } from '../services/tonAuth';
+import MoonPayModal from './MoonPayModal';
+
+interface MoonPayButtonProps {
+  usdAmount: number;
+}
+
+export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
+  const { colors } = useTheme();
+  const { fiatKey } = useAppInfo();
+  const walletAddress = useTonAddress();
+  const [visible, setVisible] = useState(false);
+  const [amountTON, setAmountTON] = useState<number | undefined>(undefined);
+
+  if (!fiatKey) return null;
+
+  const handlePress = async () => {
+    if (!walletAddress) {
+      await tonAuth.openModal();
+      return;
+    }
+    try {
+      const res = await fetch(
+        'https://api.coingecko.com/api/v3/simple/price?ids=the-open-network&vs_currencies=usd',
+      );
+      const data = await res.json();
+      const tonPrice = data['the-open-network']?.usd;
+      if (tonPrice) {
+        const amount = usdAmount / tonPrice;
+        setAmountTON(Number(amount.toFixed(2)));
+      } else {
+        setAmountTON(undefined);
+      }
+    } catch (err) {
+      console.error('Error fetching TON price:', err);
+      setAmountTON(undefined);
+    }
+    setVisible(true);
+  };
+
+  return (
+    <>
+      <TouchableOpacity
+        testID="moonpay-button"
+        style={[styles.button, { backgroundColor: colors.gold }]}
+        onPress={handlePress}
+      >
+        <Text style={[styles.text, { color: colors.text.inverse }]}>Buy TON</Text>
+      </TouchableOpacity>
+      <MoonPayModal
+        visible={visible}
+        onClose={() => setVisible(false)}
+        walletAddress={walletAddress!}
+        coin="ton"
+        amountTON={amountTON}
+        amountUSD={amountTON ? undefined : usdAmount}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/components/MoonPayModal.tsx
+++ b/components/MoonPayModal.tsx
@@ -3,7 +3,7 @@ import { Modal, View, StyleSheet, Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
 import LoadingSpinner from './LoadingSpinner';
 import { useTheme } from '../contexts/ThemeContext';
-import config from '../utils/appConfig';
+import { useAppInfo } from '../contexts/AppInfoContext';
 
 interface MoonPayModalProps {
   visible: boolean;
@@ -23,11 +23,12 @@ export default function MoonPayModal({
   amountTON,
 }: MoonPayModalProps) {
   const { colors } = useTheme();
+  const { fiatKey } = useAppInfo();
   const [loading, setLoading] = useState(true);
 
-  if (!config.fiatKey) return null;
+  if (!fiatKey) return null;
 
-  const url = `https://buy.moonpay.com?apiKey=${config.fiatKey}&currencyCode=${coin}&walletAddress=${walletAddress}&baseCurrencyCode=usd`;
+  const url = `https://buy.moonpay.com?apiKey=${fiatKey}&currencyCode=${coin}&walletAddress=${walletAddress}&baseCurrencyCode=usd`;
 
   let injectedJavaScript: string | undefined;
   if (typeof amountTON === 'number') {

--- a/tests/moonPayButton.test.ts
+++ b/tests/moonPayButton.test.ts
@@ -1,0 +1,65 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import MoonPayButton from '../components/MoonPayButton';
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: { gold: 'gold', text: { inverse: '#fff' } } }),
+}));
+
+jest.mock('../contexts/AppInfoContext', () => ({
+  useAppInfo: jest.fn(),
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  __esModule: true,
+  default: { openModal: jest.fn() },
+  useTonAddress: jest.fn(() => 'addr'),
+}));
+
+const modalMock = jest.fn(({ visible, amountTON, amountUSD }: any) =>
+  visible ? React.createElement('MoonPayModal', { amountTON, amountUSD }) : null,
+);
+
+jest.mock('../components/MoonPayModal', () => ({
+  __esModule: true,
+  default: (props: any) => modalMock(props),
+}));
+
+describe('MoonPayButton', () => {
+  afterEach(() => {
+    // @ts-ignore
+    global.fetch && (global.fetch as jest.Mock).mockRestore?.();
+  });
+
+  it('computes TON amount and renders modal', async () => {
+    const { useAppInfo } = require('../contexts/AppInfoContext');
+    (useAppInfo as jest.Mock).mockReturnValue({ fiatKey: 'key' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ 'the-open-network': { usd: 2 } }) }),
+    ) as any;
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(React.createElement(MoonPayButton, { usdAmount: 6 }));
+    });
+    const button = root!.root.findByProps({ testID: 'moonpay-button' });
+    await act(async () => {
+      await button.props.onPress();
+    });
+    const call = modalMock.mock.calls.find((c) => c[0].visible);
+    expect(call && call[0].amountTON).toBe(3);
+  });
+
+  it('renders nothing without moonpay key', async () => {
+    const { useAppInfo } = require('../contexts/AppInfoContext');
+    (useAppInfo as jest.Mock).mockReturnValue({ fiatKey: undefined });
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(React.createElement(MoonPayButton, { usdAmount: 6 }));
+    });
+    expect(root!.toJSON()).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add reusable MoonPayButton that computes TON amount and opens MoonPay with pre-filled data
- derive MoonPay API key from settings context
- use MoonPayButton in cart flow

## Testing
- `NODE_OPTIONS=--experimental-vm-modules yarn test tests/moonPayButton.test.ts` *(fails: SyntaxError: Unexpected token '<')*


------
https://chatgpt.com/codex/tasks/task_e_689a7bf138988326a4c3554abd18a7b3