### PR TITLE
feat: refresh admin settings cache

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -4,6 +4,7 @@ import {
   setSetting,
   getAdmins as fetchAdmins,
   setAdmins as storeAdmins,
+  subscribeToSettingsWrites,
 } from '../services/tonSettings';
 
 type SettingKey =
@@ -18,8 +19,17 @@ type SettingKey =
 class SettingsAgent {
   private static instance: SettingsAgent;
   private admins: string[] = [];
+  private adminsFetchedAt = 0;
+  private static ADMIN_CACHE_TTL = 60_000; // 1 minute
 
-  private constructor() {}
+  private constructor() {
+    void subscribeToSettingsWrites((evt) => {
+      if (evt.key === 'admins') {
+        this.admins = [];
+        this.adminsFetchedAt = 0;
+      }
+    });
+  }
 
   private async ensureWallet() {
     const address = tonAuth.getAddress();
@@ -49,8 +59,13 @@ class SettingsAgent {
   }
 
   async getAdmins(): Promise<string[]> {
-    if (this.admins.length === 0) {
+    const now = Date.now();
+    if (
+      this.admins.length === 0 ||
+      now - this.adminsFetchedAt > SettingsAgent.ADMIN_CACHE_TTL
+    ) {
       this.admins = await fetchAdmins();
+      this.adminsFetchedAt = now;
     }
     return this.admins;
   }
@@ -60,6 +75,7 @@ class SettingsAgent {
     const actor = tonAuth.getAddress()!;
     await storeAdmins(admins, actor);
     this.admins = admins;
+    this.adminsFetchedAt = Date.now();
   }
 
   static getInstance(): SettingsAgent {

--- a/services/__mocks__/tonSettings.ts
+++ b/services/__mocks__/tonSettings.ts
@@ -1,0 +1,36 @@
+const store: Record<string, string> = {};
+
+export async function getSetting(key: string): Promise<string | null> {
+  return store[key] ?? null;
+}
+
+export async function setSetting(key: string, value: string): Promise<void> {
+  store[key] = value;
+}
+
+export async function getAdmins(): Promise<string[]> {
+  return store['admins'] ? JSON.parse(store['admins']) : [];
+}
+
+export async function setAdmins(admins: string[]): Promise<void> {
+  store['admins'] = JSON.stringify(admins);
+}
+
+export async function fetchSettings() {
+  return {
+    tenantId: store['tenantId'] ?? 'thecongress',
+    appName: store['appName'] ?? 'Blue Ocean',
+    theme: { primary: store['theme.primary'] ?? '#B99C5A' },
+    brand: { logoCid: store['brand.logoCid'] ?? '' },
+    fiatKey: store['fiatKey'],
+    feeAddress: store['feeAddress'] ?? '',
+    feeBps: store['feeBps'] ? Number(store['feeBps']) : 0,
+    admins: store['admins'] ? JSON.parse(store['admins']) : [],
+  };
+}
+
+export const subscribeToSettingsWrites = jest
+  .fn()
+  .mockResolvedValue(() => {});
+
+export const __store = store;

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -6,7 +6,9 @@ import {
   createLightNode,
   waitForRemotePeer,
   createEncoder,
+  createDecoder,
   utf8ToBytes,
+  bytesToUtf8,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 
@@ -44,7 +46,7 @@ async function ensureNode(): Promise<LightNode | null> {
   try {
     const bootstrap = getWakuBootstrapNodes();
     if (bootstrap.length === 0) return null;
-    node = await createLightNode({ libp2p: { bootstrap } });
+    node = await createLightNode({ libp2p: { bootstrap } as any });
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);
     return node;
@@ -66,6 +68,35 @@ async function emit(event: SettingsWriteEvent) {
   } catch (err) {
     console.error('Failed to broadcast settings.write', err);
   }
+}
+
+export async function subscribeToSettingsWrites(
+  cb: (event: SettingsWriteEvent) => void,
+): Promise<() => void> {
+  const n = await ensureNode();
+  if (!n) return () => {};
+  const decoder = createDecoder('/congress/settings/1');
+  const handler = (wakuMsg: any) => {
+    if (!wakuMsg.payload) return;
+    try {
+      const evt = JSON.parse(bytesToUtf8(wakuMsg.payload));
+      if (evt && evt.type === 'settings.write') {
+        cb(evt as SettingsWriteEvent);
+      }
+    } catch {
+      /* ignore malformed events */
+    }
+  };
+  const maybeUnsub = (n.relay as any).addObserver(handler, [decoder]) as
+    | (() => void)
+    | void;
+  return () => {
+    if (typeof maybeUnsub === 'function') {
+      maybeUnsub();
+    } else {
+      (n.relay as any)?.deleteObserver?.(handler);
+    }
+  };
 }
 
 export async function setSetting(

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -6,15 +6,21 @@ jest.mock('../services/tonAuth', () => ({
     sendTransaction: jest.fn().mockResolvedValue({}),
   }),
 }));
+jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
+jest.mock('../services/tonSettings');
 
 import SettingsAgent from '../agents/settings-agent';
-jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 import { __clear } from './tonKvMock';
+import * as tonSettings from '../services/tonSettings';
+const directSetAdmins = tonSettings.setAdmins;
+const __store = (tonSettings as any).__store;
 
 describe('SettingsAgent TON integration', () => {
   beforeEach(() => {
     __clear();
     (SettingsAgent as any).instance = undefined;
+    (SettingsAgent as any).ADMIN_CACHE_TTL = 10; // short TTL for tests
+    for (const k of Object.keys(__store)) delete __store[k];
   });
 
   it('returns null when setting missing', async () => {
@@ -35,5 +41,20 @@ describe('SettingsAgent TON integration', () => {
     await agent.updateSettingValue('feeBps', '500');
     const fee = await agent.getSettingValue('feeBps');
     expect(fee).toBe('500');
+  });
+
+  it('refreshes admin list after TTL expiry', async () => {
+    const agent = SettingsAgent.getInstance();
+    await agent.setAdmins(['addr_admin']);
+    const first = await agent.getAdmins();
+    expect(first).toEqual(['addr_admin']);
+
+    await directSetAdmins(['addr_other'], 'addr_admin');
+    const stillCached = await agent.getAdmins();
+    expect(stillCached).toEqual(['addr_admin']);
+
+    await new Promise((r) => setTimeout(r, 20));
+    const refreshed = await agent.getAdmins();
+    expect(refreshed).toEqual(['addr_other']);
   });
 });

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 import { insertConfig } from './testUtils';
 jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
-import { loadTenantSettings } from '../constants/tenant';
+jest.mock('../services/tonSettings');
+const { loadTenantSettings } = require('../constants/tenant');
 
 var __DEV__ = false;
 


### PR DESCRIPTION
## Summary
- refresh admin cache with TTL and settings.write invalidation
- expose subscribeToSettingsWrites in tonSettings service
- test admin cache refresh logic

## Testing
- `npx jest tests/settingsAgent.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b115151f08326b061b402129a8d71