### PR TITLE
feat: retry room key derivation after failure

### DIFF
--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -3,20 +3,33 @@ import { deriveSharedKey, aesEncrypt, aesDecrypt } from './encryption';
 
 // roomKeys stores derived AES keys per chat room. To keep memory usage bounded
 // we maintain a simple LRU cache with a fixed size.
-const roomKeys = new Map<string, CryptoKey | null>();
+const roomKeys = new Map<string, CryptoKey>();
 const MAX_ROOM_KEYS = 100;
+
+// Track failed derivations to avoid hammering key generation when it previously
+// failed. After a cooldown, we allow another attempt.
+const failedDerivations = new Map<string, number>();
+const DERIVATION_COOLDOWN_MS = 60_000;
 
 export async function getRoomKey(
   roomId: string,
   peerPublicKey: string,
 ): Promise<CryptoKey> {
+  const failedAt = failedDerivations.get(roomId);
+  if (failedAt) {
+    const elapsed = Date.now() - failedAt;
+    if (elapsed < DERIVATION_COOLDOWN_MS) {
+      throw new Error('Room key derivation on cooldown');
+    }
+    failedDerivations.delete(roomId);
+  }
+
   if (roomKeys.has(roomId)) {
-    const cached = roomKeys.get(roomId);
+    const cached = roomKeys.get(roomId)!;
     // refresh LRU ordering
     roomKeys.delete(roomId);
-    roomKeys.set(roomId, cached ?? null);
-    if (cached) return cached;
-    throw new Error('Missing room key');
+    roomKeys.set(roomId, cached);
+    return cached;
   }
   try {
     const myPrivEd = await getPrivateKey();
@@ -26,9 +39,10 @@ export async function getRoomKey(
       const oldest = roomKeys.keys().next().value;
       roomKeys.delete(oldest);
     }
+    failedDerivations.delete(roomId);
     return key;
   } catch (err) {
-    roomKeys.set(roomId, null);
+    failedDerivations.set(roomId, Date.now());
     throw new Error(`Failed to derive room key: ${err instanceof Error ? err.message : String(err)}`);
   }
 }


### PR DESCRIPTION
## Summary
- avoid caching failed room key derivations
- track recent derivation failures and retry after a cooldown

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" )*


------
https://chatgpt.com/codex/tasks/task_e_689b45b2f42883268fa5a1e8091f10fb