### PR TITLE
Replace ScrollView with FlatList in storefront and wishlist

### DIFF
--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
   TextInput,
   TouchableOpacity,
   FlatList,
@@ -89,45 +88,55 @@ export default function StorefrontScreen({ initialCategory }: Props) {
         value={search}
         onChangeText={setSearch}
       />
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filterRow}>
-        <TouchableOpacity
-          testID="category-null"
-          style={[styles.chip, { borderColor: colors.border.primary, backgroundColor: selectedCategory === null ? colors.gold : 'transparent' }]}
-          onPress={() => setSelectedCategory(null)}
-        >
-          <Text style={{ color: selectedCategory === null ? colors.text.inverse : colors.text.primary }}>All</Text>
-        </TouchableOpacity>
-        {categories.map((c) => (
+      <FlatList
+        horizontal
+        data={[null, ...categories]}
+        keyExtractor={(item) => item ?? 'all'}
+        renderItem={({ item }) => (
           <TouchableOpacity
-            key={c}
-            testID={`category-${c}`}
-            style={[styles.chip, { borderColor: colors.border.primary, backgroundColor: selectedCategory === c ? colors.gold : 'transparent' }]}
-            onPress={() => setSelectedCategory(c)}
+            testID={`category-${item ?? 'null'}`}
+            style={[
+              styles.chip,
+              {
+                borderColor: colors.border.primary,
+                backgroundColor: selectedCategory === item ? colors.gold : 'transparent',
+              },
+            ]}
+            onPress={() => setSelectedCategory(item)}
           >
-            <Text style={{ color: selectedCategory === c ? colors.text.inverse : colors.text.primary }}>{c}</Text>
+            <Text style={{ color: selectedCategory === item ? colors.text.inverse : colors.text.primary }}>
+              {item === null ? 'All' : item}
+            </Text>
           </TouchableOpacity>
-        ))}
-      </ScrollView>
+        )}
+        showsHorizontalScrollIndicator={false}
+        style={styles.filterRow}
+      />
       {tags.length > 0 && (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filterRow}>
-          <TouchableOpacity
-            testID="tag-null"
-            style={[styles.chip, { borderColor: colors.border.primary, backgroundColor: selectedTag === null ? colors.gold : 'transparent' }]}
-            onPress={() => setSelectedTag(null)}
-          >
-            <Text style={{ color: selectedTag === null ? colors.text.inverse : colors.text.primary }}>All tags</Text>
-          </TouchableOpacity>
-          {tags.map((tag) => (
+        <FlatList
+          horizontal
+          data={[null, ...tags]}
+          keyExtractor={(item) => item ?? 'all'}
+          renderItem={({ item }) => (
             <TouchableOpacity
-              key={tag}
-              testID={`tag-${tag}`}
-              style={[styles.chip, { borderColor: colors.border.primary, backgroundColor: selectedTag === tag ? colors.gold : 'transparent' }]}
-              onPress={() => setSelectedTag(tag)}
+              testID={`tag-${item ?? 'null'}`}
+              style={[
+                styles.chip,
+                {
+                  borderColor: colors.border.primary,
+                  backgroundColor: selectedTag === item ? colors.gold : 'transparent',
+                },
+              ]}
+              onPress={() => setSelectedTag(item)}
             >
-              <Text style={{ color: selectedTag === tag ? colors.text.inverse : colors.text.primary }}>{tag}</Text>
+              <Text style={{ color: selectedTag === item ? colors.text.inverse : colors.text.primary }}>
+                {item === null ? 'All tags' : item}
+              </Text>
             </TouchableOpacity>
-          ))}
-        </ScrollView>
+          )}
+          showsHorizontalScrollIndicator={false}
+          style={styles.filterRow}
+        />
       )}
     </>
   );

--- a/components/WishlistModal.tsx
+++ b/components/WishlistModal.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   Modal,
   TouchableOpacity,
-  ScrollView,
+  FlatList,
   Alert,
 } from 'react-native';
 import SmartImage from './SmartImage';
@@ -63,22 +63,26 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
     router.push(`/product/${productId}`);
   };
 
-  const renderWishlistItem = (item: WishlistItem) => (
+  const ITEM_HEIGHT = 118;
+
+  const renderWishlistItem = ({ item }: { item: WishlistItem }) => (
     <TouchableOpacity
-      key={item.id}
-      style={[styles.wishlistItem, { 
-        backgroundColor: colors.surface.primary,
-        borderColor: colors.border.primary 
-      }]}
+      style={[
+        styles.wishlistItem,
+        {
+          backgroundColor: colors.surface.primary,
+          borderColor: colors.border.primary,
+        },
+      ]}
       onPress={() => viewProduct(item.productId)}
     >
       <SmartImage uri={item.product.images[0]} style={styles.productImage} contentFit="cover" cachePolicy="disk" />
-      
+
       <View style={styles.productInfo}>
         <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={2}>
           {item.product.name}
         </Text>
-        
+
         <View style={styles.priceContainer}>
           <Text style={[styles.currentPrice, { color: colors.gold }]}>{currencySymbol}{item.product.price.toFixed(2)}</Text>
           {item.product.originalPrice && (
@@ -92,10 +96,14 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
         </View>
 
         <View style={styles.stockContainer}>
-          <View style={[
-            styles.stockIndicator,
-            { backgroundColor: item.product.stock > 0 ? colors.status.success : colors.status.error }
-          ]} />
+          <View
+            style={[
+              styles.stockIndicator,
+              {
+                backgroundColor: item.product.stock > 0 ? colors.status.success : colors.status.error,
+              },
+            ]}
+          />
           <Text style={[styles.stockText, { color: colors.text.secondary }]}>
             {item.product.stock > 0 ? `במלאי (${item.product.stock})` : 'אזל מהמלאי'}
           </Text>
@@ -134,9 +142,18 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
         </View>
 
         {wishlistItems.length > 0 ? (
-          <ScrollView style={styles.wishlistList} showsVerticalScrollIndicator={false}>
-            {wishlistItems.map(renderWishlistItem)}
-          </ScrollView>
+          <FlatList
+            data={wishlistItems}
+            keyExtractor={(item) => item.id}
+            renderItem={renderWishlistItem}
+            style={styles.wishlistList}
+            showsVerticalScrollIndicator={false}
+            getItemLayout={(_, index) => ({
+              length: ITEM_HEIGHT,
+              offset: ITEM_HEIGHT * index,
+              index,
+            })}
+          />
         ) : (
           <View style={styles.emptyWishlist}>
             <Heart size={80} color={colors.interactive.disabled} />


### PR DESCRIPTION
## Summary
- use FlatList for storefront category and tag filters with stable keys
- switch wishlist modal to FlatList and add getItemLayout for fixed-height items

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1623dfc832693a5639035c5ae4d