### PR TITLE
Use UUIDs for order notifications

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Order, OrderStatus, Notification } from '../types';
 import tonAuth from '../services/tonAuth';
 import notificationsAgent from './notifications-agent';
@@ -228,7 +229,7 @@ class OrdersAgent {
 
   private async notifyStatusChange(order: Order) {
     const notification: Notification = {
-      id: `ntf_${Date.now()}`,
+      id: randomUUID(),
       userId: order.userId,
       title: 'Order status updated',
       message: `Order ${order.id} status changed to ${order.status}`,
@@ -245,7 +246,7 @@ class OrdersAgent {
 
   private async notifyOrderCreated(order: Order) {
     const notification: Notification = {
-      id: `ntf_${Date.now()}`,
+      id: randomUUID(),
       userId: order.userId,
       title: 'Order created',
       message: `Order ${order.id} has been created`,
@@ -262,7 +263,7 @@ class OrdersAgent {
 
   private async notifyPaymentReceived(order: Order) {
     const notification: Notification = {
-      id: `ntf_${Date.now()}`,
+      id: randomUUID(),
       userId: order.userId,
       title: 'Payment received',
       message: `Payment for order ${order.id} has been released`,
@@ -279,7 +280,7 @@ class OrdersAgent {
 
   private async notifyDisputeUpdate(order: Order) {
     const notification: Notification = {
-      id: `ntf_${Date.now()}`,
+      id: randomUUID(),
       userId: order.userId,
       title: 'Order dispute updated',
       message: `Order ${order.id} dispute status: ${order.status}`,

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -41,6 +41,7 @@ const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
 (getPrivateKey as jest.Mock).mockResolvedValue(sellerKey.secretKey);
 
 const ordersAgent = require('../agents/orders-agent').default;
+const notificationsAgent = require('../agents/notifications-agent');
 
 describe('ordersAgent.add', () => {
   it('encrypts shipping address and persists new fields', async () => {
@@ -99,6 +100,25 @@ describe('ordersAgent.add', () => {
     expect(persisted?.escrowAddr).toBe('escrow1');
     expect(persisted?.itemsHash).toBe(itemsHash);
     expect(persisted?.shipAddrEnc).toBeDefined();
+  });
+});
+
+describe('ordersAgent notification IDs', () => {
+  it('generates unique IDs under rapid calls', async () => {
+    notificationsAgent.broadcast.mockClear();
+    const order = { id: 'o1', userId: 'u1' } as any;
+    const notify = (ordersAgent as any).notifyOrderCreated.bind(ordersAgent);
+    const originalNow = Date.now;
+    Date.now = () => 123;
+    try {
+      await Promise.all(Array.from({ length: 5 }).map(() => notify(order)));
+    } finally {
+      Date.now = originalNow;
+    }
+    const ids = notificationsAgent.broadcast.mock.calls.map((c: any) => c[1].id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const timestamps = notificationsAgent.broadcast.mock.calls.map((c: any) => c[1].timestamp);
+    expect(timestamps.every((ts: number) => ts === 123)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- switch order notification IDs to `crypto.randomUUID` and keep separate timestamp metadata
- test that rapid notification calls produce unique IDs

## Testing
- `yarn test tests/ordersAgent.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689acb8eade88326a07a3be591ac8526