### PR TITLE
refactor: virtualize storefront product list

### DIFF
--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView, TextInput, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  I18nManager,
+} from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import productsAgent from '../../agents/products-agent';
 import reviewAgent from '../../agents/review-agent';
@@ -26,6 +35,7 @@ export default function StorefrontScreen({ initialCategory }: Props) {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [filtered, setFiltered] = useState<Product[]>([]);
   const fuseRef = useRef<Fuse<Product> | null>(null);
+  const CARD_HEIGHT = 220;
 
   useEffect(() => {
     const load = async () => {
@@ -69,11 +79,8 @@ export default function StorefrontScreen({ initialCategory }: Props) {
     setFiltered(result);
   }, [products, search, selectedCategory, selectedTag]);
 
-  return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={styles.content}
-    >
+  const renderHeader = () => (
+    <>
       <TextInput
         testID="search-input"
         style={[styles.searchInput, { borderColor: colors.border.primary, color: colors.text.primary }]}
@@ -122,20 +129,44 @@ export default function StorefrontScreen({ initialCategory }: Props) {
           ))}
         </ScrollView>
       )}
-      {filtered.map((p) => (
-        <View key={p.id} style={styles.product}>
-          <ProductCard product={p} style={{ marginBottom: 4 }} />
-          <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
-            ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
-          </Text>
-        </View>
-      ))}
-      {filtered.length === 0 && (
+    </>
+  );
+
+  const renderItem = ({ item: p }: { item: Product }) => (
+    <View style={styles.product}>
+      <ProductCard product={p} style={{ marginBottom: 4 }} />
+      <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+        ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
+      </Text>
+    </View>
+  );
+
+  const getItemLayout = (_data: any, index: number) => ({
+    length: CARD_HEIGHT,
+    offset: CARD_HEIGHT * index,
+    index,
+  });
+
+  return (
+    <FlatList
+      data={filtered}
+      keyExtractor={(item) => item.id}
+      renderItem={renderItem}
+      ListHeaderComponent={renderHeader}
+      ListEmptyComponent={() => (
         <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
           אין מוצרים זמינים
         </Text>
       )}
-    </ScrollView>
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[
+        styles.content,
+        { direction: I18nManager.isRTL ? 'rtl' : 'ltr' },
+      ]}
+      initialNumToRender={8}
+      windowSize={5}
+      getItemLayout={getItemLayout}
+    />
   );
 }
 

--- a/tests/__mocks__/react-native.js
+++ b/tests/__mocks__/react-native.js
@@ -10,4 +10,53 @@ const TextInput = ({ value, onChangeText, placeholder, style, testID }) =>
   React.createElement('TextInput', { value, onChangeText, placeholder, style, testID });
 const StyleSheet = { create: (s) => s };
 
-module.exports = { Platform: { OS: 'ios' }, View, Text, ScrollView, TouchableOpacity, TextInput, StyleSheet };
+const FlatList = ({
+  data = [],
+  renderItem,
+  keyExtractor,
+  ListHeaderComponent,
+  ListEmptyComponent,
+  style,
+  contentContainerStyle,
+}) => {
+  const children = [];
+  if (ListHeaderComponent) {
+    children.push(
+      typeof ListHeaderComponent === 'function'
+        ? ListHeaderComponent()
+        : ListHeaderComponent
+    );
+  }
+  if (data && renderItem) {
+    data.forEach((item, index) => {
+      const element = renderItem({ item, index });
+      children.push(
+        React.cloneElement(element, {
+          key: keyExtractor ? keyExtractor(item, index) : String(index),
+        })
+      );
+    });
+  }
+  if (data.length === 0 && ListEmptyComponent) {
+    children.push(
+      typeof ListEmptyComponent === 'function'
+        ? ListEmptyComponent()
+        : ListEmptyComponent
+    );
+  }
+  return React.createElement('FlatList', { style, contentContainerStyle }, children);
+};
+
+const I18nManager = { isRTL: false };
+
+module.exports = {
+  Platform: { OS: 'ios' },
+  View,
+  Text,
+  ScrollView,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  StyleSheet,
+  I18nManager,
+};


### PR DESCRIPTION
## Summary
- replace storefront ScrollView with FlatList keyed by product ids
- add constant card height and getItemLayout for smoother scrolling
- mock FlatList and I18nManager in tests

## Testing
- `npm test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4"*)

------
https://chatgpt.com/codex/tasks/task_e_689cd737084883269e321d49881416b3