### PR TITLE
feat(chat): cache recent messages

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -73,6 +73,7 @@ export default function ChatWidget() {
   const [unreadTotal, setUnreadTotal] = useState(0);
   const [defaultRoomId, setDefaultRoomId] = useState<string | null>(null);
   const messageSoundRef = useRef<Audio.AudioPlayer | null>(null);
+  const lastTimestampRef = useRef(0);
   const isMounted = useRef(true);
   const [pinataConfigured, setPinataConfigured] = useState(true);
   // Modal states
@@ -253,11 +254,12 @@ const loadOrCreateDefaultRoom = async () => {
         unreadCount: 0,
       };
 
+      await db.markChatRoomRead(roomId);
+      const ts = await loadMessages(roomId, adminKey || '');
+      lastTimestampRef.current = ts;
       if (isMounted.current) {
         setSelectedRoom(defaultRoom);
       }
-      await db.markChatRoomRead(roomId);
-      await loadMessages(roomId, adminKey || '');
       await maybeSendOnboardMessage(roomId, adminKey || '');
     } catch (error) {
       console.error('Error creating default room:', error);
@@ -292,6 +294,8 @@ const loadOrCreateDefaultRoom = async () => {
           messagesEndRef.current?.scrollToEnd({ animated: false });
         }
       }, 100);
+
+      return decrypted.length ? decrypted[decrypted.length - 1].timestamp : 0;
     } catch (error) {
       console.error('Error loading messages:', error);
       // Use default welcome message as fallback
@@ -307,6 +311,7 @@ const loadOrCreateDefaultRoom = async () => {
           },
         ]);
       }
+      return 0;
     }
   };
 
@@ -328,6 +333,7 @@ const loadOrCreateDefaultRoom = async () => {
       if (isMounted.current) {
         setMessages((prev) => [...prev, saved]);
       }
+      lastTimestampRef.current = saved.timestamp;
       await AsyncStorage.setItem(CHAT_ONBOARDED_KEY, 'true');
     } catch (error) {
       console.error('Failed to send onboard message', error);
@@ -335,9 +341,6 @@ const loadOrCreateDefaultRoom = async () => {
   };
 
   const openChat = async (room: ChatRoom) => {
-    if (isMounted.current) {
-      setSelectedRoom(room);
-    }
     const db = DatabaseService.getInstance();
     await db.markChatRoomRead(room.id);
     if (isMounted.current) {
@@ -345,7 +348,11 @@ const loadOrCreateDefaultRoom = async () => {
         prev.map((r) => (r.id === room.id ? { ...r, unreadCount: 0 } : r))
       );
     }
-    await loadMessages(room.id, room.userPublicKey || '');
+    const ts = await loadMessages(room.id, room.userPublicKey || '');
+    lastTimestampRef.current = ts;
+    if (isMounted.current) {
+      setSelectedRoom(room);
+    }
     await maybeSendOnboardMessage(room.id, room.userPublicKey || '');
   };
 
@@ -363,22 +370,24 @@ const loadOrCreateDefaultRoom = async () => {
       if (isMounted.current) {
         setMessages((prev) => [...prev, m]);
       }
+      lastTimestampRef.current = m.timestamp;
     };
     let unsubscribe: (() => void) | undefined;
-      waku
-        .subscribe(
-          selectedRoom.id,
-          selectedRoom.userPublicKey || adminKey || '',
-          handler,
-        )
-      .then((unsub) => {
-      unsubscribe = unsub;
-    });
-      waku.fetchHistory(
+    waku
+      .subscribe(
         selectedRoom.id,
         selectedRoom.userPublicKey || adminKey || '',
         handler,
-      );
+      )
+      .then((unsub) => {
+        unsubscribe = unsub;
+      });
+    waku.fetchHistory(
+      selectedRoom.id,
+      selectedRoom.userPublicKey || adminKey || '',
+      handler,
+      lastTimestampRef.current,
+    );
     return () => {
       unsubscribe?.();
     };
@@ -392,9 +401,9 @@ const loadOrCreateDefaultRoom = async () => {
     try {
       let room = chatRooms.find((r) => r.userId === result.id);
       let roomId = room?.id;
+      const db = DatabaseService.getInstance();
 
       if (!roomId) {
-        const db = DatabaseService.getInstance();
         roomId = await db.getOrCreateChatRoom(
           result.id,
           result.displayName,
@@ -413,10 +422,6 @@ const loadOrCreateDefaultRoom = async () => {
         }
       }
 
-      if (isMounted.current) {
-        setSelectedRoom(room!);
-      }
-      const db = DatabaseService.getInstance();
       await db.markChatRoomRead(roomId);
       if (isMounted.current) {
         setChatRooms((prev) =>
@@ -425,7 +430,11 @@ const loadOrCreateDefaultRoom = async () => {
         setSearchQuery('');
         setSearchResults([]);
       }
-      await loadMessages(roomId, room?.userPublicKey || '');
+      const ts = await loadMessages(roomId, room?.userPublicKey || '');
+      lastTimestampRef.current = ts;
+      if (isMounted.current) {
+        setSelectedRoom(room!);
+      }
       await maybeSendOnboardMessage(roomId, room?.userPublicKey || '');
     } catch (error) {
       console.error('Error opening chat with user:', error);
@@ -483,6 +492,7 @@ const loadOrCreateDefaultRoom = async () => {
         setMessages((prev) => [...prev, saved]);
         setNewMessage('');
       }
+      lastTimestampRef.current = saved.timestamp;
 
       setTimeout(() => {
         if (isMounted.current) {

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -32,6 +32,7 @@ export interface WakuClient {
     roomId: string,
     peerPublicKey: string,
     callback: (msg: ChatMessage) => void,
+    after?: number,
   ) => Promise<void>;
   broadcastSystem: (message: string) => Promise<void>;
   subscribeSystem: (cb: (msg: string) => void) => Promise<() => void>;
@@ -144,12 +145,15 @@ export function useWakuClient(): WakuClient {
     roomId: string,
     peerPublicKey: string,
     cb: (msg: ChatMessage) => void,
+    after?: number,
   ) => {
     if (!nodeRef.current) return;
     const decoder = createDecoder(chatTopic(roomId));
-    for await (const msgs of nodeRef.current.store.queryGenerator({
-      contentTopics: [chatTopic(roomId)],
-    })) {
+    const options: any = { contentTopics: [chatTopic(roomId)] };
+    if (after) {
+      options.timeFilter = { startTime: new Date(after + 1) };
+    }
+    for await (const msgs of nodeRef.current.store.queryGenerator(options)) {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
         const encrypted = bytesToUtf8(wakuMsg.payload);

--- a/hooks/useWakuClient.web.ts
+++ b/hooks/useWakuClient.web.ts
@@ -29,6 +29,7 @@ export function useWakuClient() {
       _roomId: string,
       _peerPublicKey: string,
       _cb: (msg: ChatMessage) => void,
+      _after?: number,
     ) => {},
     broadcastSystem: async (_msg: string) => {},
     subscribeSystem: async (_cb: (msg: string) => void) => () => {},

--- a/services/database.ts
+++ b/services/database.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import usersAgent from '../agents/users-agent';
 import categoriesAgent from '../agents/categories-agent';
 import productsAgent from '../agents/products-agent';
@@ -22,6 +23,9 @@ import {
   Order,
   WishlistItem,
 } from '../types';
+
+const CHAT_MESSAGE_LIMIT = 50;
+const CHAT_STORAGE_PREFIX = 'chat_messages_';
 
 class DatabaseService {
   private static instance: DatabaseService;
@@ -287,13 +291,33 @@ class DatabaseService {
   }
 
   async getChatMessages(roomId: string): Promise<ChatMessage[]> {
-    return this.chatMessages.get(roomId) || [];
+    let msgs = this.chatMessages.get(roomId);
+    if (!msgs) {
+      try {
+        const raw = await AsyncStorage.getItem(`${CHAT_STORAGE_PREFIX}${roomId}`);
+        msgs = raw ? JSON.parse(raw) : [];
+      } catch {
+        msgs = [];
+      }
+      msgs = (msgs || []).slice(-CHAT_MESSAGE_LIMIT);
+      this.chatMessages.set(roomId, msgs!);
+    }
+    return msgs || [];
   }
 
   async sendChatMessage(roomId: string, msg: ChatMessage): Promise<void> {
     const msgs = this.chatMessages.get(roomId) || [];
     msgs.push(msg);
-    this.chatMessages.set(roomId, msgs);
+    const trimmed = msgs.slice(-CHAT_MESSAGE_LIMIT);
+    this.chatMessages.set(roomId, trimmed);
+    try {
+      await AsyncStorage.setItem(
+        `${CHAT_STORAGE_PREFIX}${roomId}`,
+        JSON.stringify(trimmed),
+      );
+    } catch (err) {
+      console.error('Failed to persist chat messages', err);
+    }
     const room = this.chatRooms.get(roomId);
     if (room) {
       room.lastMessage = msg.message;
@@ -309,6 +333,14 @@ class DatabaseService {
       if (idx >= 0) {
         msgs[idx] = { ...msgs[idx], reactions };
         this.chatMessages.set(roomId, msgs);
+        try {
+          await AsyncStorage.setItem(
+            `${CHAT_STORAGE_PREFIX}${roomId}`,
+            JSON.stringify(msgs),
+          );
+        } catch (err) {
+          console.error('Failed to persist chat messages', err);
+        }
         return;
       }
     }


### PR DESCRIPTION
## Summary
- persist last 50 chat messages per room using AsyncStorage
- hydrate chats from cache then fetch only newer Waku history
- allow Waku fetchHistory to query messages after a timestamp

## Testing
- `yarn install --frozen-lockfile --ignore-engines`
- `yarn test` *(fails: tests/reputation.test.ts, tests/databaseService.test.ts, tests/storeDashboard.test.tsx, tests/storefront.test.tsx, tests/moonPayButton.test.ts, tests/storefrontCategory.test.tsx, tests/pinataService.test.ts, tests/orderRevenueMetrics.test.tsx, tests/tonSettings.test.ts, tests/chatConfig.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d886974832696531d9e1bb60eb6