### PR TITLE
Add seed data fixture for stores and products

### DIFF
--- a/assets/seed/seed-data.json
+++ b/assets/seed/seed-data.json
@@ -1,0 +1,2011 @@
+{
+  "users": [
+    {
+      "id": "user_1755121136441_6963580379332608",
+      "username": "Weldon_Kulas",
+      "email": "Alfreda44@gmail.com",
+      "displayName": "Michael VonRueden",
+      "role": "user",
+      "tenant_id": "thecongress",
+      "isAdmin": false
+    },
+    {
+      "id": "user_1755121136444_8275548606300160",
+      "username": "Aryanna.Parisian",
+      "email": "Nyah.Hackett@yahoo.com",
+      "displayName": "Carl Mante",
+      "role": "user",
+      "tenant_id": "thebull",
+      "isAdmin": false
+    },
+    {
+      "id": "user_1755121136444_5678700777439232",
+      "username": "Frederic_Predovic60",
+      "email": "Garland.Ebert@gmail.com",
+      "displayName": "Beatrice Bogisich",
+      "role": "user",
+      "tenant_id": "thecongress",
+      "isAdmin": false
+    },
+    {
+      "id": "user_1755121136445_277579831443456",
+      "username": "Rossie9",
+      "email": "Jailyn82@yahoo.com",
+      "displayName": "Yolanda Langworth",
+      "role": "user",
+      "tenant_id": "thecongress",
+      "isAdmin": false
+    },
+    {
+      "id": "user_1755121136445_4704508231811072",
+      "username": "Willy_Larson",
+      "email": "Myrl.Koepp73@gmail.com",
+      "displayName": "Tyrone Powlowski",
+      "role": "user",
+      "tenant_id": "thebull",
+      "isAdmin": false
+    }
+  ],
+  "stores": [
+    {
+      "id": "store_1755121136445_7979549119741952",
+      "name": "Rogahn - Bahringer",
+      "owner": "Geraldine Gorczany DDS",
+      "nftId": "a0313e29-81bb-4f14-a821-bb19fb283e4e",
+      "reputation": 3.8
+    },
+    {
+      "id": "store_1755121136448_1952280202969088",
+      "name": "Quitzon and Sons",
+      "owner": "Scott Grady",
+      "nftId": "a83ee9af-97d1-4db5-bc77-53ac537ee567",
+      "reputation": 3.4
+    },
+    {
+      "id": "store_1755121136448_4513369254002688",
+      "name": "Doyle - Herzog",
+      "owner": "Iris Cartwright",
+      "nftId": "80b99f4c-8122-4f6e-9529-c2ca70e43e24",
+      "reputation": 2.6
+    },
+    {
+      "id": "store_1755121136448_5898906808352768",
+      "name": "Hane, Rutherford and Graham",
+      "owner": "Brandi Altenwerth DVM",
+      "nftId": "8c8dbd80-4c6a-4e86-b99f-7bdcc070aef7",
+      "reputation": 4.2
+    },
+    {
+      "id": "store_1755121136448_6054709322317824",
+      "name": "Braun, Hamill and Bruen",
+      "owner": "Alyssa Hilpert MD",
+      "nftId": "b4762ddc-5043-451b-9695-6081d4d1a980",
+      "reputation": 1.9
+    },
+    {
+      "id": "store_1755121136448_8244856069554176",
+      "name": "Bins, Prosacco and Zulauf",
+      "owner": "Gwen Zieme",
+      "nftId": "30289803-b9f1-4e75-9117-6df1f2555fdc",
+      "reputation": 0
+    },
+    {
+      "id": "store_1755121136449_5812266049994752",
+      "name": "Bode LLC",
+      "owner": "Catherine Roberts",
+      "nftId": "7f4a1712-7c6d-4d2d-9786-1b2a99d4b043",
+      "reputation": 3.3
+    },
+    {
+      "id": "store_1755121136449_3055014098501632",
+      "name": "Konopelski - Harris",
+      "owner": "Bryan Mosciski",
+      "nftId": "7a8d4ef3-4923-4c81-82c3-e878928aa81f",
+      "reputation": 5
+    },
+    {
+      "id": "store_1755121136449_8373897976086528",
+      "name": "Marquardt - Donnelly",
+      "owner": "Alexandra Jakubowski DDS",
+      "nftId": "4d53b1e1-6cc8-4a57-96d0-be3cf4165724",
+      "reputation": 4.5
+    },
+    {
+      "id": "store_1755121136449_1673486026145792",
+      "name": "Abbott LLC",
+      "owner": "Sylvia Nolan",
+      "nftId": "c0e97b77-c21f-4e9c-a996-105d43291353",
+      "reputation": 1.6
+    }
+  ],
+  "products": [
+    {
+      "id": "prod_1755121136450_2497607293206528",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Unbranded Granite Bike",
+      "price": 96,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/pWIKzrKKIM/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 73
+    },
+    {
+      "id": "prod_1755121136450_4791077980602368",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Handmade Soft Keyboard",
+      "price": 51,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/E9RnutfVnJ/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 37
+    },
+    {
+      "id": "prod_1755121136450_3492205626916864",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Elegant Fresh Mouse",
+      "price": 32,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/76FEDA/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 9
+    },
+    {
+      "id": "prod_1755121136451_4491041589690368",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Refined Concrete Bike",
+      "price": 8,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/dR1cl0P/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 61
+    },
+    {
+      "id": "prod_1755121136451_8867989732458496",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Licensed Wooden Sausages",
+      "price": 36,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/qROcJwm/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 61
+    },
+    {
+      "id": "prod_1755121136451_3216826500644864",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Bespoke Plastic Computer",
+      "price": 13,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=1276165299896320"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 97
+    },
+    {
+      "id": "prod_1755121136451_721912674123776",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Handmade Fresh Ball",
+      "price": 32,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/CzlCA7/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 12
+    },
+    {
+      "id": "prod_1755121136451_6893034811686912",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Rustic Fresh Pants",
+      "price": 73,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/Z1rg41V/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 77
+    },
+    {
+      "id": "prod_1755121136451_1952487890223104",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Refined Fresh Keyboard",
+      "price": 16,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/dk4bIa/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 98
+    },
+    {
+      "id": "prod_1755121136451_1422351914762240",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Fantastic Frozen Cheese",
+      "price": 82,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6878695023181824"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 12
+    },
+    {
+      "id": "prod_1755121136451_8904979454623744",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Licensed Soft Pizza",
+      "price": 65,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8470815836209152"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 3
+    },
+    {
+      "id": "prod_1755121136451_4394380496470016",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Luxurious Frozen Towels",
+      "price": 50,
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4680698369671168"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 82
+    },
+    {
+      "id": "prod_1755121136451_2291389209509888",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Luxurious Frozen Pants",
+      "price": 27,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4670410821992448"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 13
+    },
+    {
+      "id": "prod_1755121136451_6856570396737536",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Handmade Bronze Ball",
+      "price": 88,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/YfjCM7E/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 74
+    },
+    {
+      "id": "prod_1755121136451_3360682554687488",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Oriental Cotton Fish",
+      "price": 92,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=7691217479401472"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 91
+    },
+    {
+      "id": "prod_1755121136452_2694106507640832",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Elegant Plastic Sausages",
+      "price": 63,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/108whYEnl/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 16
+    },
+    {
+      "id": "prod_1755121136452_1921511969521664",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Modern Bronze Car",
+      "price": 35,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/fJGBF9tx1O/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 98
+    },
+    {
+      "id": "prod_1755121136452_8710415515123712",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Refined Wooden Ball",
+      "price": 10,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/9XHaUF5K/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 1
+    },
+    {
+      "id": "prod_1755121136452_7142872149131264",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Elegant Rubber Salad",
+      "price": 73,
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4824521997549568"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 67
+    },
+    {
+      "id": "prod_1755121136452_3742431390466048",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Intelligent Steel Car",
+      "price": 78,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=5805666178433024"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 41
+    },
+    {
+      "id": "prod_1755121136452_4396662290120704",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Gorgeous Metal Computer",
+      "price": 9,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=2602787231760384"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 17
+    },
+    {
+      "id": "prod_1755121136452_6124751242133504",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Handcrafted Granite Sausages",
+      "price": 70,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/2I0sULMZ/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 18
+    },
+    {
+      "id": "prod_1755121136452_1072242578423808",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Handcrafted Frozen Towels",
+      "price": 72,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4303406623621120"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 62
+    },
+    {
+      "id": "prod_1755121136452_1652076509659136",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Oriental Cotton Chicken",
+      "price": 15,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/q1Rup/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 64
+    },
+    {
+      "id": "prod_1755121136452_8705978019086336",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Tasty Plastic Table",
+      "price": 87,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/1iXVydwlo/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 44
+    },
+    {
+      "id": "prod_1755121136452_7401177572442112",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Incredible Wooden Gloves",
+      "price": 63,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/FTxAKvYIZ/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 100
+    },
+    {
+      "id": "prod_1755121136452_2333588620050432",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Ergonomic Steel Salad",
+      "price": 80,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/tcNsJK4HEy/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 94
+    },
+    {
+      "id": "prod_1755121136452_1036897658863616",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Oriental Fresh Car",
+      "price": 61,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=3401178696122368"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 49
+    },
+    {
+      "id": "prod_1755121136452_1469580541165568",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Intelligent Concrete Car",
+      "price": 9,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/iJxf5n/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 28
+    },
+    {
+      "id": "prod_1755121136452_8620703039356928",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Incredible Rubber Car",
+      "price": 82,
+      "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=1842011923546112"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 44
+    },
+    {
+      "id": "prod_1755121136452_3467104502153216",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Luxurious Wooden Fish",
+      "price": 76,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6663241639919616"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 24
+    },
+    {
+      "id": "prod_1755121136452_2394502882918400",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Licensed Cotton Pizza",
+      "price": 84,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=43652971757568"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 44
+    },
+    {
+      "id": "prod_1755121136452_4513090009825280",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Gorgeous Bronze Soap",
+      "price": 78,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/GYle7q/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 9
+    },
+    {
+      "id": "prod_1755121136452_8181784132976640",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Fantastic Fresh Table",
+      "price": 60,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/3LuOjASPa/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 99
+    },
+    {
+      "id": "prod_1755121136452_8902992801562624",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Generic Rubber Table",
+      "price": 96,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=2253195457855488"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 92
+    },
+    {
+      "id": "prod_1755121136452_4697535333531648",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Rustic Rubber Towels",
+      "price": 37,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6224382282170368"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 78
+    },
+    {
+      "id": "prod_1755121136452_8761806075985920",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Small Bronze Shirt",
+      "price": 35,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/JXgL11MX/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 16
+    },
+    {
+      "id": "prod_1755121136452_2810294539649024",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Rustic Granite Gloves",
+      "price": 100,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4323380859764736"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 18
+    },
+    {
+      "id": "prod_1755121136452_5330594204483584",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Refined Plastic Car",
+      "price": 83,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/pyM0XKU9/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 84
+    },
+    {
+      "id": "prod_1755121136452_1621976946835456",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Fantastic Fresh Tuna",
+      "price": 6,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=951350632382464"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 81
+    },
+    {
+      "id": "prod_1755121136452_2306122922852352",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Practical Rubber Salad",
+      "price": 68,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/6JtCLJ2Co/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 95
+    },
+    {
+      "id": "prod_1755121136452_7632600132747264",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Bespoke Concrete Tuna",
+      "price": 20,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/1VsBA/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 20
+    },
+    {
+      "id": "prod_1755121136452_299315352305664",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Modern Rubber Hat",
+      "price": 100,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/IFhRh4UJet/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 46
+    },
+    {
+      "id": "prod_1755121136452_5809726449254400",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Electronic Fresh Computer",
+      "price": 93,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/iLxt2yOi/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 21
+    },
+    {
+      "id": "prod_1755121136452_7906135159865344",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Handcrafted Granite Chicken",
+      "price": 65,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/r25eK0C/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 84
+    },
+    {
+      "id": "prod_1755121136452_4518704284958720",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Recycled Soft Chair",
+      "price": 65,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/ubqZ3h95lM/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 57
+    },
+    {
+      "id": "prod_1755121136453_3501813181448192",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Elegant Concrete Ball",
+      "price": 27,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6907195415330816"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 47
+    },
+    {
+      "id": "prod_1755121136453_8587831561682944",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Electronic Plastic Shirt",
+      "price": 26,
+      "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/ahUnmXIq/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 4
+    },
+    {
+      "id": "prod_1755121136453_397222925565952",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Handcrafted Plastic Chair",
+      "price": 37,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=5146155912527872"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 34
+    },
+    {
+      "id": "prod_1755121136453_733054786076672",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Fantastic Soft Computer",
+      "price": 59,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4237320217690112"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 33
+    },
+    {
+      "id": "prod_1755121136453_1132329609199616",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Bespoke Frozen Towels",
+      "price": 37,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=7896746904518656"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 25
+    },
+    {
+      "id": "prod_1755121136453_11213943603200",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Fantastic Cotton Pizza",
+      "price": 80,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/Gzp74747/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 33
+    },
+    {
+      "id": "prod_1755121136453_4617805177552896",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Handcrafted Concrete Table",
+      "price": 33,
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4475943689125888"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 3
+    },
+    {
+      "id": "prod_1755121136453_239124550254592",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Modern Wooden Table",
+      "price": 38,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=4917050554187776"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 2
+    },
+    {
+      "id": "prod_1755121136453_6574610371837952",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Luxurious Rubber Sausages",
+      "price": 42,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8829685274247168"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 9
+    },
+    {
+      "id": "prod_1755121136453_5794070548971520",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Small Granite Pizza",
+      "price": 15,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/P6xmjBirsw/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 74
+    },
+    {
+      "id": "prod_1755121136453_277090207268864",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Electronic Soft Chicken",
+      "price": 94,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=311107621224448"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 6
+    },
+    {
+      "id": "prod_1755121136453_220543343132672",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Electronic Plastic Car",
+      "price": 68,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/pRmJlAom5D/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 98
+    },
+    {
+      "id": "prod_1755121136453_7928250204422144",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Ergonomic Concrete Gloves",
+      "price": 84,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8842966504308736"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 73
+    },
+    {
+      "id": "prod_1755121136453_1970732070338560",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Practical Steel Soap",
+      "price": 30,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6678617987743744"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 25
+    },
+    {
+      "id": "prod_1755121136453_1093607417184256",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Tasty Steel Sausages",
+      "price": 26,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8400708556554240"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 80
+    },
+    {
+      "id": "prod_1755121136453_4333357492076544",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Bespoke Cotton Fish",
+      "price": 57,
+      "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/ejKnL/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 30
+    },
+    {
+      "id": "prod_1755121136453_6865738916691968",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Tasty Fresh Bike",
+      "price": 66,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/dwnAACCa/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 58
+    },
+    {
+      "id": "prod_1755121136453_3407449937674240",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Oriental Frozen Towels",
+      "price": 97,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6597364684947456"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 26
+    },
+    {
+      "id": "prod_1755121136453_1736032324157440",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Incredible Cotton Car",
+      "price": 62,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/wZxmAA/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 51
+    },
+    {
+      "id": "prod_1755121136453_1707333652578304",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Elegant Soft Fish",
+      "price": 14,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=7539369776775168"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 22
+    },
+    {
+      "id": "prod_1755121136453_4340925889249280",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Intelligent Soft Bacon",
+      "price": 26,
+      "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=1128601854410752"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 99
+    },
+    {
+      "id": "prod_1755121136453_6124277885566976",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Generic Steel Salad",
+      "price": 40,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=7319924856848384"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 47
+    },
+    {
+      "id": "prod_1755121136453_8817343419383808",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Bespoke Granite Soap",
+      "price": 54,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=1632798739791872"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 2
+    },
+    {
+      "id": "prod_1755121136453_2083451343732736",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Licensed Cotton Soap",
+      "price": 12,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/SaiCPP/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 64
+    },
+    {
+      "id": "prod_1755121136453_5467050224910336",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Unbranded Cotton Keyboard",
+      "price": 98,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/kp3G6EE/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 12
+    },
+    {
+      "id": "prod_1755121136453_5001308933193728",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Luxurious Metal Sausages",
+      "price": 85,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/A2GLTc9MP/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 25
+    },
+    {
+      "id": "prod_1755121136453_7399073413857280",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Fantastic Soft Bike",
+      "price": 59,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=2598219821350912"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 41
+    },
+    {
+      "id": "prod_1755121136453_6835677488480256",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Tasty Wooden Tuna",
+      "price": 20,
+      "description": "The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8988465775509504"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 10
+    },
+    {
+      "id": "prod_1755121136453_2205871281012736",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Small Granite Cheese",
+      "price": 52,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/gWl68k/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 91
+    },
+    {
+      "id": "prod_1755121136453_2246031402074112",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Oriental Fresh Chicken",
+      "price": 11,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=856710161891328"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 93
+    },
+    {
+      "id": "prod_1755121136453_3190247265402880",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Gorgeous Fresh Sausages",
+      "price": 12,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=2768014481031168"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 36
+    },
+    {
+      "id": "prod_1755121136453_955220951564288",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Luxurious Soft Shoes",
+      "price": 66,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6167903470616576"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 55
+    },
+    {
+      "id": "prod_1755121136453_8132237081968640",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Small Soft Sausages",
+      "price": 53,
+      "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=5726044629762048"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 85
+    },
+    {
+      "id": "prod_1755121136453_7632024749735936",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Sleek Granite Chips",
+      "price": 61,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/kvkrw/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 52
+    },
+    {
+      "id": "prod_1755121136453_7887180187828224",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_8244856069554176",
+      "name": "Intelligent Soft Chicken",
+      "price": 35,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=5585772409257984"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 22
+    },
+    {
+      "id": "prod_1755121136453_8900127347441664",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Oriental Rubber Pants",
+      "price": 89,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6857017111085056"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 48
+    },
+    {
+      "id": "prod_1755121136453_4692531002474496",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_4513369254002688",
+      "name": "Recycled Metal Salad",
+      "price": 58,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/wa48WU4d/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 4
+    },
+    {
+      "id": "prod_1755121136453_4459446486958080",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136448_1952280202969088",
+      "name": "Incredible Bronze Ball",
+      "price": 71,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6327518346870784"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 81
+    },
+    {
+      "id": "prod_1755121136453_3418160095035392",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Handcrafted Steel Gloves",
+      "price": 34,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=8816738753839104"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 52
+    },
+    {
+      "id": "prod_1755121136453_6063663364440064",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Bespoke Wooden Cheese",
+      "price": 70,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=6922358805757952"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 72
+    },
+    {
+      "id": "prod_1755121136453_2659138297397248",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_8373897976086528",
+      "name": "Luxurious Fresh Cheese",
+      "price": 7,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/7A8QuMfnp/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 94
+    },
+    {
+      "id": "prod_1755121136453_3694577846321152",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Bespoke Cotton Cheese",
+      "price": 35,
+      "description": "The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/65Dlc/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 35
+    },
+    {
+      "id": "prod_1755121136453_560801953873920",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Gorgeous Fresh Hat",
+      "price": 79,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/Wi9SGCyw/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 69
+    },
+    {
+      "id": "prod_1755121136454_217329803722752",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_5812266049994752",
+      "name": "Handmade Cotton Computer",
+      "price": 74,
+      "description": "Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=3732843402362880"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 9
+    },
+    {
+      "id": "prod_1755121136454_2559873722089472",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Handmade Cotton Bacon",
+      "price": 67,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/BAk6r/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 0
+    },
+    {
+      "id": "prod_1755121136454_6227356016443392",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Awesome Concrete Towels",
+      "price": 73,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "misc",
+      "images": [
+        "https://loremflickr.com/640/480?lock=333936953655296"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 36
+    },
+    {
+      "id": "prod_1755121136454_4215943341277184",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Handmade Rubber Keyboard",
+      "price": 10,
+      "description": "Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/Tjt2PSj/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 60
+    },
+    {
+      "id": "prod_1755121136454_2146212065050624",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136445_7979549119741952",
+      "name": "Electronic Concrete Keyboard",
+      "price": 72,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/vhEDG/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 23
+    },
+    {
+      "id": "prod_1755121136454_6547126798516224",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_5898906808352768",
+      "name": "Awesome Steel Chicken",
+      "price": 80,
+      "description": "The Football Is Good For Training And Recreational Purposes",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/IAsHdZ/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 59
+    },
+    {
+      "id": "prod_1755121136454_5396513853276160",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Refined Wooden Shirt",
+      "price": 22,
+      "description": "The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/w7Zz5Sk/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 28
+    },
+    {
+      "id": "prod_1755121136454_846721529675776",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_1673486026145792",
+      "name": "Modern Cotton Computer",
+      "price": 90,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "general",
+      "images": [
+        "https://picsum.photos/seed/Oa9Nygc/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 79
+    },
+    {
+      "id": "prod_1755121136454_4690566551961600",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136448_6054709322317824",
+      "name": "Handmade Metal Sausages",
+      "price": 97,
+      "description": "New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016",
+      "category": "general",
+      "images": [
+        "https://loremflickr.com/640/480?lock=7756192182960128"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 93
+    },
+    {
+      "id": "prod_1755121136454_8237705156624384",
+      "tenant_id": "thebull",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Modern Metal Soap",
+      "price": 54,
+      "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/cfsY8E/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 3
+    },
+    {
+      "id": "prod_1755121136454_6796575743410176",
+      "tenant_id": "thecongress",
+      "storeId": "store_1755121136449_3055014098501632",
+      "name": "Practical Rubber Fish",
+      "price": 23,
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
+      "category": "misc",
+      "images": [
+        "https://picsum.photos/seed/UddS6U/640/480"
+      ],
+      "rating": 0,
+      "reviews": 0,
+      "stock": 43
+    }
+  ],
+  "orders": [
+    {
+      "id": "order_1755121136454_0",
+      "tenant_id": "thebull",
+      "userId": "user_1755121136444_8275548606300160",
+      "items": [
+        {
+          "id": "oi_1755121136454_8522380576030720",
+          "productId": "prod_1755121136453_8132237081968640",
+          "product": {
+            "id": "prod_1755121136453_8132237081968640",
+            "tenant_id": "thecongress",
+            "storeId": "store_1755121136448_5898906808352768",
+            "name": "Small Soft Sausages",
+            "price": 53,
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "category": "misc",
+            "images": [
+              "https://loremflickr.com/640/480?lock=5726044629762048"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 85
+          },
+          "quantity": 1,
+          "addedAt": "2025-08-13T21:38:56.454Z",
+          "unitPrice": 53
+        },
+        {
+          "id": "oi_1755121136455_4893099740364800",
+          "productId": "prod_1755121136451_3360682554687488",
+          "product": {
+            "id": "prod_1755121136451_3360682554687488",
+            "tenant_id": "thecongress",
+            "storeId": "store_1755121136449_1673486026145792",
+            "name": "Oriental Cotton Fish",
+            "price": 92,
+            "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+            "category": "misc",
+            "images": [
+              "https://loremflickr.com/640/480?lock=7691217479401472"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 91
+          },
+          "quantity": 4,
+          "addedAt": "2025-08-13T21:38:56.455Z",
+          "unitPrice": 92
+        }
+      ],
+      "total": 421,
+      "status": "pending",
+      "paymentMethod": "cash_on_delivery",
+      "shippingAddress": {
+        "name": "Mabel Haag",
+        "phone": "1-936-305-2871",
+        "street": "6804 S 8th Street",
+        "city": "Wellington",
+        "postalCode": "06270",
+        "notes": "Angulus crustulum quisquam distinctio cura timor videlicet appono surculus vociferor."
+      },
+      "createdAt": "2025-08-13T21:38:56.455Z",
+      "updatedAt": "2025-08-13T21:38:56.455Z",
+      "trackingSteps": []
+    },
+    {
+      "id": "order_1755121136455_1",
+      "tenant_id": "thebull",
+      "userId": "user_1755121136445_4704508231811072",
+      "items": [
+        {
+          "id": "oi_1755121136455_5771912795914240",
+          "productId": "prod_1755121136451_8904979454623744",
+          "product": {
+            "id": "prod_1755121136451_8904979454623744",
+            "tenant_id": "thecongress",
+            "storeId": "store_1755121136445_7979549119741952",
+            "name": "Licensed Soft Pizza",
+            "price": 65,
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "category": "general",
+            "images": [
+              "https://loremflickr.com/640/480?lock=8470815836209152"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 3
+          },
+          "quantity": 2,
+          "addedAt": "2025-08-13T21:38:56.455Z",
+          "unitPrice": 65
+        },
+        {
+          "id": "oi_1755121136455_8794166838427648",
+          "productId": "prod_1755121136452_4518704284958720",
+          "product": {
+            "id": "prod_1755121136452_4518704284958720",
+            "tenant_id": "thecongress",
+            "storeId": "store_1755121136449_5812266049994752",
+            "name": "Recycled Soft Chair",
+            "price": 65,
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "category": "misc",
+            "images": [
+              "https://picsum.photos/seed/ubqZ3h95lM/640/480"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 57
+          },
+          "quantity": 5,
+          "addedAt": "2025-08-13T21:38:56.455Z",
+          "unitPrice": 65
+        }
+      ],
+      "total": 455,
+      "status": "pending",
+      "paymentMethod": "cash_on_delivery",
+      "shippingAddress": {
+        "name": "Chad Lesch",
+        "phone": "644-649-6100 x98153",
+        "street": "43857 Myrtle Centers",
+        "city": "Kubberg",
+        "postalCode": "06987",
+        "notes": "Consectetur aestivus tersus."
+      },
+      "createdAt": "2025-08-13T21:38:56.456Z",
+      "updatedAt": "2025-08-13T21:38:56.456Z",
+      "trackingSteps": []
+    },
+    {
+      "id": "order_1755121136456_2",
+      "tenant_id": "thebull",
+      "userId": "user_1755121136444_8275548606300160",
+      "items": [
+        {
+          "id": "oi_1755121136456_1589513421848576",
+          "productId": "prod_1755121136453_5467050224910336",
+          "product": {
+            "id": "prod_1755121136453_5467050224910336",
+            "tenant_id": "thebull",
+            "storeId": "store_1755121136449_5812266049994752",
+            "name": "Unbranded Cotton Keyboard",
+            "price": 98,
+            "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
+            "category": "misc",
+            "images": [
+              "https://picsum.photos/seed/kp3G6EE/640/480"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 12
+          },
+          "quantity": 5,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 98
+        }
+      ],
+      "total": 490,
+      "status": "pending",
+      "paymentMethod": "cash_on_delivery",
+      "shippingAddress": {
+        "name": "Wanda Barrows",
+        "phone": "232-203-3328 x26299",
+        "street": "285 Birch Close",
+        "city": "Bellfurt",
+        "postalCode": "67718",
+        "notes": "Ascit benevolentia decumbo alius amicitia ambulo volaticus arcus."
+      },
+      "createdAt": "2025-08-13T21:38:56.456Z",
+      "updatedAt": "2025-08-13T21:38:56.456Z",
+      "trackingSteps": []
+    },
+    {
+      "id": "order_1755121136456_3",
+      "tenant_id": "thecongress",
+      "userId": "user_1755121136444_8275548606300160",
+      "items": [
+        {
+          "id": "oi_1755121136456_6440909476462592",
+          "productId": "prod_1755121136452_8620703039356928",
+          "product": {
+            "id": "prod_1755121136452_8620703039356928",
+            "tenant_id": "thebull",
+            "storeId": "store_1755121136449_3055014098501632",
+            "name": "Incredible Rubber Car",
+            "price": 82,
+            "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
+            "category": "general",
+            "images": [
+              "https://loremflickr.com/640/480?lock=1842011923546112"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 44
+          },
+          "quantity": 1,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 82
+        },
+        {
+          "id": "oi_1755121136456_3278353509384192",
+          "productId": "prod_1755121136452_1652076509659136",
+          "product": {
+            "id": "prod_1755121136452_1652076509659136",
+            "tenant_id": "thebull",
+            "storeId": "store_1755121136445_7979549119741952",
+            "name": "Oriental Cotton Chicken",
+            "price": 15,
+            "description": "Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support",
+            "category": "general",
+            "images": [
+              "https://picsum.photos/seed/q1Rup/640/480"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 64
+          },
+          "quantity": 4,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 15
+        },
+        {
+          "id": "oi_1755121136456_6989848390926336",
+          "productId": "prod_1755121136453_4340925889249280",
+          "product": {
+            "id": "prod_1755121136453_4340925889249280",
+            "tenant_id": "thecongress",
+            "storeId": "store_1755121136448_4513369254002688",
+            "name": "Intelligent Soft Bacon",
+            "price": 26,
+            "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+            "category": "general",
+            "images": [
+              "https://loremflickr.com/640/480?lock=1128601854410752"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 99
+          },
+          "quantity": 1,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 26
+        }
+      ],
+      "total": 168,
+      "status": "pending",
+      "paymentMethod": "cash_on_delivery",
+      "shippingAddress": {
+        "name": "Gina Parisian",
+        "phone": "(779) 766-7047 x655",
+        "street": "689 Kings Highway",
+        "city": "Jadenstad",
+        "postalCode": "41213",
+        "notes": "Excepturi veritatis delibero adfero aggero sollers ambulo."
+      },
+      "createdAt": "2025-08-13T21:38:56.456Z",
+      "updatedAt": "2025-08-13T21:38:56.456Z",
+      "trackingSteps": []
+    },
+    {
+      "id": "order_1755121136456_4",
+      "tenant_id": "thebull",
+      "userId": "user_1755121136444_5678700777439232",
+      "items": [
+        {
+          "id": "oi_1755121136456_5915416505352192",
+          "productId": "prod_1755121136452_2694106507640832",
+          "product": {
+            "id": "prod_1755121136452_2694106507640832",
+            "tenant_id": "thebull",
+            "storeId": "store_1755121136449_1673486026145792",
+            "name": "Elegant Plastic Sausages",
+            "price": 63,
+            "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+            "category": "general",
+            "images": [
+              "https://picsum.photos/seed/108whYEnl/640/480"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 16
+          },
+          "quantity": 3,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 63
+        },
+        {
+          "id": "oi_1755121136456_3847518557306880",
+          "productId": "prod_1755121136452_7632600132747264",
+          "product": {
+            "id": "prod_1755121136452_7632600132747264",
+            "tenant_id": "thebull",
+            "storeId": "store_1755121136449_5812266049994752",
+            "name": "Bespoke Concrete Tuna",
+            "price": 20,
+            "description": "New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart",
+            "category": "misc",
+            "images": [
+              "https://picsum.photos/seed/1VsBA/640/480"
+            ],
+            "rating": 0,
+            "reviews": 0,
+            "stock": 20
+          },
+          "quantity": 1,
+          "addedAt": "2025-08-13T21:38:56.456Z",
+          "unitPrice": 20
+        }
+      ],
+      "total": 209,
+      "status": "pending",
+      "paymentMethod": "cash_on_delivery",
+      "shippingAddress": {
+        "name": "Luther McClure",
+        "phone": "(986) 477-3454 x369",
+        "street": "819 Keegan Square",
+        "city": "Lehnerchester",
+        "postalCode": "71470-1328",
+        "notes": "Defendo benigne quasi truculenter quisquam caelum textor vaco neque."
+      },
+      "createdAt": "2025-08-13T21:38:56.456Z",
+      "updatedAt": "2025-08-13T21:38:56.456Z",
+      "trackingSteps": []
+    }
+  ],
+  "notifications": [
+    {
+      "id": "ntf_1755121136456_6500399137685504",
+      "userId": "user_1755121136444_8275548606300160",
+      "title": "chirographum conculco amo dolorem avaritia",
+      "message": "Textor deserunt et denuncio depraedor officiis carcer.",
+      "type": "system",
+      "read": false,
+      "timestamp": 1755121136456
+    },
+    {
+      "id": "ntf_1755121136456_7482335131860992",
+      "userId": "user_1755121136445_4704508231811072",
+      "title": "eveniet vacuus incidunt uxor",
+      "message": "Repellendus tepidus sequi credo.",
+      "type": "system",
+      "read": false,
+      "timestamp": 1755121136456
+    },
+    {
+      "id": "ntf_1755121136456_2568413406822400",
+      "userId": "user_1755121136445_4704508231811072",
+      "title": "crux tricesimus sublime acsi territo",
+      "message": "Soleo coma commodo ager ascisco sed bonus magnam adhaero conor.",
+      "type": "system",
+      "read": false,
+      "timestamp": 1755121136456
+    },
+    {
+      "id": "ntf_1755121136456_6322824436252672",
+      "userId": "user_1755121136444_8275548606300160",
+      "title": "neque terga cernuus",
+      "message": "Deporto adstringo cruentus.",
+      "type": "system",
+      "read": false,
+      "timestamp": 1755121136456
+    },
+    {
+      "id": "ntf_1755121136456_7357858278539264",
+      "userId": "user_1755121136445_4704508231811072",
+      "title": "delego sperno aggero bardus",
+      "message": "Pel conventus statim creta alo quisquam sollers voluptatibus apostolus spiritus.",
+      "type": "system",
+      "read": false,
+      "timestamp": 1755121136456
+    }
+  ],
+  "tenantSettings": {
+    "thecongress": {
+      "tenant_id": "thecongress",
+      "platform_name": "Conroy, Mante and Kunze",
+      "platform_logo": "https://picsum.photos/seed/b5KDH/640/480",
+      "theme_color": "#8b2209"
+    },
+    "thebull": {
+      "tenant_id": "thebull",
+      "platform_name": "Abshire - Bechtelar",
+      "platform_logo": "https://picsum.photos/seed/i8Piq4/640/480",
+      "theme_color": "#daef1e"
+    }
+  }
+}

--- a/lib/memoryStore.ts
+++ b/lib/memoryStore.ts
@@ -1,4 +1,14 @@
-import type { User, Product, Order, TenantSettings, Notification, Store } from '../types';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type {
+  User,
+  Product,
+  Order,
+  TenantSettings,
+  Notification,
+  Store,
+} from '../types';
 
 export interface MemoryStore {
   users: User[];
@@ -17,3 +27,20 @@ export const store: MemoryStore = {
   notifications: [],
   tenantSettings: {},
 };
+
+// Load seed data on first import if available
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const seedPath = path.join(__dirname, '../assets/seed/seed-data.json');
+if (fs.existsSync(seedPath)) {
+  try {
+    const data = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+    store.users = data.users || [];
+    store.products = data.products || [];
+    store.stores = data.stores || [];
+    store.orders = data.orders || [];
+    store.notifications = data.notifications || [];
+    store.tenantSettings = data.tenantSettings || {};
+  } catch (err) {
+    console.error('Failed to load seed data', err);
+  }
+}

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -10,6 +10,8 @@ try {
 
 const { faker } = require('@faker-js/faker');
 const { store } = require('../lib/memoryStore');
+const fs = require('fs');
+const path = require('path');
 
 async function seed() {
   const tenants = ['thecongress', 'thebull'];
@@ -26,11 +28,22 @@ async function seed() {
   }));
   store.users.push(...users);
 
+  // Stores (sellers)
+  const stores = Array.from({ length: 10 }).map(() => ({
+    id: `store_${Date.now()}_${faker.number.int()}`,
+    name: faker.company.name(),
+    owner: faker.person.fullName(),
+    nftId: faker.string.uuid(),
+    reputation: faker.number.float({ min: 0, max: 5, precision: 0.1 }),
+  }));
+  store.stores.push(...stores);
+
   // Products
   const categories = ['general', 'misc'];
-  const products = Array.from({ length: 10 }).map(() => ({
+  const products = Array.from({ length: 100 }).map(() => ({
     id: `prod_${Date.now()}_${faker.number.int()}`,
     tenant_id: faker.helpers.arrayElement(tenants),
+    storeId: faker.helpers.arrayElement(stores).id,
     name: faker.commerce.productName(),
     price: Number(faker.commerce.price({ min: 5, max: 100 })),
     description: faker.commerce.productDescription(),
@@ -104,6 +117,22 @@ async function seed() {
       theme_color: faker.color.rgb(),
     };
   }
+
+  // Write seed data to JSON fixture
+  const outputPath = path.join(__dirname, '../assets/seed');
+  fs.mkdirSync(outputPath, { recursive: true });
+  const seedData = {
+    users: store.users,
+    stores: store.stores,
+    products: store.products,
+    orders: store.orders,
+    notifications: store.notifications,
+    tenantSettings: store.tenantSettings,
+  };
+  fs.writeFileSync(
+    path.join(outputPath, 'seed-data.json'),
+    JSON.stringify(seedData, null, 2),
+  );
 
   console.log('Seed data inserted into memory store');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
       "react",
       "react-native",
       "jest",
-      "node"
+      "node",
+      "bcryptjs",
+      "minimatch"
     ],
     "skipLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- expand seed script to generate 10 stores and 100 products and save fixture
- autoload seed data from JSON into memory store on startup
- include missing type definitions in tsconfig

## Testing
- `node -e "require('ts-node/register'); const { store } = require('./lib/memoryStore'); console.log('stores', store.stores.length, 'products', store.products.length);"`
- `yarn test` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689d051002ac8326b439e4f5f2ef1980