### PR TITLE
Add LRU caching for chat room keys and error on missing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ state via its corresponding TON service, keeping a local in-memory cache for
 fast access.
 
 Waku is only used for lightweight messaging such as chat and notification
-payloads.
+payloads. Room keys used to encrypt chats are cached in an LRU map to keep
+memory usage bounded, and encryption/decryption helpers now throw if a key
+cannot be derived instead of returning plaintext.
 
 ### Web Notes
 

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -1,45 +1,54 @@
 import { getPrivateKey } from '../services/localIdentity';
 import { deriveSharedKey, aesEncrypt, aesDecrypt } from './encryption';
 
-const roomKeys: Record<string, CryptoKey | null> = {};
+// roomKeys stores derived AES keys per chat room. To keep memory usage bounded
+// we maintain a simple LRU cache with a fixed size.
+const roomKeys = new Map<string, CryptoKey | null>();
+const MAX_ROOM_KEYS = 100;
 
 export async function getRoomKey(
   roomId: string,
   peerPublicKey: string,
-): Promise<CryptoKey | null> {
-  if (roomKeys.hasOwnProperty(roomId)) return roomKeys[roomId];
+): Promise<CryptoKey> {
+  if (roomKeys.has(roomId)) {
+    const cached = roomKeys.get(roomId);
+    // refresh LRU ordering
+    roomKeys.delete(roomId);
+    roomKeys.set(roomId, cached ?? null);
+    if (cached) return cached;
+    throw new Error('Missing room key');
+  }
   try {
     const myPrivEd = await getPrivateKey();
     const key = await deriveSharedKey(myPrivEd, peerPublicKey, roomId);
-    roomKeys[roomId] = key;
+    roomKeys.set(roomId, key);
+    if (roomKeys.size > MAX_ROOM_KEYS) {
+      const oldest = roomKeys.keys().next().value;
+      roomKeys.delete(oldest);
+    }
     return key;
   } catch (err) {
-    console.warn('Failed to derive room key', err);
-    roomKeys[roomId] = null;
-    return null;
+    roomKeys.set(roomId, null);
+    throw new Error(`Failed to derive room key: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
+/** Encrypt a message with the room key. Throws if the key cannot be derived. */
 export async function encryptMessage(
   msg: string,
   roomId: string,
   peerPublicKey: string,
 ): Promise<string> {
   const key = await getRoomKey(roomId, peerPublicKey);
-  if (!key) return msg;
   return aesEncrypt(msg, key);
 }
 
+/** Decrypt a message with the room key. Throws if the key cannot be derived. */
 export async function decryptMessage(
   msg: string,
   roomId: string,
   peerPublicKey: string,
 ): Promise<string> {
-  try {
-    const key = await getRoomKey(roomId, peerPublicKey);
-    if (!key) return msg;
-    return await aesDecrypt(msg, key);
-  } catch {
-    return msg;
-  }
+  const key = await getRoomKey(roomId, peerPublicKey);
+  return aesDecrypt(msg, key);
 }


### PR DESCRIPTION
## Summary
- cache derived chat room keys in a size-limited LRU map
- throw when a room key cannot be derived so messages are not sent in plaintext
- document chat encryption changes in README

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 12 passed, 22 total)*

------
https://chatgpt.com/codex/tasks/task_e_689aa5dc5bc48326a9b53540592eed8f