### PR TITLE
Enforce permission check on user removal

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -48,7 +48,13 @@ class UsersAgent {
   }
 
   async remove(id: string): Promise<void> {
-    await this.ensureWallet();
+    const { address } = await this.ensureWallet();
+    const user = await getUser(id);
+    if (!user) throw new Error('User not found');
+    const admins = await SettingsAgent.getInstance().getAdmins();
+    if (address !== user.address && !admins.includes(address)) {
+      throw new Error('Only the user or an admin can remove this user');
+    }
     await removeUser(id);
   }
 

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -12,10 +12,12 @@ jest.mock('../services/localIdentity', () => ({
 
 jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 import { __clear } from './tonKvMock';
+import { setAdmins } from '../services/tonSettings';
 
 describe('UsersAgent TON integration', () => {
   beforeEach(() => {
     __clear();
+    void setAdmins(['addr_admin'], 'addr_admin');
   });
 
   it('adds and retrieves users via TON service', async () => {


### PR DESCRIPTION
## Summary
- Restrict user removal to the account owner or admins
- Ensure tests set an admin when using UsersAgent

## Testing
- `npx jest tests/usersAgent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c70ed6a608326903ed45230f99dc1