### PR TITLE
refactor: optimize images with expo-image placeholders

### DIFF
--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -7,9 +7,9 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  Image,
   Platform,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -88,11 +88,7 @@ export default function AgeVerificationModal() {
                 ]}
               >
                 {logoCid ? (
-                  <Image
-                    source={{ uri: logoCid }}
-                    style={styles.logoImage}
-                    resizeMode="contain"
-                  />
+                  <SmartImage uri={logoCid} style={styles.logoImage} contentFit="contain" cachePolicy="disk" />
                 ) : (
                   <Shield size={60} color={colors.gold} />
                 )}

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -6,12 +6,12 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  Image,
   TextInput,
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import {
   X,
   Minus,
@@ -346,9 +346,11 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         { backgroundColor: colors.surface.primary, borderColor: colors.border.primary },
       ]}
     >
-      <Image
-        source={{ uri: item.product.images?.[0] || '' }}
+      <SmartImage
+        uri={item.product.images?.[0] || ''}
         style={styles.productImage}
+        contentFit="cover"
+        cachePolicy="disk"
       />
 
       <View style={styles.productInfo}>

--- a/components/FloatingCartWidget.tsx
+++ b/components/FloatingCartWidget.tsx
@@ -5,11 +5,11 @@ import {
   StyleSheet,
   TouchableOpacity,
   Animated,
-  Image,
   ScrollView,
   Dimensions,
   Platform,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { ShoppingCart, X, Plus, Minus } from 'lucide-react-native';
 import CartService from '../services/cart';
 import { CartItem } from '../types';
@@ -133,17 +133,19 @@ export default function FloatingCartWidget() {
         <View style={styles.headerRight}>
           <View style={styles.productPreview}>
             {cartItems.slice(0, 3).map((item, index) => (
-              <Image
+              <SmartImage
                 key={item.id}
-                source={{ uri: item.product.images[0] }}
+                uri={item.product.images[0]}
                 style={[
                   styles.previewImage,
-                  { 
+                  {
                     marginLeft: index > 0 ? -8 : 0,
                     zIndex: 3 - index,
                     borderColor: colors.background,
                   }
                 ]}
+                contentFit="cover"
+                cachePolicy="disk"
               />
             ))}
             {cartItems.length > 3 && (
@@ -170,9 +172,11 @@ export default function FloatingCartWidget() {
               <View key={item.id} style={[styles.cartItem, { 
                 borderBottomColor: colors.border.secondary 
               }]}>
-                <Image 
-                  source={{ uri: item.product.images[0] }} 
-                  style={styles.itemImage} 
+                <SmartImage
+                  uri={item.product.images[0]}
+                  style={styles.itemImage}
+                  contentFit="cover"
+                  cachePolicy="disk"
                 />
                 
                 <View style={styles.itemInfo}>

--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   StyleSheet,
-  Image,
   TouchableOpacity,
   TouchableWithoutFeedback,
   Dimensions,
@@ -12,6 +11,7 @@ import {
   Platform,
   Alert,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { X, ChevronLeft, ChevronRight, Share2, Download } from 'lucide-react-native';
 import { PanGestureHandler, PinchGestureHandler, State } from 'react-native-gesture-handler';
@@ -309,10 +309,11 @@ export default function FullScreenMediaViewer({
                 <Animated.View style={styles.gestureContainer}>
                   <PanGestureHandler onGestureEvent={panHandler}>
                     <Animated.View style={[styles.imageWrapper, animatedStyle]}>
-                      <Image 
-                        source={{ uri: currentMedia.uri }} 
+                      <SmartImage
+                        uri={currentMedia.uri}
                         style={styles.media}
-                        resizeMode="contain"
+                        contentFit="contain"
+                        cachePolicy="disk"
                       />
                     </Animated.View>
                   </PanGestureHandler>

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -5,8 +5,8 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
-  Image,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { Heart, Search, Star } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -61,11 +61,7 @@ export default function GlobalHeader({
             onPress={() => router.push('/(tabs)')}
           >
             {logoCid ? (
-              <Image
-                source={{ uri: logoCid }}
-                style={styles.logoImage}
-                resizeMode="contain"
-              />
+              <SmartImage uri={logoCid} style={styles.logoImage} contentFit="contain" cachePolicy="disk" />
             ) : (
               <View
                 style={[styles.logoIcon, { backgroundColor: colors.gold }]}

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -6,11 +6,11 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  Image,
   Alert,
   Platform,
   ActivityIndicator,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { Camera, Upload, X, Play, Video } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '../contexts/ThemeContext';
@@ -223,7 +223,7 @@ export default function MediaUploader({
       }]}>
         {item.type === 'video' ? (
           <View style={styles.videoContainer}>
-            <Image source={{ uri: thumbnailMap[item.id] || item.uri }} style={styles.mediaThumbnail} />
+            <SmartImage uri={thumbnailMap[item.id] || item.uri} style={styles.mediaThumbnail} contentFit="cover" cachePolicy="disk" />
             <View style={styles.playOverlay}>
               <Play size={24} color={colors.text.inverse} fill={colors.text.inverse} />
             </View>
@@ -232,7 +232,7 @@ export default function MediaUploader({
             </View>
           </View>
         ) : (
-          <Image source={{ uri: item.uri }} style={styles.mediaThumbnail} />
+          <SmartImage uri={item.uri} style={styles.mediaThumbnail} contentFit="cover" cachePolicy="disk" />
         )}
         
         <TouchableOpacity

--- a/components/MediaViewer.tsx
+++ b/components/MediaViewer.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import {
   View,
   StyleSheet,
-  Image,
   TouchableOpacity,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { X } from 'lucide-react-native';
 import { PanGestureHandler, PinchGestureHandler } from 'react-native-gesture-handler';
@@ -94,11 +94,11 @@ export default function MediaViewer({ media, initialIndex, onClose }: Props) {
             <PanGestureHandler onGestureEvent={panHandler}>
               <Animated.View style={[styles.mediaWrapper, animatedStyle]}>
                 {currentMedia?.type === 'image' ? (
-                  <Image source={{ uri: currentMedia.url }} style={styles.media} resizeMode="contain" />
+                  <SmartImage uri={currentMedia.url} style={styles.media} contentFit="contain" cachePolicy="disk" />
                 ) : (
                   <View style={styles.videoPlaceholder}>
                     {/* In a real app, you'd use react-native-video here */}
-                    <Image source={{ uri: currentMedia?.url }} style={styles.media} resizeMode="contain" />
+                    <SmartImage uri={currentMedia?.url || ''} style={styles.media} contentFit="contain" cachePolicy="disk" />
                   </View>
                 )}
               </Animated.View>

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -7,11 +7,11 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  Image,
   Animated,
   Easing,
   Alert,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { X, CircleCheck as CheckCircle, Circle, Package, Truck, MapPin, Star, Phone, MessageCircle, Copy } from 'lucide-react-native';
 import { Order, OrderStatus } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
@@ -444,9 +444,11 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
             <Text style={[styles.itemsTitle, { color: colors.text.primary }]}>פריטים בהזמנה</Text>
             {order.items.map((item, index) => (
               <View key={index} style={[styles.orderItem, { borderBottomColor: colors.border.secondary }]}>
-                <Image 
-                  source={{ uri: item.product.images[0] }}
+                <SmartImage
+                  uri={item.product.images[0]}
                   style={styles.itemImage}
+                  contentFit="cover"
+                  cachePolicy="disk"
                 />
                 <View style={styles.itemInfo}>
                   <Text style={[styles.itemName, { color: colors.text.primary }]}>{item.product.name}</Text>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -5,9 +5,9 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Image,
   Alert,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { Heart, Pencil, ShoppingCart, Tag } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { Product, PricingTier } from '../types';
@@ -160,10 +160,10 @@ export default function ProductCard({
     ]} onPress={handlePress}>
       <View style={styles.imageContainer}>
         {product.images && product.images.length > 0 ? (
-          <Image source={{ uri: product.images[0] }} style={styles.image} resizeMode="cover" />
+          <SmartImage uri={product.images[0]} style={styles.image} contentFit="cover" cachePolicy="disk" />
         ) : product.videos && product.videos.length > 0 ? (
           videoThumbnail ? (
-            <Image source={{ uri: videoThumbnail }} style={styles.image} resizeMode="cover" />
+            <SmartImage uri={videoThumbnail} style={styles.image} contentFit="cover" cachePolicy="disk" />
           ) : (
             <View style={styles.noImageContainer}>
               <Text style={styles.noImageText}>אין תמונה</Text>

--- a/components/ProofUploader.tsx
+++ b/components/ProofUploader.tsx
@@ -5,11 +5,11 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Image,
   ActivityIndicator,
   Alert,
   Platform
 } from 'react-native';
+import SmartImage from './SmartImage';
 import * as ImagePicker from 'expo-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
 import { Upload, Camera, File as FileIcon } from 'lucide-react-native';
@@ -106,7 +106,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
     <View style={styles.container}>
       {uri ? (
         uri.match(/\.(jpg|jpeg|png|gif|webp)$/i) ? (
-          <Image source={{ uri }} style={styles.preview} />
+          <SmartImage uri={uri} style={styles.preview} contentFit="cover" cachePolicy="disk" />
         ) : (
           <View style={[styles.filePreview, { borderColor: colors.border.primary }]}>
             <FileIcon size={24} color={colors.text.primary} />

--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { Image as ExpoImage, ImageProps } from 'expo-image';
+
+const placeholder = require('../assets/images/icon.png');
+
+interface SmartImageProps extends Omit<ImageProps, 'source'> {
+  uri: string;
+}
+
+export default function SmartImage({ uri, style, contentFit = 'cover', cachePolicy = 'disk', ...props }: SmartImageProps) {
+  const [source, setSource] = useState<{ uri: string } | number>({ uri });
+
+  return (
+    <ExpoImage
+      {...props}
+      source={source}
+      style={style}
+      contentFit={contentFit}
+      cachePolicy={cachePolicy}
+      placeholder={placeholder}
+      onError={() => setSource(placeholder)}
+    />
+  );
+}

--- a/components/WishlistModal.tsx
+++ b/components/WishlistModal.tsx
@@ -6,9 +6,9 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  Image,
   Alert,
 } from 'react-native';
+import SmartImage from './SmartImage';
 import { X, Heart, ShoppingCart, Trash2 } from 'lucide-react-native';
 import { router } from 'expo-router';
 import CartService from '../services/cart';
@@ -72,7 +72,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
       }]}
       onPress={() => viewProduct(item.productId)}
     >
-      <Image source={{ uri: item.product.images[0] }} style={styles.productImage} />
+      <SmartImage uri={item.product.images[0]} style={styles.productImage} contentFit="cover" cachePolicy="disk" />
       
       <View style={styles.productInfo}>
         <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={2}>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "expo-jwt": "^1.8.2",
     "expo-linear-gradient": "~14.1.3",
     "expo-linking": "~7.1.3",
+    "expo-image": "~2.4.0",
     "expo-router": "~5.1.3",
     "expo-secure-store": "^14.2.3",
     "expo-splash-screen": "~0.30.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6687,6 +6687,11 @@ expo-image-picker@~16.1.0:
   dependencies:
     expo-image-loader "~5.1.0"
 
+expo-image@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-2.4.0.tgz#02f7fd743387206914cd431a6367f5be53509e3e"
+  integrity sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw==
+
 expo-jwt@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expo-jwt/-/expo-jwt-1.8.2.tgz#cb78d84d35b3db7cd4f01f284be159ad940331fb"


### PR DESCRIPTION
## Summary
- add SmartImage wrapper built on expo-image with disk caching and fallback
- update product and list components to use SmartImage for better performance
- include expo-image dependency

## Testing
- `yarn install --ignore-engines`
- `yarn test` *(fails: Cannot find module '@/utils/logger' from 'constants/tenant.ts')*
- `yarn lint` *(fails: React Hook "useEffect" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_689cd735b7b88326a9e630494e5b820d