### PR TITLE
Use crypto.randomUUID for order IDs

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import ordersAgent from '../agents/orders-agent';
 import eventBus from './eventBus';
 import {
@@ -127,7 +128,7 @@ class OrderService {
       pay = { ...pay, contractAddress, txHash };
     }
 
-    const orderId = `order_${Date.now()}`;
+    const orderId = randomUUID();
     const timestamp = new Date().toISOString();
     const itemsHash = Buffer.from(
       sha256(Buffer.from(JSON.stringify(items)))


### PR DESCRIPTION
## Summary
- import `randomUUID` from `crypto`
- generate order IDs using `randomUUID()` instead of timestamp format

## Testing
- `yarn test` *(fails: jest not found; dependency installation blocked by Node version requirements)*

------
https://chatgpt.com/codex/tasks/task_e_689bab821bc48326be8ccad5dc0c9499