### PR TITLE
chore: guard TON private key and use signing API

### DIFF
--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -9,8 +9,7 @@ import OrderService from '../../services/orders';
 import { Order, OrderStatus, ShippingAddress } from '../../types';
 import { ALLOWED_STATUS_TRANSITIONS } from '../../agents/orders-agent';
 import tonAuth from '../../services/tonAuth';
-import * as nacl from 'tweetnacl';
-import * as ed2curve from 'ed2curve';
+import { decryptOrderShipping } from '../../services/sellerTools';
 
 export default function OrderDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -31,24 +30,17 @@ export default function OrderDetailScreen() {
       const raw: any = await svc.getOrder(id);
       let decrypted = raw as Order | null;
       if (raw && raw.shipAddrEnc && isSeller) {
-        const priv = tonAuth.getTonPrivateKey();
-        if (priv) {
-          try {
-            const privX = ed2curve.convertSecretKey(Buffer.from(priv, 'hex'));
-            const { cipher, nonce, ephem } = raw.shipAddrEnc;
-            const msg = nacl.box.open(
-              Buffer.from(cipher, 'base64'),
-              Buffer.from(nonce, 'base64'),
-              Buffer.from(ephem, 'base64'),
-              privX,
-            );
-            if (msg) {
-              raw.shippingAddress = JSON.parse(Buffer.from(msg).toString());
+        try {
+          const sig = await tonAuth.requestSignature(Buffer.from(raw.id));
+          if (sig) {
+            const addr = await decryptOrderShipping(raw);
+            if (addr) {
+              raw.shippingAddress = addr;
               decrypted = raw as Order;
             }
-          } catch (err) {
-            console.warn('Failed to decrypt shipping address', err);
           }
+        } catch (err) {
+          console.warn('Failed to decrypt shipping address', err);
         }
       }
       setOrder(decrypted);

--- a/services/tonAuth.tsx
+++ b/services/tonAuth.tsx
@@ -70,15 +70,31 @@ export const getTonPublicKey = (): string | null =>
 export const getAddress = (): string | null =>
   tonConnect?.account?.address ?? null;
 
-// Attempt to access the private key if the wallet exposes it
-export const getTonPrivateKey = (): string | null =>
-  (tonConnect?.account as any)?.privateKey ?? null;
+/**
+ * Direct access to a wallet's private key is extremely dangerous and should
+ * never occur in production builds.  Instead, wallets expose signing APIs
+ * that keep the key material inside the wallet.  For development and testing
+ * scenarios only, the private key can be accessed by explicitly opting in via
+ * the `ENABLE_UNSAFE_TON_PRIVATE_KEY` environment variable.  When the flag is
+ * unset this function will always return `null`.
+ */
+export const getTonPrivateKey = (): string | null => {
+  if (process.env.ENABLE_UNSAFE_TON_PRIVATE_KEY !== 'true') {
+    return null;
+  }
+  return (tonConnect?.account as any)?.privateKey ?? null;
+};
 
-export default {
+const api = {
   getTonConnect,
   requestSignature,
   openModal,
   getTonPublicKey,
   getAddress,
-  getTonPrivateKey,
-};
+} as const;
+
+if (process.env.ENABLE_UNSAFE_TON_PRIVATE_KEY === 'true') {
+  (api as any).getTonPrivateKey = getTonPrivateKey;
+}
+
+export default api;

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -3,7 +3,6 @@ import usersAgent from '../agents/users-agent';
 jest.mock('../services/tonAuth', () => ({
   getAddress: () => 'addr_admin',
   getTonPublicKey: () => 'pub_admin',
-  getTonPrivateKey: () => 'priv_admin',
   openModal: jest.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- gate `getTonPrivateKey` behind ENABLE_UNSAFE_TON_PRIVATE_KEY flag
- use signature based flow when decrypting shipping info
- drop private key dependency from tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689acb8add608326b903c237ab34f6e7