### PR TITLE
chore: adopt logical start/end for rtl support

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -33,8 +33,8 @@ export default function TabLayout() {
           tabBarStyle: {
             position: 'absolute',
             bottom: 0,
-            left: 0,
-            right: 0,
+            start: 0,
+            end: 0,
             backgroundColor: colors.tabBar.background,
             borderTopWidth: 1,
             borderTopColor: colors.tabBar.border,

--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -316,7 +316,7 @@ export default function CategoriesScreen() {
                   setNewCategory({ ...newCategory, id: text })
                 }
                 placeholder="הכנס מזהה קטגוריה (באנגלית)"
-                textAlign="left"
+                textAlign="start"
                 editable={!editingCategory} // Don't allow editing ID for existing categories
               />
             </View>
@@ -339,7 +339,7 @@ export default function CategoriesScreen() {
                   setNewCategory({ ...newCategory, name: text })
                 }
                 placeholder="הכנס שם קטגוריה"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -499,7 +499,7 @@ const styles = StyleSheet.create({
   adminActions: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     flexDirection: 'row',
   },
   adminActionButton: {
@@ -536,7 +536,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   formInput: {
     borderWidth: 1,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -440,7 +440,7 @@ export default function HomeScreen() {
               keyboardType="numeric"
               value={minPrice}
               onChangeText={setMinPrice}
-              textAlign="right"
+              textAlign="end"
             />
             <TextInput
               style={[
@@ -455,7 +455,7 @@ export default function HomeScreen() {
               keyboardType="numeric"
               value={maxPrice}
               onChangeText={setMaxPrice}
-              textAlign="right"
+              textAlign="end"
             />
           </View>
         </View>
@@ -814,8 +814,8 @@ const styles = StyleSheet.create({
   heroOverlay: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     bottom: 0,
     backgroundColor: 'rgba(14, 13, 10, 0.4)',
     justifyContent: 'center',
@@ -837,17 +837,17 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   heroSubtitle: {
     fontSize: 16,
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   bannerAdminActions: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     flexDirection: 'row',
   },
   bannerAdminButton: {
@@ -862,8 +862,8 @@ const styles = StyleSheet.create({
   bannerIndicators: {
     position: 'absolute',
     bottom: 16,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     flexDirection: 'row',
     justifyContent: 'center',
   },
@@ -952,7 +952,7 @@ const styles = StyleSheet.create({
   categoryAdminActions: {
     position: 'absolute',
     top: -4,
-    left: -4,
+    start: -4,
     flexDirection: 'row',
   },
   categoryAdminButton: {
@@ -1005,7 +1005,7 @@ const styles = StyleSheet.create({
   },
   sortOptionText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   selectedDot: {
     width: 12,
@@ -1015,7 +1015,7 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     marginTop: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   adminActionsContainer: {
     padding: 16,
@@ -1066,7 +1066,7 @@ const styles = StyleSheet.create({
   },
   categorySelectorText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   categorySelectorOverlay: {
     flex: 1,

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -436,17 +436,17 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   notificationMessage: {
     fontSize: 14,
     marginBottom: 8,
     lineHeight: 20,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   notificationTime: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   readIndicator: {
     justifyContent: 'center',

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -285,11 +285,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderDate: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderStatus: {
     flexDirection: 'row',
@@ -307,18 +307,18 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   itemText: {
     fontSize: 14,
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   moreItems: {
     fontSize: 12,
     fontWeight: '500',
     marginTop: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderFooter: {
     flexDirection: 'row',

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -628,7 +628,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   menuItem: {
     flexDirection: 'row',
@@ -649,7 +649,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginLeft: 12,
     fontWeight: '500',
-    textAlign: 'right',
+    textAlign: 'end',
     flex: 1,
   },
   languageContainer: {

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -617,7 +617,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   actionsGrid: {
     flexDirection: 'row',
@@ -653,7 +653,7 @@ const styles = StyleSheet.create({
   reportText: {
     fontSize: 14,
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   reportActions: {
     flexDirection: 'row',
@@ -680,7 +680,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   activityItem: {
     flexDirection: 'row',
@@ -691,7 +691,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     marginRight: 8,
     flex: 1,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   unreadText: {
     fontWeight: '600',

--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -361,8 +361,8 @@ const styles = StyleSheet.create({
   dropdownMenu: {
     position: 'absolute',
     top: '100%',
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     borderWidth: 1,
     borderTopWidth: 0,
     borderBottomLeftRadius: 8,
@@ -370,7 +370,7 @@ const styles = StyleSheet.create({
     zIndex: 1000,
   },
   dropdownItem: { padding: 8 },
-  dropdownItemText: { fontSize: 14, textAlign: 'right' },
+  dropdownItemText: { fontSize: 14, textAlign: 'end' },
   addButton: {
     width: 40,
     height: 40,
@@ -391,7 +391,7 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   jobTitle: { fontSize: 16, marginRight: 8 },
-  jobInfo: { fontSize: 14, marginBottom: 4, textAlign: 'right' },
+  jobInfo: { fontSize: 14, marginBottom: 4, textAlign: 'end' },
   actionsRow: {
     flexDirection: 'row-reverse',
     marginTop: 8,

--- a/app/admin/kyc-approvals.tsx
+++ b/app/admin/kyc-approvals.tsx
@@ -289,7 +289,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   userDetailRow: {
     flexDirection: 'row',
@@ -320,7 +320,7 @@ const styles = StyleSheet.create({
   notesText: {
     fontSize: 14,
     lineHeight: 20,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   actionButtons: {
     flexDirection: 'row',

--- a/app/admin/pricing-tiers.tsx
+++ b/app/admin/pricing-tiers.tsx
@@ -297,9 +297,9 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
-  infoText: { fontSize: 14, lineHeight: 20, textAlign: 'right' },
+  infoText: { fontSize: 14, lineHeight: 20, textAlign: 'end' },
   tiersGrid: { gap: 16 },
   tierCard: {
     borderRadius: 12,
@@ -321,9 +321,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
-  tierDiscount: { fontSize: 14, fontWeight: '600', textAlign: 'right' },
+  tierDiscount: { fontSize: 14, fontWeight: '600', textAlign: 'end' },
   editButton: { padding: 8 },
   tierDetails: { borderTopWidth: 1, paddingTop: 12 },
   tierDetailItem: {
@@ -333,7 +333,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   tierDetailText: { fontSize: 14, marginRight: 8 },
-  tierDescription: { fontSize: 14, lineHeight: 20, textAlign: 'right' },
+  tierDescription: { fontSize: 14, lineHeight: 20, textAlign: 'end' },
   emptyContainer: {
     flex: 1,
     justifyContent: 'center',

--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -327,7 +327,7 @@ export default function UserManagementScreen() {
             value={searchQuery}
             onChangeText={setSearchQuery}
             placeholderTextColor={colors.text.tertiary}
-            textAlign="right"
+            textAlign="end"
           />
         </View>
         
@@ -937,7 +937,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   activeFiltersList: {
     flexDirection: 'row',
@@ -1014,11 +1014,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 2,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   userUsername: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   userBadges: {
     flexDirection: 'row',
@@ -1053,7 +1053,7 @@ const styles = StyleSheet.create({
   },
   userDetailText: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   loadingContainer: {
     flex: 1,
@@ -1096,8 +1096,8 @@ const styles = StyleSheet.create({
   filterModalContainer: {
     position: 'absolute',
     bottom: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
@@ -1125,7 +1125,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   userDetailItem: {
     flexDirection: 'row',
@@ -1139,7 +1139,7 @@ const styles = StyleSheet.create({
   userDetailValue: {
     fontSize: 14,
     fontWeight: '500',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   dropdownContainer: {
     marginBottom: 16,
@@ -1149,7 +1149,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   dropdown: {
     flexDirection: 'row',
@@ -1167,8 +1167,8 @@ const styles = StyleSheet.create({
   dropdownMenu: {
     position: 'absolute',
     top: '100%',
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     borderWidth: 1,
     borderTopWidth: 0,
     borderBottomLeftRadius: 12,
@@ -1182,7 +1182,7 @@ const styles = StyleSheet.create({
   },
   dropdownItemText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   saveButton: {
     flexDirection: 'row',
@@ -1217,7 +1217,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   filterOption: {
     flexDirection: 'row',
@@ -1229,7 +1229,7 @@ const styles = StyleSheet.create({
   },
   filterOptionText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   filterSelectedDot: {
     width: 12,

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -310,7 +310,7 @@ export default function CategoryScreen() {
                 value={newSubcategory.id}
                 onChangeText={(text) => setNewSubcategory({...newSubcategory, id: text})}
                 placeholder="הכנס מזהה תת-קטגוריה (באנגלית)"
-                textAlign="left"
+                textAlign="start"
                 editable={!editingSubcategory} // Don't allow editing ID for existing subcategories
               />
             </View>
@@ -326,7 +326,7 @@ export default function CategoryScreen() {
                 value={newSubcategory.name}
                 onChangeText={(text) => setNewSubcategory({...newSubcategory, name: text})}
                 placeholder="הכנס שם תת-קטגוריה"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -457,7 +457,7 @@ const styles = StyleSheet.create({
   adminActions: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     flexDirection: 'row',
   },
   adminActionButton: {
@@ -527,7 +527,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   formInput: {
     borderWidth: 1,

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -211,8 +211,8 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   jobTitle: { fontSize: 16, marginRight: 8 },
-  jobStatus: { fontSize: 14, marginBottom: 4, textAlign: 'right' },
-  jobInfo: { fontSize: 14, marginBottom: 4, textAlign: 'right' },
+  jobStatus: { fontSize: 14, marginBottom: 4, textAlign: 'end' },
+  jobInfo: { fontSize: 14, marginBottom: 4, textAlign: 'end' },
   actionsRow: {
     flexDirection: 'row-reverse',
     justifyContent: 'flex-start',

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -96,21 +96,21 @@ export default function OrderDetailScreen() {
           <Text style={[styles.status, { color: colors.text.primary }]}>סטטוס נוכחי: {statusLabel(order.status)}</Text>
           {isSeller && (order.shippingAddress as ShippingAddress | undefined) && (
             <View style={{ marginBottom: 16 }}>
-              <Text style={{ color: colors.text.primary, textAlign: 'right' }}>
+              <Text style={{ color: colors.text.primary, textAlign: 'end' }}>
                 {(order.shippingAddress as ShippingAddress).name}
               </Text>
-              <Text style={{ color: colors.text.primary, textAlign: 'right' }}>
+              <Text style={{ color: colors.text.primary, textAlign: 'end' }}>
                 {(order.shippingAddress as ShippingAddress).street}
               </Text>
-              <Text style={{ color: colors.text.primary, textAlign: 'right' }}>
+              <Text style={{ color: colors.text.primary, textAlign: 'end' }}>
                 {(order.shippingAddress as ShippingAddress).city}{' '}
                 {(order.shippingAddress as ShippingAddress).postalCode}
               </Text>
-              <Text style={{ color: colors.text.primary, textAlign: 'right' }}>
+              <Text style={{ color: colors.text.primary, textAlign: 'end' }}>
                 {(order.shippingAddress as ShippingAddress).phone}
               </Text>
               {(order.shippingAddress as ShippingAddress).notes && (
-                <Text style={{ color: colors.text.primary, textAlign: 'right' }}>
+                <Text style={{ color: colors.text.primary, textAlign: 'end' }}>
                   הערות: {(order.shippingAddress as ShippingAddress).notes}
                 </Text>
               )}
@@ -148,7 +148,7 @@ export default function OrderDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   content: { padding: 16 },
-  status: { fontSize: 18, fontWeight: '600', textAlign: 'right', marginBottom: 24 },
+  status: { fontSize: 18, fontWeight: '600', textAlign: 'end', marginBottom: 24 },
   actions: { gap: 12 },
   button: { paddingVertical: 12, borderRadius: 8 },
   buttonText: { fontSize: 16, textAlign: 'center', fontWeight: '600' },

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -983,7 +983,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   galleryContent: {
     paddingRight: 16,
@@ -1004,8 +1004,8 @@ const styles = StyleSheet.create({
   videoIndicator: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     bottom: 0,
     backgroundColor: 'rgba(0,0,0,0.3)',
     justifyContent: 'center',
@@ -1073,7 +1073,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   pricingTierContainer: {
     alignItems: 'flex-end',
@@ -1099,13 +1099,13 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 24,
     marginBottom: 24,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   sectionTitle: {
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   quantitySection: {
     marginBottom: 24,
@@ -1167,17 +1167,17 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   tieredPricingText: {
     fontSize: 14,
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   tieredPricingTotal: {
     fontSize: 18,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   modalContainer: {
     flex: 1,
@@ -1204,7 +1204,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   formInput: {
     borderWidth: 1,
@@ -1249,7 +1249,7 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     marginTop: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   categorySelector: {
     borderWidth: 1,
@@ -1259,7 +1259,7 @@ const styles = StyleSheet.create({
   },
   categorySelectorText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   categorySelectorOverlay: {
     flex: 1,
@@ -1319,7 +1319,7 @@ const styles = StyleSheet.create({
   },
   pricingTierDescription: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   reviewsSection: {
     marginTop: 24,
@@ -1341,6 +1341,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   reviewComment: {
-    textAlign: 'right',
+    textAlign: 'end',
   },
 });

--- a/app/reviews/[orderId].tsx
+++ b/app/reviews/[orderId].tsx
@@ -122,7 +122,7 @@ export default function SubmitReviewScreen() {
           value={title}
           onChangeText={setTitle}
           placeholderTextColor={colors.text.tertiary}
-          textAlign="right"
+          textAlign="end"
         />
         <TextInput
           style={[styles.textarea, { borderColor: colors.border.primary, color: colors.text.primary }]}
@@ -132,7 +132,7 @@ export default function SubmitReviewScreen() {
           placeholderTextColor={colors.text.tertiary}
           multiline
           numberOfLines={4}
-          textAlign="right"
+          textAlign="end"
         />
         <TouchableOpacity style={[styles.submitButton, { backgroundColor: colors.gold }] } onPress={submit}>
           <Text style={[styles.submitText, { color: colors.text.inverse }]}>שלח</Text>
@@ -164,7 +164,7 @@ const styles = StyleSheet.create({
   content: { padding: 16 },
   productRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 24 },
   productImage: { width: 60, height: 60, borderRadius: 8, marginLeft: 12 },
-  productName: { flex: 1, fontSize: 16, fontWeight: '600', textAlign: 'right' },
+  productName: { flex: 1, fontSize: 16, fontWeight: '600', textAlign: 'end' },
   ratingSection: { alignItems: 'center', marginBottom: 24 },
   input: { borderWidth: 1, borderRadius: 8, padding: 12, marginBottom: 16 },
   textarea: { borderWidth: 1, borderRadius: 8, padding: 12, height: 120, marginBottom: 16, textAlignVertical: 'top' },

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -550,7 +550,7 @@ export default function ReviewsScreen() {
             placeholder="חיפוש ביקורות..."
             value={searchQuery}
             onChangeText={setSearchQuery}
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -741,7 +741,7 @@ export default function ReviewsScreen() {
                   onChangeText={(text) => setNewReview(prev => ({ ...prev, title: text }))}
                   placeholder="סכם את החוויה שלך"
                   maxLength={100}
-                  textAlign="right"
+                  textAlign="end"
                   placeholderTextColor={colors.text.tertiary}
                 />
               </View>
@@ -760,7 +760,7 @@ export default function ReviewsScreen() {
                   multiline
                   numberOfLines={4}
                   maxLength={500}
-                  textAlign="right"
+                  textAlign="end"
                   placeholderTextColor={colors.text.tertiary}
                 />
               </View>
@@ -951,7 +951,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   ratingFilter: {
     paddingRight: 16,
@@ -1043,13 +1043,13 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   reviewComment: {
     fontSize: 14,
     lineHeight: 20,
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   reviewActions: {
     flexDirection: 'row',
@@ -1147,12 +1147,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderSelectorDate: {
     fontSize: 14,
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderSelectorItems: {
     borderTopWidth: 1,
@@ -1173,17 +1173,17 @@ const styles = StyleSheet.create({
   orderSelectorItemName: {
     fontSize: 14,
     flex: 1,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderSelectorMoreItems: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
     marginTop: 4,
   },
   alreadyReviewedBadge: {
     position: 'absolute',
     top: 12,
-    left: 12,
+    start: 12,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -1205,12 +1205,12 @@ const styles = StyleSheet.create({
   selectedOrderTitle: {
     fontSize: 18,
     fontWeight: '600',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   selectedOrderDate: {
     fontSize: 14,
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   selectedOrderItems: {
     borderTopWidth: 1,
@@ -1236,11 +1236,11 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   selectedOrderItemQuantity: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   ratingSection: {
     marginBottom: 24,
@@ -1250,7 +1250,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   inputGroup: {
     marginBottom: 24,
@@ -1312,7 +1312,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   filterOption: {
     flexDirection: 'row',
@@ -1324,7 +1324,7 @@ const styles = StyleSheet.create({
   },
   filterOptionText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   selectedFilterDot: {
     width: 12,

--- a/app/storefront/[id].tsx
+++ b/app/storefront/[id].tsx
@@ -76,7 +76,7 @@ export default function StorefrontStoreScreen() {
       {products.map((p) => (
         <View key={p.id} style={styles.product}>
           <ProductCard product={p} style={{ marginBottom: 4 }} />
-          <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+          <Text style={{ color: colors.text.secondary, textAlign: 'end' }}>
             ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
           </Text>
         </View>

--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -144,7 +144,7 @@ export default function StorefrontScreen({ initialCategory }: Props) {
   const renderItem = ({ item: p }: { item: Product }) => (
     <View style={styles.product}>
       <ProductCard product={p} style={{ marginBottom: 4 }} />
-      <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+      <Text style={{ color: colors.text.secondary, textAlign: 'end' }}>
         ⭐ {reviews[p.id]?.rating.toFixed(1) || '0'} ({reviews[p.id]?.count || 0})
       </Text>
     </View>

--- a/app/stores/[id]/dashboard.tsx
+++ b/app/stores/[id]/dashboard.tsx
@@ -62,7 +62,7 @@ export default function StoreDashboardScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 24, textAlign: 'right' },
+  title: { fontSize: 20, fontWeight: '600', marginBottom: 24, textAlign: 'end' },
   stats: { marginBottom: 24, gap: 8, alignItems: 'flex-end' },
   statText: { fontSize: 16 },
   nav: { gap: 12 },

--- a/app/stores/[id]/orders.tsx
+++ b/app/stores/[id]/orders.tsx
@@ -73,7 +73,7 @@ export default function StoreOrdersScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   content: { padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 16, textAlign: 'right' },
+  title: { fontSize: 20, fontWeight: '600', marginBottom: 16, textAlign: 'end' },
   orderItem: { padding: 12, borderWidth: 1, borderRadius: 8, marginBottom: 12 },
 });
 

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -623,7 +623,7 @@ export default function SubcategoryScreen() {
                 value={newProduct.name}
                 onChangeText={(text) => setNewProduct({...newProduct, name: text})}
                 placeholder="הכנס שם מוצר"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -639,7 +639,7 @@ export default function SubcategoryScreen() {
                 onChangeText={(text) => setNewProduct({...newProduct, price: parseFloat(text) || 0})}
                 placeholder="הכנס מחיר"
                 keyboardType="numeric"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -655,7 +655,7 @@ export default function SubcategoryScreen() {
                 onChangeText={(text) => setNewProduct({...newProduct, originalPrice: parseFloat(text) || undefined})}
                 placeholder="הכנס מחיר מקורי"
                 keyboardType="numeric"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -696,7 +696,7 @@ export default function SubcategoryScreen() {
                 placeholder="הכנס תיאור מוצר"
                 multiline
                 numberOfLines={4}
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -767,7 +767,7 @@ export default function SubcategoryScreen() {
                 onChangeText={(text) => setNewProduct({...newProduct, stock: parseInt(text) || 0})}
                 placeholder="הכנס כמות במלאי"
                 keyboardType="numeric"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -785,7 +785,7 @@ export default function SubcategoryScreen() {
                   setNewProduct({...newProduct, badges});
                 }}
                 placeholder="הכנס תגיות מופרדות בפסיקים (למשל: חדש, מבצע, מומלץ)"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -847,7 +847,7 @@ export default function SubcategoryScreen() {
                 value={editSubcategoryData.name}
                 onChangeText={(text) => setEditSubcategoryData({ ...editSubcategoryData, name: text })}
                 placeholder="הכנס שם תת-קטגוריה"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -1178,7 +1178,7 @@ const styles = StyleSheet.create({
   favoriteButton: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     width: 28,
     height: 28,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -1189,7 +1189,7 @@ const styles = StyleSheet.create({
   adminActions: {
     position: 'absolute',
     top: 8,
-    right: 8,
+    end: 8,
     flexDirection: 'row',
   },
   adminActionButton: {
@@ -1209,7 +1209,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     marginBottom: 8,
     lineHeight: 18,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   priceContainer: {
     flexDirection: 'row',
@@ -1307,7 +1307,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   formInput: {
     borderWidth: 1,
@@ -1352,7 +1352,7 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     marginTop: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   categorySelector: {
     borderWidth: 1,
@@ -1362,7 +1362,7 @@ const styles = StyleSheet.create({
   },
   categorySelectorText: {
     fontSize: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   categorySelectorOverlay: {
     flex: 1,
@@ -1433,6 +1433,6 @@ const styles = StyleSheet.create({
   },
   pricingTierDescription: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
 });

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -330,7 +330,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   detailItem: {
     flexDirection: 'row',
@@ -354,12 +354,12 @@ const styles = StyleSheet.create({
   detailLabel: {
     fontSize: 14,
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   detailValue: {
     fontSize: 16,
     fontWeight: '500',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   actionsContainer: {
     marginBottom: 24,

--- a/components/AdminNotificationBanner.tsx
+++ b/components/AdminNotificationBanner.tsx
@@ -106,8 +106,8 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     backgroundColor: '#20B2AA',
     padding: 12,
     flexDirection: 'row',

--- a/components/AuthTabsModal.tsx
+++ b/components/AuthTabsModal.tsx
@@ -42,6 +42,6 @@ const styles = StyleSheet.create({
   close: {
     position: 'absolute',
     top: 8,
-    right: 8,
+    end: 8,
   },
 });

--- a/components/BannerFormModal.tsx
+++ b/components/BannerFormModal.tsx
@@ -206,7 +206,7 @@ export default function BannerFormModal({
                 value={imageUrl}
                 onChangeText={setImageUrl}
                 placeholder="ipfs://..."
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -228,7 +228,7 @@ export default function BannerFormModal({
                   setEditingBanner({ ...editingBanner, title: text })
                 }
                 placeholder="הכנס כותרת באנר"
-                textAlign="right"
+                textAlign="end"
                 placeholderTextColor={colors.text.tertiary}
               />
             </View>
@@ -251,7 +251,7 @@ export default function BannerFormModal({
                   setEditingBanner({ ...editingBanner, subtitle: text })
                 }
                 placeholder="הכנס כותרת משנה"
-                textAlign="right"
+                textAlign="end"
                 placeholderTextColor={colors.text.tertiary}
               />
             </View>
@@ -452,7 +452,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   formInput: {
     borderWidth: 1,
@@ -485,7 +485,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
-  categorySelectorText: { fontSize: 16, textAlign: 'right' },
+  categorySelectorText: { fontSize: 16, textAlign: 'end' },
   categorySelectorOverlay: { flex: 1, justifyContent: 'flex-end' },
   categorySelectorContent: {
     borderTopLeftRadius: 20,

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -463,7 +463,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
             value={shippingAddress.name}
             onChangeText={(text) => setShippingAddress({ ...shippingAddress, name: text })}
             placeholder="הכנס שם מלא"
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -485,7 +485,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
             onChangeText={(text) => setShippingAddress({ ...shippingAddress, phone: text })}
             placeholder="הכנס מספר טלפון"
             keyboardType="phone-pad"
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -506,7 +506,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
             value={shippingAddress.street}
             onChangeText={(text) => setShippingAddress({ ...shippingAddress, street: text })}
             placeholder="הכנס כתובת מלאה"
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -528,7 +528,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
               value={shippingAddress.city}
               onChangeText={(text) => setShippingAddress({ ...shippingAddress, city: text })}
               placeholder="עיר"
-              textAlign="right"
+              textAlign="end"
               placeholderTextColor={colors.text.tertiary}
             />
           </View>
@@ -552,7 +552,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
               }
               placeholder="מיקוד"
               keyboardType="numeric"
-              textAlign="right"
+              textAlign="end"
               placeholderTextColor={colors.text.tertiary}
             />
           </View>
@@ -577,7 +577,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
             placeholder="הערות למשלוח"
             multiline
             numberOfLines={3}
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -1320,9 +1320,9 @@ const styles = StyleSheet.create({
   },
   productImage: { width: 60, height: 60, borderRadius: 8, marginRight: 12 },
   productInfo: { flex: 1, marginRight: 12 },
-  productName: { fontSize: 14, fontWeight: '600', marginBottom: 4, textAlign: 'right' },
-  productPrice: { fontSize: 16, fontWeight: 'bold', textAlign: 'right' },
-  tierInfo: { fontSize: 12, textAlign: 'right' },
+  productName: { fontSize: 14, fontWeight: '600', marginBottom: 4, textAlign: 'end' },
+  productPrice: { fontSize: 16, fontWeight: 'bold', textAlign: 'end' },
+  tierInfo: { fontSize: 12, textAlign: 'end' },
   quantityControls: { flexDirection: 'row', alignItems: 'center', marginRight: 12 },
   quantityButton: {
     width: 32,
@@ -1343,7 +1343,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   totalContainer: { flex: 1 },
-  totalText: { fontSize: 18, fontWeight: 'bold', textAlign: 'right' },
+  totalText: { fontSize: 18, fontWeight: 'bold', textAlign: 'end' },
   checkoutButton: {
     borderRadius: 12,
     paddingVertical: 12,
@@ -1363,7 +1363,7 @@ const styles = StyleSheet.create({
   formGroup: { marginBottom: 16 },
   formRow: { flexDirection: 'row', gap: 12 },
   formGroupHalf: { flex: 1 },
-  formLabel: { fontSize: 14, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
+  formLabel: { fontSize: 14, fontWeight: '600', marginBottom: 8, textAlign: 'end' },
   formInput: {
     borderWidth: 1,
     borderRadius: 8,
@@ -1373,9 +1373,9 @@ const styles = StyleSheet.create({
   },
   textArea: { height: 80, textAlignVertical: 'top' },
   orderSummary: { borderRadius: 12, padding: 16, marginVertical: 24, borderWidth: 1 },
-  summaryTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 12, textAlign: 'right' },
+  summaryTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 12, textAlign: 'end' },
   summaryItem: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
-  summaryItemName: { fontSize: 14, flex: 1, textAlign: 'right' },
+  summaryItemName: { fontSize: 14, flex: 1, textAlign: 'end' },
   summaryItemPrice: { fontSize: 14, fontWeight: '600' },
   summaryRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
   summaryLabel: { fontSize: 14 },
@@ -1411,14 +1411,14 @@ const styles = StyleSheet.create({
   },
   paymentOptionEmoji: { fontSize: 20 },
   paymentOptionInfo: { flex: 1 },
-  paymentOptionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 4, textAlign: 'right' },
-  paymentOptionDescription: { fontSize: 12, textAlign: 'right' },
+  paymentOptionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 4, textAlign: 'end' },
+  paymentOptionDescription: { fontSize: 12, textAlign: 'end' },
   paymentOptionCheck: { marginLeft: 12 },
   shippingAddressSummary: { borderRadius: 12, padding: 16, marginBottom: 16, borderWidth: 1 },
   summaryHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 },
   editLink: { fontSize: 14, fontWeight: '500' },
-  addressText: { fontSize: 14, lineHeight: 20, textAlign: 'right' },
-  notesText: { fontSize: 12, marginTop: 8, fontStyle: 'italic', textAlign: 'right' },
+  addressText: { fontSize: 14, lineHeight: 20, textAlign: 'end' },
+  notesText: { fontSize: 12, marginTop: 8, fontStyle: 'italic', textAlign: 'end' },
   paymentMethodSummary: { borderRadius: 12, padding: 16, marginBottom: 16, borderWidth: 1 },
   paymentMethodInfo: { flexDirection: 'row', alignItems: 'center' },
   paymentMethodEmoji: { fontSize: 20, marginRight: 12 },

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -809,7 +809,7 @@ const styles = StyleSheet.create({
   fab: {
     position: 'absolute',
     bottom: 16,
-    right: 16,
+    end: 16,
     width: 56,
     height: 56,
     borderRadius: 28,
@@ -819,7 +819,7 @@ const styles = StyleSheet.create({
   unreadBadge: {
     position: 'absolute',
     top: 4,
-    right: 4,
+    end: 4,
     borderRadius: 8,
     paddingHorizontal: 4,
     paddingVertical: 2,

--- a/components/FloatingCartWidget.tsx
+++ b/components/FloatingCartWidget.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   Dimensions,
   Platform,
+  I18nManager,
 } from 'react-native';
 import SmartImage from './SmartImage';
 import { ShoppingCart, X, Plus, Minus } from 'lucide-react-native';
@@ -26,6 +27,7 @@ export default function FloatingCartWidget() {
   const [animatedOpacity] = useState(new Animated.Value(0));
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const isRTL = I18nManager.isRTL;
 
   useEffect(() => {
     const cartService = CartService.getInstance();
@@ -119,19 +121,23 @@ export default function FloatingCartWidget() {
       <TouchableOpacity style={styles.header} onPress={toggleExpanded}>
         <View style={styles.headerLeft}>
           <View style={[styles.cartIcon, { backgroundColor: colors.gold }]}>
-            <ShoppingCart size={20} color={colors.text.inverse} />
+            <ShoppingCart
+              size={20}
+              color={colors.text.inverse}
+              style={{ transform: [{ scaleX: isRTL ? -1 : 1 }] }}
+            />
             <View style={[styles.itemCount, { backgroundColor: colors.status.error }]}>
               <Text style={[styles.itemCountText, { color: colors.text.primary }]}>{getTotalItems()}</Text>
             </View>
           </View>
           <View style={styles.headerText}>
-            <Text style={[styles.headerTitle, { color: colors.text.primary }]}>עגלת קניות</Text>
-            <Text style={[styles.headerSubtitle, { color: colors.gold }]}>{currencySymbol}{getTotal().toFixed(2)}</Text>
+            <Text style={[styles.headerTitle, { color: colors.text.primary }]} numberOfLines={1}>עגלת קניות</Text>
+            <Text style={[styles.headerSubtitle, { color: colors.gold }]} numberOfLines={1}>{currencySymbol}{getTotal().toFixed(2)}</Text>
           </View>
         </View>
-        
+
         <View style={styles.headerRight}>
-          <View style={styles.productPreview}>
+          <View style={[styles.productPreview, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
             {cartItems.slice(0, 3).map((item, index) => (
               <SmartImage
                 key={item.id}
@@ -139,7 +145,7 @@ export default function FloatingCartWidget() {
                 style={[
                   styles.previewImage,
                   {
-                    marginLeft: index > 0 ? -8 : 0,
+                    marginStart: index > 0 ? -8 : 0,
                     zIndex: 3 - index,
                     borderColor: colors.background,
                   }
@@ -149,11 +155,16 @@ export default function FloatingCartWidget() {
               />
             ))}
             {cartItems.length > 3 && (
-              <View style={[styles.moreItems, { 
-                marginLeft: -8,
-                borderColor: colors.background,
-                backgroundColor: colors.interactive.disabled
-              }]}>
+              <View
+                style={[
+                  styles.moreItems,
+                  {
+                    marginStart: -8,
+                    borderColor: colors.background,
+                    backgroundColor: colors.interactive.disabled,
+                  }
+                ]}
+              >
                 <Text style={[styles.moreItemsText, { color: colors.text.inverse }]}>+{cartItems.length - 3}</Text>
               </View>
             )}
@@ -247,8 +258,8 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     bottom: 170,
-    left: 16,
-    right: 16,
+    start: 16,
+    end: 16,
     borderRadius: 16,
     zIndex: 999,
     borderWidth: 1,
@@ -273,12 +284,12 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     justifyContent: 'center',
     alignItems: 'center',
-    marginRight: 12,
+    marginEnd: 12,
   },
   itemCount: {
     position: 'absolute',
     top: -4,
-    right: -4,
+    end: -4,
     borderRadius: 8,
     minWidth: 16,
     height: 16,
@@ -296,15 +307,15 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: 16,
     fontWeight: '600',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   headerSubtitle: {
     fontSize: 14,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   headerRight: {
-    marginLeft: 12,
+    marginStart: 12,
   },
   productPreview: {
     flexDirection: 'row',
@@ -346,31 +357,31 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 8,
-    marginRight: 12,
+    marginEnd: 12,
   },
   itemInfo: {
     flex: 1,
-    marginRight: 8,
+    marginEnd: 8,
   },
   itemName: {
     fontSize: 14,
     fontWeight: '500',
     marginBottom: 2,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   itemPrice: {
     fontSize: 12,
     fontWeight: '600',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   tierInfo: {
     fontSize: 10,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   quantityControls: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginRight: 8,
+    marginEnd: 8,
   },
   quantityButton: {
     width: 24,

--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -209,7 +209,7 @@ export default function FullScreenMediaViewer({
               <TouchableOpacity
                 style={[
                   styles.exitButton,
-                  { top: insets.top + 16, right: insets.right + 16 },
+                  { top: insets.top + 16, end: insets.end + 16 },
                 ]}
                 onPress={onClose}
               >
@@ -346,8 +346,8 @@ const styles = StyleSheet.create({
   topControls: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
@@ -396,16 +396,16 @@ const styles = StyleSheet.create({
     transform: [{ translateY: -30 }],
   },
   navButtonLeft: {
-    left: 16,
+    start: 16,
   },
   navButtonRight: {
-    right: 16,
+    end: 16,
   },
   bottomControls: {
     position: 'absolute',
     bottom: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.7)',
     paddingVertical: 16,
     paddingHorizontal: 16,
@@ -465,7 +465,7 @@ const styles = StyleSheet.create({
   exitButton: {
     position: 'absolute',
     top: 16,
-    right: 16,
+    end: 16,
     width: 44,
     height: 44,
     borderRadius: 22,

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -132,7 +132,7 @@ export default function GlobalHeader({
               placeholder={t('home.searchPlaceholder')}
               value={searchQuery}
               onChangeText={onSearchChange}
-              textAlign="right"
+              textAlign="end"
               placeholderTextColor={colors.text.tertiary}
             />
           </View>
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
   badge: {
     position: 'absolute',
     top: -4,
-    left: -4,
+    start: -4,
     borderRadius: 10,
     minWidth: 20,
     height: 20,

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -173,7 +173,7 @@ const styles = StyleSheet.create({
   closeButton: {
     position: 'absolute',
     top: 12,
-    right: 12,
+    end: 12,
     padding: 4,
     zIndex: 1,
   },

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -333,7 +333,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   mediaList: {
     paddingRight: 16,
@@ -362,7 +362,7 @@ const styles = StyleSheet.create({
   playOverlay: {
     position: 'absolute',
     top: '50%',
-    left: '50%',
+    start: '50%',
     transform: [{ translateX: -12 }, { translateY: -12 }],
     width: 24,
     height: 24,
@@ -374,7 +374,7 @@ const styles = StyleSheet.create({
   videoIndicator: {
     position: 'absolute',
     top: 4,
-    right: 4,
+    end: 4,
     backgroundColor: 'rgba(0,0,0,0.7)',
     borderRadius: 4,
     padding: 2,
@@ -382,7 +382,7 @@ const styles = StyleSheet.create({
   removeButton: {
     position: 'absolute',
     top: 4,
-    left: 4,
+    start: 4,
     width: 20,
     height: 20,
     borderRadius: 10,
@@ -392,8 +392,8 @@ const styles = StyleSheet.create({
   progressWrapper: {
     position: 'absolute',
     bottom: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     height: 4,
     backgroundColor: 'rgba(255,255,255,0.3)',
     justifyContent: 'center',
@@ -410,8 +410,8 @@ const styles = StyleSheet.create({
   primaryBadge: {
     position: 'absolute',
     bottom: 4,
-    left: 4,
-    right: 4,
+    start: 4,
+    end: 4,
     borderRadius: 4,
     paddingVertical: 2,
     paddingHorizontal: 4,
@@ -445,7 +445,7 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     marginTop: 8,
-    textAlign: 'right',
+    textAlign: 'end',
     lineHeight: 16,
   },
 });

--- a/components/MediaViewer.tsx
+++ b/components/MediaViewer.tsx
@@ -81,7 +81,7 @@ export default function MediaViewer({ media, initialIndex, onClose }: Props) {
       <TouchableOpacity
         style={[
           styles.closeButton,
-          { top: insets.top + 16, right: insets.right + 16 },
+          { top: insets.top + 16, end: insets.end + 16 },
         ]}
         onPress={onClose}
       >
@@ -170,8 +170,8 @@ const styles = StyleSheet.create({
   indicators: {
     position: 'absolute',
     bottom: 100,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     flexDirection: 'row',
     justifyContent: 'center',
   },

--- a/components/MoonPayModal.tsx
+++ b/components/MoonPayModal.tsx
@@ -97,8 +97,8 @@ const styles = StyleSheet.create({
   loading: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     bottom: 0,
     justifyContent: 'center',
     alignItems: 'center',

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     position: 'absolute',
     top: -5,
-    right: -5,
+    end: -5,
     minWidth: 20,
     paddingHorizontal: 2,
   },

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -112,8 +112,8 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
+    start: 0,
+    end: 0,
     padding: 16,
     zIndex: 1000,
     width: width,

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -591,16 +591,16 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   stepDescription: {
     fontSize: 14,
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   stepTime: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   contactOptions: {
     flexDirection: 'row',
@@ -647,7 +647,7 @@ const styles = StyleSheet.create({
   orderInfoTitle: {
     fontSize: 16,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   copyButton: {
     flexDirection: 'row',
@@ -695,13 +695,13 @@ const styles = StyleSheet.create({
   shippingAddress: {
     fontSize: 14,
     lineHeight: 20,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   shippingNotes: {
     fontSize: 12,
     marginTop: 8,
     fontStyle: 'italic',
-    textAlign: 'right',
+    textAlign: 'end',
   },
   itemsContainer: {
     borderRadius: 12,
@@ -713,7 +713,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   orderItem: {
     flexDirection: 'row',
@@ -735,12 +735,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   itemDetails: {
     fontSize: 12,
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   itemColor: {
     flexDirection: 'row',
@@ -772,12 +772,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   instructionsText: {
     fontSize: 14,
     lineHeight: 20,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   reviewPrompt: {
     borderRadius: 12,

--- a/components/PricingTierFormModal.tsx
+++ b/components/PricingTierFormModal.tsx
@@ -172,7 +172,7 @@ export default function PricingTierFormModal({
                 value={formData.id}
                 onChangeText={text => setFormData({ ...formData, id: text })}
                 placeholder="הכנס מזהה מדרג (באנגלית, לדוגמה: bulk_discount)"
-                textAlign="left"
+                textAlign="start"
                 editable={!editingTier}
               />
             </View>
@@ -188,7 +188,7 @@ export default function PricingTierFormModal({
                 value={formData.name}
                 onChangeText={text => setFormData({ ...formData, name: text })}
                 placeholder="הכנס שם מדרג (לדוגמה: הנחת כמות)"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -209,7 +209,7 @@ export default function PricingTierFormModal({
                       setFormData({ ...formData, rules: updated });
                     }}
                     keyboardType="numeric"
-                    textAlign="right"
+                    textAlign="end"
                   />
                 </View>
                 <View style={styles.formGroupHalf}>
@@ -227,7 +227,7 @@ export default function PricingTierFormModal({
                       setFormData({ ...formData, rules: updated });
                     }}
                     keyboardType="numeric"
-                    textAlign="right"
+                    textAlign="end"
                   />
                 </View>
                 <View style={styles.formGroupHalf}>
@@ -245,7 +245,7 @@ export default function PricingTierFormModal({
                       setFormData({ ...formData, rules: updated });
                     }}
                     keyboardType="numeric"
-                    textAlign="right"
+                    textAlign="end"
                   />
                 </View>
                 <View style={styles.formGroupHalf}>
@@ -263,7 +263,7 @@ export default function PricingTierFormModal({
                       setFormData({ ...formData, rules: updated });
                     }}
                     keyboardType="numeric"
-                    textAlign="right"
+                    textAlign="end"
                   />
                 </View>
                 <TouchableOpacity
@@ -312,7 +312,7 @@ export default function PricingTierFormModal({
                 placeholder="הכנס תיאור מדרג (לדוגמה: מחיר מיוחד של 8₪ ליחידה בקנייה של 5 פריטים ומעלה)"
                 multiline
                 numberOfLines={4}
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -373,7 +373,7 @@ const styles = StyleSheet.create({
   formGroup: { marginBottom: 20 },
   formRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20, gap: 12 },
   formGroupHalf: { flex: 1 },
-  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
+  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'end' },
   formInput: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
   textArea: { height: 100, textAlignVertical: 'top' },
   addRuleButton: { marginBottom: 10 },

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -331,7 +331,7 @@ const styles = StyleSheet.create({
   favoriteButton: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     width: 28,
     height: 28,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -342,7 +342,7 @@ const styles = StyleSheet.create({
   cartButton: {
     position: 'absolute',
     bottom: 8,
-    right: 8,
+    end: 8,
     width: 32,
     height: 32,
     borderRadius: 16,
@@ -352,7 +352,7 @@ const styles = StyleSheet.create({
   adminActions: {
     position: 'absolute',
     top: 8,
-    right: 8,
+    end: 8,
     flexDirection: 'row',
   },
   adminButton: {
@@ -367,7 +367,7 @@ const styles = StyleSheet.create({
   badgesContainer: {
     position: 'absolute',
     bottom: 8,
-    left: 8,
+    start: 8,
     flexDirection: 'row',
     flexWrap: 'wrap',
     maxWidth: '70%',
@@ -391,7 +391,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     marginBottom: 8,
     lineHeight: 18,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   priceContainer: {
     flexDirection: 'row',
@@ -449,7 +449,7 @@ const styles = StyleSheet.create({
   selectedVariantText: {
     fontSize: 12,
     marginBottom: 4,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   stockContainer: {
     flexDirection: 'row',

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -267,7 +267,7 @@ export default function ProductFormModal({
                 value={imageUrls}
                 onChangeText={setImageUrls}
                 placeholder="ipfs://..."
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -285,7 +285,7 @@ export default function ProductFormModal({
                 value={videoUrls}
                 onChangeText={setVideoUrls}
                 placeholder="ipfs://..."
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -300,7 +300,7 @@ export default function ProductFormModal({
                 value={editingProduct.name}
                 onChangeText={text => setEditingProduct({ ...editingProduct, name: text })}
                 placeholder="הכנס שם מוצר"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -316,7 +316,7 @@ export default function ProductFormModal({
                 onChangeText={text => setEditingProduct({ ...editingProduct, price: parseFloat(text) || 0 })}
                 placeholder="הכנס מחיר"
                 keyboardType="numeric"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -352,7 +352,7 @@ export default function ProductFormModal({
                 placeholder="הכנס תיאור מוצר"
                 multiline
                 numberOfLines={4}
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -420,7 +420,7 @@ export default function ProductFormModal({
                     value={variant.color}
                     onChangeText={(text) => updateVariant(index, 'color', text)}
                     placeholder="צבע"
-                    textAlign="right"
+                    textAlign="end"
                   />
                   <TextInput
                     style={[
@@ -435,7 +435,7 @@ export default function ProductFormModal({
                     onChangeText={(text) => updateVariant(index, 'stock', parseInt(text) || 0)}
                     placeholder="מלאי"
                     keyboardType="numeric"
-                    textAlign="right"
+                    textAlign="end"
                   />
                   <TouchableOpacity onPress={() => removeVariant(index)} style={styles.removeVariantButton}>
                     <Trash2 size={20} color={colors.status.error} />
@@ -463,7 +463,7 @@ export default function ProductFormModal({
                 onChangeText={text => setEditingProduct({ ...editingProduct, stock: parseInt(text) || 0 })}
                 placeholder="הכנס כמות במלאי"
                 keyboardType="numeric"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -481,7 +481,7 @@ export default function ProductFormModal({
                   setEditingProduct({ ...editingProduct, badges });
                 }}
                 placeholder="הכנס תגיות מופרדות בפסיקים (למשל: חדש, מבצע, מומלץ)"
-                textAlign="right"
+                textAlign="end"
               />
             </View>
 
@@ -655,7 +655,7 @@ const styles = StyleSheet.create({
   modalTitle: { fontSize: 18, fontWeight: 'bold' },
   modalContent: { padding: 16 },
   formGroup: { marginBottom: 20 },
-  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
+  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'end' },
   formInput: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
   textArea: { height: 100, textAlignVertical: 'top' },
   modalActions: { gap: 16, marginTop: 20, marginBottom: 40 },
@@ -664,9 +664,9 @@ const styles = StyleSheet.create({
   buttonSpinner: { marginRight: 8 },
   deleteButton: { borderRadius: 12, paddingVertical: 16, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' },
   deleteButtonText: { fontSize: 16, fontWeight: '600', marginLeft: 8 },
-  helperText: { fontSize: 12, marginTop: 4, textAlign: 'right' },
+  helperText: { fontSize: 12, marginTop: 4, textAlign: 'end' },
   categorySelector: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12 },
-  categorySelectorText: { fontSize: 16, textAlign: 'right' },
+  categorySelectorText: { fontSize: 16, textAlign: 'end' },
   categorySelectorOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   categorySelectorContent: { borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 20, maxHeight: '80%' },
   categorySelectorHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 },
@@ -679,7 +679,7 @@ const styles = StyleSheet.create({
   categorySelectorItemId: { fontSize: 12 },
   pricingTierInfo: { marginLeft: 12, flex: 1, alignItems: 'flex-end' },
   pricingTierDiscount: { fontSize: 14, fontWeight: 'bold' },
-  pricingTierDescription: { fontSize: 12, textAlign: 'right' },
+  pricingTierDescription: { fontSize: 12, textAlign: 'end' },
   variantRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
   colorPreview: { width: 24, height: 24, borderRadius: 12, marginRight: 8, borderWidth: 1 },
   variantColorInput: { flex: 1, borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },

--- a/components/StoreCreation.tsx
+++ b/components/StoreCreation.tsx
@@ -73,8 +73,8 @@ const StoreCreation: React.FC = () => {
 
 const styles = StyleSheet.create({
   container: { gap: 16 },
-  label: { fontSize: 16, fontWeight: '600', textAlign: 'right' },
-  input: { borderWidth: 1, borderRadius: 8, padding: 8, textAlign: 'right' },
+  label: { fontSize: 16, fontWeight: '600', textAlign: 'end' },
+  input: { borderWidth: 1, borderRadius: 8, padding: 8, textAlign: 'end' },
 });
 
 export default StoreCreation;

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -276,7 +276,7 @@ const styles = StyleSheet.create({
   adminIndicator: {
     position: 'absolute',
     top: -2,
-    right: -2,
+    end: -2,
     width: 12,
     height: 12,
     borderRadius: 6,
@@ -324,11 +324,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginBottom: 2,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   userRole: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   divider: {
     height: 1,
@@ -348,7 +348,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     marginLeft: 12,
     fontWeight: '500',
-    textAlign: 'right',
+    textAlign: 'end',
     flex: 1,
   },
 });

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
   closeButton: {
     position: 'absolute',
     top: 12,
-    right: 12,
+    end: 12,
     padding: 4,
     zIndex: 1,
   },

--- a/components/WishlistModal.tsx
+++ b/components/WishlistModal.tsx
@@ -207,7 +207,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   priceContainer: {
     flexDirection: 'row',

--- a/components/chat/MessageInput.tsx
+++ b/components/chat/MessageInput.tsx
@@ -17,7 +17,7 @@ const MessageInput: React.FC<Props> = ({ value, onChange, onSend, colors }) => {
         onChangeText={onChange}
         placeholder="Type a message"
         placeholderTextColor={colors.text.tertiary}
-        textAlign="right"
+        textAlign="end"
       />
       <TouchableOpacity onPress={onSend} style={[styles.button, { backgroundColor: colors.gold }]}> 
         <Text style={[styles.buttonText, { color: colors.text.inverse }]}>Send</Text>

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
   },
   message: {
     fontSize: 14,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   loader: {
     padding: 8,

--- a/components/chat/RoomList.tsx
+++ b/components/chat/RoomList.tsx
@@ -48,13 +48,13 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   name: {
-    textAlign: 'right',
+    textAlign: 'end',
     fontSize: 16,
   },
   badge: {
     position: 'absolute',
     top: 8,
-    left: 8,
+    start: 8,
     borderRadius: 8,
     paddingHorizontal: 6,
     paddingVertical: 2,

--- a/components/settings/BrandingSettings.tsx
+++ b/components/settings/BrandingSettings.tsx
@@ -50,7 +50,7 @@ const BrandingSettings: React.FC<Props> = ({
             value={name}
             onChangeText={setName}
             placeholder={t('ageVerification.platformName')}
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -68,7 +68,7 @@ const BrandingSettings: React.FC<Props> = ({
             value={logoCidInput}
             onChangeText={setLogoCidInput}
             placeholder="ipfs://..."
-            textAlign="right"
+            textAlign="end"
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
@@ -134,7 +134,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   input: {
     borderWidth: 1,

--- a/components/settings/CurrencySettings.tsx
+++ b/components/settings/CurrencySettings.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   inputContainer: {
     marginBottom: 8,
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: 8,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   input: {
     borderWidth: 1,
@@ -92,7 +92,7 @@ const styles = StyleSheet.create({
   },
   helper: {
     fontSize: 12,
-    textAlign: 'right',
+    textAlign: 'end',
   },
 });
 

--- a/components/settings/EnvironmentSettings.tsx
+++ b/components/settings/EnvironmentSettings.tsx
@@ -52,11 +52,11 @@ const styles = StyleSheet.create({
   },
   description: {
     fontSize: 14,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   label: {
     fontSize: 14,
-    textAlign: 'right',
+    textAlign: 'end',
   },
 });
 

--- a/components/settings/LanguageSettings.tsx
+++ b/components/settings/LanguageSettings.tsx
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   infoBox: {
     borderRadius: 8,

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
     marginBottom: 16,
-    textAlign: 'right',
+    textAlign: 'end',
   },
   badge: {
     paddingHorizontal: 16,

--- a/generator.html
+++ b/generator.html
@@ -82,7 +82,7 @@
       .custom-modal {
         position: fixed;
         top: 50%;
-        left: 50%;
+        start: 50%;
         transform: translate(-50%, -50%);
         background-color: #fff;
         padding: 20px;
@@ -434,7 +434,7 @@
 
           <!-- Bottom Navy-Blue Strip -->
           <div
-            class="absolute bottom-0 left-0 w-full bg-blue-900 text-white text-[0.5rem] py-1 px-1 font-medium flex justify-center items-center text-center"
+            class="absolute bottom-0 start-0 w-full bg-blue-900 text-white text-[0.5rem] py-1 px-1 font-medium flex justify-center items-center text-center"
           >
             <span id="cardAddressMobile"></span>
           </div>


### PR DESCRIPTION
## Summary
- replace legacy left/right styles with start/end across components and screens
- handle RTL by mirroring icons and product preview images in FloatingCartWidget
- add truncation guard for cart widget headers

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf31d25f48326ad56eedb0ee1ddac