### PR TITLE
Validate TON addresses and encrypt shipping data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This Expo project uses React Native with the Expo Router.
 
    When the app loads, tap the wallet button to open the TonConnect modal. Scan the QR code with a wallet like Tonkeeper or use an injected extension to link your account.
 
+### TON Address Format
+
+Wallet addresses must use the standard TON formatting recognized by `@ton/core`. If an invalid address is provided, the app will display an "Invalid TON address" error and refuse to store it.
+
 All data is ephemeral and synchronized between peers over Waku; no external services are required. All state is held in memory and hydrated from the Waku message history on boot. No database setup or SQL migrations are required, and all prior SQLite migration files have been removed from this repository.
 
 ### Development

--- a/app/stores/[id]/orders.tsx
+++ b/app/stores/[id]/orders.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { debugLog } from '@/utils/logger';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { listOrdersBySeller } from '../../../services/tonOrders';
@@ -13,11 +14,11 @@ export default function StoreOrdersScreen() {
   const address = useTonAddress();
 
   const handlePress = (order: Order) => {
-    console.log('Pressed order', order.id);
+    debugLog('Pressed order', order.id);
   };
 
   const handleLongPress = (order: Order) => {
-    console.log('Long pressed order', order.id);
+    debugLog('Long pressed order', order.id);
   };
 
   useEffect(() => {

--- a/components/StoreCreation.tsx
+++ b/components/StoreCreation.tsx
@@ -7,6 +7,8 @@ import tonAuth from '../services/tonAuth';
 import codeBoc from '../contracts/store-nft-code.boc';
 import dataBoc from '../contracts/store-nft-data.boc';
 import { getTonWeb } from '../services/tonProvider';
+import validateTonAddress from '../utils/validateTonAddress';
+import { errorLog } from '../utils/logger';
 
 const tonweb = getTonWeb();
 
@@ -52,12 +54,18 @@ const StoreCreation: React.FC = () => {
       await tonAuth.openModal();
       return;
     }
+    if (!validateTonAddress(owner)) {
+      errorLog('Invalid TON address');
+      Alert.alert('Invalid address', 'Please connect a valid TON wallet.');
+      return;
+    }
     try {
       const nftId = await deployStoreNFT();
       const id = Date.now().toString();
       await storesAgent.add({ id, name, owner, nftId });
       setName('');
-    } catch {
+    } catch (err) {
+      errorLog('Store mint failed', err);
       // Deployment failed or was rejected
     }
   };

--- a/components/WalletConnectButton.tsx
+++ b/components/WalletConnectButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { TonConnectButton } from '@tonconnect/ui-react';
 import {
@@ -6,6 +6,8 @@ import {
   useTonAddress,
   useTonConnect,
 } from '../services/tonAuth';
+import validateTonAddress from '../utils/validateTonAddress';
+import { errorLog } from '../utils/logger';
 
 interface WalletConnectButtonProps {
   onConnect?: () => void;
@@ -15,9 +17,19 @@ export default function WalletConnectButton({ onConnect }: WalletConnectButtonPr
   const wallet = useTonWallet();
   const address = useTonAddress();
   const tonConnectUI = useTonConnect();
+  const validAddress = useMemo(() => validateTonAddress(address), [address]);
+
+  useEffect(() => {
+    if (wallet) {
+      if (!validAddress) {
+        errorLog('Invalid TON address received');
+      } else {
+        onConnect?.();
+      }
+    }
+  }, [wallet, validAddress, onConnect]);
 
   const handleTonConnect = () => {
-    onConnect?.();
     tonConnectUI?.openModal();
   };
 
@@ -29,7 +41,8 @@ export default function WalletConnectButton({ onConnect }: WalletConnectButtonPr
   return (
     <View style={styles.container}>
       <TonConnectButton onClick={handleTonConnect} />
-      {wallet && <Text>{address}</Text>}
+      {wallet && validAddress && <Text>{address}</Text>}
+      {wallet && !validAddress && <Text style={{ color: 'red' }}>Invalid address</Text>}
       <Button title="Connect with MetaMask" onPress={handleMetaMaskConnect} />
     </View>
   );

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -3,7 +3,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { Order } from '../types';
 import { decryptOrderShipping } from '../services/sellerTools';
 import { getSellerPublicKey } from '../services/sellerRegistry';
-import { getPrivateKey } from '../services/localIdentity';
+import { getEd25519KeyPair } from '../services/localIdentity';
 
 const mockStore: Record<string, any> = {};
 
@@ -46,7 +46,10 @@ jest.mock('../services/tonAuth', () => ({
 const sellerKey = nacl.sign.keyPair();
 const sellerPubEd = Buffer.from(sellerKey.publicKey).toString('hex');
 (getSellerPublicKey as jest.Mock).mockResolvedValue(sellerPubEd);
-(getPrivateKey as jest.Mock).mockResolvedValue(sellerKey.secretKey);
+(getEd25519KeyPair as jest.Mock).mockResolvedValue({
+  privateKey: sellerKey.secretKey,
+  publicKey: sellerKey.publicKey,
+});
 
 const ordersAgent = require('../agents/orders-agent').default;
 const notificationsAgent = require('../agents/notifications-agent');

--- a/tests/sellerTools.test.ts
+++ b/tests/sellerTools.test.ts
@@ -1,7 +1,7 @@
 import * as nacl from 'tweetnacl';
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { decryptOrderShipping } from '../services/sellerTools';
-import { getPrivateKey } from '../services/localIdentity';
+import { getEd25519KeyPair } from '../services/localIdentity';
 import { Order } from '../types';
 
 jest.mock('../services/localIdentity');
@@ -9,7 +9,10 @@ jest.mock('../services/localIdentity');
 describe('sellerTools.decryptOrderShipping', () => {
   it('decrypts shipping info using seller private key', async () => {
     const seller = nacl.sign.keyPair();
-    (getPrivateKey as jest.Mock).mockResolvedValue(seller.secretKey);
+    (getEd25519KeyPair as jest.Mock).mockResolvedValue({
+      privateKey: seller.secretKey,
+      publicKey: seller.publicKey,
+    });
 
     const addr = {
       name: 'Alice',

--- a/tests/shippingCrypto.test.ts
+++ b/tests/shippingCrypto.test.ts
@@ -1,8 +1,16 @@
 import * as nacl from 'tweetnacl';
 import { encryptShippingInfo, decryptShippingInfo } from '../utils/shippingCrypto';
+import { getEd25519KeyPair } from '../services/localIdentity';
+
+jest.mock('../services/localIdentity');
 
 const seller = nacl.sign.keyPair();
 const sellerPub = Buffer.from(seller.publicKey).toString('hex');
+const buyer = nacl.sign.keyPair();
+(getEd25519KeyPair as jest.Mock).mockResolvedValue({
+  privateKey: buyer.secretKey,
+  publicKey: buyer.publicKey,
+});
 
 describe('shippingCrypto', () => {
   it('performs ECDH round trip for shipping info', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -225,8 +225,7 @@ export interface Order {
   shippingAddress: ShippingAddress;
   shipAddrEnc?: {
     cipher: string;
-    nonce: string;
-    ephem: string;
+    from: string;
   };
   paymentMethod: 'cash_on_delivery' | 'ton';
   buyerAddress?: string;

--- a/utils/shippingCrypto.ts
+++ b/utils/shippingCrypto.ts
@@ -1,44 +1,42 @@
-import * as nacl from 'tweetnacl';
-import * as ed2curve from 'ed2curve';
 import { ShippingAddress } from '../types';
-import { getPrivateKey } from '../services/localIdentity';
+import { getEd25519KeyPair } from '../services/localIdentity';
+import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from './encryption';
+import { getPublicKey } from '@noble/ed25519';
 
 export interface EncryptedShipping {
   cipher: string;
-  nonce: string;
-  ephem: string;
+  from: string;
 }
 
 export async function encryptShippingInfo(
   info: ShippingAddress,
   sellerPublicKey: string,
 ): Promise<EncryptedShipping> {
-  const sellerPubX = ed2curve.convertPublicKey(Buffer.from(sellerPublicKey, 'hex'));
-  if (!sellerPubX) throw new Error('invalid seller key');
-  const ephem = nacl.box.keyPair();
-  const nonce = nacl.randomBytes(nacl.box.nonceLength);
-  const msg = Buffer.from(JSON.stringify(info));
-  const cipher = nacl.box(msg, nonce, sellerPubX, ephem.secretKey);
-  return {
-    cipher: Buffer.from(cipher).toString('base64'),
-    nonce: Buffer.from(nonce).toString('base64'),
-    ephem: Buffer.from(ephem.publicKey).toString('base64'),
-  };
+  const { privateKey, publicKey } = await getEd25519KeyPair();
+  const from = Buffer.from(publicKey).toString('hex');
+  const salt = deriveChatSalt(from, sellerPublicKey);
+  const key = await deriveSharedKey(privateKey, sellerPublicKey, 'shipping', salt);
+  const cipher = await aesEncrypt(JSON.stringify(info), key);
+  return { cipher, from };
 }
 
 export async function decryptShippingInfo(
   enc: EncryptedShipping,
   privKey?: Uint8Array,
 ): Promise<ShippingAddress | null> {
-  const secret = privKey ?? (await getPrivateKey());
-  const privX = ed2curve.convertSecretKey(secret);
-  if (!privX) return null;
-  const decrypted = nacl.box.open(
-    Buffer.from(enc.cipher, 'base64'),
-    Buffer.from(enc.nonce, 'base64'),
-    Buffer.from(enc.ephem, 'base64'),
-    privX,
-  );
-  if (!decrypted) return null;
-  return JSON.parse(Buffer.from(decrypted).toString());
+  let myPriv: Uint8Array;
+  let myPubHex: string;
+  if (privKey) {
+    myPriv = privKey;
+    const pub = await getPublicKey(privKey);
+    myPubHex = Buffer.from(pub).toString('hex');
+  } else {
+    const kp = await getEd25519KeyPair();
+    myPriv = kp.privateKey;
+    myPubHex = Buffer.from(kp.publicKey).toString('hex');
+  }
+  const salt = deriveChatSalt(enc.from, myPubHex);
+  const key = await deriveSharedKey(myPriv, enc.from, 'shipping', salt);
+  const dec = await aesDecrypt(enc.cipher, key);
+  return JSON.parse(dec);
 }


### PR DESCRIPTION
## Summary
- validate wallet addresses in StoreCreation and WalletConnectButton before saving
- encrypt shipping information with shared-key utilities
- document required TON address format and hook up debug logging

## Testing
- `yarn lint` *(fails: React Hook useEffect is called conditionally; missing deps)*
- `yarn typecheck` *(fails: TS1005 errors in ChatWidget and reputation tests)*
- `yarn test` *(fails: Cannot find module '@/utils/logger' from constants/tenant.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cf40dec6483269afaeee93027d577