### PR TITLE
Apply escrow fees on release

### DIFF
--- a/contracts/Escrow.tact
+++ b/contracts/Escrow.tact
@@ -1,4 +1,5 @@
 import "@tact-lang/core";
+import "./Settings.tact";
 
 message Release {}
 message Refund {}
@@ -14,8 +15,9 @@ contract Escrow {
     disputeWindow: Int;
     createdAt: Int;
     status: Int; // 0 pending, 1 released, 2 refunded
+    settings: Address;
 
-    init(buyer: Address, seller: Address, amount: Int, disputeWindow: Int) {
+    init(buyer: Address, seller: Address, amount: Int, disputeWindow: Int, settings: Address) {
         self.buyer = buyer;
         self.seller = seller;
         self.amount = amount;
@@ -23,6 +25,7 @@ contract Escrow {
         self.admin = sender();
         self.createdAt = now();
         self.status = 0;
+        self.settings = settings;
     }
 
     private isExpired(): Bool {
@@ -36,7 +39,13 @@ contract Escrow {
         } else {
             require(sender() == self.buyer || sender() == self.seller, 102);
         }
-        send(self.seller, self.amount);
+        let feeBps = Settings(self.settings).feeBps();
+        let feeRecipient = Settings(self.settings).admin();
+        let fee = (self.amount * feeBps) / 10000;
+        if (fee > 0) {
+            send(feeRecipient, fee);
+        }
+        send(self.seller, self.amount - fee);
         self.status = 1;
     }
 
@@ -55,7 +64,13 @@ contract Escrow {
         require(self.status == 0, 106);
         require(sender() == self.admin, 107);
         if (msg.toSeller) {
-            send(self.seller, self.amount);
+            let feeBps = Settings(self.settings).feeBps();
+            let feeRecipient = Settings(self.settings).admin();
+            let fee = (self.amount * feeBps) / 10000;
+            if (fee > 0) {
+                send(feeRecipient, fee);
+            }
+            send(self.seller, self.amount - fee);
             self.status = 1;
         } else {
             send(self.buyer, balance());

--- a/contracts/EscrowFactory.tact
+++ b/contracts/EscrowFactory.tact
@@ -6,11 +6,12 @@ message CreateEscrow {
     seller: Address;
     amount: Int;
     disputeWindow: Int;
+    settings: Address;
 }
 
 contract EscrowFactory {
     receive(msg: CreateEscrow) {
-        let init = initOf Escrow(msg.buyer, msg.seller, msg.amount, msg.disputeWindow);
+        let init = initOf Escrow(msg.buyer, msg.seller, msg.amount, msg.disputeWindow, msg.settings);
         let addr = contractAddress(init);
         send(addr, msg.amount, null, 0, init);
     }

--- a/tests/escrowContract.test.ts
+++ b/tests/escrowContract.test.ts
@@ -7,9 +7,19 @@ class EscrowSim {
   start: number;
   now: number;
   status: number; // 0 pending, 1 released, 2 refunded
-  lastRecipient: string | null;
+  transfers: { to: string; amount: number }[];
+  feeBps: number;
+  feeRecipient: string;
 
-  constructor(buyer: string, seller: string, admin: string, amount: number, disputeWindow: number) {
+  constructor(
+    buyer: string,
+    seller: string,
+    admin: string,
+    amount: number,
+    disputeWindow: number,
+    feeBps: number,
+    feeRecipient: string,
+  ) {
     this.buyer = buyer;
     this.seller = seller;
     this.admin = admin;
@@ -18,7 +28,9 @@ class EscrowSim {
     this.start = 0;
     this.now = 0;
     this.status = 0;
-    this.lastRecipient = null;
+    this.transfers = [];
+    this.feeBps = feeBps;
+    this.feeRecipient = feeRecipient;
   }
 
   private expired() {
@@ -29,6 +41,10 @@ class EscrowSim {
     this.now += seconds;
   }
 
+  private feeAmount() {
+    return Math.floor((this.amount * this.feeBps) / 10000);
+  }
+
   release(sender: string) {
     if (this.status !== 0) throw new Error('finalized');
     if (!this.expired()) {
@@ -36,8 +52,10 @@ class EscrowSim {
     } else {
       if (sender !== this.buyer && sender !== this.seller) throw new Error('not allowed');
     }
+    const fee = this.feeAmount();
+    if (fee > 0) this.transfers.push({ to: this.feeRecipient, amount: fee });
+    this.transfers.push({ to: this.seller, amount: this.amount - fee });
     this.status = 1;
-    this.lastRecipient = this.seller;
   }
 
   refund(sender: string) {
@@ -47,15 +65,22 @@ class EscrowSim {
     } else {
       if (sender !== this.buyer && sender !== this.seller) throw new Error('not allowed');
     }
+    this.transfers.push({ to: this.buyer, amount: this.amount });
     this.status = 2;
-    this.lastRecipient = this.buyer;
   }
 
   adminResolve(sender: string, toSeller: boolean) {
     if (this.status !== 0) throw new Error('finalized');
     if (sender !== this.admin) throw new Error('not admin');
-    this.status = toSeller ? 1 : 2;
-    this.lastRecipient = toSeller ? this.seller : this.buyer;
+    if (toSeller) {
+      const fee = this.feeAmount();
+      if (fee > 0) this.transfers.push({ to: this.feeRecipient, amount: fee });
+      this.transfers.push({ to: this.seller, amount: this.amount - fee });
+      this.status = 1;
+    } else {
+      this.transfers.push({ to: this.buyer, amount: this.amount });
+      this.status = 2;
+    }
   }
 }
 
@@ -63,59 +88,77 @@ describe('EscrowSim', () => {
   const buyer = 'buyer';
   const seller = 'seller';
   const admin = 'admin';
+  const feeRecipient = 'fee';
   const amount = 100;
   const dispute = 10;
+  const feeBps = 200; // 2%
 
-  test('buyer releases before timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+  test('buyer releases before timeout with fee', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     e.release(buyer);
     expect(e.status).toBe(1);
-    expect(e.lastRecipient).toBe(seller);
+    expect(e.transfers).toEqual([
+      { to: feeRecipient, amount: 2 },
+      { to: seller, amount: 98 },
+    ]);
   });
 
   test('seller cannot release before timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     expect(() => e.release(seller)).toThrow();
     expect(e.status).toBe(0);
   });
 
-  test('seller refunds before timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+  test('seller refunds before timeout without fee', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     e.refund(seller);
     expect(e.status).toBe(2);
-    expect(e.lastRecipient).toBe(buyer);
+    expect(e.transfers).toEqual([{ to: buyer, amount: 100 }]);
   });
 
   test('buyer cannot refund before timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     expect(() => e.refund(buyer)).toThrow();
   });
 
-  test('seller releases after timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+  test('seller releases after timeout with fee', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     e.advance(dispute + 1);
     e.release(seller);
     expect(e.status).toBe(1);
-    expect(e.lastRecipient).toBe(seller);
+    expect(e.transfers).toEqual([
+      { to: feeRecipient, amount: 2 },
+      { to: seller, amount: 98 },
+    ]);
   });
 
   test('buyer refunds after timeout', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     e.advance(dispute + 1);
     e.refund(buyer);
     expect(e.status).toBe(2);
-    expect(e.lastRecipient).toBe(buyer);
+    expect(e.transfers).toEqual([{ to: buyer, amount: 100 }]);
   });
 
-  test('admin resolves to seller', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+  test('admin resolves to seller with fee', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     e.adminResolve(admin, true);
     expect(e.status).toBe(1);
-    expect(e.lastRecipient).toBe(seller);
+    expect(e.transfers).toEqual([
+      { to: feeRecipient, amount: 2 },
+      { to: seller, amount: 98 },
+    ]);
+  });
+
+  test('admin resolves to buyer', () => {
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
+    e.adminResolve(admin, false);
+    expect(e.status).toBe(2);
+    expect(e.transfers).toEqual([{ to: buyer, amount: 100 }]);
   });
 
   test('unauthorized admin resolve rejected', () => {
-    const e = new EscrowSim(buyer, seller, admin, amount, dispute);
+    const e = new EscrowSim(buyer, seller, admin, amount, dispute, feeBps, feeRecipient);
     expect(() => e.adminResolve('other', true)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- query fee settings in Escrow contract and send basis-point fee to recipient on release
- pass settings address via EscrowFactory
- extend EscrowSim tests to cover fee deductions and admin resolution

## Testing
- `npm test tests/escrowContract.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a81768e748326ae0337e1f06c069c