### PR TITLE
Refactor chat search to use app identifiers

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -128,10 +128,10 @@ export default function ChatWidget() {
         try {
           const db = DatabaseService.getInstance();
           const results = await db.searchUserProfiles(searchQuery.trim());
-          const mapped = results.map((r: User) => ({
+          const mapped = results.map((r) => ({
             id: r.id,
             displayName: r.displayName || r.username || r.id,
-            isAppUser: true,
+            chatPublicKey: r.chatPublicKey,
           }));
           setSearchResults(mapped);
         } catch (error) {
@@ -342,7 +342,7 @@ const loadOrCreateDefaultRoom = async () => {
   const openSearchResult = async (result: {
     id: string;
     displayName: string;
-    isAppUser: boolean;
+    chatPublicKey?: string;
   }) => {
     try {
       let room = chatRooms.find((r) => r.userId === result.id);
@@ -353,7 +353,7 @@ const loadOrCreateDefaultRoom = async () => {
         roomId = await db.getOrCreateChatRoom(
           result.id,
           result.displayName,
-          (result as any).chatPublicKey
+          result.chatPublicKey
         );
         room = {
           id: roomId,
@@ -391,7 +391,7 @@ const loadOrCreateDefaultRoom = async () => {
     setProfileModalVisible(false);
     setProfileUserId(null);
     setIsOpen(true);
-    await openSearchResult({ id, displayName: name, isAppUser: true });
+    await openSearchResult({ id, displayName: name });
   };
 
   const ensureChatConfigured = async (): Promise<boolean> => {

--- a/services/database.ts
+++ b/services/database.ts
@@ -257,12 +257,20 @@ class DatabaseService {
     return usersAgent.getAll();
   }
 
-  async searchUserProfiles(query: string): Promise<User[]> {
+  async searchUserProfiles(
+    query: string,
+  ): Promise<Pick<User, 'id' | 'username' | 'displayName' | 'chatPublicKey'>[]> {
     return usersAgent
       .getAll()
       .filter((u) =>
         u.displayName?.toLowerCase().includes(query.toLowerCase()),
-      );
+      )
+      .map((u) => ({
+        id: u.id,
+        username: u.username,
+        displayName: u.displayName,
+        chatPublicKey: u.chatPublicKey,
+      }));
   }
 
   async updateUserCustomerTier(


### PR DESCRIPTION
## Summary
- remove legacy Matrix fields from chat search mapping
- return only app-specific identifiers from `searchUserProfiles`

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb893da1c8326b4065fc4730eed00