### PR TITLE
feat: add analytics event tracking

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -48,6 +48,7 @@ import commonStyles from '../../constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '../../components/FloatingCartWidget';
 import SmartImage from '../../components/SmartImage';
+import eventBus from '../../services/eventBus';
 
 
 
@@ -158,7 +159,10 @@ export default function ProductDetailScreen() {
         });
         return;
       }
-      setProduct(fetched);
+      if (fetched) {
+        setProduct(fetched);
+        eventBus.track('catalog.product_view', { productId: fetched.id });
+      }
     } catch (error) {
       errorLog('Error loading product:', error);
       setInfoModal({

--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -14,6 +14,7 @@ import reviewAgent from '../../agents/review-agent';
 import ProductCard from '../../components/ProductCard';
 import { Product } from '../../types';
 import Fuse from 'fuse.js';
+import eventBus from '../../services/eventBus';
 
 interface ReviewMap {
   [productId: string]: { rating: number; count: number };
@@ -35,6 +36,10 @@ export default function StorefrontScreen({ initialCategory }: Props) {
   const [filtered, setFiltered] = useState<Product[]>([]);
   const fuseRef = useRef<Fuse<Product> | null>(null);
   const CARD_HEIGHT = 220;
+
+  useEffect(() => {
+    eventBus.track('catalog.view', { category: initialCategory || null });
+  }, [initialCategory]);
 
   useEffect(() => {
     const load = async () => {

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -28,6 +28,7 @@ import CartService from '../services/cart';
 import { getStore } from '../services/tonStores';
 import { CartItem, ShippingAddress, Store } from '../types';
 import OrderService from '../services/orders';
+import eventBus from '../services/eventBus';
 import { useAuth } from './AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import commonStyles from '../constants/styles';
@@ -236,6 +237,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       return;
     }
 
+    eventBus.track('checkout.start', { items: cartItems.length, total: getTotal() });
     setCheckoutStep('shipping');
   };
 
@@ -314,7 +316,10 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         shippingAddress,
         'ton'
       );
-
+      eventBus.track('checkout.complete', {
+        orderIds: orders.map((o) => o.id),
+        total: getTotal(),
+      });
       setOrderIds(orders.map((o) => o.id));
       setOrderPlaced(true);
       await cartService.clearCart();

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   FlatList,
   View,
@@ -9,6 +9,7 @@ import {
   NativeScrollEvent,
 } from 'react-native';
 import { ChatMessage } from '../../types';
+import eventBus from '../../services/eventBus';
 
 interface Props {
   messages: ChatMessage[];
@@ -25,9 +26,14 @@ const MessageList: React.FC<Props> = ({
   hasMore,
   loadingMore,
 }) => {
+  useEffect(() => {
+    eventBus.track('chat.view', { messageCount: messages.length });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
     if (!onLoadMore || !hasMore || loadingMore) return;
     if (e.nativeEvent.contentOffset.y <= 0) {
+      eventBus.track('chat.load_more', { messageCount: messages.length });
       onLoadMore();
     }
   };

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,42 @@
+# Analytics Events
+
+This app records anonymized funnel events over Waku for basic analytics.
+
+## Event Schema
+
+Events published on `/congress/analytics/1` follow this structure:
+
+```json
+{
+  "id": "uuid",
+  "timestamp": 0,
+  "sessionId": "uuid",
+  "actor": "sha256(userAddress)",
+  "type": "event.type",
+  "payload": { "key": "value" }
+}
+```
+
+- **id** – unique event identifier.
+- **timestamp** – milliseconds since epoch.
+- **sessionId** – random identifier for the current session.
+- **actor** – hashed wallet address when available.
+- **type** – event name.
+- **payload** – event-specific data.
+
+## Event Types
+
+| Type | Payload |
+|------|---------|
+| `catalog.view` | `{ category: string | null }` |
+| `catalog.product_view` | `{ productId: string }` |
+| `cart.add` | `{ productId: string, quantity: number }` |
+| `cart.remove` | `{ itemId: string }` |
+| `cart.update` | `{ itemId: string, quantity: number }` |
+| `cart.clear` | `{}` |
+| `checkout.start` | `{ items: number, total: number }` |
+| `checkout.complete` | `{ orderIds: string[], total: number }` |
+| `chat.view` | `{ messageCount: number }` |
+| `chat.load_more` | `{ messageCount: number }` |
+
+These events can be expanded as the analytics needs evolve.

--- a/services/cart.ts
+++ b/services/cart.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '../types';
 import DatabaseService from './database';
 import cartAgent from '../agents/cart-agent';
+import eventBus from './eventBus';
  
 
 const CART_STORAGE_KEY = 'cart_items';
@@ -181,7 +182,7 @@ class CartService {
       this.cartItems.push(cartItem);
       await cartAgent.add(cartItem);
     }
-
+    eventBus.track('cart.add', { productId: product.id, quantity });
     await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();
@@ -190,6 +191,7 @@ class CartService {
   public async removeFromCart(itemId: string): Promise<void> {
     this.cartItems = this.cartItems.filter(item => item.id !== itemId);
     await cartAgent.remove(itemId);
+    eventBus.track('cart.remove', { itemId });
     await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();
@@ -203,6 +205,7 @@ class CartService {
       } else {
         this.cartItems[itemIndex].quantity = quantity;
         await cartAgent.update(this.cartItems[itemIndex]);
+        eventBus.track('cart.update', { itemId, quantity });
         await this.recalcPricing();
         await this.saveToStorage();
         this.notifyListeners();
@@ -215,6 +218,7 @@ class CartService {
     for (const item of cartAgent.getAll()) {
       await cartAgent.remove(item.id);
     }
+    eventBus.track('cart.clear');
     await this.recalcPricing();
     await this.saveToStorage();
     this.notifyListeners();

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -8,11 +8,13 @@ import {
   utf8ToBytes,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
 import tonAuth from './tonAuth';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
+const ANALYTICS_TOPIC = '/congress/analytics/1';
+const sessionId = randomUUID();
 
 let node: LightNode | null = null;
 
@@ -46,10 +48,12 @@ export async function publish(
   if (!n) return;
   try {
     const encoder = createEncoder({ contentTopic });
+    const addr = tonAuth.getAddress();
     const event = {
       id: randomUUID(),
       timestamp: Date.now(),
-      actor: tonAuth.getAddress(),
+      actor: addr ? createHash('sha256').update(addr).digest('hex') : undefined,
+      sessionId,
       type,
       ...payload,
     };
@@ -61,5 +65,12 @@ export async function publish(
   }
 }
 
-export default { publish };
+export async function track(
+  type: string,
+  payload: Record<string, any> = {},
+): Promise<void> {
+  await publish(ANALYTICS_TOPIC, type, payload);
+}
+
+export default { publish, track };
 


### PR DESCRIPTION
## Summary
- implement Waku-based analytics bus with anonymous session tracking
- emit funnel events for catalog browsing, cart updates, checkout flow, and chat
- document analytics event schema

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d051162fc8326a13a9e5d5b1403dc