### PR TITLE
Refactor settings fee to basis points and emit write events

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -13,7 +13,7 @@ type SettingKey =
   | 'brand.logoCid'
   | 'fiatKey'
   | 'feeAddress'
-  | 'feePercent';
+  | 'feeBps';
 
 class SettingsAgent {
   private static instance: SettingsAgent;
@@ -32,7 +32,8 @@ class SettingsAgent {
 
   async set(key: string, value: string): Promise<void> {
     await this.ensureWallet();
-    await setSetting(key, value);
+    const actor = tonAuth.getAddress()!;
+    await setSetting(key, value, actor);
   }
 
   async get(key: string): Promise<string | null> {
@@ -56,7 +57,8 @@ class SettingsAgent {
 
   async setAdmins(admins: string[]): Promise<void> {
     await this.ensureWallet();
-    await storeAdmins(admins);
+    const actor = tonAuth.getAddress()!;
+    await storeAdmins(admins, actor);
     this.admins = admins;
   }
 

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -9,7 +9,7 @@ export interface TenantSettings {
   logoCid: string;
   fiatKey?: string;
   feeAddress?: string;
-  feePercent?: number;
+  feeBps?: number;
   admins?: string[];
 }
 
@@ -18,7 +18,7 @@ export let AppConfig: TenantSettings = {
   primaryColor: '#B99C5A',
   logoCid: '',
   feeAddress: '',
-  feePercent: 0,
+  feeBps: 0,
   admins: [],
 };
 
@@ -29,11 +29,11 @@ export async function loadTenantSettings(): Promise<void> {
   const LOGO_KEY = 'app_logo';
   const FIAT_KEY = 'app_fiat_key';
   const FEE_ADDR_KEY = 'app_fee_address';
-  const FEE_PERCENT_KEY = 'app_fee_percent';
+  const FEE_BPS_KEY = 'app_fee_bps';
   const ADMINS_KEY = 'app_admins';
 
   try {
-    const [t, name, color, logo, fiat, feeAddr, feePercent, admins] =
+    const [t, name, color, logo, fiat, feeAddr, feeBps, admins] =
       await AsyncStorage.multiGet([
         TENANT_KEY,
         NAME_KEY,
@@ -41,7 +41,7 @@ export async function loadTenantSettings(): Promise<void> {
         LOGO_KEY,
         FIAT_KEY,
         FEE_ADDR_KEY,
-        FEE_PERCENT_KEY,
+        FEE_BPS_KEY,
         ADMINS_KEY,
       ]);
 
@@ -52,7 +52,7 @@ export async function loadTenantSettings(): Promise<void> {
       logoCid: logo?.[1] || AppConfig.logoCid,
       fiatKey: fiat?.[1] || undefined,
       feeAddress: feeAddr?.[1] || '',
-      feePercent: feePercent?.[1] ? parseInt(feePercent[1]) : 0,
+      feeBps: feeBps?.[1] ? parseInt(feeBps[1]) : 0,
       admins: admins?.[1] ? JSON.parse(admins[1]) : [],
     };
 
@@ -64,7 +64,7 @@ export async function loadTenantSettings(): Promise<void> {
       logoCid: remote.brand.logoCid,
       fiatKey: remote.fiatKey,
       feeAddress: remote.feeAddress ?? '',
-      feePercent: remote.feePercent ?? 0,
+      feeBps: remote.feeBps ?? 0,
       admins: remote.admins ?? [],
     };
 
@@ -75,7 +75,7 @@ export async function loadTenantSettings(): Promise<void> {
       [LOGO_KEY, remote.brand.logoCid],
       [FIAT_KEY, remote.fiatKey ?? ''],
       [FEE_ADDR_KEY, remote.feeAddress ?? ''],
-      [FEE_PERCENT_KEY, String(remote.feePercent ?? 0)],
+      [FEE_BPS_KEY, String(remote.feeBps ?? 0)],
       [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
     ]);
   } catch (e) {
@@ -99,14 +99,14 @@ export async function getAppConfig(): Promise<TenantSettings> {
 
 export async function getFeeSettings(): Promise<{
   feeAddress: string;
-  feePercent: number;
+  feeBps: number;
 }> {
-  if (!AppConfig.feeAddress && !AppConfig.feePercent) {
+  if (!AppConfig.feeAddress && !AppConfig.feeBps) {
     await loadTenantSettings();
   }
   return {
     feeAddress: AppConfig.feeAddress || '',
-    feePercent: AppConfig.feePercent || 0,
+    feeBps: AppConfig.feeBps || 0,
   };
 }
 

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -18,7 +18,7 @@ interface AppInfoContextType {
   themeColor: string;
   fiatKey?: string;
   feeAddress?: string;
-  feePercent?: number;
+  feeBps?: number;
   admins: string[];
   setAppName: (name: string) => Promise<void>;
   setLogoCid: (logo: string) => Promise<void>;
@@ -32,7 +32,7 @@ const AppInfoContext = createContext<AppInfoContextType>({
   themeColor: '#B99C5A',
   fiatKey: undefined,
   feeAddress: undefined,
-  feePercent: 0,
+  feeBps: 0,
   admins: [],
   setAppName: async () => {},
   setLogoCid: async () => {},
@@ -54,7 +54,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
   const [themeColor, setThemeColorState] = useState('#B99C5A');
   const [fiatKey, setFiatKey] = useState<string | undefined>(undefined);
   const [feeAddress, setFeeAddress] = useState<string>('');
-  const [feePercent, setFeePercent] = useState<number>(0);
+  const [feeBps, setFeeBps] = useState<number>(0);
   const [admins, setAdmins] = useState<string[]>([]);
   const reloadTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -107,8 +107,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
           );
         }
         if (remote.feeAddress) setFeeAddress(remote.feeAddress);
-        if (remote.feePercent !== undefined)
-          setFeePercent(remote.feePercent);
+        if (remote.feeBps !== undefined) setFeeBps(remote.feeBps);
         if (remote.admins) setAdmins(remote.admins);
       } catch (err) {
         Alert.alert('שגיאה', 'טעינת הגדרות מהשרת נכשלה');
@@ -219,7 +218,7 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
         themeColor,
         fiatKey,
         feeAddress,
-        feePercent,
+        feeBps,
         admins,
         setAppName,
         setLogoCid,

--- a/contracts/order-payment.tact
+++ b/contracts/order-payment.tact
@@ -14,16 +14,16 @@ contract OrderPayment {
     amount: Int;
     paid: Bool;
     feeAddress: Address;
-    feePercent: Int;
+    feeBps: Int;
 
-    init(owner: Address, seller: Address, buyer: Address, amount: Int, feeAddress: Address, feePercent: Int) {
+    init(owner: Address, seller: Address, buyer: Address, amount: Int, feeAddress: Address, feeBps: Int) {
         self.owner = owner;
         self.seller = seller;
         self.buyer = buyer;
         self.amount = amount;
         self.paid = false;
         self.feeAddress = feeAddress;
-        self.feePercent = feePercent;
+        self.feeBps = feeBps;
     }
 
     receive(msg: Pay) {
@@ -37,7 +37,7 @@ contract OrderPayment {
     receive(msg: Release) {
         require(sender() == self.owner, 104);
         require(self.paid, 105);
-        let fee = (self.amount * self.feePercent) / 100;
+        let fee = (self.amount * self.feeBps) / 10000;
         send(self.feeAddress, fee);
         send(self.seller, self.amount - fee);
     }

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -45,10 +45,8 @@ export async function deployOrderPayment(
   try {
     const settings = await fetchSettings();
     const feeAddress = settings.feeAddress ?? '';
-    const feePercent = settings.feePercent ?? 0;
-    const payload = makeComment(
-      `Pay:${amount}:${feeAddress}:${feePercent}`,
-    );
+    const feeBps = settings.feeBps ?? 0;
+    const payload = makeComment(`Pay:${amount}:${feeAddress}:${feeBps}`);
     const payloadBoc = TonWeb.utils.bytesToBase64(
       await payload.toBoc(false),
     );

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -1,5 +1,14 @@
 import { getValue, setValue, listValues } from './tonKvStore';
 import config from '../utils/appConfig';
+import {
+  LightNode,
+  Protocols,
+  createLightNode,
+  waitForRemotePeer,
+  createEncoder,
+  utf8ToBytes,
+} from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../utils/appConfig';
 
 const ADDRESS =
   config.TON_SETTINGS_ADDRESS ??
@@ -12,7 +21,7 @@ export interface TonSettings {
   brand: { logoCid: string };
   fiatKey?: string;
   feeAddress?: string;
-  feePercent?: number;
+  feeBps?: number;
   admins: string[];
 }
 
@@ -20,8 +29,59 @@ export async function getSetting(key: string): Promise<string | null> {
   return await getValue(ADDRESS, key);
 }
 
-export async function setSetting(key: string, value: string) {
-  return await setValue(ADDRESS, key, value);
+export interface SettingsWriteEvent {
+  type: 'settings.write';
+  key: string;
+  value: string;
+  actor: string;
+  timestamp: number;
+}
+
+let node: LightNode | null = null;
+
+async function ensureNode(): Promise<LightNode | null> {
+  if (node) return node;
+  try {
+    const bootstrap = getWakuBootstrapNodes();
+    if (bootstrap.length === 0) return null;
+    node = await createLightNode({ libp2p: { bootstrap } });
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.Relay]);
+    return node;
+  } catch (err) {
+    console.error('Failed to start Waku node', err);
+    node = null;
+    return null;
+  }
+}
+
+async function emit(event: SettingsWriteEvent) {
+  const n = await ensureNode();
+  if (!n) return;
+  try {
+    const encoder = createEncoder({ contentTopic: '/congress/settings/1' });
+    await n.lightPush.send(encoder, {
+      payload: utf8ToBytes(JSON.stringify(event)),
+    });
+  } catch (err) {
+    console.error('Failed to broadcast settings.write', err);
+  }
+}
+
+export async function setSetting(
+  key: string,
+  value: string,
+  actor: string,
+) {
+  const res = await setValue(ADDRESS, key, value);
+  await emit({
+    type: 'settings.write',
+    key,
+    value,
+    actor,
+    timestamp: Date.now(),
+  });
+  return res;
 }
 
 export async function listSettings(): Promise<{ key: string; value: string }[]> {
@@ -34,15 +94,15 @@ export async function fetchSettings(): Promise<TonSettings> {
   for (const { key, value } of entries) {
     map[key] = value;
   }
-  let feePercent = 0;
-  if (map['feePercent'] !== undefined) {
-    const parsed = Number(map['feePercent']);
+  let feeBps = 0;
+  if (map['feeBps'] !== undefined) {
+    const parsed = Number(map['feeBps']);
     if (Number.isNaN(parsed)) {
       console.warn(
-        `Invalid feePercent value "${map['feePercent']}"; defaulting to 0`,
+        `Invalid feeBps value "${map['feeBps']}"; defaulting to 0`,
       );
     } else {
-      feePercent = parsed;
+      feeBps = parsed;
     }
   }
   return {
@@ -52,7 +112,7 @@ export async function fetchSettings(): Promise<TonSettings> {
     brand: { logoCid: map['brand.logoCid'] ?? '' },
     fiatKey: map['fiatKey'],
     feeAddress: map['feeAddress'] ?? '',
-    feePercent,
+    feeBps,
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
   };
 }
@@ -66,6 +126,6 @@ export async function getAdmins(): Promise<string[]> {
   }
 }
 
-export async function setAdmins(admins: string[]): Promise<void> {
-  await setSetting('admins', JSON.stringify(admins));
+export async function setAdmins(admins: string[], actor: string): Promise<void> {
+  await setSetting('admins', JSON.stringify(admins), actor);
 }

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -32,8 +32,8 @@ describe('SettingsAgent TON integration', () => {
 
   it('handles fee settings', async () => {
     const agent = SettingsAgent.getInstance();
-    await agent.updateSettingValue('feePercent', '5');
-    const fee = await agent.getSettingValue('feePercent');
-    expect(fee).toBe('5');
+    await agent.updateSettingValue('feeBps', '500');
+    const fee = await agent.getSettingValue('feeBps');
+    expect(fee).toBe('500');
   });
 });

--- a/tests/tonAuthContract.test.ts
+++ b/tests/tonAuthContract.test.ts
@@ -4,7 +4,7 @@ import * as tonAuth from '../services/tonAuth';
 jest.mock('../services/tonSettings', () => ({
   fetchSettings: jest.fn().mockResolvedValue({
     feeAddress: 'feeAddr',
-    feePercent: 5,
+    feeBps: 500,
   }),
 }));
 

--- a/tests/tonSettings.test.ts
+++ b/tests/tonSettings.test.ts
@@ -4,18 +4,18 @@ jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 
 const { setValue, __clear } = require('./tonKvMock');
 
-describe('fetchSettings feePercent parsing', () => {
+describe('fetchSettings feeBps parsing', () => {
   beforeEach(() => {
     __clear();
   });
 
-  it('defaults feePercent to 0 for non-numeric values', async () => {
-    await setValue('', 'feePercent', 'not-a-number');
-    await expect(fetchSettings()).resolves.toMatchObject({ feePercent: 0 });
+  it('defaults feeBps to 0 for non-numeric values', async () => {
+    await setValue('', 'feeBps', 'not-a-number');
+    await expect(fetchSettings()).resolves.toMatchObject({ feeBps: 0 });
   });
 
-  it('handles float feePercent values', async () => {
-    await setValue('', 'feePercent', '1.5');
-    await expect(fetchSettings()).resolves.toMatchObject({ feePercent: 1.5 });
+  it('handles numeric feeBps values', async () => {
+    await setValue('', 'feeBps', '150');
+    await expect(fetchSettings()).resolves.toMatchObject({ feeBps: 150 });
   });
 });


### PR DESCRIPTION
## Summary
- switch settings storage to `feeBps` (basis points)
- broadcast a `settings.write` Waku event on setting or admin changes
- ensure SettingsAgent passes the actor address when updating settings or admins

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*


------
https://chatgpt.com/codex/tasks/task_e_689adcac06b08326814cd871ec7706ed