### PR TITLE
Validate feePercent parsing

### DIFF
--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -34,6 +34,17 @@ export async function fetchSettings(): Promise<TonSettings> {
   for (const { key, value } of entries) {
     map[key] = value;
   }
+  let feePercent = 0;
+  if (map['feePercent'] !== undefined) {
+    const parsed = Number(map['feePercent']);
+    if (Number.isNaN(parsed)) {
+      console.warn(
+        `Invalid feePercent value "${map['feePercent']}"; defaulting to 0`,
+      );
+    } else {
+      feePercent = parsed;
+    }
+  }
   return {
     tenantId: map['tenantId'] ?? 'thecongress',
     appName: map['appName'] ?? 'Blue Ocean',
@@ -41,7 +52,7 @@ export async function fetchSettings(): Promise<TonSettings> {
     brand: { logoCid: map['brand.logoCid'] ?? '' },
     fiatKey: map['fiatKey'],
     feeAddress: map['feeAddress'] ?? '',
-    feePercent: map['feePercent'] ? parseInt(map['feePercent']) : 0,
+    feePercent,
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
   };
 }

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { insertConfig } from './testUtils';
+jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 import { loadTenantSettings } from '../constants/tenant';
 
 var __DEV__ = false;

--- a/tests/tonSettings.test.ts
+++ b/tests/tonSettings.test.ts
@@ -1,0 +1,21 @@
+import { fetchSettings } from '../services/tonSettings';
+
+jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
+
+const { setValue, __clear } = require('./tonKvMock');
+
+describe('fetchSettings feePercent parsing', () => {
+  beforeEach(() => {
+    __clear();
+  });
+
+  it('defaults feePercent to 0 for non-numeric values', async () => {
+    await setValue('', 'feePercent', 'not-a-number');
+    await expect(fetchSettings()).resolves.toMatchObject({ feePercent: 0 });
+  });
+
+  it('handles float feePercent values', async () => {
+    await setValue('', 'feePercent', '1.5');
+    await expect(fetchSettings()).resolves.toMatchObject({ feePercent: 1.5 });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `feePercent` settings are parsed as numbers and fall back to `0` when invalid
- cover non-numeric and float `feePercent` values with unit tests

## Testing
- `yarn test tests/tonSettings.test.ts`
- `yarn test` *(fails: SyntaxError: Unexpected token '<', PinataService validates CID, TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_689acb89730883269f3bfc14080fd741