### PR TITLE
feat: enforce user admin permissions

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -2,6 +2,7 @@ import { User } from '../types';
 import tonAuth from '../services/tonAuth';
 import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 import { getPublicKeyHex } from '../services/localIdentity';
+import SettingsAgent from './settings-agent';
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
@@ -26,6 +27,10 @@ class UsersAgent {
 
   async add(user: User): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
+    const admins = await SettingsAgent.getInstance().getAdmins();
+    if (address !== user.address && !admins.includes(address)) {
+      throw new Error('Only the user or an admin can add this user');
+    }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = { ...user, publicKey, address, chatPublicKey };
     await setUser(enriched);
@@ -33,6 +38,10 @@ class UsersAgent {
 
   async update(user: User): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
+    const admins = await SettingsAgent.getInstance().getAdmins();
+    if (address !== user.address && !admins.includes(address)) {
+      throw new Error('Only the user or an admin can update this user');
+    }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = { ...user, publicKey, address, chatPublicKey };
     await setUser(enriched);
@@ -48,6 +57,10 @@ class UsersAgent {
     const { address, publicKey } = await this.ensureWallet();
     const user = await getUser(userId);
     if (!user) throw new Error('User not found');
+    const admins = await SettingsAgent.getInstance().getAdmins();
+    if (address !== user.address && !admins.includes(address)) {
+      throw new Error('Only the user or an admin can request KYC');
+    }
     const enriched: User = {
       ...user,
       publicKey,
@@ -66,6 +79,10 @@ class UsersAgent {
     adminId?: string,
   ): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
+    const admins = await SettingsAgent.getInstance().getAdmins();
+    if (!admins.includes(address)) {
+      throw new Error('Only admins can update KYC');
+    }
     const user = await getUser(userId);
     if (!user) throw new Error('User not found');
     const enriched: User = {


### PR DESCRIPTION
## Summary
- verify caller is target user or admin for add/update/requestKyc
- restrict KYC updates to admins only

## Testing
- `yarn lint agents/users-agent.ts` *(fails: expo not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" )*
- `yarn test tests/usersAgent.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bab7f70f88326b60453d84449151f