### PR TITLE
Verify Waku message signatures

### DIFF
--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -14,6 +14,8 @@ import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
 import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
+import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import { WakuMessage } from '../types/waku';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
@@ -114,19 +116,33 @@ export function useWakuClient(): WakuClient {
     const decoder = createDecoder(chatTopic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
-      const encrypted = bytesToUtf8(wakuMsg.payload);
-      const text = await decryptMessage(encrypted, roomId, peerPublicKey);
-      const chat: ChatMessage = {
-        id: Date.now().toString(),
-        senderId: wakuMsg.meta?.sender || 'peer',
-        senderName: wakuMsg.meta?.sender || 'peer',
-        message: text,
-        timestamp: Date.now(),
-        isAdmin: false,
-      };
-      const db = DatabaseService.getInstance();
-      await db.sendChatMessage(roomId, { ...chat, message: encrypted });
-      cb(chat);
+      try {
+        const signed: WakuMessage<string> = JSON.parse(
+          bytesToUtf8(wakuMsg.payload),
+        );
+        if (
+          !(await verifyMessageSignature(signed, signed.sender.publicKey))
+        )
+          return;
+        const text = await decryptMessage(
+          signed.payload,
+          roomId,
+          peerPublicKey,
+        );
+        const chat: ChatMessage = {
+          id: Date.now().toString(),
+          senderId: signed.sender.publicKey,
+          senderName: signed.sender.publicKey,
+          message: text,
+          timestamp: Date.now(),
+          isAdmin: false,
+        };
+        const db = DatabaseService.getInstance();
+        await db.sendChatMessage(roomId, { ...chat, message: signed.payload });
+        cb(chat);
+      } catch {
+        /* ignore malformed messages */
+      }
     };
     const maybeUnsub = (nodeRef.current.relay as any).addObserver(
       handler,
@@ -157,19 +173,35 @@ export function useWakuClient(): WakuClient {
     for await (const msgs of nodeRef.current.store.queryGenerator(options)) {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
-        const encrypted = bytesToUtf8(wakuMsg.payload);
-        const text = await decryptMessage(encrypted, roomId, peerPublicKey);
-        const chat: ChatMessage = {
-          id: Date.now().toString(),
-          senderId: wakuMsg.meta?.sender || 'peer',
-          senderName: wakuMsg.meta?.sender || 'peer',
-          message: text,
-          timestamp: wakuMsg.timestamp ? Number(wakuMsg.timestamp) : Date.now(),
-          isAdmin: false,
-        };
-        const db = DatabaseService.getInstance();
-        await db.sendChatMessage(roomId, { ...chat, message: encrypted });
-        cb(chat);
+        try {
+          const signed: WakuMessage<string> = JSON.parse(
+            bytesToUtf8(wakuMsg.payload),
+          );
+          if (
+            !(await verifyMessageSignature(signed, signed.sender.publicKey))
+          )
+            continue;
+          const text = await decryptMessage(
+            signed.payload,
+            roomId,
+            peerPublicKey,
+          );
+          const chat: ChatMessage = {
+            id: Date.now().toString(),
+            senderId: signed.sender.publicKey,
+            senderName: signed.sender.publicKey,
+            message: text,
+            timestamp: wakuMsg.timestamp
+              ? Number(wakuMsg.timestamp)
+              : Date.now(),
+            isAdmin: false,
+          };
+          const db = DatabaseService.getInstance();
+          await db.sendChatMessage(roomId, { ...chat, message: signed.payload });
+          cb(chat);
+        } catch {
+          /* ignore malformed messages */
+        }
       }
     }
   };

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -12,6 +12,10 @@ import {
   bytesToUtf8,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
+import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import { WakuMessage } from '../types/waku';
+import { sign } from '@noble/ed25519';
+import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
 const ADDRESS =
   config.TON_SETTINGS_ADDRESS ??
@@ -64,9 +68,23 @@ async function emit(event: SettingsWriteEvent) {
   const n = await ensureNode();
   if (!n) return;
   try {
+    const priv = await getPrivateKey();
+    const pub = await getPublicKeyHex();
+    const msg: WakuMessage<SettingsWriteEvent> = {
+      type: event.type,
+      payload: event,
+      sender: { publicKey: pub },
+      signature: '',
+    };
+    const msgBytes = new TextEncoder().encode(
+      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+    );
+    const sig = await sign(msgBytes, priv);
+    msg.signature = Buffer.from(sig).toString('hex');
+
     const encoder = createEncoder({ contentTopic: '/congress/settings/1' });
     await n.lightPush.send(encoder, {
-      payload: utf8ToBytes(JSON.stringify(event)),
+      payload: utf8ToBytes(JSON.stringify(msg)),
     });
   } catch (err) {
     errorLog('Failed to broadcast settings.write', err);
@@ -79,12 +97,19 @@ export async function subscribeToSettingsWrites(
   const n = await ensureNode();
   if (!n) return () => {};
   const decoder = createDecoder('/congress/settings/1');
-  const handler = (wakuMsg: any) => {
+  const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
-      const evt = JSON.parse(bytesToUtf8(wakuMsg.payload));
+      const signed: WakuMessage<SettingsWriteEvent> = JSON.parse(
+        bytesToUtf8(wakuMsg.payload),
+      );
+      if (
+        !(await verifyMessageSignature(signed, signed.sender.publicKey))
+      )
+        return;
+      const evt = signed.payload;
       if (evt && evt.type === 'settings.write') {
-        cb(evt as SettingsWriteEvent);
+        cb(evt);
       }
     } catch {
       /* ignore malformed events */

--- a/tests/verifyMessageSignature.test.ts
+++ b/tests/verifyMessageSignature.test.ts
@@ -1,0 +1,28 @@
+import { getPublicKey, sign, utils } from '@noble/ed25519';
+import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import type { WakuMessage } from '../types/waku';
+
+describe('verifyMessageSignature', () => {
+  it('accepts valid signatures and rejects invalid ones', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const pubHex = Buffer.from(pub).toString('hex');
+
+    const msg: WakuMessage<string> = {
+      type: 'test',
+      payload: 'hello',
+      sender: { publicKey: pubHex },
+      signature: '',
+    };
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+    );
+    const sig = await sign(bytes, priv);
+    msg.signature = Buffer.from(sig).toString('hex');
+
+    await expect(verifyMessageSignature(msg, pubHex)).resolves.toBe(true);
+
+    const tampered = { ...msg, payload: 'bye' };
+    await expect(verifyMessageSignature(tampered, pubHex)).resolves.toBe(false);
+  });
+});

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -1,0 +1,9 @@
+export interface WakuMessage<T = any> {
+  type: string;
+  payload: T;
+  sender: {
+    publicKey: string;
+    role?: string;
+  };
+  signature: string;
+}

--- a/utils/verifyMessageSignature.ts
+++ b/utils/verifyMessageSignature.ts
@@ -1,0 +1,26 @@
+import { verify } from '@noble/ed25519';
+import type { WakuMessage } from '../types/waku';
+
+export async function verifyMessageSignature<T>(
+  message: WakuMessage<T>,
+  publicKey: string,
+): Promise<boolean> {
+  try {
+    const msgBytes = new TextEncoder().encode(
+      JSON.stringify({
+        type: message.type,
+        payload: message.payload,
+        sender: message.sender,
+      }),
+    );
+    const sigBytes = Uint8Array.from(
+      Buffer.from(message.signature.replace(/^0x/, ''), 'hex'),
+    );
+    const pubBytes = Uint8Array.from(
+      Buffer.from(publicKey.replace(/^0x/, ''), 'hex'),
+    );
+    return await verify(sigBytes, msgBytes, pubBytes);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- define shared `WakuMessage` interface
- add `verifyMessageSignature` utility using ed25519
- validate signatures in Waku client and TON settings handlers
- cover signature verification with unit tests

## Testing
- `npm test` *(fails: Cannot find module '@/utils/logger' from 'constants/tenant.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689cd73b2f088326802c7ac5dde60ef9