### PR TITLE
Add store reputation aggregation and display

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -27,7 +27,7 @@ class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
   private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};
 
-  private recordSellerMetric(seller?: string, type?: 'completed' | 'refunded') {
+  private async recordSellerMetric(seller?: string, type?: 'completed' | 'refunded') {
     if (!seller) return;
     if (!this.sellerMetrics[seller]) {
       this.sellerMetrics[seller] = { completed: 0, refunds: 0 };
@@ -39,7 +39,7 @@ class OrdersAgent {
     }
     const { completed, refunds } = this.sellerMetrics[seller];
     const score = completed + refunds > 0 ? completed / (completed + refunds) : 0;
-    storesAgent.updateReputationByOwner(seller, score);
+    await storesAgent.updateReputationByOwner(seller, score);
   }
 
   getSellerMetrics(address: string) {
@@ -123,9 +123,9 @@ class OrdersAgent {
     if (statusChanged) {
       await this.notifyStatusChange(order);
       if (order.status === 'released') {
-        this.recordSellerMetric(order.sellerAddress, 'completed');
+        await this.recordSellerMetric(order.sellerAddress, 'completed');
       } else if (order.status === 'refunded') {
-        this.recordSellerMetric(order.sellerAddress, 'refunded');
+        await this.recordSellerMetric(order.sellerAddress, 'refunded');
       }
     }
   }
@@ -182,7 +182,7 @@ class OrdersAgent {
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
     await this.notifyPaymentReceived(updated);
-    this.recordSellerMetric(order.sellerAddress, 'completed');
+    await this.recordSellerMetric(order.sellerAddress, 'completed');
     return hash;
   }
 
@@ -208,7 +208,7 @@ class OrdersAgent {
     await setOrder(updated);
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
-    this.recordSellerMetric(order.sellerAddress, 'refunded');
+    await this.recordSellerMetric(order.sellerAddress, 'refunded');
     return hash;
   }
 

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -2,6 +2,8 @@ import { Review } from '../types';
 import tonAuth from '../services/tonAuth';
 import { addReview, getReviews } from '../services/tonReviews';
 import ordersAgent from './orders-agent';
+import productsAgent from './products-agent';
+import storesAgent from './stores-agent';
 
 const TOPIC = '/congress/reviews/1';
 
@@ -41,6 +43,10 @@ class ReviewAgent {
 
     await addReview(review);
     this.subscribers.forEach((cb) => cb(review));
+    const product = await productsAgent.get(review.productId);
+    if (product) {
+      await storesAgent.recordReview(product.storeId, review.rating);
+    }
   }
 
   async getByProduct(productId: string): Promise<Review[]> {

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -2,7 +2,17 @@ import { Store } from '../types';
 import tonAuth from '../services/tonAuth';
 import { setStore, getStore, listStores, removeStore } from '../services/tonStores';
 
+interface Metrics {
+  reviewSum: number;
+  reviewCount: number;
+  reliability: number;
+  score: number;
+}
+
 class StoresAgent {
+  private reputation: Record<string, Metrics> = {};
+  private subscribers: Set<(id: string, score: number) => void> = new Set();
+
   private async ensureWallet() {
     const address = tonAuth.getAddress();
     const publicKey = tonAuth.getTonPublicKey();
@@ -17,6 +27,53 @@ class StoresAgent {
     return { id, name, owner, nftId, reputation };
   }
 
+  private computeScore(id: string) {
+    const m = this.reputation[id];
+    const avg = m.reviewCount > 0 ? m.reviewSum / m.reviewCount : 0;
+    m.score = (avg + m.reliability * 5) / 2;
+    this.subscribers.forEach((cb) => cb(id, m.score));
+  }
+
+  async recordReview(storeId: string, rating: number) {
+    if (!this.reputation[storeId]) {
+      this.reputation[storeId] = { reviewSum: 0, reviewCount: 0, reliability: 0, score: 0 };
+    }
+    const m = this.reputation[storeId];
+    m.reviewSum += rating;
+    m.reviewCount += 1;
+    this.computeScore(storeId);
+    const store = await getStore(storeId);
+    if (store) {
+      await setStore(this.toRecord({ ...store, reputation: m.score }));
+    }
+  }
+
+  async updateReputationByOwner(owner: string, reliability: number): Promise<void> {
+    const stores = await listStores();
+    const store = stores.find((s) => s.owner === owner);
+    if (store) {
+      const id = store.id;
+      if (!this.reputation[id]) {
+        this.reputation[id] = { reviewSum: 0, reviewCount: 0, reliability: 0, score: 0 };
+      }
+      this.reputation[id].reliability = reliability;
+      this.computeScore(id);
+      await setStore(this.toRecord({ ...store, reputation: this.reputation[id].score }));
+    }
+  }
+
+  getReputationScore(id: string): number {
+    return this.reputation[id]?.score || 0;
+  }
+
+  subscribe(cb: (id: string, score: number) => void) {
+    this.subscribers.add(cb);
+  }
+
+  unsubscribe(cb: (id: string, score: number) => void) {
+    this.subscribers.delete(cb);
+  }
+
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
     await setStore(this.toRecord(item));
@@ -25,14 +82,6 @@ class StoresAgent {
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
     await setStore(this.toRecord(item));
-  }
-
-  async updateReputationByOwner(owner: string, reputation: number): Promise<void> {
-    const stores = await listStores();
-    const store = stores.find((s) => s.owner === owner);
-    if (store) {
-      await setStore(this.toRecord({ ...store, reputation }));
-    }
   }
 
   async remove(id: string): Promise<void> {

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -39,7 +39,8 @@ export default function AdminDashboardScreen() {
     averageRating: 0,
     totalStock: 0,
     pendingKycRequests: 0,
-    totalUsers: 0
+    totalUsers: 0,
+    storeReputation: 0
   });
   const { showNotification } = useNotifications();
   const { isAdmin, isDriver, user } = useAuth();
@@ -71,14 +72,15 @@ export default function AdminDashboardScreen() {
       const db = DatabaseService.getInstance();
       const notificationService = NotificationService.getInstance();
       
-      const [productsData, chatRoomsData, notificationsData, reviewsData, pendingKycRequests, allUsers, reportsData] = await Promise.all([
+      const [productsData, chatRoomsData, notificationsData, reviewsData, pendingKycRequests, allUsers, reportsData, storesData] = await Promise.all([
         db.getProducts(),
         db.getChatRooms(),
         notificationService.getNotifications(user?.id),
         db.getReviews(),
         db.getPendingKycRequests(),
         db.getAllUserProfiles(),
-        moderationAgent.getAll()
+        moderationAgent.getAll(),
+        storesAgent.getAll()
       ]);
       
       setProducts(productsData);
@@ -95,6 +97,10 @@ export default function AdminDashboardScreen() {
       const unreadNotifications = notificationsData.filter(n => !n.read).length;
       const activeChats = chatRoomsData.filter(room => room.unreadCount > 0).length;
 
+      const storeReputation = storesData.length > 0
+        ? storesData.reduce((sum, s) => sum + storesAgent.getReputationScore(s.id), 0) / storesData.length
+        : 0;
+
       setStats({
         totalProducts: productsData.length,
         totalReviews: reviewsData.length,
@@ -103,7 +109,8 @@ export default function AdminDashboardScreen() {
         averageRating,
         totalStock,
         pendingKycRequests: pendingKycRequests.length,
-        totalUsers: allUsers.length
+        totalUsers: allUsers.length,
+        storeReputation
       });
       
       // Show a welcome notification
@@ -258,40 +265,50 @@ export default function AdminDashboardScreen() {
           </View>
 
           <View style={styles.statsRow}>
-            <View style={[styles.statCard, { 
+          <View style={[styles.statCard, {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.border.primary
+          }]}> 
+            <Users size={32} color={colors.gold} />
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}>{stats.totalUsers}</Text>
+            <Text style={[styles.statLabel, { color: colors.text.secondary }]}>משתמשים</Text>
+          </View>
+          <View style={[
+            styles.statCard,
+            stats.pendingKycRequests > 0 ? [styles.highlightedStatCard, {
+              backgroundColor: colors.interactive.secondary,
+              borderColor: colors.status.warning
+            }] : {
               backgroundColor: colors.surface.primary,
-              borderColor: colors.border.primary 
-            }]}>
-              <Users size={32} color={colors.gold} />
-              <Text style={[styles.statNumber, { color: colors.text.primary }]}>{stats.totalUsers}</Text>
-              <Text style={[styles.statLabel, { color: colors.text.secondary }]}>משתמשים</Text>
-            </View>
-            <View style={[
-              styles.statCard, 
-              stats.pendingKycRequests > 0 ? [styles.highlightedStatCard, { 
-                backgroundColor: colors.interactive.secondary,
-                borderColor: colors.status.warning 
-              }] : { 
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary 
-              }
+              borderColor: colors.border.primary
+            }
+          ]}>
+            <Clock size={32} color={stats.pendingKycRequests > 0 ? colors.status.warning : colors.gold} />
+            <Text style={[
+              styles.statNumber,
+              stats.pendingKycRequests > 0 ? [styles.highlightedStatNumber, { color: colors.status.warning }] : { color: colors.text.primary }
             ]}>
-              <Clock size={32} color={stats.pendingKycRequests > 0 ? colors.status.warning : colors.gold} />
-              <Text style={[
-                styles.statNumber,
-                stats.pendingKycRequests > 0 ? [styles.highlightedStatNumber, { color: colors.status.warning }] : { color: colors.text.primary }
-              ]}>
-                {stats.pendingKycRequests}
-              </Text>
-              <Text style={[
-                styles.statLabel,
-                stats.pendingKycRequests > 0 ? [styles.highlightedStatLabel, { color: colors.status.warning }] : { color: colors.text.secondary }
-              ]}>
-                בקשות KYC ממתינות
-              </Text>
-            </View>
+              {stats.pendingKycRequests}
+            </Text>
+            <Text style={[
+              styles.statLabel,
+              stats.pendingKycRequests > 0 ? [styles.highlightedStatLabel, { color: colors.status.warning }] : { color: colors.text.secondary }
+            ]}>
+              בקשות KYC ממתינות
+            </Text>
           </View>
         </View>
+        <View style={styles.statsRow}>
+          <View style={[styles.statCard, {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.border.primary
+          }]}> 
+            <TrendingUp size={32} color={colors.gold} />
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}>{stats.storeReputation.toFixed(1)}</Text>
+            <Text style={[styles.statLabel, { color: colors.text.secondary }]}>מוניטין חנויות</Text>
+          </View>
+        </View>
+      </View>
 
         {/* Quick Actions */}
         <View style={styles.section}>

--- a/app/storefront/[id].tsx
+++ b/app/storefront/[id].tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import storesAgent from '../../agents/stores-agent';
+import { useTheme } from '../../contexts/ThemeContext';
+import { Store } from '../../types';
+
+export default function StorefrontStoreScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors } = useTheme();
+  const [store, setStore] = useState<Store | null>(null);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    let callback: ((sid: string, s: number) => void) | undefined;
+    const load = async () => {
+      if (!id) return;
+      const s = await storesAgent.get(id);
+      setStore(s);
+      setScore(storesAgent.getReputationScore(id));
+      callback = (sid: string, sc: number) => {
+        if (sid === id) setScore(sc);
+      };
+      storesAgent.subscribe(callback);
+    };
+    load();
+    return () => {
+      if (callback) storesAgent.unsubscribe(callback);
+    };
+  }, [id]);
+
+  if (!store) {
+    return (
+      <View
+        style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.background }}
+      >
+        <Text style={{ color: colors.text.primary }}>Store not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.name, { color: colors.text.primary }]}>{store.name}</Text>
+      <Text style={{ color: colors.text.secondary }}>Reputation: {score.toFixed(1)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  name: { fontSize: 24, fontWeight: 'bold', marginBottom: 8 },
+});
+

--- a/tests/databaseService.test.ts
+++ b/tests/databaseService.test.ts
@@ -8,8 +8,8 @@ beforeEach(() => {
   (DatabaseService as any).instance = undefined;
   (productsAgent as any).store.clear();
   (categoriesAgent as any).store.clear();
-  (storesAgent as any).store.clear();
   (tonAuth as any).getAddress = () => 'owner1';
+  (tonAuth as any).getTonPublicKey = () => 'pub';
   (productsAgent as any).sendFn = async () => {};
   (productsAgent as any).clearHashCache();
 });

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -18,6 +18,7 @@ jest.mock('../services/tonOrders', () => ({
 }));
 
 jest.mock('../agents/notifications-agent', () => ({ broadcast: jest.fn() }));
+jest.mock('../agents/stores-agent', () => ({ updateReputationByOwner: jest.fn() }));
 
 jest.mock('../services/tonContract', () => ({
   deployOrderPayment: jest.fn().mockResolvedValue({ contractAddress: 'escrow1', txHash: 'tx1' }),

--- a/tests/reputation.test.ts
+++ b/tests/reputation.test.ts
@@ -1,0 +1,107 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('../services/tonStores', () => ({
+  getStore: jest.fn(async (id: string) => ({ id, name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 })),
+  setStore: jest.fn(async () => {}),
+  listStores: jest.fn(async () => [{ id: 's1', name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 }]),
+  removeStore: jest.fn(),
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  getAddress: jest.fn().mockReturnValue('addr'),
+  getTonPublicKey: jest.fn().mockReturnValue('pub'),
+  openModal: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ id: 's1' }),
+  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+}));
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: { primary: '#fff' },
+      text: { primary: '#000', secondary: '#666', tertiary: '#999', inverse: '#fff' },
+      border: { primary: '#000' },
+      gold: '#ff0',
+      status: { warning: 'orange', error: 'red' },
+      interactive: { secondary: '#eee' },
+    },
+  }),
+}));
+
+jest.mock('../components/NotificationContext', () => ({
+  useNotifications: () => ({ showNotification: jest.fn() }),
+}));
+
+jest.mock('../components/AuthContext', () => ({
+  useAuth: () => ({ isAdmin: true, isDriver: false, user: { id: 'u1' } }),
+}));
+
+jest.mock('../components/AuthModalContext', () => ({
+  useAuthModal: () => ({ openAuthModal: jest.fn() }),
+}));
+
+jest.mock('../services/database', () => ({
+  getInstance: () => ({
+    getProducts: jest.fn(async () => []),
+    getChatRooms: jest.fn(async () => []),
+    getReviews: jest.fn(async () => []),
+    getPendingKycRequests: jest.fn(async () => []),
+    getAllUserProfiles: jest.fn(async () => []),
+  }),
+}));
+
+jest.mock('../services/notification', () => ({
+  getInstance: () => ({ getNotifications: jest.fn(async () => []) }),
+}));
+
+jest.mock('../agents/moderation-agent', () => ({
+  getAll: jest.fn(async () => []),
+  reportStore: jest.fn(),
+}));
+
+jest.mock('../agents/products-agent', () => ({ remove: jest.fn() }));
+
+jest.mock('../components/InfoModal', () => () => null);
+jest.mock('../components/LoadingSpinner', () => () => null);
+
+// minimal mocks for unused components
+jest.mock('../components/ProductCard', () => ({ __esModule: true, default: () => null }));
+
+import storesAgent from '../agents/stores-agent';
+import StorefrontStoreScreen from '../app/storefront/[id]';
+import AdminDashboardScreen from '../app/admin/dashboard';
+
+describe('store reputation', () => {
+  it('aggregates reviews and orders into reputation score', async () => {
+    await storesAgent.recordReview('s1', 4);
+    expect(storesAgent.getReputationScore('s1')).toBeCloseTo(2);
+    await storesAgent.updateReputationByOwner('owner1', 1);
+    expect(storesAgent.getReputationScore('s1')).toBeCloseTo(4.5);
+  });
+
+  it('displays reputation score in storefront and admin dashboard', async () => {
+    jest.spyOn(storesAgent, 'get').mockResolvedValue({ id: 's1', name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 } as any);
+    jest.spyOn(storesAgent, 'getAll').mockResolvedValue([{ id: 's1', name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 }] as any);
+    jest.spyOn(storesAgent, 'getReputationScore').mockReturnValue(4.5);
+    jest.spyOn(storesAgent, 'subscribe').mockImplementation(() => {});
+    jest.spyOn(storesAgent, 'unsubscribe').mockImplementation(() => {});
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StorefrontStoreScreen />);
+    });
+    expect(JSON.stringify(root!.toJSON())).toContain('4.5');
+
+    let adminRoot: renderer.ReactTestRenderer;
+    await act(async () => {
+      adminRoot = renderer.create(<AdminDashboardScreen />);
+    });
+    expect(JSON.stringify(adminRoot!.toJSON())).toContain('4.5');
+  });
+});
+

--- a/tests/reviewAgent.test.ts
+++ b/tests/reviewAgent.test.ts
@@ -24,6 +24,14 @@ jest.mock('../agents/orders-agent', () => ({
   get: jest.fn(async (id: string) => orders[id] || null),
 }));
 
+jest.mock('../agents/products-agent', () => ({
+  get: jest.fn(async () => ({ id: 'p1', storeId: 's1' })),
+}));
+
+jest.mock('../agents/stores-agent', () => ({
+  recordReview: jest.fn(async () => {}),
+}));
+
 jest.mock('../services/tonAuth', () => ({
   getAddress: jest.fn().mockReturnValue('user1'),
   getTonPublicKey: jest.fn().mockReturnValue('pub'),


### PR DESCRIPTION
## Summary
- aggregate reviews and order outcomes into per-store reputation scores
- expose reputation in storefront store screen and admin dashboard
- add tests for reputation aggregation and display

## Testing
- `yarn install --frozen-lockfile` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*
- `npx -y jest tests/reputation.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8ac3444c83268ad5191639f3905a