### PR TITLE
feat: add TON address validation

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -3,6 +3,7 @@ import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 import { getPublicKeyHex } from '../services/localIdentity';
 import SettingsAgent from './settings-agent';
 import ensureTonWallet from '../utils/ensureTonWallet';
+import validateTonAddress from '../utils/validateTonAddress';
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
@@ -27,6 +28,9 @@ class UsersAgent {
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = { ...user, publicKey, address, chatPublicKey };
+    if (!validateTonAddress(address)) {
+      throw new Error('Invalid TON address');
+    }
     await setUser(enriched);
   }
 
@@ -38,6 +42,9 @@ class UsersAgent {
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = { ...user, publicKey, address, chatPublicKey };
+    if (!validateTonAddress(address)) {
+      throw new Error('Invalid TON address');
+    }
     await setUser(enriched);
   }
 

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -1,5 +1,11 @@
 import usersAgent from '../agents/users-agent';
 
+jest.mock('../utils/validateTonAddress', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(true),
+}));
+import validateTonAddress from '../utils/validateTonAddress';
+
 jest.mock('../services/tonAuth', () => ({
   getAddress: () => 'addr_admin',
   getTonPublicKey: () => 'pub_admin',
@@ -56,5 +62,18 @@ describe('UsersAgent TON integration', () => {
     const verified = await usersAgent.get('u2');
     expect(verified?.kycStatus).toBe('verified');
     expect(verified?.kycApprovedBy).toBe('admin1');
+  });
+
+  it('rejects invalid TON addresses', async () => {
+    (validateTonAddress as jest.Mock).mockReturnValueOnce(false);
+    const user: any = {
+      id: 'u3',
+      username: 'charlie',
+      displayName: 'Charlie',
+      role: 'user',
+      address: '',
+      publicKey: '',
+    };
+    await expect(usersAgent.add(user)).rejects.toThrow('Invalid TON address');
   });
 });

--- a/utils/validateTonAddress.ts
+++ b/utils/validateTonAddress.ts
@@ -1,0 +1,10 @@
+import { Address } from '@ton/core';
+
+export default function validateTonAddress(address: string): boolean {
+  try {
+    Address.parse(address);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add utility to validate TON addresses
- verify addresses in UsersAgent add/update
- cover invalid address scenario in user agent tests

## Testing
- `npm test` *(fails: TypeError mockedGetAdmins.mockResolvedValue is not a function; Jest encountered unexpected token in multiple test files)*

------
https://chatgpt.com/codex/tasks/task_e_689cb891051483268b822c3024cbb0a4