### PR TITLE
Use event bus for order events

### DIFF
--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -1,0 +1,43 @@
+import {
+  LightNode,
+  createLightNode,
+  waitForRemotePeer,
+  createEncoder,
+  Protocols,
+  utf8ToBytes,
+} from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../utils/appConfig';
+
+let node: LightNode | null = null;
+
+async function ensureNode(): Promise<LightNode | null> {
+  if (node) return node;
+  try {
+    const bootstrap = getWakuBootstrapNodes();
+    if (bootstrap.length === 0) return null;
+    node = await createLightNode({ libp2p: { bootstrap } });
+    await node.start();
+    await waitForRemotePeer(node, [Protocols.Relay]);
+    return node;
+  } catch (err) {
+    console.error('Failed to start Waku node', err);
+    node = null;
+    return null;
+  }
+}
+
+export async function publish(contentTopic: string, payload: unknown): Promise<void> {
+  const n = await ensureNode();
+  if (!n) return;
+  try {
+    const encoder = createEncoder({ contentTopic });
+    await n.lightPush.send(encoder, {
+      payload: utf8ToBytes(JSON.stringify(payload)),
+    });
+  } catch (err) {
+    console.error('Failed to publish event', err);
+  }
+}
+
+export default { publish };
+

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,5 +1,5 @@
 import ordersAgent from '../agents/orders-agent';
-import notificationsAgent from '../agents/notifications-agent';
+import eventBus from './eventBus';
 import {
   Order,
   OrderStatus,
@@ -12,8 +12,10 @@ import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
 
+const ORDER_TOPIC = '/congress/orders/1';
+
 export async function emitOrderEvents(order: Order, storeId: string) {
-  const payload = {
+  const baseEvent = {
     id: order.id,
     orderId: order.id,
     storeId,
@@ -27,9 +29,15 @@ export async function emitOrderEvents(order: Order, storeId: string) {
     },
   };
   try {
-    await notificationsAgent.broadcast('order.created', payload as any);
+    await eventBus.publish(ORDER_TOPIC, {
+      type: 'order.created',
+      ...baseEvent,
+    });
     if (order.paymentMethod === 'ton') {
-      await notificationsAgent.broadcast('escrow.deployed' as any, payload as any);
+      await eventBus.publish(ORDER_TOPIC, {
+        type: 'escrow.deployed',
+        ...baseEvent,
+      });
     }
   } catch (err) {
     console.error('Failed to emit order events', err);

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -12,7 +12,7 @@ jest.mock('../services/tonOrders', () => ({
   listOrdersBySeller: jest.fn().mockResolvedValue([]),
 }));
 
-jest.mock('../agents/notifications-agent', () => ({ broadcast: jest.fn() }));
+jest.mock('../services/eventBus', () => ({ publish: jest.fn() }));
 
 jest.mock('../services/tonContract', () => ({
   deployOrderPayment: jest
@@ -108,9 +108,9 @@ describe('multi-seller checkout flow', () => {
       true,
     );
 
-    const notificationsAgent = require('../agents/notifications-agent');
-    expect(notificationsAgent.broadcast).toHaveBeenCalledTimes(4);
-    const events = notificationsAgent.broadcast.mock.calls.map((c: any) => c[0]);
+    const eventBus = require('../services/eventBus');
+    expect(eventBus.publish).toHaveBeenCalledTimes(4);
+    const events = eventBus.publish.mock.calls.map((c: any) => c[1].type);
     expect(events).toEqual([
       'order.created',
       'escrow.deployed',
@@ -118,7 +118,7 @@ describe('multi-seller checkout flow', () => {
       'escrow.deployed',
     ]);
 
-    const firstPayload = notificationsAgent.broadcast.mock.calls[0][1];
+    const firstPayload = eventBus.publish.mock.calls[0][1];
     expect(firstPayload.orderId).toBe(orders[0].id);
     expect(firstPayload.storeId).toBe('s1');
     expect(firstPayload.buyerAddress).toBe('buyer_address');


### PR DESCRIPTION
## Summary
- Add lightweight Waku event bus service
- Publish order created and escrow deployed events via event bus
- Adjust multi-seller checkout test to track event bus publishes

## Testing
- `npm test` *(fails: jest not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" )*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae3e3e8748326b5322910121bf2f2