### PR TITLE
feat: optimize chat context and message loading

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -733,11 +733,15 @@ const loadOrCreateDefaultRoom = async () => {
 
   const { chatRooms, selectedRoom, setSelectedRoom, loadChatRooms, unreadTotal } =
     useChatRooms(isOpen);
-  const { messages, newMessage, setNewMessage, sendMessage } = useChatMessages(
-    selectedRoom,
-    user,
-    isAdmin,
-  );
+  const {
+    messages,
+    newMessage,
+    setNewMessage,
+    sendMessage,
+    loadOlderMessages,
+    hasMore,
+    loadingMore,
+  } = useChatMessages(selectedRoom, user, isAdmin);
 
   const toggleOpen = () => {
     const next = !isOpen;
@@ -780,7 +784,13 @@ const loadOrCreateDefaultRoom = async () => {
               />
             </View>
             <View style={styles.chatArea}>
-              <MessageList messages={messages} colors={colors} />
+              <MessageList
+                messages={messages}
+                colors={colors}
+                onLoadMore={loadOlderMessages}
+                hasMore={hasMore}
+                loadingMore={loadingMore}
+              />
               <MessageInput
                 value={newMessage}
                 onChange={setNewMessage}

--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -1,40 +1,116 @@
 import { errorLog } from '@/utils/logger';
-import React, { createContext, useState, useContext, useEffect, ReactNode, useRef } from 'react';
+import React, {
+  createContext,
+  useState,
+  useContext,
+  useEffect,
+  ReactNode,
+  useRef,
+  useCallback,
+} from 'react';
 import NotificationService from '../services/notification';
 import { Notification } from '../types';
 import NotificationPopup from './NotificationPopup';
 import { useAuth } from './AuthContext';
 import { useWakuClient } from '../hooks/useWakuClient';
 
-interface NotificationContextType {
+interface NotificationState {
   unreadCount: number;
-  showNotification: (title: string, message: string, type?: 'success' | 'info' | 'warning' | 'error') => void;
   refreshNotifications: () => Promise<void>;
 }
 
-const NotificationContext = createContext<NotificationContextType>({
+interface NotificationActions {
+  showNotification: (
+    title: string,
+    message: string,
+    type?: 'success' | 'info' | 'warning' | 'error',
+  ) => void;
+}
+
+const NotificationStateContext = createContext<NotificationState>({
   unreadCount: 0,
-  showNotification: () => {},
   refreshNotifications: async () => {},
 });
 
-export const useNotifications = () => useContext(NotificationContext);
+const NotificationActionsContext = createContext<NotificationActions>({
+  showNotification: () => {},
+});
+
+export const useNotificationState = () => useContext(NotificationStateContext);
+export const useNotificationActions = () => useContext(NotificationActionsContext);
+
+export const useNotifications = () => {
+  return { ...useNotificationState(), ...useNotificationActions() };
+};
 
 interface NotificationProviderProps {
   children: ReactNode;
 }
 
 export function NotificationProvider({ children }: NotificationProviderProps) {
-  const [unreadCount, setUnreadCount] = useState(0);
+  return (
+    <NotificationPopupProvider>
+      <NotificationCountProvider>{children}</NotificationCountProvider>
+    </NotificationPopupProvider>
+  );
+}
+
+function NotificationPopupProvider({ children }: { children: ReactNode }) {
   const [activeNotification, setActiveNotification] = useState<{
     title: string;
     message: string;
     type: 'success' | 'info' | 'warning' | 'error';
   } | null>(null);
+
+  const showNotification = useCallback(
+    (
+      title: string,
+      message: string,
+      type: 'success' | 'info' | 'warning' | 'error' = 'info',
+    ) => {
+      setActiveNotification({ title, message, type });
+    },
+    [],
+  );
+
+  const handleClose = () => setActiveNotification(null);
+
+  return (
+    <NotificationActionsContext.Provider value={{ showNotification }}>
+      {children}
+      {activeNotification && (
+        <NotificationPopup
+          title={activeNotification.title}
+          message={activeNotification.message}
+          type={activeNotification.type}
+          onClose={handleClose}
+        />
+      )}
+    </NotificationActionsContext.Provider>
+  );
+}
+
+function NotificationCountProvider({ children }: { children: ReactNode }) {
+  const [unreadCount, setUnreadCount] = useState(0);
   const { isLoggedIn, user } = useAuth();
   const notificationSubscription = useRef<any>(null);
   const waku = useWakuClient();
   const wakuUnsub = useRef<(() => void) | null>(null);
+  const { showNotification } = useNotificationActions();
+
+  const refreshNotifications = useCallback(async () => {
+    if (!isLoggedIn || !user) {
+      setUnreadCount(0);
+      return;
+    }
+    try {
+      const notificationService = NotificationService.getInstance();
+      const count = await notificationService.getUnreadCount(user.id);
+      setUnreadCount(count);
+    } catch (error) {
+      errorLog('Error refreshing notifications:', error);
+    }
+  }, [isLoggedIn, user]);
 
   useEffect(() => {
     if (isLoggedIn && user) {
@@ -46,38 +122,30 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
       cleanupSubscription();
       cleanupWakuSubscription();
     }
-
     return () => {
       cleanupSubscription();
       cleanupWakuSubscription();
     };
-  }, [isLoggedIn, user]);
+  }, [isLoggedIn, user, refreshNotifications]);
 
   const setupRealtimeSubscription = () => {
     if (!user) return;
-    
     const notificationService = NotificationService.getInstance();
-    
-    // Clean up any existing subscription
     cleanupSubscription();
-    
-    // Set up new subscription
     notificationSubscription.current = notificationService.subscribeToUserNotifications(
       user.id,
       (notification) => {
-        // Update unread count
-        setUnreadCount(prev => prev + 1);
-        
-        // Show notification popup
+        setUnreadCount((prev) => prev + 1);
         showNotification(
           notification.title,
           notification.message,
-          notification.type === 'order' ? 'success' :
-          notification.type === 'promo' ? 'info' :
-          notification.type === 'message' ? 'info' :
-          'info'
+          notification.type === 'order'
+            ? 'success'
+            : notification.type === 'promo' || notification.type === 'message'
+              ? 'info'
+              : 'info',
         );
-      }
+      },
     );
   };
 
@@ -122,50 +190,12 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     }
   };
 
-  const refreshNotifications = async () => {
-    if (!isLoggedIn || !user) {
-      setUnreadCount(0);
-      return;
-    }
-    
-    try {
-      const notificationService = NotificationService.getInstance();
-      const count = await notificationService.getUnreadCount(user.id);
-      setUnreadCount(count);
-    } catch (error) {
-      errorLog('Error refreshing notifications:', error);
-    }
-  };
-
-  const showNotification = (
-    title: string, 
-    message: string, 
-    type: 'success' | 'info' | 'warning' | 'error' = 'info'
-  ) => {
-    setActiveNotification({ title, message, type });
-  };
-
-  const handleCloseNotification = () => {
-    setActiveNotification(null);
-  };
-
   return (
-    <NotificationContext.Provider 
-      value={{ 
-        unreadCount, 
-        showNotification,
-        refreshNotifications
-      }}
+    <NotificationStateContext.Provider
+      value={{ unreadCount, refreshNotifications }}
     >
       {children}
-      {activeNotification && (
-        <NotificationPopup
-          title={activeNotification.title}
-          message={activeNotification.message}
-          type={activeNotification.type}
-          onClose={handleCloseNotification}
-        />
-      )}
-    </NotificationContext.Provider>
+    </NotificationStateContext.Provider>
   );
 }
+

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -1,22 +1,55 @@
 import React from 'react';
-import { FlatList, View, Text, StyleSheet } from 'react-native';
+import {
+  FlatList,
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+} from 'react-native';
 import { ChatMessage } from '../../types';
 
 interface Props {
   messages: ChatMessage[];
   colors: any;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
 }
 
-const MessageList: React.FC<Props> = ({ messages, colors }) => {
+const MessageList: React.FC<Props> = ({
+  messages,
+  colors,
+  onLoadMore,
+  hasMore,
+  loadingMore,
+}) => {
+  const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (!onLoadMore || !hasMore || loadingMore) return;
+    if (e.nativeEvent.contentOffset.y <= 0) {
+      onLoadMore();
+    }
+  };
+
   return (
     <FlatList
       data={messages}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
         <View style={styles.item}>
-          <Text style={[styles.message, { color: colors.text.primary }]}>{item.message}</Text>
+          <Text style={[styles.message, { color: colors.text.primary }]}>
+            {item.message}
+          </Text>
         </View>
       )}
+      onScroll={handleScroll}
+      scrollEventThrottle={16}
+      ListHeaderComponent={
+        loadingMore ? (
+          <ActivityIndicator style={styles.loader} />
+        ) : null
+      }
     />
   );
 };
@@ -28,6 +61,9 @@ const styles = StyleSheet.create({
   message: {
     fontSize: 14,
     textAlign: 'right',
+  },
+  loader: {
+    padding: 8,
   },
 });
 

--- a/hooks/useChatMessages.ts
+++ b/hooks/useChatMessages.ts
@@ -1,11 +1,26 @@
 import { errorLog } from '@/utils/logger';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import DatabaseService from '../services/database';
 import { ChatMessage, ChatRoom, User } from '../types';
+import { useWakuClient } from './useWakuClient';
 
 export function useChatMessages(selectedRoom: ChatRoom | null, user: User | null | undefined, isAdmin: boolean) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [newMessage, setNewMessage] = useState('');
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const waku = useWakuClient();
+
+  const loadMessages = useCallback(async (roomId: string) => {
+    try {
+      const db = DatabaseService.getInstance();
+      const msgs = await db.getChatMessages(roomId);
+      setMessages(msgs);
+      setHasMore(true);
+    } catch (err) {
+      errorLog('Failed to load messages', err);
+    }
+  }, []);
 
   useEffect(() => {
     if (selectedRoom) {
@@ -13,19 +28,9 @@ export function useChatMessages(selectedRoom: ChatRoom | null, user: User | null
     } else {
       setMessages([]);
     }
-  }, [selectedRoom?.id]);
+  }, [selectedRoom?.id, loadMessages]);
 
-  const loadMessages = async (roomId: string) => {
-    try {
-      const db = DatabaseService.getInstance();
-      const msgs = await db.getChatMessages(roomId);
-      setMessages(msgs);
-    } catch (err) {
-      errorLog('Failed to load messages', err);
-    }
-  };
-
-  const sendMessage = async () => {
+  const sendMessage = useCallback(async () => {
     if (!selectedRoom || !user || !newMessage.trim()) return;
     const msg: ChatMessage = {
       id: `msg_${Date.now()}`,
@@ -43,8 +48,44 @@ export function useChatMessages(selectedRoom: ChatRoom | null, user: User | null
     } catch (err) {
       errorLog('Failed to send message', err);
     }
-  };
+  }, [selectedRoom, user, newMessage, isAdmin]);
 
-  return { messages, newMessage, setNewMessage, sendMessage };
+  const loadOlderMessages = useCallback(async () => {
+    if (!selectedRoom || loadingMore || !hasMore) return;
+    const oldest = messages[0]?.timestamp;
+    if (!oldest) return;
+    setLoadingMore(true);
+    try {
+      const fetched = await waku.fetchHistory(
+        selectedRoom.id,
+        selectedRoom.userPublicKey || '',
+        (msg) => {
+          setMessages((prev) => [msg, ...prev]);
+        },
+        undefined,
+        oldest - 1,
+      );
+      if (fetched === 0) setHasMore(false);
+    } catch (err) {
+      errorLog('Failed to load older messages', err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [selectedRoom, loadingMore, hasMore, messages, waku]);
+
+  const sortedMessages = useMemo(
+    () => [...messages].sort((a, b) => a.timestamp - b.timestamp),
+    [messages],
+  );
+
+  return {
+    messages: sortedMessages,
+    newMessage,
+    setNewMessage,
+    sendMessage,
+    loadOlderMessages,
+    hasMore,
+    loadingMore,
+  };
 }
 export default useChatMessages;

--- a/hooks/useChatRooms.ts
+++ b/hooks/useChatRooms.ts
@@ -1,14 +1,13 @@
 import { errorLog } from '@/utils/logger';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import DatabaseService from '../services/database';
 import { ChatRoom } from '../types';
 
 export function useChatRooms(isOpen: boolean) {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
   const [selectedRoom, setSelectedRoom] = useState<ChatRoom | null>(null);
-  const [unreadTotal, setUnreadTotal] = useState(0);
 
-  const loadChatRooms = async () => {
+  const loadChatRooms = useCallback(async () => {
     try {
       const db = DatabaseService.getInstance();
       const rooms = await db.getChatRooms();
@@ -16,17 +15,18 @@ export function useChatRooms(isOpen: boolean) {
     } catch (err) {
       errorLog('Failed to load chat rooms', err);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
       loadChatRooms();
     }
-  }, [isOpen]);
+  }, [isOpen, loadChatRooms]);
 
-  useEffect(() => {
-    setUnreadTotal(chatRooms.reduce((sum, r) => sum + r.unreadCount, 0));
-  }, [chatRooms]);
+  const unreadTotal = useMemo(
+    () => chatRooms.reduce((sum, r) => sum + r.unreadCount, 0),
+    [chatRooms],
+  );
 
   return { chatRooms, selectedRoom, setSelectedRoom, loadChatRooms, unreadTotal };
 }

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -36,7 +36,8 @@ export interface WakuClient {
     peerPublicKey: string,
     callback: (msg: ChatMessage) => void,
     after?: number,
-  ) => Promise<void>;
+    before?: number,
+  ) => Promise<number>;
   broadcastSystem: (message: string) => Promise<void>;
   subscribeSystem: (cb: (msg: string) => void) => Promise<() => void>;
   broadcastOrder: (message: string) => Promise<void>;
@@ -163,13 +164,17 @@ export function useWakuClient(): WakuClient {
     peerPublicKey: string,
     cb: (msg: ChatMessage) => void,
     after?: number,
+    before?: number,
   ) => {
-    if (!nodeRef.current) return;
+    if (!nodeRef.current) return 0;
     const decoder = createDecoder(chatTopic(roomId));
     const options: any = { contentTopics: [chatTopic(roomId)] };
-    if (after) {
-      options.timeFilter = { startTime: new Date(after + 1) };
+    if (after || before) {
+      options.timeFilter = {};
+      if (after) options.timeFilter.startTime = new Date(after + 1);
+      if (before) options.timeFilter.endTime = new Date(before - 1);
     }
+    let count = 0;
     for await (const msgs of nodeRef.current.store.queryGenerator(options)) {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
@@ -199,11 +204,13 @@ export function useWakuClient(): WakuClient {
           const db = DatabaseService.getInstance();
           await db.sendChatMessage(roomId, { ...chat, message: signed.payload });
           cb(chat);
+          count += 1;
         } catch {
           /* ignore malformed messages */
         }
       }
     }
+    return count;
   };
 
   const broadcastSystem = async (message: string) => {

--- a/services/database.ts
+++ b/services/database.ts
@@ -51,6 +51,22 @@ class DatabaseService {
 
   private constructor() {}
 
+  private async cacheChatMessages(
+    roomId: string,
+    msgs: ChatMessage[],
+  ): Promise<void> {
+    const trimmed = msgs.slice(-CHAT_MESSAGE_LIMIT);
+    this.chatMessages.set(roomId, trimmed);
+    try {
+      await AsyncStorage.setItem(
+        `${CHAT_STORAGE_PREFIX}${roomId}`,
+        JSON.stringify(trimmed),
+      );
+    } catch (err) {
+      errorLog('Failed to persist chat messages', err);
+    }
+  }
+
   public static getInstance(): DatabaseService {
     if (!DatabaseService.instance) {
       DatabaseService.instance = new DatabaseService();
@@ -353,8 +369,7 @@ class DatabaseService {
       } catch {
         msgs = [];
       }
-      msgs = msgs.slice(-CHAT_MESSAGE_LIMIT);
-      this.chatMessages.set(roomId, msgs);
+      await this.cacheChatMessages(roomId, msgs);
     }
     return msgs;
   }
@@ -362,16 +377,7 @@ class DatabaseService {
   async sendChatMessage(roomId: string, msg: ChatMessage): Promise<void> {
     const msgs = this.chatMessages.get(roomId) || [];
     msgs.push(msg);
-    const trimmed = msgs.slice(-CHAT_MESSAGE_LIMIT);
-    this.chatMessages.set(roomId, trimmed);
-    try {
-      await AsyncStorage.setItem(
-        `${CHAT_STORAGE_PREFIX}${roomId}`,
-        JSON.stringify(trimmed),
-      );
-    } catch (err) {
-      errorLog('Failed to persist chat messages', err);
-    }
+    await this.cacheChatMessages(roomId, msgs);
     const room = this.chatRooms.get(roomId);
     if (room) {
       room.lastMessage = msg.message;
@@ -389,15 +395,7 @@ class DatabaseService {
       const idx = msgs.findIndex((m) => m.id === id);
       if (idx >= 0) {
         msgs[idx] = { ...msgs[idx], reactions };
-        this.chatMessages.set(roomId, msgs);
-        try {
-          await AsyncStorage.setItem(
-            `${CHAT_STORAGE_PREFIX}${roomId}`,
-            JSON.stringify(msgs),
-          );
-        } catch (err) {
-          errorLog('Failed to persist chat messages', err);
-        }
+        await this.cacheChatMessages(roomId, msgs);
         return;
       }
     }


### PR DESCRIPTION
## Summary
- memoize chat selectors and support loading older messages on scroll
- split notification context into focused state and actions providers
- cache last N chat messages locally and expose history fetching

## Testing
- `yarn lint hooks/useChatMessages.ts hooks/useChatRooms.ts hooks/useWakuClient.ts components/chat/MessageList.tsx components/NotificationContext.tsx components/ChatWidget.tsx services/database.ts` *(fails: expo not found)*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cea0f8a2c8326ba23c578f18986ca