### PR TITLE
feat: storefront catalog and owner dashboard tests

### DIFF
--- a/app/storefront/[id].tsx
+++ b/app/storefront/[id].tsx
@@ -1,15 +1,24 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import storesAgent from '../../agents/stores-agent';
+import productsAgent from '../../agents/products-agent';
+import reviewAgent from '../../agents/review-agent';
+import ProductCard from '../../components/ProductCard';
 import { useTheme } from '../../contexts/ThemeContext';
-import { Store } from '../../types';
+import { Store, Product } from '../../types';
+
+interface ReviewMap {
+  [productId: string]: { rating: number; count: number };
+}
 
 export default function StorefrontStoreScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { colors } = useTheme();
   const [store, setStore] = useState<Store | null>(null);
   const [score, setScore] = useState(0);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [reviews, setReviews] = useState<ReviewMap>({});
 
   useEffect(() => {
     let callback: ((sid: string, s: number) => void) | undefined;
@@ -18,6 +27,22 @@ export default function StorefrontStoreScreen() {
       const s = await storesAgent.get(id);
       setStore(s);
       setScore(storesAgent.getReputationScore(id));
+      const all = await productsAgent.getAll();
+      const filtered = all.filter((p) => p.storeId === id);
+      setProducts(filtered);
+      const entries = await Promise.all(
+        filtered.map(async (p) => {
+          const revs = await reviewAgent.getByProduct(p.id);
+          const count = revs.length;
+          const rating = count > 0 ? revs.reduce((a, r) => a + r.rating, 0) / count : 0;
+          return [p.id, { rating, count }] as [string, { rating: number; count: number }];
+        })
+      );
+      const map: ReviewMap = {};
+      entries.forEach(([pid, data]) => {
+        map[pid] = data;
+      });
+      setReviews(map);
       callback = (sid: string, sc: number) => {
         if (sid === id) setScore(sc);
       };
@@ -40,15 +65,35 @@ export default function StorefrontStoreScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+    >
       <Text style={[styles.name, { color: colors.text.primary }]}>{store.name}</Text>
-      <Text style={{ color: colors.text.secondary }}>Reputation: {score.toFixed(1)}</Text>
-    </View>
+      <Text style={{ color: colors.text.secondary, marginBottom: 16 }}>
+        Reputation: {score.toFixed(1)}
+      </Text>
+      {products.map((p) => (
+        <View key={p.id} style={styles.product}>
+          <ProductCard product={p} style={{ marginBottom: 4 }} />
+          <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+            ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
+          </Text>
+        </View>
+      ))}
+      {products.length === 0 && (
+        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+          אין מוצרים זמינים
+        </Text>
+      )}
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  name: { fontSize: 24, fontWeight: 'bold', marginBottom: 8 },
+  container: { flex: 1 },
+  content: { padding: 16 },
+  name: { fontSize: 24, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' },
+  product: { marginBottom: 12 },
 });
 

--- a/app/stores/[id]/dashboard.tsx
+++ b/app/stores/[id]/dashboard.tsx
@@ -12,21 +12,17 @@ export default function StoreDashboardScreen() {
   const { colors } = useTheme();
   const { user } = useAuth();
   const [productCount, setProductCount] = useState(0);
+  const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
-    const checkOwner = async () => {
+    const loadStats = async () => {
       if (!id) return;
       const store = await getStore(id);
       if (!store || store.owner !== user?.address) {
         router.replace(`/stores/${id}`);
-        return false;
+        return;
       }
-      return true;
-    };
-
-    const loadStats = async () => {
-      const isOwner = await checkOwner();
-      if (!isOwner) return;
+      setAuthorized(true);
       const products = await listProducts();
       setProductCount(products.filter((p) => p.storeId === id).length);
     };
@@ -34,6 +30,10 @@ export default function StoreDashboardScreen() {
     loadStats();
   }, [id, user?.address]);
   
+
+  if (!authorized) {
+    return null;
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import StoreDashboardScreen from '../app/stores/[id]/dashboard';
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(),
+  router: { replace: jest.fn(), push: jest.fn() },
+}));
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      text: { primary: '#000' },
+      border: { primary: '#000' },
+    },
+  }),
+}));
+
+jest.mock('../services/tonStores', () => ({ getStore: jest.fn() }));
+jest.mock('../services/tonProducts', () => ({ listProducts: jest.fn() }));
+
+jest.mock('../components/AuthContext', () => ({ useAuth: jest.fn() }));
+
+jest.mock('../components/OrderRevenueMetrics', () => ({
+  __esModule: true,
+  default: () => React.createElement('OrderRevenueMetrics', null, 'metrics'),
+}));
+
+describe('StoreDashboardScreen', () => {
+  const { useLocalSearchParams, router } = require('expo-router');
+  const { getStore } = require('../services/tonStores');
+  const { listProducts } = require('../services/tonProducts');
+  const { useAuth } = require('../components/AuthContext');
+
+  beforeEach(() => {
+    useLocalSearchParams.mockReturnValue({ id: 's1' });
+    router.replace.mockReset();
+    listProducts.mockReset();
+    getStore.mockReset();
+    useAuth.mockReset();
+  });
+
+  it('shows metrics for store owner', async () => {
+    getStore.mockResolvedValue({ id: 's1', owner: 'owner1', name: 'Store' });
+    listProducts.mockResolvedValue([
+      { id: 'p1', storeId: 's1' },
+      { id: 'p2', storeId: 's1' },
+    ]);
+    useAuth.mockReturnValue({ user: { address: 'owner1' } });
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StoreDashboardScreen />);
+    });
+    await act(async () => {});
+    const str = JSON.stringify(root!.toJSON());
+    expect(str).toContain('מוצרים: 2');
+    expect(str).toContain('metrics');
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects if not owner', async () => {
+    getStore.mockResolvedValue({ id: 's1', owner: 'owner1', name: 'Store' });
+    useAuth.mockReturnValue({ user: { address: 'other' } });
+    listProducts.mockResolvedValue([]);
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StoreDashboardScreen />);
+    });
+    await act(async () => {});
+    expect(router.replace).toHaveBeenCalledWith('/stores/s1');
+    expect(root!.toJSON()).toBeNull();
+  });
+});

--- a/tests/storefrontStore.test.tsx
+++ b/tests/storefrontStore.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import StorefrontStoreScreen from '../app/storefront/[id]';
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ id: 's1' }),
+}));
+
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      text: { primary: '#000', secondary: '#666', inverse: '#fff' },
+      border: { primary: '#000' },
+    },
+  }),
+}));
+
+jest.mock('../agents/stores-agent', () => ({
+  get: jest.fn(async () => ({ id: 's1', name: 'Test Store' })),
+  getReputationScore: jest.fn(() => 4.5),
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+}));
+
+jest.mock('../agents/products-agent', () => ({
+  getAll: jest.fn(async () => [
+    {
+      id: 'p1',
+      name: 'Apple',
+      storeId: 's1',
+      price: 1,
+      stock: 1,
+      description: '',
+      images: [],
+      category: 'fruits',
+    } as any,
+    {
+      id: 'p2',
+      name: 'Carrot',
+      storeId: 's1',
+      price: 1,
+      stock: 1,
+      description: '',
+      images: [],
+      category: 'vegetables',
+    } as any,
+  ]),
+}));
+
+jest.mock('../agents/review-agent', () => ({
+  getByProduct: jest.fn(async (id: string) => {
+    if (id === 'p1') return [{ rating: 4 }, { rating: 5 }] as any;
+    if (id === 'p2') return [{ rating: 3 }] as any;
+    return [];
+  }),
+}));
+
+jest.mock('../components/ProductCard', () => ({
+  __esModule: true,
+  default: ({ product }: any) => React.createElement('ProductCard', null, product.name),
+}));
+
+describe('StorefrontStoreScreen', () => {
+  it('shows store catalog with reviews', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StorefrontStoreScreen />);
+    });
+    await act(async () => {});
+    const str = JSON.stringify(root!.toJSON());
+    expect(str).toContain('Test Store');
+    expect(str).toContain('Apple');
+    expect(str).toContain('Carrot');
+    expect(str).toContain('⭐ 4.5 (2)');
+    expect(str).toContain('⭐ 3.0 (1)');
+  });
+});


### PR DESCRIPTION
## Summary
- display catalog and review stats on public storefront pages
- enforce owner-only access with order and revenue metrics on store dashboard
- add UI tests covering storefront pages and dashboard access

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a92a78c388326b1625ce9f4dd9b67