### PR TITLE
Emit order event notifications

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -16,6 +16,9 @@ import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '../services/eventLog';
 import ensureTonWallet from '../utils/ensureTonWallet';
+import eventBus from '../services/eventBus';
+
+const ORDER_TOPIC = '/congress/orders/1';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -31,6 +34,22 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
   private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};
+
+  private buildBaseEvent(order: Order) {
+    return {
+      id: order.id,
+      orderId: order.id,
+      storeId: order.items?.[0]?.product?.storeId || '',
+      buyerAddress: order.buyerAddress,
+      sellerAddress: order.sellerAddress,
+      payment: {
+        method: order.paymentMethod,
+        contractAddress: order.paymentContractAddress,
+        txHash: order.paymentTxHash,
+        total: order.total,
+      },
+    };
+  }
 
   private async recordSellerMetric(seller?: string, type?: 'completed' | 'refunded') {
     if (!seller) return;
@@ -151,6 +170,11 @@ class OrdersAgent {
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+      ...this.buildBaseEvent(order),
+      prevStatus: current.status,
+      newStatus: order.status,
+    });
     this.subscribers.forEach((cb) => cb(order));
     if (statusChanged) {
       await this.notifyStatusChange(order);
@@ -160,6 +184,11 @@ class OrdersAgent {
         await this.recordSellerMetric(order.sellerAddress, 'refunded');
       }
       if (order.status === 'disputed' || current.status === 'disputed') {
+        await eventBus.publish(ORDER_TOPIC, 'dispute.updated', {
+          ...this.buildBaseEvent(order),
+          prevStatus: current.status,
+          newStatus: order.status,
+        });
         await this.notifyDisputeUpdate(order);
       }
     }
@@ -228,6 +257,14 @@ class OrdersAgent {
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+      ...this.buildBaseEvent(updated),
+      prevStatus: order.status,
+      newStatus: updated.status,
+    });
+    await eventBus.publish(ORDER_TOPIC, 'payment.received', {
+      ...this.buildBaseEvent(updated),
+    });
     await Promise.all(
       order.items.map((item) =>
         productsAgent.decrementStock(
@@ -273,6 +310,11 @@ class OrdersAgent {
       },
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
+    });
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+      ...this.buildBaseEvent(updated),
+      prevStatus: order.status,
+      newStatus: updated.status,
     });
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -28,13 +28,14 @@ jest.mock('../agents/settings-agent', () => ({
 
 jest.mock('../services/tonContract', () => ({
   deployOrderPayment: jest.fn().mockResolvedValue({ contractAddress: 'escrow1', txHash: 'tx1' }),
-  releasePayment: jest.fn(),
-  refundPayment: jest.fn(),
+  releasePayment: jest.fn().mockResolvedValue('hash-release'),
+  refundPayment: jest.fn().mockResolvedValue('hash-refund'),
 }));
 
 jest.mock('../services/sellerRegistry');
 jest.mock('../services/localIdentity');
 jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+jest.mock('../services/eventBus', () => ({ publish: jest.fn() }));
 
 jest.mock('../services/tonAuth', () => ({
   getAddress: jest.fn().mockReturnValue('seller'),
@@ -50,6 +51,7 @@ const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
 const ordersAgent = require('../agents/orders-agent').default;
 const notificationsAgent = require('../agents/notifications-agent');
 const tonAuth = require('../services/tonAuth');
+const eventBus = require('../services/eventBus');
 
 describe('ordersAgent.add', () => {
   it('encrypts shipping address and persists new fields', async () => {
@@ -154,6 +156,120 @@ describe('ordersAgent admin authorization', () => {
       ordersAgent.update({ ...order, status: 'courier_found' })
     ).resolves.not.toThrow();
     expect(mockStore[order.id].status).toBe('courier_found');
+  });
+});
+
+describe('ordersAgent event emission', () => {
+  beforeEach(() => {
+    eventBus.publish.mockClear();
+    tonAuth.getAddress.mockReturnValue('seller');
+  });
+
+  it('emits order.updated on status change', async () => {
+    const order: Order = {
+      id: 'evt1',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'order_received',
+      itemsHash: '',
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      createdAt: '',
+      updatedAt: '',
+      trackingSteps: [],
+    } as any;
+    mockStore[order.id] = order;
+    await ordersAgent.update({ ...order, status: 'courier_found' });
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      '/congress/orders/1',
+      'order.updated',
+      expect.objectContaining({ orderId: order.id, prevStatus: 'order_received', newStatus: 'courier_found' }),
+    );
+  });
+
+  it('emits dispute.updated when entering dispute', async () => {
+    const order: Order = {
+      id: 'evt2',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'delivered',
+      itemsHash: '',
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      createdAt: '',
+      updatedAt: '',
+      trackingSteps: [],
+    } as any;
+    mockStore[order.id] = order;
+    await ordersAgent.update({ ...order, status: 'disputed' });
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      '/congress/orders/1',
+      'dispute.updated',
+      expect.objectContaining({ orderId: order.id, prevStatus: 'delivered', newStatus: 'disputed' }),
+    );
+  });
+
+  it('emits payment.received when releasing payment', async () => {
+    const order: Order = {
+      id: 'evt3',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'delivered',
+      itemsHash: '',
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      escrowAddr: 'esc',
+      paymentContractAddress: 'esc',
+      paymentTxHash: 'tx',
+      createdAt: '',
+      updatedAt: '',
+      trackingSteps: [],
+    } as any;
+    mockStore[order.id] = order;
+    await ordersAgent.releasePayment(order.id);
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      '/congress/orders/1',
+      'payment.received',
+      expect.objectContaining({ orderId: order.id }),
+    );
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      '/congress/orders/1',
+      'order.updated',
+      expect.objectContaining({ prevStatus: 'delivered', newStatus: 'released' }),
+    );
+  });
+
+  it('emits order.updated when refunding payment', async () => {
+    const order: Order = {
+      id: 'evt4',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'delivered',
+      itemsHash: '',
+      paymentMethod: 'ton',
+      buyerAddress: 'buyer',
+      sellerAddress: 'seller',
+      escrowAddr: 'esc',
+      paymentContractAddress: 'esc',
+      paymentTxHash: 'tx',
+      createdAt: '',
+      updatedAt: '',
+      trackingSteps: [],
+    } as any;
+    mockStore[order.id] = order;
+    await ordersAgent.refundPayment(order.id);
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      '/congress/orders/1',
+      'order.updated',
+      expect.objectContaining({ prevStatus: 'delivered', newStatus: 'refunded' }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- publish order lifecycle events from `orders-agent` using eventBus
- broadcast release and refund events with structured payloads
- test event emissions for status changes, disputes, and payments

## Testing
- `npm test tests/ordersAgent.test.ts` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_689c97d5b83083268f7d390f648b8705