### PR TITLE
feat: add default Waku bootstrap fallback

### DIFF
--- a/services/eventLog.ts
+++ b/services/eventLog.ts
@@ -24,13 +24,20 @@ export interface OrderEvent {
 }
 
 const ORDER_TOPIC = '/congress/orders/1';
+const DEFAULT_BOOTSTRAP =
+  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 let node: LightNode | null = null;
 
 async function ensureNode(): Promise<LightNode | null> {
   if (node) return node;
   try {
     const bootstrap = getWakuBootstrapNodes();
-    if (bootstrap.length === 0) return null;
+    if (bootstrap.length === 0) {
+      console.warn(
+        'No Waku bootstrap nodes configured; using default bootstrap. Please configure your own nodes.',
+      );
+      bootstrap.push(DEFAULT_BOOTSTRAP);
+    }
     node = await createLightNode({ libp2p: { bootstrap } });
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -13,6 +13,8 @@ import { getWakuBootstrapNodes } from '../utils/appConfig';
 const ADDRESS =
   config.TON_SETTINGS_ADDRESS ??
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+const DEFAULT_BOOTSTRAP =
+  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 
 export interface TonSettings {
   tenantId: string;
@@ -43,7 +45,12 @@ async function ensureNode(): Promise<LightNode | null> {
   if (node) return node;
   try {
     const bootstrap = getWakuBootstrapNodes();
-    if (bootstrap.length === 0) return null;
+    if (bootstrap.length === 0) {
+      console.warn(
+        'No Waku bootstrap nodes configured; using default bootstrap. Please configure your own nodes.',
+      );
+      bootstrap.push(DEFAULT_BOOTSTRAP);
+    }
     node = await createLightNode({ libp2p: { bootstrap } });
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);


### PR DESCRIPTION
## Summary
- add default Waku bootstrap fallback to event logging and TON settings services
- warn operators when default bootstrap is used

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b11491b7083268a33b43fead5f428