### PR TITLE
Add admin dispute resolution flow with IPFS evidence

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -19,7 +19,8 @@ import { getWakuBootstrapNodes } from '../utils/appConfig';
 type NotificationEvent =
   | 'order.created'
   | 'payment.received'
-  | 'status.updated';
+  | 'status.updated'
+  | 'dispute.updated';
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -18,7 +18,8 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   courier_found: ['courier_picked_up'],
   courier_picked_up: ['courier_on_way'],
   courier_on_way: ['delivered'],
-  delivered: ['released', 'refunded'],
+  delivered: ['released', 'refunded', 'disputed'],
+  disputed: ['released', 'refunded'],
   released: [],
   refunded: [],
 };
@@ -126,6 +127,9 @@ class OrdersAgent {
         this.recordSellerMetric(order.sellerAddress, 'completed');
       } else if (order.status === 'refunded') {
         this.recordSellerMetric(order.sellerAddress, 'refunded');
+      }
+      if (order.status === 'disputed' || current.status === 'disputed') {
+        await this.notifyDisputeUpdate(order);
       }
     }
   }
@@ -266,6 +270,23 @@ class OrdersAgent {
     };
     try {
       await notificationsAgent.broadcast('payment.received', notification);
+    } catch (err) {
+      console.error('Failed to send notification', err);
+    }
+  }
+
+  private async notifyDisputeUpdate(order: Order) {
+    const notification: Notification = {
+      id: `ntf_${Date.now()}`,
+      userId: order.userId,
+      title: 'Order dispute updated',
+      message: `Order ${order.id} dispute status: ${order.status}`,
+      type: 'order',
+      read: false,
+      timestamp: Date.now(),
+    };
+    try {
+      await notificationsAgent.broadcast('dispute.updated', notification);
     } catch (err) {
       console.error('Failed to send notification', err);
     }

--- a/app/admin/disputes.tsx
+++ b/app/admin/disputes.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ArrowLeft } from 'lucide-react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useAuth } from '../../components/AuthContext';
+import { router } from 'expo-router';
+import ordersAgent from '../../agents/orders-agent';
+import { Order } from '../../types';
+import DisputeEvidence from '../../components/DisputeEvidence';
+import DisputeResolver from '../../components/DisputeResolver';
+import commonStyles from '../../constants/styles';
+
+export default function AdminDisputesScreen() {
+  const { colors } = useTheme();
+  const { isAdmin } = useAuth();
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace('/');
+      return;
+    }
+    const load = async () => {
+      const all = await ordersAgent.getAll();
+      setOrders(all.filter(o => o.status === 'disputed'));
+    };
+    load();
+    const sub = async (o: Order) => {
+      if (o.status === 'disputed') {
+        load();
+      } else {
+        setOrders(prev => prev.filter(ord => ord.id !== o.id));
+      }
+    };
+    ordersAgent.subscribe(sub);
+    return () => ordersAgent.unsubscribe(sub);
+  }, [isAdmin]);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          padding: 16,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border.primary,
+        }}
+      >
+        <TouchableOpacity onPress={() => router.back()}>
+          <ArrowLeft size={24} color={colors.text.primary} />
+        </TouchableOpacity>
+        <Text style={{ flex: 1, textAlign: 'center', fontSize: 18, color: colors.text.primary }}>
+          Disputes
+        </Text>
+        <View style={commonStyles.spacer24} />
+      </View>
+      <ScrollView style={{ padding: 16 }}>
+        {orders.map(order => (
+          <View
+            key={order.id}
+            style={{
+              marginBottom: 24,
+              borderWidth: 1,
+              borderColor: colors.border.primary,
+              padding: 16,
+            }}
+          >
+            <Text style={{ color: colors.text.primary }}>Order: {order.id}</Text>
+            <DisputeEvidence uri={order.disputeEvidenceUri} />
+            <DisputeResolver orderId={order.id} />
+          </View>
+        ))}
+        {orders.length === 0 && (
+          <Text style={{ color: colors.text.secondary }}>No disputes</Text>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/components/DisputeEvidence.tsx
+++ b/components/DisputeEvidence.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text } from 'react-native';
+
+interface Props {
+  uri?: string;
+}
+
+export default function DisputeEvidence({ uri }: Props) {
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchEvidence() {
+      if (!uri) return;
+      try {
+        const cid = uri.replace(/^ipfs:\/\//, '');
+        const res = await fetch(`https://ipfs.io/ipfs/${cid}`);
+        const text = await res.text();
+        if (!cancelled) setContent(text);
+      } catch {
+        if (!cancelled) setContent(null);
+      }
+    }
+    fetchEvidence();
+    return () => {
+      cancelled = true;
+    };
+  }, [uri]);
+
+  if (!uri) return <Text>No evidence</Text>;
+  if (content == null) return <Text>Loading evidence...</Text>;
+  return (
+    <View>
+      <Text selectable>{content}</Text>
+    </View>
+  );
+}

--- a/components/DisputeResolver.tsx
+++ b/components/DisputeResolver.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { View, Button, ActivityIndicator } from 'react-native';
+import OrderService from '../services/orders';
+
+interface Props {
+  orderId: string;
+}
+
+export default function DisputeResolver({ orderId }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  const resolve = async (toSeller: boolean) => {
+    setLoading(true);
+    try {
+      await OrderService.getInstance().resolveDispute(orderId, toSeller);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <Button title="Release to Seller" onPress={() => resolve(true)} />
+      <Button title="Refund Buyer" onPress={() => resolve(false)} />
+    </View>
+  );
+}

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -3,6 +3,7 @@ import { Order, OrderStatus, CartItem, ShippingAddress, OrderTrackingStep } from
 import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
+import { adminResolve } from './tonContract';
 
 class OrderService {
   private static instance: OrderService;
@@ -181,6 +182,13 @@ class OrderService {
     order.updatedAt = new Date().toISOString();
     await ordersAgent.update(order);
     this.notifyListeners();
+  }
+
+  async resolveDispute(orderId: string, toSeller: boolean): Promise<void> {
+    const order = await ordersAgent.get(orderId);
+    if (!order || !order.escrowAddr) return;
+    await adminResolve(order.escrowAddr, toSeller);
+    await this.updateOrderStatus(orderId, toSeller ? 'released' : 'refunded');
   }
 }
 

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -108,3 +108,26 @@ export async function refundPayment(contractAddress: string): Promise<string> {
   }
 }
 
+export async function adminResolve(
+  contractAddress: string,
+  toSeller: boolean,
+): Promise<string> {
+  try {
+    const payload = makeComment(`AdminResolve:${toSeller ? 1 : 0}`);
+    const payloadBoc = TonWeb.utils.bytesToBase64(
+      await payload.toBoc({ idx: false }),
+    );
+    const txHash = await sendTonConnect([
+      {
+        address: contractAddress,
+        amount: '0',
+        payload: payloadBoc,
+      },
+    ]);
+    return txHash;
+  } catch (e) {
+    console.error('Failed to resolve dispute', e);
+    throw e;
+  }
+}
+

--- a/tests/admin-disputes.test.tsx
+++ b/tests/admin-disputes.test.tsx
@@ -1,0 +1,65 @@
+import OrderService from '../services/orders';
+import ordersAgent from '../agents/orders-agent';
+import { adminResolve } from '../services/tonContract';
+
+jest.mock('../agents/orders-agent', () => ({
+  get: jest.fn(),
+  update: jest.fn(),
+  subscribe: jest.fn(),
+}));
+
+jest.mock('../services/tonContract', () => ({
+  adminResolve: jest.fn().mockResolvedValue('tx'),
+}));
+
+describe('OrderService.resolveDispute', () => {
+  const svc = OrderService.getInstance();
+
+  beforeEach(() => {
+    (ordersAgent.get as jest.Mock).mockReset();
+    (ordersAgent.update as jest.Mock).mockReset();
+    (adminResolve as jest.Mock).mockClear();
+  });
+
+  it('resolves dispute in favor of seller', async () => {
+    const order: any = {
+      id: 'o1',
+      escrowAddr: 'esc1',
+      status: 'disputed',
+      trackingSteps: [],
+      items: [],
+      total: 0,
+      paymentMethod: 'ton',
+      itemsHash: '',
+      createdAt: '',
+      updatedAt: '',
+    };
+    (ordersAgent.get as jest.Mock).mockResolvedValue(order);
+    await svc.resolveDispute('o1', true);
+    expect(adminResolve).toHaveBeenCalledWith('esc1', true);
+    expect(ordersAgent.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'released' }),
+    );
+  });
+
+  it('resolves dispute in favor of buyer', async () => {
+    const order: any = {
+      id: 'o2',
+      escrowAddr: 'esc2',
+      status: 'disputed',
+      trackingSteps: [],
+      items: [],
+      total: 0,
+      paymentMethod: 'ton',
+      itemsHash: '',
+      createdAt: '',
+      updatedAt: '',
+    };
+    (ordersAgent.get as jest.Mock).mockResolvedValue(order);
+    await svc.resolveDispute('o2', false);
+    expect(adminResolve).toHaveBeenCalledWith('esc2', false);
+    expect(ordersAgent.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'refunded' }),
+    );
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -234,6 +234,7 @@ export interface Order {
   driverAddress?: string;
   paymentContractAddress?: string;
   escrowAddr?: string;
+  disputeEvidenceUri?: string;
   itemsHash: string;
   createdAt: string;
   updatedAt: string;
@@ -247,6 +248,7 @@ export type OrderStatus =
   | 'courier_picked_up'   // שליח אסף את ההזמנה
   | 'courier_on_way'      // שליח בדרך אלייך
   | 'delivered'           // הזמנה התקבלה
+  | 'disputed'            // מחלוקת פתוחה
   | 'released'            // תשלום שוחרר
   | 'refunded';           // תשלום הוחזר
 


### PR DESCRIPTION
## Summary
- Add admin disputes page listing disputed orders and resolution controls
- Fetch IPFS-hosted evidence and allow admins to resolve via escrow contract
- Support disputed status and notifications in agents and services

## Testing
- `yarn test tests/admin-disputes.test.tsx` *(fails: jest not found)*
- `yarn install --mode=skip-build` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689a8ac4fba08326af4b1b4532be847e