### PR TITLE
feat: enable hash routing and document IPFS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,19 @@ the app works from any gateway.
 - **Upload:** Manually pin the `dist/` directory to your pinning service (e.g.,
   Pinata) to publish it to IPFS.
 
+#### Pin `dist/` Checklist
+
+1. `npm run web:release`
+2. `node scripts/assert-relative-assets.js`
+3. Pin the entire `dist/` folder to your IPFS node or pinning service
+4. Record the returned CID for later reference
+
+#### Gateway Test Steps
+
+1. Open `https://ipfs.io/ipfs/<CID>/` and ensure the app loads
+2. Repeat with another gateway such as `https://dweb.link/ipfs/<CID>/`
+3. Navigate to a route like `/#/product/1` to confirm hash routing
+
 Deep links require additional rewrite support.
 
 ## Troubleshooting

--- a/app.config.js
+++ b/app.config.js
@@ -2,4 +2,7 @@ const { expo } = require('./app.json');
 module.exports = {
   ...expo,
   experiments: { web: { fastRefresh: false } },
+  router: {
+    history: 'hash',
+  },
 };

--- a/scripts/assert-relative-assets.js
+++ b/scripts/assert-relative-assets.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const globby = require('globby');
+
+(async () => {
+  const dist = path.join(__dirname, '..', 'dist');
+  if (!fs.existsSync(dist)) {
+    console.error('dist/ directory not found');
+    process.exit(1);
+  }
+
+  const files = await globby(['**/*.html', '**/*.js', '**/*.css'], { cwd: dist });
+  const problems = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(dist, file), 'utf8');
+    if (/src="\//.test(content) || /href="\//.test(content) || /url\(\//.test(content)) {
+      problems.push(file);
+    }
+  }
+
+  if (problems.length) {
+    console.error('Found absolute asset paths in:');
+    for (const p of problems) {
+      console.error('  ' + p);
+    }
+    process.exit(1);
+  }
+
+  console.log('All asset paths are relative.');
+})();


### PR DESCRIPTION
## Summary
- configure Expo router to use hash history for web builds
- document IPFS deployment with pinning checklist and gateway tests
- add script to assert built asset paths stay relative

## Testing
- `npm test` *(fails: Cannot find module '@/utils/logger' from 'constants/tenant.ts')*
- `node scripts/assert-relative-assets.js` *(fails: dist/ directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cea1222ec83269de118fd404efdd6