### PR TITLE
Emit order events for TON escrow

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -20,7 +20,8 @@ type NotificationEvent =
   | 'order.created'
   | 'payment.received'
   | 'status.updated'
-  | 'dispute.updated';
+  | 'dispute.updated'
+  | 'escrow.deployed';
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,4 +1,5 @@
 import ordersAgent from '../agents/orders-agent';
+import notificationsAgent from '../agents/notifications-agent';
 import {
   Order,
   OrderStatus,
@@ -10,6 +11,30 @@ import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
+
+export async function emitOrderEvents(order: Order, storeId: string) {
+  const payload = {
+    id: order.id,
+    orderId: order.id,
+    storeId,
+    buyerAddress: order.buyerAddress,
+    sellerAddress: order.sellerAddress,
+    payment: {
+      method: order.paymentMethod,
+      contractAddress: order.paymentContractAddress,
+      txHash: order.paymentTxHash,
+      total: order.total,
+    },
+  };
+  try {
+    await notificationsAgent.broadcast('order.created', payload as any);
+    if (order.paymentMethod === 'ton') {
+      await notificationsAgent.broadcast('escrow.deployed' as any, payload as any);
+    }
+  } catch (err) {
+    console.error('Failed to emit order events', err);
+  }
+}
 
 class OrderService {
   private static instance: OrderService;
@@ -156,6 +181,7 @@ class OrderService {
         shippingAddress,
         payment,
       );
+      await emitOrderEvents(order, storeId);
       orders.push(order);
     }
     return orders;

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -105,6 +105,24 @@ describe('multi-seller checkout flow', () => {
     expect(orders.every((o) => o.paymentTxHash && o.paymentContractAddress)).toBe(
       true,
     );
+
+    const notificationsAgent = require('../agents/notifications-agent');
+    expect(notificationsAgent.broadcast).toHaveBeenCalledTimes(4);
+    const events = notificationsAgent.broadcast.mock.calls.map((c: any) => c[0]);
+    expect(events).toEqual([
+      'order.created',
+      'escrow.deployed',
+      'order.created',
+      'escrow.deployed',
+    ]);
+
+    const firstPayload = notificationsAgent.broadcast.mock.calls[0][1];
+    expect(firstPayload.orderId).toBe(orders[0].id);
+    expect(firstPayload.storeId).toBe('s1');
+    expect(firstPayload.buyerAddress).toBe('buyer_address');
+    expect(firstPayload.sellerAddress).toBe('seller_s1');
+    expect(firstPayload.payment.method).toBe('ton');
+    expect(firstPayload.payment.contractAddress).toBe('escrow_5');
   });
 });
 


### PR DESCRIPTION
## Summary
- add `emitOrderEvents` helper to broadcast `order.created` and `escrow.deployed`
- fire events after each order creation from cart
- allow notifications agent to handle new `escrow.deployed` event and test

## Testing
- `npm test` *(fails: jest not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4".)*

------
https://chatgpt.com/codex/tasks/task_e_689adca661f883268d680fd5478a5756