### PR TITLE
feat: use SmartImage for cached images

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   StyleSheet,
   ScrollView,
-  Image,
   TouchableOpacity,
   FlatList,
   Dimensions,
@@ -37,6 +36,7 @@ import EmptyState from '../../components/EmptyState';
 import BannerFormModal from '../../components/BannerFormModal';
 import CartModal from '../../components/CartModal';
 import ProductFormModal from '../../components/ProductFormModal';
+import SmartImage from '../../components/SmartImage';
 
 const { width } = Dimensions.get('window');
 const BANNER_WIDTH = width - 32;
@@ -265,10 +265,11 @@ export default function HomeScreen() {
         style={styles.bannerTouchable}
         onPress={() => router.push(`/category/${item.category}`)}
       >
-        <Image
-          source={{ uri: item.image }}
+        <SmartImage
+          uri={item.image}
           style={styles.heroImage}
-          resizeMode="cover"
+          contentFit="cover"
+          cachePolicy="disk"
         />
         <View style={styles.heroOverlay}>
           <View style={styles.heroContent}>

--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -8,7 +8,6 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
-  Image,
   Linking,
   Platform,
 } from 'react-native';
@@ -21,6 +20,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
 import { DeliveryJob, User } from '../../types';
 import commonStyles from '../../constants/styles';
+import SmartImage from '../../components/SmartImage';
 
 export default function AdminDeliveriesScreen() {
   const { isAdmin } = useAuth();
@@ -250,9 +250,10 @@ export default function AdminDeliveriesScreen() {
             )}
             {job.proofUri && (
               <TouchableOpacity onPress={() => openProof(job.proofUri!)}>
-                <Image
-                  source={{ uri: job.proofUri }}
+                <SmartImage
+                  uri={job.proofUri}
                   style={styles.proofImage}
+                  cachePolicy="disk"
                 />
               </TouchableOpacity>
             )}

--- a/app/admin/kyc-approvals.tsx
+++ b/app/admin/kyc-approvals.tsx
@@ -7,7 +7,6 @@ import {
   TouchableOpacity,
   ScrollView,
   Alert,
-  Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -18,6 +17,7 @@ import DatabaseService from '../../services/database';
 import { User as UserType } from '../../types';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import commonStyles from '../../constants/styles';
+import SmartImage from '../../components/SmartImage';
 
 
 
@@ -144,7 +144,11 @@ export default function KycApprovalsScreen() {
                 <View style={styles.userInfo}>
                   <View style={styles.avatarContainer}>
                     {request.avatar ? (
-                      <Image source={{ uri: request.avatar }} style={[styles.avatar, { borderColor: colors.gold }]} />
+                      <SmartImage
+                        uri={request.avatar}
+                        style={[styles.avatar, { borderColor: colors.gold }]}
+                        cachePolicy="disk"
+                      />
                     ) : (
                       <View style={[styles.avatarPlaceholder, { 
                         backgroundColor: colors.surface.secondary,

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  Image,
   Alert,
   Dimensions,
   Modal,
@@ -48,6 +47,7 @@ import reviewAgent from '../../agents/review-agent';
 import commonStyles from '../../constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '../../components/FloatingCartWidget';
+import SmartImage from '../../components/SmartImage';
 
 
 
@@ -479,10 +479,11 @@ export default function ProductDetailScreen() {
           onPress={() => openMediaViewer(0)}
         >
           {mainImageUri ? (
-            <Image
-              source={{ uri: mainImageUri }}
+            <SmartImage
+              uri={mainImageUri}
               style={styles.coverImage}
-              resizeMode="cover"
+              contentFit="cover"
+              cachePolicy="disk"
             />
           ) : (
             <View style={styles.noImageContainer}>
@@ -511,10 +512,11 @@ export default function ProductDetailScreen() {
                   ]}
                   onPress={() => openMediaViewer(idx)}
                 >
-                  <Image
-                    source={{ uri: media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri }}
+                  <SmartImage
+                    uri={media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri}
                     style={styles.galleryImage}
-                    resizeMode="cover"
+                    contentFit="cover"
+                    cachePolicy="disk"
                   />
                   {media.type === 'video' && (
                     <View style={styles.videoIndicator}>
@@ -685,10 +687,11 @@ export default function ProductDetailScreen() {
                     ]}
                     onPress={() => openMediaViewer(index)}
                   >
-                    <Image
-                      source={{ uri: media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri }}
+                    <SmartImage
+                      uri={media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri}
                       style={styles.galleryImage}
-                      resizeMode="cover"
+                      contentFit="cover"
+                      cachePolicy="disk"
                     />
                     {media.type === 'video' && (
                       <View style={styles.videoIndicator}>

--- a/app/reviews/[orderId].tsx
+++ b/app/reviews/[orderId].tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, ScrollView, Image, StyleSheet } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, router } from 'expo-router';
 import { Star, ArrowLeft } from 'lucide-react-native';
@@ -9,6 +9,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import ordersAgent from '../../agents/orders-agent';
 import reviewAgent from '../../agents/review-agent';
 import { Order, Review } from '../../types';
+import SmartImage from '../../components/SmartImage';
 
 export default function SubmitReviewScreen() {
   const { orderId } = useLocalSearchParams<{ orderId: string }>();
@@ -102,9 +103,15 @@ export default function SubmitReviewScreen() {
         <View style={{ width: 40 }} />
       </View>
       <ScrollView contentContainerStyle={styles.content}> 
-        <View style={styles.productRow}> 
-          <Image source={{ uri: item.product.images[0] }} style={styles.productImage} />
-          <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={1}>{item.product.name}</Text>
+        <View style={styles.productRow}>
+          <SmartImage
+            uri={item.product.images[0]}
+            style={styles.productImage}
+            cachePolicy="disk"
+          />
+          <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={1}>
+            {item.product.name}
+          </Text>
         </View>
         <View style={styles.ratingSection}> 
           {renderStars()}

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Image,
   TextInput,
   Modal,
   Platform,
@@ -24,6 +23,7 @@ import ConfirmationModal from '../../components/ConfirmationModal';
 import { useAuthModal } from '../../components/AuthModalContext';
 import commonStyles from '../../constants/styles';
 import Card from '../../components/Card';
+import SmartImage from '../../components/SmartImage';
 
 
 
@@ -297,7 +297,11 @@ export default function ReviewsScreen() {
           style={styles.productInfo}
           onPress={() => router.push(`/product/${item.productId}`)}
         >
-          <Image source={{ uri: item.productImage }} style={styles.productThumbnail} />
+          <SmartImage
+            uri={item.productImage}
+            style={styles.productThumbnail}
+            cachePolicy="disk"
+          />
           <View style={styles.productDetails}>
             <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={1}>
               {item.productName}
@@ -312,7 +316,11 @@ export default function ReviewsScreen() {
 
       <View style={[styles.reviewContent, { borderTopColor: colors.border.primary }]}>
         <View style={styles.userInfo}>
-          <Image source={{ uri: item.userAvatar }} style={styles.userAvatar} />
+          <SmartImage
+            uri={item.userAvatar}
+            style={styles.userAvatar}
+            cachePolicy="disk"
+          />
           <View>
             <Text style={[styles.userName, { color: colors.text.primary }]}>{item.userName}</Text>
             {item.verified && (
@@ -395,9 +403,10 @@ export default function ReviewsScreen() {
           <View style={[styles.orderSelectorItems, { borderTopColor: colors.border.secondary }]}>
             {item.items.slice(0, 2).map((orderItem, index) => (
               <View key={index} style={styles.orderSelectorItemRow}>
-                <Image 
-                  source={{ uri: orderItem.product.images[0] }} 
-                  style={styles.orderSelectorItemImage} 
+                <SmartImage
+                  uri={orderItem.product.images[0]}
+                  style={styles.orderSelectorItemImage}
+                  cachePolicy="disk"
                 />
                 <Text style={[styles.orderSelectorItemName, { color: colors.text.primary }]} numberOfLines={1}>
                   {orderItem.product.name} x{orderItem.quantity}
@@ -695,9 +704,10 @@ export default function ReviewsScreen() {
                 <View style={[styles.selectedOrderItems, { borderTopColor: colors.border.secondary }]}>
                   {selectedOrder.items.map((item, index) => (
                     <View key={index} style={styles.selectedOrderItem}>
-                      <Image 
-                        source={{ uri: item.product.images[0] }} 
-                        style={styles.selectedOrderItemImage} 
+                      <SmartImage
+                        uri={item.product.images[0]}
+                        style={styles.selectedOrderItemImage}
+                        cachePolicy="disk"
                       />
                       <View style={styles.selectedOrderItemDetails}>
                         <Text style={[styles.selectedOrderItemName, { color: colors.text.primary }]}>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Image,
   Modal,
   TextInput,
   Platform,
@@ -26,6 +25,7 @@ import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import commonStyles from '../../constants/styles';
 import Card from '../../components/Card';
+import SmartImage from '../../components/SmartImage';
 
 
 
@@ -436,7 +436,12 @@ export default function SubcategoryScreen() {
     >
       <View style={styles.productImageContainer}>
         {item.images && item.images.length > 0 ? (
-          <Image source={{ uri: item.images[0] }} style={styles.productImage} resizeMode="cover" />
+          <SmartImage
+            uri={item.images[0]}
+            style={styles.productImage}
+            contentFit="cover"
+            cachePolicy="disk"
+          />
         ) : (
           <View style={styles.noImageContainer}>
             <Text style={styles.noImageText}>אין תמונה</Text>

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Image,
   Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -17,6 +16,7 @@ import { User } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import commonStyles from '../../constants/styles';
+import SmartImage from '../../components/SmartImage';
 
 
 
@@ -156,7 +156,11 @@ export default function UserProfileScreen() {
         <View style={[styles.profileHeader, { borderBottomColor: colors.border.primary }]}>
           <View style={styles.avatarContainer}>
             {user.avatar ? (
-              <Image source={{ uri: user.avatar }} style={[styles.avatar, { borderColor: colors.gold }]} />
+              <SmartImage
+                uri={user.avatar}
+                style={[styles.avatar, { borderColor: colors.gold }]}
+                cachePolicy="disk"
+              />
             ) : (
               <View style={[styles.avatarPlaceholder, { backgroundColor: colors.surface.primary, borderColor: colors.border.primary }]}>
                 <UserIcon size={40} color={colors.interactive.disabled} />

--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -1,13 +1,21 @@
 import React, { useState } from 'react';
 import { Image as ExpoImage, ImageProps } from 'expo-image';
 
-const placeholder = require('../assets/images/icon.png');
+const fallback = require('../assets/images/icon.png');
+const shimmer = { blurhash: 'L5H2EC=PM+yV0g-mq.wG9c010J]' };
 
 interface SmartImageProps extends Omit<ImageProps, 'source'> {
   uri: string;
 }
 
-export default function SmartImage({ uri, style, contentFit = 'cover', cachePolicy = 'disk', ...props }: SmartImageProps) {
+export default function SmartImage({
+  uri,
+  style,
+  contentFit = 'cover',
+  cachePolicy = 'disk',
+  placeholder = shimmer,
+  ...props
+}: SmartImageProps) {
   const [source, setSource] = useState<{ uri: string } | number>({ uri });
 
   return (
@@ -18,7 +26,8 @@ export default function SmartImage({ uri, style, contentFit = 'cover', cachePoli
       contentFit={contentFit}
       cachePolicy={cachePolicy}
       placeholder={placeholder}
-      onError={() => setSource(placeholder)}
+      transition={300}
+      onError={() => setSource(fallback)}
     />
   );
 }


### PR DESCRIPTION
## Summary
- replace React Native Image components with SmartImage across screens
- add shimmer placeholder, disk cache and fallback icon support to SmartImage

## Testing
- `yarn lint` (fails: React Hooks must be called in same order)
- `yarn test` (fails: Cannot find module '@/utils/logger')

------
https://chatgpt.com/codex/tasks/task_e_689ce15d5d6c8326ac36ebf9a1d8f975