### PR TITLE
feat: centralize wallet connection guard

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,15 +1,10 @@
 import { CartItem } from '../types';
-import tonAuth from '../services/tonAuth';
 import { setCartItem, getCartItem, listCartItems, removeCartItem } from '../services/tonCart';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 class CartAgent {
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage your cart.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage your cart.');
   }
 
   async add(item: CartItem): Promise<void> {

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -1,15 +1,10 @@
 import { Category } from '../types';
-import tonAuth from '../services/tonAuth';
 import { setCategory, getCategory, listCategories, removeCategory } from '../services/tonCategories';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 class CategoriesAgent {
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage categories.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage categories.');
   }
 
   async add(item: Category): Promise<void> {

--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -1,16 +1,13 @@
 import { randomUUID } from 'crypto';
-import tonAuth from '../services/tonAuth';
 import { Report } from '../types';
 import { addReport, listReports, removeReport } from '../services/tonReports';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 class ModerationAgent {
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to report items.');
-    }
+    const { address } = await ensureTonWallet(
+      'Please connect your TON wallet to report items.',
+    );
     return { address };
   }
 

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,5 +1,4 @@
 import { Notification } from '../types';
-import tonAuth from '../services/tonAuth';
 import {
   setNotification,
   getNotification,
@@ -15,6 +14,7 @@ import {
   utf8ToBytes,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
@@ -62,12 +62,7 @@ class NotificationsAgent {
   private node: LightNode | null = null;
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to send notifications.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to send notifications.');
   }
 
   async add(item: Notification): Promise<void> {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -15,6 +15,7 @@ import { getSellerPublicKey } from '../services/sellerRegistry';
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '../services/eventLog';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -51,12 +52,7 @@ class OrdersAgent {
   }
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage orders.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage orders.');
   }
 
   private async ensureAuthorized(order: Order) {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,5 +1,4 @@
 import { Product } from '../types';
-import tonAuth from '../services/tonAuth';
 import {
   setProduct,
   getProduct,
@@ -7,6 +6,7 @@ import {
   removeProduct,
 } from '../services/tonProducts';
 import { getStore } from '../services/tonStores';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 interface ProductSummary {
   rating: number;
@@ -18,12 +18,9 @@ class ProductsAgent {
   private summaries: Map<string, ProductSummary> = new Map();
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage products.');
-    }
+    const { address } = await ensureTonWallet(
+      'Please connect your TON wallet to manage products.',
+    );
     return { address };
   }
 

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -1,9 +1,9 @@
 import { Review } from '../types';
-import tonAuth from '../services/tonAuth';
 import { addReview, getReviews } from '../services/tonReviews';
 import ordersAgent from './orders-agent';
 import productsAgent from './products-agent';
 import storesAgent from './stores-agent';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 const TOPIC = '/congress/reviews/1';
 
@@ -11,12 +11,7 @@ class ReviewAgent {
   private subscribers: Set<(r: Review) => void> = new Set();
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage reviews.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage reviews.');
   }
 
   async add(review: Review): Promise<void> {

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -6,6 +6,7 @@ import {
   setAdmins as storeAdmins,
   subscribeToSettingsWrites,
 } from '../services/tonSettings';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 type SettingKey =
   | 'tenantId'
@@ -32,12 +33,7 @@ class SettingsAgent {
   }
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage settings.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage settings.');
   }
 
   async set(key: string, value: string): Promise<void> {

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,6 +1,6 @@
 import { Store } from '../types';
-import tonAuth from '../services/tonAuth';
 import { setStore, getStore, listStores, removeStore } from '../services/tonStores';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 interface Metrics {
   reviewSum: number;
@@ -14,12 +14,7 @@ class StoresAgent {
   private subscribers: Set<(id: string, score: number) => void> = new Set();
 
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage stores.');
-    }
+    await ensureTonWallet('Please connect your TON wallet to manage stores.');
   }
 
   private toRecord(item: Store) {

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,8 +1,8 @@
 import { User } from '../types';
-import tonAuth from '../services/tonAuth';
 import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 import { getPublicKeyHex } from '../services/localIdentity';
 import SettingsAgent from './settings-agent';
+import ensureTonWallet from '../utils/ensureTonWallet';
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
@@ -16,13 +16,7 @@ export type UsersAgentMessage =
 
 class UsersAgent {
   private async ensureWallet() {
-    const address = tonAuth.getAddress();
-    const publicKey = tonAuth.getTonPublicKey();
-    if (!address || !publicKey) {
-      await tonAuth.openModal();
-      throw new Error('Please connect your TON wallet to manage users.');
-    }
-    return { address, publicKey };
+    return ensureTonWallet('Please connect your TON wallet to manage users.');
   }
 
   async add(user: User): Promise<void> {

--- a/utils/ensureTonWallet.ts
+++ b/utils/ensureTonWallet.ts
@@ -1,0 +1,15 @@
+import tonAuth from '../services/tonAuth';
+
+export default async function ensureTonWallet(errorMessage: string) {
+  let address = tonAuth.getAddress();
+  let publicKey = tonAuth.getTonPublicKey();
+  if (!address || !publicKey) {
+    await tonAuth.openModal();
+    address = tonAuth.getAddress();
+    publicKey = tonAuth.getTonPublicKey();
+  }
+  if (!address || !publicKey) {
+    throw new Error(errorMessage);
+  }
+  return { address, publicKey };
+}


### PR DESCRIPTION
## Summary
- add shared `ensureTonWallet` utility to verify TON address and key, opening auth modal when missing
- refactor all agents' `ensureWallet` helpers to use centralized utility

## Testing
- `yarn test` *(fails: TS errors and jest configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_689c732f07bc8326abce42420509dbcb