### PR TITLE
chore: enforce lint and type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Run the linter and TypeScript checker before committing:
 yarn lint && yarn typecheck
 ```
 
+The project uses Husky and `lint-staged` to run these checks on staged files.
+Install the Git hooks after cloning:
+
+```sh
+yarn husky install
+```
+
 ### Environment Variables
 
 The project reads configuration from a `.env` file using Expo's env support

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
   },
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],
+  globalSetup: '<rootDir>/tests/lintTypeCheck.js',
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "seed": "node scripts/seed.js",
     "lint": "expo lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",

--- a/tests/lintTypeCheck.js
+++ b/tests/lintTypeCheck.js
@@ -1,0 +1,6 @@
+const { execSync } = require('child_process');
+
+module.exports = async () => {
+  execSync('yarn lint', { stdio: 'inherit' });
+  execSync('yarn typecheck', { stdio: 'inherit' });
+};


### PR DESCRIPTION
## Summary
- document Husky + lint-staged pre-commit setup
- ensure tests fail on lint or type errors via Jest global setup
- add Husky install script

## Testing
- `yarn lint` *(fails: React hooks rule-of-hooks)*
- `yarn typecheck` *(fails: TypeScript syntax errors)*
- `yarn test` *(fails: lint errors detected in global setup)*

------
https://chatgpt.com/codex/tasks/task_e_689cf320d6388326a98ece203e628a17