### PR TITLE
feat: add shared waku schemas and logging

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,4 +1,5 @@
 import { Notification } from '../types';
+import { NotificationEvent } from '../types/waku';
 import {
   setNotification,
   getNotification,
@@ -15,17 +16,11 @@ import {
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import ensureTonWallet from '../utils/ensureTonWallet';
+import { errorLog } from '../utils/logger';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 const ORDER_TOPIC = '/congress/orders/1';
-
-export type NotificationEvent =
-  | 'order.created'
-  | 'payment.received'
-  | 'status.updated'
-  | 'dispute.updated'
-  | 'escrow.deployed';
 
 type NotificationTemplate = (
   item: Notification,
@@ -117,7 +112,7 @@ class NotificationsAgent {
       await waitForRemotePeer(this.node, [Protocols.Relay]);
       return this.node;
     } catch (err) {
-      console.error('Failed to start Waku node', err);
+      errorLog('Failed to start Waku node', err);
       this.node = null;
       return null;
     }
@@ -142,7 +137,7 @@ class NotificationsAgent {
         });
       }
     } catch (err) {
-      console.error('Failed to broadcast notification', err);
+      errorLog('Failed to broadcast notification', err);
     }
   }
 }

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -17,6 +17,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '../services/eventLog';
 import ensureTonWallet from '../utils/ensureTonWallet';
 import eventBus from '../services/eventBus';
+import { errorLog } from '../utils/logger';
 
 const ORDER_TOPIC = '/congress/orders/1';
 
@@ -125,7 +126,7 @@ class OrdersAgent {
           delete toStore.shippingAddress;
         }
       } catch (err) {
-        console.warn('Failed to encrypt shipping address', err);
+        errorLog('Failed to encrypt shipping address', err);
       }
     }
     await setOrder(toStore);
@@ -343,7 +344,7 @@ class OrdersAgent {
     try {
       await notificationsAgent.broadcast('status.updated', notification);
     } catch (err) {
-      console.error('Failed to send notification', err);
+      errorLog('Failed to send notification', err);
     }
   }
 
@@ -360,7 +361,7 @@ class OrdersAgent {
     try {
       await notificationsAgent.broadcast('order.created', notification);
     } catch (err) {
-      console.error('Failed to send notification', err);
+      errorLog('Failed to send notification', err);
     }
   }
 
@@ -377,7 +378,7 @@ class OrdersAgent {
     try {
       await notificationsAgent.broadcast('payment.received', notification);
     } catch (err) {
-      console.error('Failed to send notification', err);
+      errorLog('Failed to send notification', err);
     }
   }
 
@@ -394,7 +395,7 @@ class OrdersAgent {
     try {
       await notificationsAgent.broadcast('dispute.updated', notification);
     } catch (err) {
-      console.error('Failed to send notification', err);
+      errorLog('Failed to send notification', err);
     }
   }
 }

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -4,6 +4,8 @@ import { getPublicKeyHex } from '../services/localIdentity';
 import SettingsAgent from './settings-agent';
 import ensureTonWallet from '../utils/ensureTonWallet';
 import validateTonAddress from '../utils/validateTonAddress';
+import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import type { WakuMessage } from '../types/waku';
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
@@ -111,7 +113,9 @@ class UsersAgent {
     return await listUsers();
   }
 
-  async handleMessage(msg: UsersAgentMessage): Promise<void> {
+  async handleMessage(signed: WakuMessage<UsersAgentMessage>): Promise<void> {
+    if (!(await verifyMessageSignature(signed, signed.sender.publicKey))) return;
+    const msg = signed.payload;
     switch (msg.type) {
       case 'user.add':
         await this.add(msg.payload);

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -13,7 +13,7 @@ import {
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyMessageSignature } from '../utils/verifyMessageSignature';
-import { WakuMessage } from '../types/waku';
+import { WakuMessage, SettingsWriteEvent } from '../types/waku';
 import { sign } from '@noble/ed25519';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
@@ -36,14 +36,6 @@ export interface TonSettings {
 
 export async function getSetting(key: string): Promise<string | null> {
   return await getValue(ADDRESS, key);
-}
-
-export interface SettingsWriteEvent {
-  type: 'settings.write';
-  key: string;
-  value: string;
-  actor: string;
-  timestamp: number;
 }
 
 let node: LightNode | null = null;

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -1,3 +1,5 @@
+import type { Notification } from './index';
+
 export interface WakuMessage<T = any> {
   type: string;
   payload: T;
@@ -6,4 +8,24 @@ export interface WakuMessage<T = any> {
     role?: string;
   };
   signature: string;
+}
+
+export interface SettingsWriteEvent {
+  type: 'settings.write';
+  key: string;
+  value: string;
+  actor: string;
+  timestamp: number;
+}
+
+export type NotificationEvent =
+  | 'order.created'
+  | 'payment.received'
+  | 'status.updated'
+  | 'dispute.updated'
+  | 'escrow.deployed';
+
+export interface NotificationWakuPayload {
+  type: NotificationEvent;
+  notification: Notification;
 }

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -3,14 +3,33 @@ import config from './appConfig';
 let DEBUG_LOGS = false;
 DEBUG_LOGS = config.EXPO_PUBLIC_DEBUG_LOGS === 'true';
 
+function redact(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value
+      .replace(/\b0x[a-fA-F0-9]{40,}\b/g, '[REDACTED]')
+      .replace(/\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b/g, '[REDACTED]');
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => redact(v));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redact(v)]),
+    );
+  }
+  return value;
+}
+
 export function debugLog(...args: unknown[]): void {
   if (DEBUG_LOGS) {
     // eslint-disable-next-line no-console
-    console.debug(...args);
+    console.debug(...args.map((a) => redact(a)));
   }
 }
 
 export function errorLog(...args: unknown[]): void {
   // eslint-disable-next-line no-console
-  console.error(...args);
+  console.error(...args.map((a) => redact(a)));
 }
+
+export { redact as redactLogValue };


### PR DESCRIPTION
## Summary
- add reusable Waku message schemas
- verify signed messages in users agent
- sanitize logs and use debug/error helpers

## Testing
- `npm test` *(fails: Cannot find module '@/utils/logger' from 'constants/tenant.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689ce166723483269ad519769d89877e