### PR TITLE
Persist buyer address for order updates

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -128,6 +128,10 @@ class OrderService {
       pay = { ...pay, contractAddress, txHash };
     }
 
+    if (!pay?.buyerAddress) {
+      pay = { ...pay, buyerAddress: tonAuth.getAddress() || undefined };
+    }
+
     const orderId = randomUUID();
     const timestamp = new Date().toISOString();
     const itemsHash = Buffer.from(
@@ -183,6 +187,7 @@ class OrderService {
             }
           : {
               method: 'cash_on_delivery' as const,
+              buyerAddress: tonAuth.getAddress() || undefined,
               sellerAddress: store?.owner,
             };
       const order = await this.createOrder(


### PR DESCRIPTION
## Summary
- include `buyerAddress` for cash-on-delivery payments when creating orders
- default missing `buyerAddress` in `createOrder` to current TON address

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: @waku/sdk@0.0.33: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4". Found incompatible module.)*


------
https://chatgpt.com/codex/tasks/task_e_689c70e738a08326862ab81e45383432