### PR TITLE
feat: include admins in order authorization

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -4,6 +4,7 @@ import tonAuth from '../services/tonAuth';
 import notificationsAgent from './notifications-agent';
 import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
 import storesAgent from './stores-agent';
+import SettingsAgent from './settings-agent';
 import {
   deployOrderPayment,
   releasePayment,
@@ -60,9 +61,17 @@ class OrdersAgent {
   private async ensureAuthorized(order: Order) {
     await this.ensureWallet();
     const address = tonAuth.getAddress();
-    const allowed = [order.buyerAddress, order.sellerAddress, order.driverAddress].filter(Boolean);
+    let allowed = [
+      order.buyerAddress,
+      order.sellerAddress,
+      order.driverAddress,
+    ].filter(Boolean) as string[];
     if (!address || !allowed.includes(address)) {
-      throw new Error('Unauthorized order update');
+      const admins = await SettingsAgent.getInstance().getAdmins();
+      allowed = allowed.concat(admins);
+      if (!address || !allowed.includes(address)) {
+        throw new Error('Unauthorized order update');
+      }
     }
   }
 

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -20,6 +20,12 @@ jest.mock('../services/tonOrders', () => ({
 jest.mock('../agents/notifications-agent', () => ({ broadcast: jest.fn() }));
 jest.mock('../agents/stores-agent', () => ({ updateReputationByOwner: jest.fn() }));
 
+const getAdminsMock = jest.fn().mockResolvedValue(['admin']);
+jest.mock('../agents/settings-agent', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ getAdmins: getAdminsMock }) },
+}));
+
 jest.mock('../services/tonContract', () => ({
   deployOrderPayment: jest.fn().mockResolvedValue({ contractAddress: 'escrow1', txHash: 'tx1' }),
   releasePayment: jest.fn(),
@@ -42,9 +48,11 @@ const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
 
 const ordersAgent = require('../agents/orders-agent').default;
 const notificationsAgent = require('../agents/notifications-agent');
+const tonAuth = require('../services/tonAuth');
 
 describe('ordersAgent.add', () => {
   it('encrypts shipping address and persists new fields', async () => {
+    tonAuth.getAddress.mockReturnValue('seller');
     const items = [{
       id: 'i1',
       productId: 'p1',
@@ -105,6 +113,7 @@ describe('ordersAgent.add', () => {
 
 describe('ordersAgent notification IDs', () => {
   it('generates unique IDs under rapid calls', async () => {
+    tonAuth.getAddress.mockReturnValue('seller');
     notificationsAgent.broadcast.mockClear();
     const order = { id: 'o1', userId: 'u1' } as any;
     const notify = (ordersAgent as any).notifyOrderCreated.bind(ordersAgent);
@@ -119,6 +128,31 @@ describe('ordersAgent notification IDs', () => {
     expect(new Set(ids).size).toBe(ids.length);
     const timestamps = notificationsAgent.broadcast.mock.calls.map((c: any) => c[1].timestamp);
     expect(timestamps.every((ts: number) => ts === 123)).toBe(true);
+  });
+});
+
+describe('ordersAgent admin authorization', () => {
+  it('allows admin to update orders', async () => {
+    tonAuth.getAddress.mockReturnValue('admin');
+    const order: Order = {
+      id: 'order-admin',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'order_received',
+      itemsHash: '',
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      createdAt: '',
+      updatedAt: '',
+      trackingSteps: [],
+    } as any;
+    mockStore[order.id] = order;
+    await expect(
+      ordersAgent.update({ ...order, status: 'courier_found' })
+    ).resolves.not.toThrow();
+    expect(mockStore[order.id].status).toBe('courier_found');
   });
 });
 


### PR DESCRIPTION
## Summary
- load admin wallets from SettingsAgent and include in order authorization
- add tests covering admin-triggered order updates

## Testing
- `npm test tests/ordersAgent.test.ts` *(fails: services/tonSettings.ts:47:46 - error TS2353: Object literal may only specify known properties, and 'bootstrap' does not exist in type 'Partial<CreateLibp2pOptions>'.)*

------
https://chatgpt.com/codex/tasks/task_e_689ae0b0c98083268d1326855a88a3f3