### PR TITLE
feat: add cross-platform card component

### DIFF
--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -25,6 +25,7 @@ import { PricingTier } from '../../types';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 import PricingTierFormModal from '../../components/PricingTierFormModal';
+import Card from '../../components/Card';
 
 export default function PricingTiersScreen() {
   const { isAdmin, isDriver } = useAuth();
@@ -80,7 +81,8 @@ export default function PricingTiersScreen() {
   };
 
   const renderTierCard = (tier: PricingTier) => (
-    <TouchableOpacity
+    <Card
+      Component={TouchableOpacity}
       key={tier.id}
       style={[
         styles.tierCard,
@@ -150,7 +152,7 @@ export default function PricingTiersScreen() {
           {tier.description}
         </Text>
       </View>
-    </TouchableOpacity>
+    </Card>
   );
 
   if (loading && pricingTiers.length === 0) {
@@ -302,11 +304,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     borderWidth: 1,
-    ...Platform.select({
-      ios: { elevation: 2 },
-      android: { elevation: 2 },
-      web: { boxShadow: '0px 2px 4px rgba(0,0,0,0.1)' },
-    }),
   },
   tierHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 12 },
   tierIcon: {

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -20,6 +20,7 @@ import InfoModal from '../../components/InfoModal';
 import { useAppInfo } from '../../contexts/AppInfoContext';
 import commonStyles from '../../constants/styles';
 import SettingsAgent from '../../agents/settings-agent';
+import Card from '../../components/Card';
 
 
 
@@ -163,15 +164,10 @@ export default function SettingsScreen() {
         </View>
 
         {/* Branding Settings */}
-        <View style={[styles.settingCard, {
+        <Card style={[styles.settingCard, {
           backgroundColor: colors.surface.primary,
           borderColor: colors.border.primary,
-          ...Platform.select({
-            ios: { elevation: 2 },
-            android: { elevation: 2 },
-            web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-          }),
-        }]}>
+        }]}> 
           <View style={styles.settingHeader}>
             <SettingsIcon size={20} color={colors.gold} />
             <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות מיתוג</Text>
@@ -246,18 +242,13 @@ export default function SettingsScreen() {
               )}
             </View>
           </View>
-        </View>
+        </Card>
 
         {/* Currency Settings */}
-        <View style={[styles.settingCard, {
+        <Card style={[styles.settingCard, {
           backgroundColor: colors.surface.primary,
           borderColor: colors.border.primary,
-          ...Platform.select({
-            ios: { elevation: 2 },
-            android: { elevation: 2 },
-            web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-          }),
-        }]}>
+        }]}> 
           <View style={styles.settingHeader}>
             <DollarSign size={20} color={colors.gold} />
             <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות מטבע</Text>
@@ -288,20 +279,15 @@ export default function SettingsScreen() {
               דוגמאות: ₪, $, €, £
             </Text>
           </View>
-        </View>
+        </Card>
 
         {/* Advanced Settings */}
-        <View
+        <Card
           style={[
             styles.settingCard,
             {
               backgroundColor: colors.surface.primary,
               borderColor: colors.border.primary,
-              ...Platform.select({
-                ios: { elevation: 2 },
-                android: { elevation: 2 },
-                web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' },
-              }),
             },
           ]}
         >
@@ -329,18 +315,13 @@ export default function SettingsScreen() {
               Admin Addresses: {admins.join(', ') || 'Not set'}
             </Text>
           </View>
-        </View>
+        </Card>
 
         {/* Language Settings - Info Only */}
-        <View style={[styles.settingCard, { 
+        <Card style={[styles.settingCard, {
           backgroundColor: colors.surface.primary,
           borderColor: colors.border.primary,
-          ...Platform.select({
-            ios: { elevation: 2 },
-            android: { elevation: 2 },
-            web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-          }),
-        }]}>
+        }]}> 
           <View style={styles.settingHeader}>
             <Globe size={20} color={colors.gold} />
             <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות שפה</Text>
@@ -357,19 +338,14 @@ export default function SettingsScreen() {
               </Text>
             </View>
           </View>
-        </View>
+        </Card>
 
         {/* Notification Settings - Coming Soon */}
-        <View style={[styles.settingCard, { 
+        <Card style={[styles.settingCard, {
           backgroundColor: colors.surface.primary,
           borderColor: colors.border.primary,
           opacity: 0.7,
-          ...Platform.select({
-            ios: { elevation: 2 },
-            android: { elevation: 2 },
-            web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-          }),
-        }]}>
+        }]}> 
           <View style={styles.settingHeader}>
             <Bell size={20} color={colors.gold} />
             <Text style={[styles.settingTitle, { color: colors.text.primary }]}>הגדרות התראות</Text>
@@ -384,7 +360,7 @@ export default function SettingsScreen() {
               <Text style={[styles.comingSoonText, { color: colors.text.inverse }]}>בקרוב</Text>
             </View>
           </View>
-        </View>
+        </Card>
 
         <TouchableOpacity 
           style={[styles.saveButton, { backgroundColor: colors.gold }]}

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -22,6 +22,7 @@ import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import { useAuthModal } from '../../components/AuthModalContext';
 import commonStyles from '../../constants/styles';
+import Card from '../../components/Card';
 
 
 
@@ -286,15 +287,10 @@ export default function ReviewsScreen() {
   };
 
   const renderReview = (item: Review) => (
-    <View key={item.id} style={[styles.reviewCard, { 
-      backgroundColor: colors.surface.primary, 
+    <Card key={item.id} style={[styles.reviewCard, {
+      backgroundColor: colors.surface.primary,
       borderColor: colors.border.primary,
-      ...Platform.select({
-        ios: { elevation: 2 },
-        android: { elevation: 2 },
-        web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-      }),
-    }]}>
+    }]}> 
       <View style={styles.reviewHeader}>
         <TouchableOpacity 
           style={styles.productInfo}
@@ -353,7 +349,7 @@ export default function ReviewsScreen() {
           )}
         </View>
       </View>
-    </View>
+    </Card>
   );
 
   const renderOrderSelector = (item: Order) => {
@@ -363,18 +359,14 @@ export default function ReviewsScreen() {
     );
 
     return (
-      <TouchableOpacity
+      <Card
+        Component={TouchableOpacity}
         key={item.id}
         style={[
           styles.orderSelectorItem,
           {
             backgroundColor: colors.surface.primary,
             borderColor: colors.border.primary,
-            ...Platform.select({
-              ios: { elevation: 2 },
-              android: { elevation: 2 },
-              web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-            }),
           },
           alreadyReviewed && styles.orderSelectorItemDisabled
         ]}
@@ -424,7 +416,7 @@ export default function ReviewsScreen() {
             <Text style={[styles.alreadyReviewedText, { color: colors.text.inverse }]}>נסקר</Text>
           </View>
         )}
-      </TouchableOpacity>
+      </Card>
     );
   };
 
@@ -688,15 +680,10 @@ export default function ReviewsScreen() {
             </ScrollView>
           ) : (
             <ScrollView style={styles.reviewForm}>
-              <View style={[styles.selectedOrder, {
+              <Card style={[styles.selectedOrder, {
                 backgroundColor: colors.surface.primary,
                 borderColor: colors.border.primary,
-                ...Platform.select({
-                  ios: { elevation: 2 },
-                  android: { elevation: 2 },
-                  web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-                }),
-              }]}>
+              }]}> 
                 <Text style={[styles.selectedOrderTitle, { color: colors.text.primary }]}>
                   הזמנה #{selectedOrder.id.slice(-6)}
                 </Text>
@@ -722,7 +709,7 @@ export default function ReviewsScreen() {
                     </View>
                   ))}
                 </View>
-              </View>
+              </Card>
 
               <View style={styles.ratingSection}>
                 <Text style={[styles.formLabel, { color: colors.text.primary }]}>דירוג *</Text>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -24,6 +24,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import commonStyles from '../../constants/styles';
+import Card from '../../components/Card';
 
 
 
@@ -423,16 +424,12 @@ export default function SubcategoryScreen() {
   };
 
   const renderProduct = (item: Product) => (
-    <TouchableOpacity
+    <Card
+      Component={TouchableOpacity}
       key={item.id}
-      style={[styles.productCard, { 
-        backgroundColor: colors.surface.primary, 
+      style={[styles.productCard, {
+        backgroundColor: colors.surface.primary,
         borderColor: colors.border.primary,
-        ...Platform.select({
-          ios: { elevation: 2 },
-          android: { elevation: 2 },
-          web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-        }),
       }]}
       onPress={() => router.push(`/product/${item.id}`)}
     >
@@ -494,7 +491,7 @@ export default function SubcategoryScreen() {
           </Text>
         </View>
       </View>
-    </TouchableOpacity>
+    </Card>
   );
 
   if (loading && !subcategory) {
@@ -1149,11 +1146,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     marginBottom: 16,
     borderWidth: 1,
-    ...Platform.select({
-      ios: { elevation: 2 },
-      android: { elevation: 2 },
-      web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-    }),
   },
   productImageContainer: {
     position: 'relative',

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, StyleSheet, Platform, ViewStyle, StyleProp } from 'react-native';
+
+interface CardProps {
+  children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  elevation?: number;
+  Component?: React.ComponentType<any>;
+  [key: string]: any;
+}
+
+function getBoxShadow(elevation: number) {
+  switch (elevation) {
+    case 5:
+      return '0px 4px 12px rgba(0, 0, 0, 0.15)';
+    case 8:
+      return '0px 4px 8px rgba(0, 0, 0, 0.3)';
+    case 12:
+      return '0px 8px 16px rgba(0, 0, 0, 0.3)';
+    default:
+      return `0px ${elevation}px ${elevation * 2}px rgba(0, 0, 0, 0.1)`;
+  }
+}
+
+export default function Card({
+  children,
+  style,
+  elevation = 2,
+  Component = View,
+  ...rest
+}: CardProps) {
+  const shadowStyle = Platform.select({
+    ios: { elevation },
+    android: { elevation },
+    web: { boxShadow: getBoxShadow(elevation) },
+  });
+
+  return (
+    <Component style={[styles.card, shadowStyle, style]} {...rest}>
+      {children}
+    </Component>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+  },
+});
+

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   Image,
   Alert,
-  Platform,
 } from 'react-native';
 import { Heart, Pencil, ShoppingCart, Tag } from 'lucide-react-native';
 import { router } from 'expo-router';
@@ -18,6 +17,7 @@ import DatabaseService from '../services/database';
 import MediaService from '../services/media';
 import { useTonAddress } from '../services/tonAuth';
 import productsAgent from '../agents/products-agent';
+import Card from './Card';
 
 interface ProductCardProps {
   product: Product;
@@ -149,18 +149,13 @@ export default function ProductCard({
   const hasTieredPricing = pricingTier && pricingTier.pricePerUnit !== undefined;
 
   return (
-    <TouchableOpacity style={[
+    <Card Component={TouchableOpacity} style={[
       styles.container,
-      { 
+      {
         backgroundColor: colors.surface.primary,
-        borderColor: colors.border.primary 
+        borderColor: colors.border.primary
       },
       style,
-      Platform.select({
-        ios: { elevation: 2 },
-        android: { elevation: 2 },
-        web: { boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)' }
-      }),
     ]} onPress={handlePress}>
       <View style={styles.imageContainer}>
         {product.images && product.images.length > 0 ? (
@@ -303,7 +298,7 @@ export default function ProductCard({
           </Text>
         </View>
       </View>
-    </TouchableOpacity>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- create reusable Card component with platform-specific elevation/box shadows
- replace inline card styles with Card across admin settings, reviews, pricing tiers, subcategory, and product card components

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d0ade288326b7f6ad037e29291b