### PR TITLE
Add runbooks and operational checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This Expo project uses React Native with the Expo Router.
 
+## Quickstart
+
+```sh
+yarn install
+yarn dev        # mobile
+yarn start      # web
+yarn test
+```
+
 ## Setup
 
 1. **Install dependencies**
@@ -192,27 +201,32 @@ deploying the static build, verify the manifest is accessible:
 curl https://<your-site>/tonconnect-manifest.json
 ```
 
-### Web/IPFS Deployment
+### IPFS Deployment Guide
 
 Use the IPFS-friendly Vite build to create static assets with relative paths so
 the app works from any gateway.
 
-- **Build:**
+1. **Build**
 
-  ```sh
-  npm run web:release
-  ```
+   ```sh
+   npm run web:release
+   ```
 
-- **Local preview:**
+2. **Preview locally**
 
-  ```sh
-  npm run web:preview
-  ```
+   ```sh
+   npm run web:preview
+   ```
 
-  Then open `http://localhost:4173/` and navigate within the app (no deep links).
+   Then open `http://localhost:4173/` and navigate within the app (no deep links).
 
-- **Upload:** Manually pin the `dist/` directory to your pinning service (e.g.,
-  Pinata) to publish it to IPFS.
+3. **Upload to IPFS**
+
+   ```sh
+   ipfs add -r dist
+   ```
+
+   Pin the returned CID using your pinning service (e.g., Pinata) to publish it.
 
 #### Pin `dist/` Checklist
 
@@ -228,6 +242,13 @@ the app works from any gateway.
 3. Navigate to a route like `/#/product/1` to confirm hash routing
 
 Deep links require additional rewrite support.
+
+## Debugging Tips
+
+- Set `EXPO_PUBLIC_DEBUG_LOGS=true` to emit verbose agent logs.
+- Run `expo start -c` to clear caches when Metro behaves oddly.
+- Use React Native Debugger or Chrome DevTools for network inspection.
+- Prefix commands with `DEBUG=waku:*` to trace Waku network traffic.
 
 ## Troubleshooting
 
@@ -263,6 +284,12 @@ yarn test
 ```
 
 Run `yarn install` before executing `yarn test` so Jest and other dependencies are present.
+
+## Runbooks & Checklists
+
+- [Incident Runbook](docs/incident-runbook.md)
+- [QA Checklist](docs/checklists/qa.md)
+- [Rollout Checklist](docs/checklists/rollout.md)
 
 ## Apple Pay Integration
 

--- a/docs/checklists/qa.md
+++ b/docs/checklists/qa.md
@@ -1,0 +1,9 @@
+# QA Checklist
+
+- [ ] Install dependencies with `yarn install`
+- [ ] Run `yarn lint` and address all warnings
+- [ ] Run `yarn typecheck` and fix type errors
+- [ ] Execute tests with `yarn test`
+- [ ] Verify app boots on web and mobile simulators
+- [ ] Confirm Waku peer discovery and message sync
+- [ ] Validate UI flows for login, product listing, and checkout

--- a/docs/checklists/rollout.md
+++ b/docs/checklists/rollout.md
@@ -1,0 +1,9 @@
+# Rollout Checklist
+
+- [ ] Tag the release in git and generate release notes
+- [ ] Build web assets with `npm run web:release`
+- [ ] Pin `dist/` to IPFS and record the CID
+- [ ] Update gateway links and announce the new CID
+- [ ] Deploy mobile bundles to app stores if applicable
+- [ ] Monitor logs and metrics for the first 24 hours
+- [ ] Execute rollback plan if critical issues arise

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -1,0 +1,24 @@
+# Incident Runbook
+
+When production goes sideways, use this guide to restore service quickly.
+
+## Rollback
+
+1. **Identify last known good build.** Consult commit history or previous IPFS CID.
+2. **Revert code:** `git revert <bad_commit>` and push or rebuild from prior tag.
+3. **Redeploy:** rebuild the web bundle and pin the previous CID to IPFS or redeploy the mobile build.
+4. **Verify:** confirm the app loads and agents synchronize as expected.
+
+## Endpoint Failover
+
+1. **Swap Waku bootstrap peers** in `.env` with a healthy list.
+2. **Override TON RPC:** restart deployments using `--endpoint <backup-url>`.
+3. **Flush caches** with `expo start -c` to ensure new endpoints are used.
+4. **Monitor** connectivity logs from agents for successful peer discovery.
+
+## Gateway Failover
+
+1. **Publish the build** to an alternate IPFS pinning service if the current gateway is down.
+2. **Update links** to point at a healthy gateway, e.g. `https://dweb.link/ipfs/<CID>/`.
+3. **Clear caches** and refresh clients to force retrieval from the new gateway.
+4. **Backfill** the original pinning service when it recovers to maintain redundancy.


### PR DESCRIPTION
## Summary
- document quickstart, debugging, and IPFS deploy steps in README
- add incident runbook with rollback and failover guidance
- provide QA and rollout checklists for deployments

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn install` *(fails: node engine incompatibility)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf40fbdec8326b8c1772935e56aed