### PR TITLE
Refactor TonWeb usage with typed provider and fallback

### DIFF
--- a/components/StoreCreation.tsx
+++ b/components/StoreCreation.tsx
@@ -6,8 +6,9 @@ import storesAgent from '../agents/stores-agent';
 import tonAuth from '../services/tonAuth';
 import codeBoc from '../contracts/store-nft-code.boc';
 import dataBoc from '../contracts/store-nft-data.boc';
+import { getTonWeb } from '../services/tonProvider';
 
-const provider = new TonWeb.HttpProvider('https://testnet.toncenter.com/api/v2/jsonRPC');
+const tonweb = getTonWeb();
 
 const StoreCreation: React.FC = () => {
   const [name, setName] = useState('');
@@ -15,9 +16,11 @@ const StoreCreation: React.FC = () => {
   const deployStoreNFT = async () => {
     const code = TonWeb.boc.Cell.fromBoc(Buffer.from(codeBoc, 'base64'))[0];
     const data = TonWeb.boc.Cell.fromBoc(Buffer.from(dataBoc, 'base64'))[0];
-    const contract = new (TonWeb as any).Contract(provider, { code, data });
+    const contract = new TonWeb.Contract(tonweb.provider, { code, data });
     const init = await contract.createStateInit();
-    const stateInitBoc = TonWeb.utils.bytesToBase64(await init.stateInit.toBoc({ idx: false }));
+    const stateInitBoc = TonWeb.utils.bytesToBase64(
+      await init.stateInit.toBoc(false),
+    );
     const address = (await contract.getAddress()).toString(true, true, true);
     try {
       await (tonAuth as any).tonConnectUI?.sendTransaction({

--- a/contracts/ton/deploy.ts
+++ b/contracts/ton/deploy.ts
@@ -1,10 +1,7 @@
 import { execSync } from 'child_process';
 import path from 'path';
-import TonWeb from 'tonweb';
 import { getTonConnect } from '../../services/tonAuth';
-
-const provider = new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC');
-const tonweb = new TonWeb(provider);
+import { getTonWeb } from '../../services/tonProvider';
 
 export async function compile(contract: string) {
   const file = path.resolve(__dirname, `${contract}.tact`);
@@ -13,6 +10,7 @@ export async function compile(contract: string) {
 
 export async function deploy(contract: string, init: string) {
   await compile(contract);
+  getTonWeb();
   const tonConnect = getTonConnect();
   if (!tonConnect) throw new Error('TonConnect not initialized');
   await tonConnect.sendTransaction({

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -1,5 +1,5 @@
-// @ts-nocheck
 import TonWeb from 'tonweb';
+import type { Cell } from 'tonweb/dist/types/boc/cell';
 import { Buffer } from 'buffer';
 import { createHash } from 'crypto';
 import { getTonConnect } from './tonAuth';
@@ -13,10 +13,10 @@ export const ORDER_PAYMENT_FACTORY_ADDRESS =
   process.env.ORDER_PAYMENT_FACTORY_ADDRESS ??
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 
-function makeComment(message: string): TonWeb.boc.Cell {
+function makeComment(message: string): Cell {
   const cell = new TonWeb.boc.Cell();
-  (cell.bits as any).writeUint(0, 32);
-  (cell.bits as any).writeBytes(TonWeb.utils.stringToBytes(message));
+  cell.bits.writeUint(0, 32);
+  cell.bits.writeBytes(TonWeb.utils.stringToBytes(message));
   return cell;
 }
 
@@ -50,7 +50,7 @@ export async function deployOrderPayment(
       `Pay:${amount}:${feeAddress}:${feePercent}`,
     );
     const payloadBoc = TonWeb.utils.bytesToBase64(
-      await payload.toBoc({ idx: false }),
+      await payload.toBoc(false),
     );
     const txHash = await sendTonConnect([
       {
@@ -72,7 +72,7 @@ export async function releasePayment(contractAddress: string): Promise<string> {
   try {
     const payload = makeComment('Release');
     const payloadBoc = TonWeb.utils.bytesToBase64(
-      await payload.toBoc({ idx: false }),
+      await payload.toBoc(false),
     );
     const txHash = await sendTonConnect([
       {
@@ -92,7 +92,7 @@ export async function refundPayment(contractAddress: string): Promise<string> {
   try {
     const payload = makeComment('Refund');
     const payloadBoc = TonWeb.utils.bytesToBase64(
-      await payload.toBoc({ idx: false }),
+      await payload.toBoc(false),
     );
     const txHash = await sendTonConnect([
       {
@@ -115,7 +115,7 @@ export async function adminResolve(
   try {
     const payload = makeComment(`AdminResolve:${toSeller ? 1 : 0}`);
     const payloadBoc = TonWeb.utils.bytesToBase64(
-      await payload.toBoc({ idx: false }),
+      await payload.toBoc(false),
     );
     const txHash = await sendTonConnect([
       {

--- a/services/tonKvStore.ts
+++ b/services/tonKvStore.ts
@@ -1,16 +1,21 @@
-// @ts-nocheck
 import TonWeb from 'tonweb';
+import type { Cell } from 'tonweb/dist/types/boc/cell';
 import { Buffer } from 'buffer';
 import { getTonConnect } from './tonAuth';
+import { withTonWeb } from './tonProvider';
 
-const provider = new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC');
-const tonweb = new TonWeb(provider);
+interface Slice {
+  readDict<T>(keySize: number, parser: (cell: Slice) => T): Map<bigint, T>;
+  readRemaining(): Uint8Array;
+}
 
-function makeSetPayload(key: string, value: string): TonWeb.boc.Cell {
+type CellWithParse = Cell & { beginParse: () => Slice };
+
+function makeSetPayload(key: string, value: string): Cell {
   const cell = new TonWeb.boc.Cell();
-  (cell.bits as any).writeUint(0, 32);
+  cell.bits.writeUint(0, 32);
   const body = JSON.stringify({ key, value });
-  (cell.bits as any).writeBytes(Buffer.from(body, 'utf8'));
+  cell.bits.writeBytes(Buffer.from(body, 'utf8'));
   return cell;
 }
 
@@ -18,7 +23,7 @@ export async function setValue(address: string, key: string, value: string) {
   const tonConnect = getTonConnect();
   if (!tonConnect) throw new Error('TonConnect not initialized');
   const cell = makeSetPayload(key, value);
-  const payload = TonWeb.utils.bytesToBase64(await cell.toBoc({ idx: false }));
+  const payload = TonWeb.utils.bytesToBase64(await cell.toBoc(false));
   return await tonConnect.sendTransaction({
     validUntil: Math.floor(Date.now() / 1000) + 60,
     messages: [
@@ -33,32 +38,39 @@ export async function removeValue(address: string, key: string) {
 
 export async function getValue(address: string, key: string): Promise<string | null> {
   try {
-    const result = await tonweb.provider.call(address, 'get', [
-      { type: 'int', value: TonWeb.utils.bytesToHex(Buffer.from(key, 'utf8')) },
-    ]);
-    const cellBoc = result.stack?.[0]?.[1]?.bytes;
-    if (!cellBoc) return null;
-    const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(cellBoc, 'base64'))[0];
-    const bytes = (cell.bits as any).array.slice(0, cell.bits.cursor);
-    return Buffer.from(bytes).toString('utf8');
+    return await withTonWeb(async tw => {
+      const result = await tw.provider.call(address, 'get', [
+        { type: 'int', value: TonWeb.utils.bytesToHex(Buffer.from(key, 'utf8')) } as any,
+      ]);
+      const cellBoc = result.stack?.[0]?.[1]?.bytes;
+      if (!cellBoc) return null;
+      const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(cellBoc, 'base64'))[0];
+      const bytes = cell.bits.array.slice(0, cell.bits.cursor);
+      return Buffer.from(bytes).toString('utf8');
+    });
   } catch (e) {
+    console.error('Failed to get value', e);
     return null;
   }
 }
 
 export async function listValues(address: string): Promise<{ key: string; value: string }[]> {
   try {
-    const result = await tonweb.provider.call(address, 'list', []);
-    const dictBoc = result.stack?.[0]?.[1]?.bytes;
-    if (!dictBoc) return [];
-    const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(dictBoc, 'base64'))[0];
-    const dict = cell.beginParse().readDict(256, (c: any) => c.readRemaining());
-    const items: { key: string; value: string }[] = [];
-    for (const [k, v] of dict.entries()) {
-      items.push({ key: k.toString(), value: Buffer.from(v).toString('utf8') });
-    }
-    return items;
-  } catch {
+    return await withTonWeb(async tw => {
+      const result = await tw.provider.call(address, 'list', []);
+      const dictBoc = result.stack?.[0]?.[1]?.bytes;
+      if (!dictBoc) return [];
+      const cell = TonWeb.boc.Cell.fromBoc(Buffer.from(dictBoc, 'base64'))[0];
+      const slice = (cell as CellWithParse).beginParse();
+      const dict = slice.readDict<Uint8Array>(256, (c: Slice) => c.readRemaining());
+      const items: { key: string; value: string }[] = [];
+      for (const [k, v] of dict.entries()) {
+        items.push({ key: k.toString(), value: Buffer.from(v).toString('utf8') });
+      }
+      return items;
+    });
+  } catch (e) {
+    console.error('Failed to list values', e);
     return [];
   }
 }

--- a/services/tonProvider.ts
+++ b/services/tonProvider.ts
@@ -1,0 +1,24 @@
+import TonWeb from 'tonweb';
+
+const DEFAULT_RPC = 'https://toncenter.com/api/v2/jsonRPC';
+const FALLBACK_RPC = process.env.TON_RPC_FALLBACK_URLS?.split(',').filter(Boolean) ?? [];
+const RPC_ENDPOINTS = [process.env.TON_RPC_URL || DEFAULT_RPC, ...FALLBACK_RPC];
+
+export function getTonWeb(url: string = RPC_ENDPOINTS[0]): TonWeb {
+  const provider = new TonWeb.HttpProvider(url);
+  return new TonWeb(provider);
+}
+
+export async function withTonWeb<T>(callback: (tonweb: TonWeb) => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (const url of RPC_ENDPOINTS) {
+    try {
+      const tonweb = getTonWeb(url);
+      return await callback(tonweb);
+    } catch (error) {
+      lastError = error;
+      console.error(`Ton RPC call failed for ${url}`, error);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` from TonWeb services and add proper TypeScript types
- centralize TonWeb provider via environment variables with optional fallbacks
- add error logging and retry logic around Ton RPC calls

## Testing
- `yarn lint` *(fails: React Hooks lint errors)*
- `yarn test` *(fails: multiple test suite failures and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_689aa5e2e0b48326bf28c5d856ae5263