### PR TITLE
feat: ton escrow tracking & multi-seller checkout test

### DIFF
--- a/components/EscrowStatusTracker.tsx
+++ b/components/EscrowStatusTracker.tsx
@@ -1,7 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import ordersAgent from '../agents/orders-agent';
-import { Order } from '../types';
+import { Order, OrderStatus } from '../types';
+
+const LABELS: Record<OrderStatus | 'unknown', string> = {
+  order_received: 'Escrow funded',
+  courier_found: 'Escrow funded',
+  courier_picked_up: 'Escrow funded',
+  courier_on_way: 'Escrow funded',
+  delivered: 'Escrow funded',
+  disputed: 'Disputed',
+  released: 'Released to seller',
+  refunded: 'Refunded to buyer',
+  unknown: 'Loading...',
+};
 
 interface Props {
   orderId: string;
@@ -11,39 +23,39 @@ export default function EscrowStatusTracker({ orderId }: Props) {
   const [order, setOrder] = useState<Order | null>(null);
 
   useEffect(() => {
-    let active = true;
-    const load = async () => {
+    let mounted = true;
+    const fetchOrder = async () => {
       const o = await ordersAgent.get(orderId);
-      if (active) setOrder(o);
+      if (mounted) setOrder(o);
     };
-    load();
-    const cb = (o: Order) => {
-      if (o.id === orderId) setOrder(o);
+    fetchOrder();
+    const sub = (updated: Order) => {
+      if (updated.id === orderId) setOrder(updated);
     };
-    ordersAgent.subscribe(cb);
+    ordersAgent.subscribe(sub);
     return () => {
-      active = false;
-      ordersAgent.unsubscribe(cb);
+      mounted = false;
+      ordersAgent.unsubscribe(sub);
     };
   }, [orderId]);
 
-  if (!order) return null;
-
-  let message = 'Awaiting payment';
-  if (order.paymentTxHash && order.status === 'order_received') {
-    message = 'Escrow funded';
-  }
-  if (order.status === 'delivered') {
-    message = 'Awaiting release';
-  } else if (order.status === 'released') {
-    message = 'Payment released';
-  } else if (order.status === 'refunded') {
-    message = 'Payment refunded';
-  }
+  const status: OrderStatus | 'unknown' = order?.status || 'unknown';
+  const label = LABELS[status];
 
   return (
-    <View>
-      <Text>{message}</Text>
+    <View style={styles.container}>
+      <Text style={styles.title}>Escrow Status</Text>
+      <Text style={styles.status}>{label}</Text>
+      {order?.escrowAddr && (
+        <Text style={styles.address}>Contract: {order.escrowAddr}</Text>
+      )}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  title: { fontSize: 16, fontWeight: 'bold', marginBottom: 8 },
+  status: { fontSize: 14 },
+  address: { fontSize: 12, marginTop: 4 },
+});

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,9 +1,15 @@
 import ordersAgent from '../agents/orders-agent';
-import { Order, OrderStatus, CartItem, ShippingAddress, OrderTrackingStep } from '../types';
+import {
+  Order,
+  OrderStatus,
+  CartItem,
+  ShippingAddress,
+  OrderTrackingStep,
+} from '../types';
 import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
-import { adminResolve } from './tonContract';
+import { adminResolve, deployOrderPayment } from './tonContract';
 
 class OrderService {
   private static instance: OrderService;
@@ -78,6 +84,15 @@ class OrderService {
       return sum + price * item.quantity;
     }, 0);
 
+    let pay = payment;
+    if (pay?.method === 'ton' && (!pay.contractAddress || !pay.txHash)) {
+      if (!tonAuth.getAddress() || !tonAuth.getTonPublicKey()) {
+        await tonAuth.openModal();
+      }
+      const { contractAddress, txHash } = await deployOrderPayment(total);
+      pay = { ...pay, contractAddress, txHash };
+    }
+
     const orderId = `order_${Date.now()}`;
     const timestamp = new Date().toISOString();
     const itemsHash = Buffer.from(
@@ -91,12 +106,12 @@ class OrderService {
       status: 'order_received',
       shippingAddress,
        itemsHash,
-      paymentMethod: payment?.method ?? 'cash_on_delivery',
-      buyerAddress: payment?.buyerAddress,
-      sellerAddress: payment?.sellerAddress,
-      paymentContractAddress: payment?.contractAddress,
-      escrowAddr: payment?.contractAddress,
-      paymentTxHash: payment?.txHash,
+      paymentMethod: pay?.method ?? 'cash_on_delivery',
+      buyerAddress: pay?.buyerAddress,
+      sellerAddress: pay?.sellerAddress,
+      paymentContractAddress: pay?.contractAddress,
+      escrowAddr: pay?.contractAddress,
+      paymentTxHash: pay?.txHash,
       createdAt: timestamp,
       updatedAt: timestamp,
       trackingSteps: this.getTrackingSteps('order_received'),

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -1,4 +1,5 @@
 import OrderService from '../services/orders';
+import { deployOrderPayment } from '../services/tonContract';
 import { CartItem, ShippingAddress } from '../types';
 
 const mockStore: Record<string, any> = {};
@@ -95,9 +96,15 @@ describe('multi-seller checkout flow', () => {
 
     const orders = await svc.createOrdersFromCart('user1', items, shipping, 'ton');
     expect(orders).toHaveLength(2);
+    expect(deployOrderPayment).toHaveBeenCalledTimes(2);
     const totals = orders.map((o) => o.total).sort();
     expect(totals).toEqual([5, 6]);
     expect(orders.every((o) => o.paymentMethod === 'ton')).toBe(true);
+    const escrows = orders.map((o) => o.escrowAddr).sort();
+    expect(escrows).toEqual(['escrow_5', 'escrow_6']);
+    expect(orders.every((o) => o.paymentTxHash && o.paymentContractAddress)).toBe(
+      true,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- trigger TonConnect escrow deployment during order creation
- expose EscrowStatusTracker component for live escrow updates
- cover multi-seller TON checkout in tests

## Testing
- `npx jest` *(fails: 8 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a9077943483268eb346f66bc724cc