### PR TITLE
feat: add notification templates

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -16,11 +16,41 @@ import {
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 
-type NotificationEvent =
+const DEFAULT_BOOTSTRAP =
+  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
+const ORDER_TOPIC = '/congress/orders/1';
+
+export type NotificationEvent =
   | 'order.created'
   | 'payment.received'
   | 'status.updated'
   | 'dispute.updated';
+
+type NotificationTemplate = (
+  item: Notification,
+) => {
+  contentTopic: string;
+  payload: any;
+};
+
+export const notificationTemplates: Record<NotificationEvent, NotificationTemplate> = {
+  'order.created': (item) => ({
+    contentTopic: ORDER_TOPIC,
+    payload: { type: 'order.created', notification: item },
+  }),
+  'payment.received': (item) => ({
+    contentTopic: ORDER_TOPIC,
+    payload: { type: 'payment.received', notification: item },
+  }),
+  'status.updated': (item) => ({
+    contentTopic: ORDER_TOPIC,
+    payload: { type: 'status.updated', notification: item },
+  }),
+  'dispute.updated': (item) => ({
+    contentTopic: ORDER_TOPIC,
+    payload: { type: 'dispute.updated', notification: item },
+  }),
+};
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
@@ -66,7 +96,7 @@ class NotificationsAgent {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item);
+    await this.broadcastWaku(item, event);
   }
 
   subscribe(cb: (n: Notification) => void) {
@@ -93,22 +123,28 @@ class NotificationsAgent {
     }
   }
 
-  private async broadcastWaku(item: Notification) {
+  private async broadcastWaku(item: Notification, event?: NotificationEvent) {
     const node = await this.ensureNode();
     if (!node) return;
     try {
-      const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
-      await node.lightPush.send(encoder, {
-        payload: utf8ToBytes(JSON.stringify(item)),
-      });
+      if (event) {
+        const template = notificationTemplates[event];
+        if (!template) return;
+        const { contentTopic, payload } = template(item);
+        const encoder = createEncoder({ contentTopic });
+        await node.lightPush.send(encoder, {
+          payload: utf8ToBytes(JSON.stringify(payload)),
+        });
+      } else {
+        const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
+        await node.lightPush.send(encoder, {
+          payload: utf8ToBytes(JSON.stringify(item)),
+        });
+      }
     } catch (err) {
       console.error('Failed to broadcast notification', err);
     }
   }
 }
-
-const DEFAULT_BOOTSTRAP =
-  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
-const ORDER_TOPIC = '/congress/orders/1';
 
 export default new NotificationsAgent();

--- a/services/notification.ts
+++ b/services/notification.ts
@@ -1,5 +1,8 @@
 import { Notification } from '../types';
-import notificationsAgent from '../agents/notifications-agent';
+import notificationsAgent, {
+  notificationTemplates,
+  NotificationEvent,
+} from '../agents/notifications-agent';
 
 class NotificationService {
   private static instance: NotificationService;
@@ -123,3 +126,5 @@ class NotificationService {
 }
 
 export default NotificationService;
+
+export { notificationTemplates, NotificationEvent };


### PR DESCRIPTION
## Summary
- define notification template map keyed by event type
- serialize notification payloads using templates when broadcasting to Waku
- expose template definitions through NotificationService for localization

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689adca90290832698a2101fabdb402d