### PR TITLE
feat: extend TON settings handling

### DIFF
--- a/contracts/ton/settings.tact
+++ b/contracts/ton/settings.tact
@@ -1,10 +1,12 @@
 contract Settings {
   address owner;
   map<int, cell> data;
+  int feeBps;
   string[] admins;
 
-  init(owner: address, admins: string[]) {
+  init(owner: address, feeBps: int, admins: string[]) {
     self.owner = owner;
+    self.feeBps = feeBps;
     self.admins = admins;
   }
 
@@ -13,13 +15,24 @@ contract Settings {
     self.data.set(key, value);
   }
 
+  receive("set_fee_bps", value: int) {
+    require(sender == self.owner, "only owner");
+    self.feeBps = value;
+    emit("FeeBpsChanged".asComment());
+  }
+
   receive("set_admins", admins: string[]) {
     require(sender == self.owner, "only owner");
     self.admins = admins;
+    emit("AdminsChanged".asComment());
   }
 
   get fun get(key: int): cell? {
     return self.data.get(key);
+  }
+
+  get fun get_fee_bps(): int {
+    return self.feeBps;
   }
 
   get fun get_admins(): string[] {

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -150,6 +150,16 @@ export async function fetchSettings(): Promise<TonSettings> {
   };
 }
 
+export async function getFeeBps(): Promise<number> {
+  const raw = await getSetting('feeBps');
+  const parsed = Number(raw);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export async function setFeeBps(value: number, actor: string): Promise<void> {
+  await setSetting('feeBps', String(value), actor);
+}
+
 export async function getAdmins(): Promise<string[]> {
   const raw = await getSetting('admins');
   try {

--- a/tests/settingsContract.test.ts
+++ b/tests/settingsContract.test.ts
@@ -2,6 +2,40 @@ import { Blockchain } from '@ton/sandbox';
 import { toNano } from 'ton-core';
 import { Settings } from '../contracts/Settings.tact_Settings';
 
+jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
+jest.mock('../utils/appConfig', () => ({
+  getWakuBootstrapNodes: () => ['mock'],
+}));
+const sendMock = jest.fn();
+jest.mock(
+  '@waku/sdk',
+  () => ({
+    Protocols: { Relay: 0 },
+    createLightNode: jest.fn().mockResolvedValue({
+      start: jest.fn(),
+      lightPush: { send: sendMock },
+      relay: { addObserver: jest.fn(), deleteObserver: jest.fn() },
+    }),
+    waitForRemotePeer: jest.fn().mockResolvedValue(undefined),
+    createEncoder: jest.fn(() => 'encoder'),
+    createDecoder: jest.fn(),
+    utf8ToBytes: (s: string) => new TextEncoder().encode(s),
+    bytesToUtf8: (b: Uint8Array) => new TextDecoder().decode(b),
+  }),
+  { virtual: true },
+);
+
+import { __clear } from './tonKvMock';
+let setFeeBps: any, getFeeBps: any, setAdmins: any, getAdmins: any;
+beforeAll(async () => {
+  jest.unmock('../services/tonSettings');
+  const mod = await import('../services/tonSettings');
+  setFeeBps = mod.setFeeBps;
+  getFeeBps = mod.getFeeBps;
+  setAdmins = mod.setAdmins;
+  getAdmins = mod.getAdmins;
+});
+
 describe('Settings contract', () => {
   it('enforces admin gating and updates state', async () => {
     const blockchain = await Blockchain.create();
@@ -21,5 +55,42 @@ describe('Settings contract', () => {
     expect(await contract.getBrand()).toBe('BrandX');
     expect(await contract.getMoonpayKey()).toBe('Moon');
     expect(await contract.getEscrowPolicy()).toBe('Policy');
+  });
+});
+
+describe('tonSettings service', () => {
+  beforeEach(() => {
+    __clear();
+    sendMock.mockClear();
+  });
+
+  it('updates feeBps and admins and emits events', async () => {
+    await setFeeBps(250, 'actor');
+    expect(await getFeeBps()).toBe(250);
+    await setAdmins(['addr1', 'addr2'], 'actor');
+    expect(await getAdmins()).toEqual(['addr1', 'addr2']);
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    const payloads = sendMock.mock.calls.map((c) =>
+      JSON.parse(new TextDecoder().decode(c[1].payload)),
+    );
+    expect(payloads[0]).toEqual(
+      expect.objectContaining({
+        type: 'settings.write',
+        key: 'feeBps',
+        value: '250',
+        actor: 'actor',
+        timestamp: expect.any(Number),
+      }),
+    );
+    expect(payloads[1]).toEqual(
+      expect.objectContaining({
+        type: 'settings.write',
+        key: 'admins',
+        value: JSON.stringify(['addr1', 'addr2']),
+        actor: 'actor',
+        timestamp: expect.any(Number),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add fee basis points and admin tracking to TON settings contract with events
- expose getFeeBps/setFeeBps helpers and reuse for admin updates
- test settings updates emit Waku events

## Testing
- `yarn test tests/settingsContract.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c97d039708326aa99b145b23b5eaa