### PR TITLE
feat: add salt to shared key derivation

### DIFF
--- a/tests/encryption.test.ts
+++ b/tests/encryption.test.ts
@@ -1,5 +1,5 @@
 import * as nacl from 'tweetnacl';
-import { deriveSharedKey, aesEncrypt, aesDecrypt } from '../utils/encryption';
+import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from '../utils/encryption';
 
 describe('ECDH + AES utilities', () => {
   it('allow buyer and seller to exchange encrypted messages', async () => {
@@ -8,8 +8,11 @@ describe('ECDH + AES utilities', () => {
     const buyer = nacl.sign.keyPair.fromSeed(buyerSeed);
     const seller = nacl.sign.keyPair.fromSeed(sellerSeed);
 
-    const buyerKey = await deriveSharedKey(buyerSeed, Buffer.from(seller.publicKey).toString('hex'), 'room1');
-    const sellerKey = await deriveSharedKey(sellerSeed, Buffer.from(buyer.publicKey).toString('hex'), 'room1');
+    const buyerPubHex = Buffer.from(buyer.publicKey).toString('hex');
+    const sellerPubHex = Buffer.from(seller.publicKey).toString('hex');
+    const salt = deriveChatSalt(buyerPubHex, sellerPubHex);
+    const buyerKey = await deriveSharedKey(buyerSeed, sellerPubHex, 'room1', salt);
+    const sellerKey = await deriveSharedKey(sellerSeed, buyerPubHex, 'room1', salt);
 
     const message = 'hello seller';
     const cipher = await aesEncrypt(message, buyerKey);

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -1,5 +1,5 @@
-import { getPrivateKey } from '../services/localIdentity';
-import { deriveSharedKey, aesEncrypt, aesDecrypt } from './encryption';
+import { getEd25519KeyPair } from '../services/localIdentity';
+import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from './encryption';
 
 // roomKeys stores derived AES keys per chat room. To keep memory usage bounded
 // we maintain a simple LRU cache with a fixed size.
@@ -19,8 +19,10 @@ export async function getRoomKey(
     throw new Error('Missing room key');
   }
   try {
-    const myPrivEd = await getPrivateKey();
-    const key = await deriveSharedKey(myPrivEd, peerPublicKey, roomId);
+    const { privateKey: myPrivEd, publicKey: myPub } = await getEd25519KeyPair();
+    const myPubHex = Buffer.from(myPub).toString('hex');
+    const salt = deriveChatSalt(myPubHex, peerPublicKey);
+    const key = await deriveSharedKey(myPrivEd, peerPublicKey, roomId, salt);
     roomKeys.set(roomId, key);
     if (roomKeys.size > MAX_ROOM_KEYS) {
       const oldest = roomKeys.keys().next().value;

--- a/utils/encryption.ts
+++ b/utils/encryption.ts
@@ -13,12 +13,13 @@ export async function deriveSharedKey(
   myPrivateEd25519: Uint8Array,
   peerPublicEd25519Hex: string,
   info: string,
+  salt: Uint8Array,
 ): Promise<CryptoKey> {
   const myX = ed2curve.convertSecretKey(myPrivateEd25519);
   const peerX = ed2curve.convertPublicKey(Buffer.from(peerPublicEd25519Hex, 'hex'));
   if (!myX || !peerX) throw new Error('key conversion failed');
   const shared = nacl.scalarMult(myX, peerX);
-  const derived = hkdf(sha256, shared, undefined, info, 32);
+  const derived = hkdf(sha256, shared, salt, info, 32);
   return crypto.subtle.importKey(
     'raw',
     derived,
@@ -26,6 +27,17 @@ export async function deriveSharedKey(
     false,
     ['encrypt', 'decrypt'],
   );
+}
+
+/**
+ * Derive a deterministic salt from two public ed25519 keys.
+ * The keys are sorted to ensure consistent salt regardless of caller order.
+ */
+export function deriveChatSalt(aHex: string, bHex: string): Uint8Array {
+  const a = Buffer.from(aHex, 'hex');
+  const b = Buffer.from(bHex, 'hex');
+  const [first, second] = [a, b].sort(Buffer.compare);
+  return sha256(Buffer.concat([first, second]));
 }
 
 /**


### PR DESCRIPTION
## Summary
- accept external salt when deriving shared encryption keys
- derive chat-specific salt from participants' public keys
- update encryption tests for salted key derivation

## Testing
- `yarn test tests/encryption.test.ts` *(fails: jest not found)*
- `yarn install --frozen-lockfile` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*


------
https://chatgpt.com/codex/tasks/task_e_689b45b31fe083269c075d77bb52a0c3