### PR TITLE
feat: log order lifecycle events

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -13,6 +13,7 @@ import productsAgent from './products-agent';
 import { getSellerPublicKey } from '../services/sellerRegistry';
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
+import { logOrderEvent } from '../services/eventLog';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -104,6 +105,14 @@ class OrdersAgent {
       }
     }
     await setOrder(toStore);
+    await logOrderEvent({
+      type: 'order.created',
+      orderId: enriched.id,
+      prevStatus: null,
+      newStatus: enriched.status,
+      actor: tonAuth.getAddress() || '',
+      timestamp: Date.now(),
+    });
     this.subscribers.forEach((cb) => cb(enriched));
     await this.notifyOrderCreated(enriched);
   }
@@ -123,6 +132,14 @@ class OrdersAgent {
       statusChanged = true;
     }
     await setOrder(order);
+    await logOrderEvent({
+      type: 'order.updated',
+      orderId: order.id,
+      prevStatus: current.status,
+      newStatus: order.status,
+      actor: tonAuth.getAddress() || '',
+      timestamp: Date.now(),
+    });
     this.subscribers.forEach((cb) => cb(order));
     if (statusChanged) {
       await this.notifyStatusChange(order);
@@ -144,6 +161,14 @@ class OrdersAgent {
     }
     await this.ensureAuthorized(order);
     await removeOrder(id);
+    await logOrderEvent({
+      type: 'order.deleted',
+      orderId: id,
+      prevStatus: order.status,
+      newStatus: 'deleted',
+      actor: tonAuth.getAddress() || '',
+      timestamp: Date.now(),
+    });
   }
 
   async get(id: string): Promise<Order | null> {
@@ -178,6 +203,14 @@ class OrdersAgent {
       updatedAt: new Date().toISOString(),
     };
     await setOrder(updated);
+    await logOrderEvent({
+      type: 'order.updated',
+      orderId: updated.id,
+      prevStatus: order.status,
+      newStatus: updated.status,
+      actor: tonAuth.getAddress() || '',
+      timestamp: Date.now(),
+    });
     await Promise.all(
       order.items.map((item) =>
         productsAgent.decrementStock(
@@ -213,6 +246,14 @@ class OrdersAgent {
       updatedAt: new Date().toISOString(),
     };
     await setOrder(updated);
+    await logOrderEvent({
+      type: 'order.updated',
+      orderId: updated.id,
+      prevStatus: order.status,
+      newStatus: updated.status,
+      actor: tonAuth.getAddress() || '',
+      timestamp: Date.now(),
+    });
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
     await this.recordSellerMetric(order.sellerAddress, 'refunded');

--- a/services/eventLog.ts
+++ b/services/eventLog.ts
@@ -1,0 +1,56 @@
+import {
+  LightNode,
+  createLightNode,
+  waitForRemotePeer,
+  createEncoder,
+  Protocols,
+  utf8ToBytes,
+} from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../utils/appConfig';
+import { OrderStatus } from '../types';
+
+export type OrderEventType =
+  | 'order.created'
+  | 'order.updated'
+  | 'order.deleted';
+
+export interface OrderEvent {
+  type: OrderEventType;
+  orderId: string;
+  prevStatus?: OrderStatus | null;
+  newStatus?: OrderStatus | 'deleted';
+  actor: string;
+  timestamp: number;
+}
+
+const ORDER_TOPIC = '/congress/orders/1';
+let node: LightNode | null = null;
+
+async function ensureNode(): Promise<LightNode | null> {
+  if (node) return node;
+  try {
+    const bootstrap = getWakuBootstrapNodes();
+    if (bootstrap.length === 0) return null;
+    node = await createLightNode({ libp2p: { bootstrap } });
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.Relay]);
+    return node;
+  } catch (err) {
+    console.error('Failed to start Waku node', err);
+    node = null;
+    return null;
+  }
+}
+
+export async function logOrderEvent(event: OrderEvent): Promise<void> {
+  const n = await ensureNode();
+  if (!n) return;
+  try {
+    const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
+    await n.lightPush.send(encoder, {
+      payload: utf8ToBytes(JSON.stringify(event)),
+    });
+  } catch (err) {
+    console.error('Failed to log order event', err);
+  }
+}

--- a/tests/admin-disputes.test.tsx
+++ b/tests/admin-disputes.test.tsx
@@ -12,6 +12,8 @@ jest.mock('../services/tonContract', () => ({
   adminResolve: jest.fn().mockResolvedValue('tx'),
 }));
 
+jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+
 describe('OrderService.resolveDispute', () => {
   const svc = OrderService.getInstance();
 

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -33,6 +33,8 @@ jest.mock('../services/tonStores', () => ({
   getStore: jest.fn(async (id: string) => ({ id, name: id, owner: `seller_${id}`, nftId: id })),
 }));
 
+jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+
 jest.mock('../services/tonAuth', () => ({
   getAddress: jest.fn().mockReturnValue('buyer_address'),
   getTonPublicKey: jest.fn().mockReturnValue('buyer_pub'),

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -28,6 +28,7 @@ jest.mock('../services/tonContract', () => ({
 
 jest.mock('../services/sellerRegistry');
 jest.mock('../services/localIdentity');
+jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
 
 jest.mock('../services/tonAuth', () => ({
   getAddress: jest.fn().mockReturnValue('seller'),


### PR DESCRIPTION
## Summary
- add Waku-based event logger for order events
- emit order.created, order.updated, and order.deleted events from orders-agent with status details and actor wallet
- mock event logger in relevant tests

## Testing
- `yarn test tests/ordersAgent.test.ts` *(fails: jest: not found)*
- `yarn install --ignore-scripts` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4".)*

------
https://chatgpt.com/codex/tasks/task_e_689ae0b372108326a2d2d0dffbd5c49d