### PR TITLE
feat: add escrow deployed notification

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -51,6 +51,10 @@ export const notificationTemplates: Record<NotificationEvent, NotificationTempla
     contentTopic: ORDER_TOPIC,
     payload: { type: 'dispute.updated', notification: item },
   }),
+  'escrow.deployed': (item) => ({
+    contentTopic: ORDER_TOPIC,
+    payload: { type: 'escrow.deployed', notification: item },
+  }),
 };
 
 class NotificationsAgent {

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -29,7 +29,7 @@ export async function emitOrderEvents(order: Order, storeId: string) {
   try {
     await notificationsAgent.broadcast('order.created', payload as any);
     if (order.paymentMethod === 'ton') {
-      await notificationsAgent.broadcast('escrow.deployed' as any, payload as any);
+      await notificationsAgent.broadcast('escrow.deployed', payload as any);
     }
   } catch (err) {
     console.error('Failed to emit order events', err);


### PR DESCRIPTION
## Summary
- handle `escrow.deployed` notifications in templates
- allow order service to broadcast escrow deployment events

## Testing
- `npm test` *(fails: Object literal may only specify known properties, and 'bootstrap' does not exist in type 'Partial<CreateLibp2pOptions>')*
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_689ae3e260d48326ac49ae29db32b656