### PR TITLE
Refactor order event structure with tenant context

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -115,10 +115,13 @@ class OrdersAgent {
     }
     await setOrder(toStore);
     await logOrderEvent({
+      tenant: enriched.items?.[0]?.product?.storeId || '',
       type: 'order.created',
-      orderId: enriched.id,
-      prevStatus: null,
-      newStatus: enriched.status,
+      payload: {
+        orderId: enriched.id,
+        prevStatus: null,
+        newStatus: enriched.status,
+      },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
@@ -142,10 +145,13 @@ class OrdersAgent {
     }
     await setOrder(order);
     await logOrderEvent({
+      tenant: order.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
-      orderId: order.id,
-      prevStatus: current.status,
-      newStatus: order.status,
+      payload: {
+        orderId: order.id,
+        prevStatus: current.status,
+        newStatus: order.status,
+      },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
@@ -171,10 +177,13 @@ class OrdersAgent {
     await this.ensureAuthorized(order);
     await removeOrder(id);
     await logOrderEvent({
+      tenant: order.items?.[0]?.product?.storeId || '',
       type: 'order.deleted',
-      orderId: id,
-      prevStatus: order.status,
-      newStatus: 'deleted',
+      payload: {
+        orderId: id,
+        prevStatus: order.status,
+        newStatus: 'deleted',
+      },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
@@ -213,10 +222,13 @@ class OrdersAgent {
     };
     await setOrder(updated);
     await logOrderEvent({
+      tenant: updated.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
-      orderId: updated.id,
-      prevStatus: order.status,
-      newStatus: updated.status,
+      payload: {
+        orderId: updated.id,
+        prevStatus: order.status,
+        newStatus: updated.status,
+      },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
@@ -256,10 +268,13 @@ class OrdersAgent {
     };
     await setOrder(updated);
     await logOrderEvent({
+      tenant: updated.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
-      orderId: updated.id,
-      prevStatus: order.status,
-      newStatus: updated.status,
+      payload: {
+        orderId: updated.id,
+        prevStatus: order.status,
+        newStatus: updated.status,
+      },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });

--- a/services/eventLog.ts
+++ b/services/eventLog.ts
@@ -6,6 +6,7 @@ import {
   Protocols,
   utf8ToBytes,
 } from '@waku/sdk';
+import { randomUUID } from 'crypto';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { OrderStatus } from '../types';
 
@@ -15,10 +16,14 @@ export type OrderEventType =
   | 'order.deleted';
 
 export interface OrderEvent {
+  id: string;
+  tenant: string;
   type: OrderEventType;
-  orderId: string;
-  prevStatus?: OrderStatus | null;
-  newStatus?: OrderStatus | 'deleted';
+  payload: {
+    orderId: string;
+    prevStatus?: OrderStatus | null;
+    newStatus?: OrderStatus | 'deleted';
+  };
   actor: string;
   timestamp: number;
 }
@@ -42,13 +47,16 @@ async function ensureNode(): Promise<LightNode | null> {
   }
 }
 
-export async function logOrderEvent(event: OrderEvent): Promise<void> {
+export async function logOrderEvent(
+  event: Omit<OrderEvent, 'id'>,
+): Promise<void> {
   const n = await ensureNode();
   if (!n) return;
   try {
+    const eventWithId: OrderEvent = { id: randomUUID(), ...event };
     const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
     await n.lightPush.send(encoder, {
-      payload: utf8ToBytes(JSON.stringify(event)),
+      payload: utf8ToBytes(JSON.stringify(eventWithId)),
     });
   } catch (err) {
     console.error('Failed to log order event', err);


### PR DESCRIPTION
## Summary
- expand OrderEvent to include unique id, tenant, and payload details
- generate ids automatically when logging order events
- update order agent to provide tenant/store id and payload structure

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn install --frozen-lockfile` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4"*)

------
https://chatgpt.com/codex/tasks/task_e_689b1146dd2483268516872525a94895