### PR TITLE
Rename congress tenant and topics to blue-ocean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# 🤖 Autonomous Agents Overview – TheCongress
+# 🤖 Autonomous Agents Overview – Blue Ocean
 
-This document outlines the autonomous agents in **TheCongress**, a fully decentralized, serverless, encrypted e-commerce protocol.  
+This document outlines the autonomous agents in **Blue Ocean**, a fully decentralized, serverless, encrypted e-commerce protocol.
 All agents communicate over the Waku network and replicate data locally in memory.  
 There is **no centralized backend**, **no SQLite**, and **no .env config**.
 All SQL migration files have been removed.
@@ -20,11 +20,11 @@ All SQL migration files have been removed.
 
 | Topic                  | Purpose                             |
 |------------------------|-------------------------------------|
-| `/congress/settings/1` | Store name, color, app config       |
-| `/congress/users/1`    | Registered users + roles + keys     |
-| `/congress/products/1` | Product catalog                     |
-| `/congress/stores/1`   | Store registry + metadata           |
-| `/congress/orders/1`   | Orders placed by users              |
+| `/blue-ocean/settings/1` | Store name, color, app config       |
+| `/blue-ocean/users/1`    | Registered users + roles + keys     |
+| `/blue-ocean/products/1` | Product catalog                     |
+| `/blue-ocean/stores/1`   | Store registry + metadata           |
+| `/blue-ocean/orders/1`   | Orders placed by users              |
 
 All topics are encrypted (optionally) and signed.
 
@@ -33,25 +33,25 @@ All topics are encrypted (optionally) and signed.
 ## 🧱 Agents
 
 ### 🛠 `settings-agent.ts`
-- Subscribes to `/congress/settings/1`
+- Subscribes to `/blue-ocean/settings/1`
 - Receives system config updates
 - Validates sender as `admin`
 - Updates in-memory state (e.g. theme color, app name)
 
 ### 🧍 `users-agent.ts`
-- Subscribes to `/congress/users/1`
+- Subscribes to `/blue-ocean/users/1`
 - On first boot, creates local identity and registers user as `admin`
 - Accepts signed user messages
 - Rejects duplicate or unauthenticated roles
 
 ### 🛍️ `products-agent.ts`
-- Subscribes to `/congress/products/1`
+- Subscribes to `/blue-ocean/products/1`
 - Validates that `product.create` and `product.update` come from verified admins
 - Hydrates catalog in memory
 - Optionally stores lightweight index in IPFS
 
 ### 📦 `orders-agent.ts`
-- Subscribes to `/congress/orders/1`
+- Subscribes to `/blue-ocean/orders/1`
 - Receives new order messages
 - Only applies if sender matches `userId` in message
 - Maintains ephemeral order history locally

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
-Copyright (c) 2025 The Congress
+Copyright (c) 2025 Blue Ocean
 
 All rights reserved.
 
-This software is the confidential and proprietary information of The Congress. 
+This software is the confidential and proprietary information of Blue Ocean.
 Unauthorized copying, modification, or distribution of this software, via any 
 medium, is strictly prohibited. No license is granted to use, copy, modify, 
 merge, publish, distribute, sublicense, or sell copies of the Software without 
-explicit prior written permission from The Congress.
+explicit prior written permission from Blue Ocean.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Congress
+# Blue Ocean
 
 This Expo project uses React Native with the Expo Router.
 

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -20,7 +20,7 @@ import { errorLog } from '../utils/logger';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
-const ORDER_TOPIC = '/congress/orders/1';
+const ORDER_TOPIC = '/blue-ocean/orders/1';
 
 type NotificationTemplate = (
   item: Notification,

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -19,7 +19,7 @@ import ensureTonWallet from '../utils/ensureTonWallet';
 import eventBus from '../services/eventBus';
 import { errorLog, warnLog } from '../utils/logger';
 
-const ORDER_TOPIC = '/congress/orders/1';
+const ORDER_TOPIC = '/blue-ocean/orders/1';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -5,7 +5,7 @@ import productsAgent from './products-agent';
 import storesAgent from './stores-agent';
 import ensureTonWallet from '../utils/ensureTonWallet';
 
-const TOPIC = '/congress/reviews/1';
+const TOPIC = '/blue-ocean/reviews/1';
 
 class ReviewAgent {
   private subscribers: Set<(r: Review) => void> = new Set();

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "ecommerce",
-    "slug": "ecommerce",
+    "name": "blue-ocean",
+    "slug": "blue-ocean",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/assets/seed/seed-data.json
+++ b/assets/seed/seed-data.json
@@ -6,7 +6,7 @@
       "email": "Alfreda44@gmail.com",
       "displayName": "Michael VonRueden",
       "role": "user",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "isAdmin": false
     },
     {
@@ -24,7 +24,7 @@
       "email": "Garland.Ebert@gmail.com",
       "displayName": "Beatrice Bogisich",
       "role": "user",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "isAdmin": false
     },
     {
@@ -33,7 +33,7 @@
       "email": "Jailyn82@yahoo.com",
       "displayName": "Yolanda Langworth",
       "role": "user",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "isAdmin": false
     },
     {
@@ -121,7 +121,7 @@
   "products": [
     {
       "id": "prod_1755121136450_2497607293206528",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_8373897976086528",
       "name": "Unbranded Granite Bike",
       "price": 96,
@@ -151,7 +151,7 @@
     },
     {
       "id": "prod_1755121136450_3492205626916864",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Elegant Fresh Mouse",
       "price": 32,
@@ -166,7 +166,7 @@
     },
     {
       "id": "prod_1755121136451_4491041589690368",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_6054709322317824",
       "name": "Refined Concrete Bike",
       "price": 8,
@@ -181,7 +181,7 @@
     },
     {
       "id": "prod_1755121136451_8867989732458496",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Licensed Wooden Sausages",
       "price": 36,
@@ -196,7 +196,7 @@
     },
     {
       "id": "prod_1755121136451_3216826500644864",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Bespoke Plastic Computer",
       "price": 13,
@@ -211,7 +211,7 @@
     },
     {
       "id": "prod_1755121136451_721912674123776",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_8373897976086528",
       "name": "Handmade Fresh Ball",
       "price": 32,
@@ -226,7 +226,7 @@
     },
     {
       "id": "prod_1755121136451_6893034811686912",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_3055014098501632",
       "name": "Rustic Fresh Pants",
       "price": 73,
@@ -241,7 +241,7 @@
     },
     {
       "id": "prod_1755121136451_1952487890223104",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Refined Fresh Keyboard",
       "price": 16,
@@ -256,7 +256,7 @@
     },
     {
       "id": "prod_1755121136451_1422351914762240",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Fantastic Frozen Cheese",
       "price": 82,
@@ -271,7 +271,7 @@
     },
     {
       "id": "prod_1755121136451_8904979454623744",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Licensed Soft Pizza",
       "price": 65,
@@ -286,7 +286,7 @@
     },
     {
       "id": "prod_1755121136451_4394380496470016",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Luxurious Frozen Towels",
       "price": 50,
@@ -301,7 +301,7 @@
     },
     {
       "id": "prod_1755121136451_2291389209509888",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Luxurious Frozen Pants",
       "price": 27,
@@ -316,7 +316,7 @@
     },
     {
       "id": "prod_1755121136451_6856570396737536",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_3055014098501632",
       "name": "Handmade Bronze Ball",
       "price": 88,
@@ -331,7 +331,7 @@
     },
     {
       "id": "prod_1755121136451_3360682554687488",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_1673486026145792",
       "name": "Oriental Cotton Fish",
       "price": 92,
@@ -391,7 +391,7 @@
     },
     {
       "id": "prod_1755121136452_7142872149131264",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_1673486026145792",
       "name": "Elegant Rubber Salad",
       "price": 73,
@@ -406,7 +406,7 @@
     },
     {
       "id": "prod_1755121136452_3742431390466048",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Intelligent Steel Car",
       "price": 78,
@@ -421,7 +421,7 @@
     },
     {
       "id": "prod_1755121136452_4396662290120704",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Gorgeous Metal Computer",
       "price": 9,
@@ -436,7 +436,7 @@
     },
     {
       "id": "prod_1755121136452_6124751242133504",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Handcrafted Granite Sausages",
       "price": 70,
@@ -451,7 +451,7 @@
     },
     {
       "id": "prod_1755121136452_1072242578423808",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Handcrafted Frozen Towels",
       "price": 72,
@@ -481,7 +481,7 @@
     },
     {
       "id": "prod_1755121136452_8705978019086336",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Tasty Plastic Table",
       "price": 87,
@@ -496,7 +496,7 @@
     },
     {
       "id": "prod_1755121136452_7401177572442112",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Incredible Wooden Gloves",
       "price": 63,
@@ -511,7 +511,7 @@
     },
     {
       "id": "prod_1755121136452_2333588620050432",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_6054709322317824",
       "name": "Ergonomic Steel Salad",
       "price": 80,
@@ -601,7 +601,7 @@
     },
     {
       "id": "prod_1755121136452_4513090009825280",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Gorgeous Bronze Soap",
       "price": 78,
@@ -616,7 +616,7 @@
     },
     {
       "id": "prod_1755121136452_8181784132976640",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Fantastic Fresh Table",
       "price": 60,
@@ -646,7 +646,7 @@
     },
     {
       "id": "prod_1755121136452_4697535333531648",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Rustic Rubber Towels",
       "price": 37,
@@ -721,7 +721,7 @@
     },
     {
       "id": "prod_1755121136452_2306122922852352",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Practical Rubber Salad",
       "price": 68,
@@ -751,7 +751,7 @@
     },
     {
       "id": "prod_1755121136452_299315352305664",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Modern Rubber Hat",
       "price": 100,
@@ -796,7 +796,7 @@
     },
     {
       "id": "prod_1755121136452_4518704284958720",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_5812266049994752",
       "name": "Recycled Soft Chair",
       "price": 65,
@@ -826,7 +826,7 @@
     },
     {
       "id": "prod_1755121136453_8587831561682944",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Electronic Plastic Shirt",
       "price": 26,
@@ -841,7 +841,7 @@
     },
     {
       "id": "prod_1755121136453_397222925565952",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Handcrafted Plastic Chair",
       "price": 37,
@@ -856,7 +856,7 @@
     },
     {
       "id": "prod_1755121136453_733054786076672",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Fantastic Soft Computer",
       "price": 59,
@@ -871,7 +871,7 @@
     },
     {
       "id": "prod_1755121136453_1132329609199616",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Bespoke Frozen Towels",
       "price": 37,
@@ -886,7 +886,7 @@
     },
     {
       "id": "prod_1755121136453_11213943603200",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Fantastic Cotton Pizza",
       "price": 80,
@@ -901,7 +901,7 @@
     },
     {
       "id": "prod_1755121136453_4617805177552896",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_8373897976086528",
       "name": "Handcrafted Concrete Table",
       "price": 33,
@@ -931,7 +931,7 @@
     },
     {
       "id": "prod_1755121136453_6574610371837952",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_8373897976086528",
       "name": "Luxurious Rubber Sausages",
       "price": 42,
@@ -946,7 +946,7 @@
     },
     {
       "id": "prod_1755121136453_5794070548971520",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Small Granite Pizza",
       "price": 15,
@@ -1036,7 +1036,7 @@
     },
     {
       "id": "prod_1755121136453_4333357492076544",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_5812266049994752",
       "name": "Bespoke Cotton Fish",
       "price": 57,
@@ -1051,7 +1051,7 @@
     },
     {
       "id": "prod_1755121136453_6865738916691968",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Tasty Fresh Bike",
       "price": 66,
@@ -1066,7 +1066,7 @@
     },
     {
       "id": "prod_1755121136453_3407449937674240",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_6054709322317824",
       "name": "Oriental Frozen Towels",
       "price": 97,
@@ -1081,7 +1081,7 @@
     },
     {
       "id": "prod_1755121136453_1736032324157440",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Incredible Cotton Car",
       "price": 62,
@@ -1111,7 +1111,7 @@
     },
     {
       "id": "prod_1755121136453_4340925889249280",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Intelligent Soft Bacon",
       "price": 26,
@@ -1141,7 +1141,7 @@
     },
     {
       "id": "prod_1755121136453_8817343419383808",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_5812266049994752",
       "name": "Bespoke Granite Soap",
       "price": 54,
@@ -1231,7 +1231,7 @@
     },
     {
       "id": "prod_1755121136453_2205871281012736",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_6054709322317824",
       "name": "Small Granite Cheese",
       "price": 52,
@@ -1291,7 +1291,7 @@
     },
     {
       "id": "prod_1755121136453_8132237081968640",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Small Soft Sausages",
       "price": 53,
@@ -1306,7 +1306,7 @@
     },
     {
       "id": "prod_1755121136453_7632024749735936",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_5898906808352768",
       "name": "Sleek Granite Chips",
       "price": 61,
@@ -1321,7 +1321,7 @@
     },
     {
       "id": "prod_1755121136453_7887180187828224",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_8244856069554176",
       "name": "Intelligent Soft Chicken",
       "price": 35,
@@ -1336,7 +1336,7 @@
     },
     {
       "id": "prod_1755121136453_8900127347441664",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_6054709322317824",
       "name": "Oriental Rubber Pants",
       "price": 89,
@@ -1351,7 +1351,7 @@
     },
     {
       "id": "prod_1755121136453_4692531002474496",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_4513369254002688",
       "name": "Recycled Metal Salad",
       "price": 58,
@@ -1366,7 +1366,7 @@
     },
     {
       "id": "prod_1755121136453_4459446486958080",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136448_1952280202969088",
       "name": "Incredible Bronze Ball",
       "price": 71,
@@ -1441,7 +1441,7 @@
     },
     {
       "id": "prod_1755121136453_560801953873920",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Gorgeous Fresh Hat",
       "price": 79,
@@ -1456,7 +1456,7 @@
     },
     {
       "id": "prod_1755121136454_217329803722752",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_5812266049994752",
       "name": "Handmade Cotton Computer",
       "price": 74,
@@ -1471,7 +1471,7 @@
     },
     {
       "id": "prod_1755121136454_2559873722089472",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136445_7979549119741952",
       "name": "Handmade Cotton Bacon",
       "price": 67,
@@ -1546,7 +1546,7 @@
     },
     {
       "id": "prod_1755121136454_5396513853276160",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_1673486026145792",
       "name": "Refined Wooden Shirt",
       "price": 22,
@@ -1606,7 +1606,7 @@
     },
     {
       "id": "prod_1755121136454_6796575743410176",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "storeId": "store_1755121136449_3055014098501632",
       "name": "Practical Rubber Fish",
       "price": 23,
@@ -1631,7 +1631,7 @@
           "productId": "prod_1755121136453_8132237081968640",
           "product": {
             "id": "prod_1755121136453_8132237081968640",
-            "tenant_id": "thecongress",
+            "tenant_id": "blue-ocean",
             "storeId": "store_1755121136448_5898906808352768",
             "name": "Small Soft Sausages",
             "price": 53,
@@ -1653,7 +1653,7 @@
           "productId": "prod_1755121136451_3360682554687488",
           "product": {
             "id": "prod_1755121136451_3360682554687488",
-            "tenant_id": "thecongress",
+            "tenant_id": "blue-ocean",
             "storeId": "store_1755121136449_1673486026145792",
             "name": "Oriental Cotton Fish",
             "price": 92,
@@ -1696,7 +1696,7 @@
           "productId": "prod_1755121136451_8904979454623744",
           "product": {
             "id": "prod_1755121136451_8904979454623744",
-            "tenant_id": "thecongress",
+            "tenant_id": "blue-ocean",
             "storeId": "store_1755121136445_7979549119741952",
             "name": "Licensed Soft Pizza",
             "price": 65,
@@ -1718,7 +1718,7 @@
           "productId": "prod_1755121136452_4518704284958720",
           "product": {
             "id": "prod_1755121136452_4518704284958720",
-            "tenant_id": "thecongress",
+            "tenant_id": "blue-ocean",
             "storeId": "store_1755121136449_5812266049994752",
             "name": "Recycled Soft Chair",
             "price": 65,
@@ -1796,7 +1796,7 @@
     },
     {
       "id": "order_1755121136456_3",
-      "tenant_id": "thecongress",
+      "tenant_id": "blue-ocean",
       "userId": "user_1755121136444_8275548606300160",
       "items": [
         {
@@ -1848,7 +1848,7 @@
           "productId": "prod_1755121136453_4340925889249280",
           "product": {
             "id": "prod_1755121136453_4340925889249280",
-            "tenant_id": "thecongress",
+            "tenant_id": "blue-ocean",
             "storeId": "store_1755121136448_4513369254002688",
             "name": "Intelligent Soft Bacon",
             "price": 26,
@@ -1995,8 +1995,8 @@
     }
   ],
   "tenantSettings": {
-    "thecongress": {
-      "tenant_id": "thecongress",
+    "blue-ocean": {
+      "tenant_id": "blue-ocean",
       "platform_name": "Conroy, Mante and Kunze",
       "platform_logo": "https://picsum.photos/seed/b5KDH/640/480",
       "theme_color": "#8b2209"

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fetchSettings } from '../services/tonSettings';
 
-export let TENANT = 'thecongress';
+export let TENANT = 'blue-ocean';
 
 export interface TenantSettings {
   appName: string;

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -4,7 +4,7 @@ This app records anonymized funnel events over Waku for basic analytics.
 
 ## Event Schema
 
-Events published on `/congress/analytics/1` follow this structure:
+Events published on `/blue-ocean/analytics/1` follow this structure:
 
 ```json
 {

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -45,11 +45,11 @@ export interface WakuClient {
 }
 
 function chatTopic(roomId: string) {
-  return `/congress/chat/1/${roomId}`;
+  return `/blue-ocean/chat/1/${roomId}`;
 }
 
-const SYSTEM_TOPIC = '/congress/notifications/1';
-const ORDER_TOPIC = '/congress/orders/1';
+const SYSTEM_TOPIC = '/blue-ocean/notifications/1';
+const ORDER_TOPIC = '/blue-ocean/orders/1';
 
 export function useWakuClient(): WakuClient {
   const nodeRef = useRef<LightNode>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "thecongress-app",
+  "name": "blue-ocean-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "thecongress-app",
+      "name": "blue-ocean-app",
       "version": "1.0.0",
       "dependencies": {
         "@babel/plugin-transform-template-literals": "^7.27.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "thecongress-app",
+  "name": "blue-ocean-app",
   "main": "index.ts",
   "version": "1.0.0",
   "private": true,

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,6 +1,6 @@
 {
   "url": "https://tonapi.io",
-  "name": "The Congress",
+  "name": "Blue Ocean",
   "iconUrl": "https://red-definite-wolf-677.mypinata.cloud/ipfs/bafybeicl42ot7h3itsvxrzp4qv6t7t2f4n657jxilei65ni3nemv7ykony",
   "termsOfUseUrl": "https://tonapi.io/terms",
   "privacyPolicyUrl": "https://tonapi.io/privacy"

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 const path = require('path');
 
 async function seed() {
-  const tenants = ['thecongress', 'thebull'];
+  const tenants = ['blue-ocean', 'thebull'];
 
   // Users
   const users = Array.from({ length: 5 }).map(() => ({

--- a/services/__mocks__/tonSettings.ts
+++ b/services/__mocks__/tonSettings.ts
@@ -18,7 +18,7 @@ export async function setAdmins(admins: string[]): Promise<void> {
 
 export async function fetchSettings() {
   return {
-    tenantId: store['tenantId'] ?? 'thecongress',
+    tenantId: store['tenantId'] ?? 'blue-ocean',
     appName: store['appName'] ?? 'Blue Ocean',
     theme: { primary: store['theme.primary'] ?? '#B99C5A' },
     brand: { logoCid: store['brand.logoCid'] ?? '' },

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -13,7 +13,7 @@ import tonAuth from './tonAuth';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
-const ANALYTICS_TOPIC = '/congress/analytics/1';
+const ANALYTICS_TOPIC = '/blue-ocean/analytics/1';
 const sessionId = randomUUID();
 
 let node: LightNode | null = null;

--- a/services/eventLog.ts
+++ b/services/eventLog.ts
@@ -29,7 +29,7 @@ export interface OrderEvent {
   timestamp: number;
 }
 
-const ORDER_TOPIC = '/congress/orders/1';
+const ORDER_TOPIC = '/blue-ocean/orders/1';
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
 let node: LightNode | null = null;

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -14,7 +14,7 @@ import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
 
-const ORDER_TOPIC = '/congress/orders/1';
+const ORDER_TOPIC = '/blue-ocean/orders/1';
 
 export async function emitOrderEvents(order: Order, storeId: string) {
   const baseEvent = {

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -74,7 +74,7 @@ async function emit(event: SettingsWriteEvent) {
     const sig = await sign(msgBytes, priv);
     msg.signature = Buffer.from(sig).toString('hex');
 
-    const encoder = createEncoder({ contentTopic: '/congress/settings/1' });
+    const encoder = createEncoder({ contentTopic: '/blue-ocean/settings/1' });
     await n.lightPush.send(encoder, {
       payload: utf8ToBytes(JSON.stringify(msg)),
     });
@@ -88,7 +88,7 @@ export async function subscribeToSettingsWrites(
 ): Promise<() => void> {
   const n = await ensureNode();
   if (!n) return () => {};
-  const decoder = createDecoder('/congress/settings/1');
+  const decoder = createDecoder('/blue-ocean/settings/1');
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
@@ -157,7 +157,7 @@ export async function fetchSettings(): Promise<TonSettings> {
     }
   }
   return {
-    tenantId: map['tenantId'] ?? 'thecongress',
+    tenantId: map['tenantId'] ?? 'blue-ocean',
     appName: map['appName'] ?? 'Blue Ocean',
     theme: { primary: map['theme.primary'] ?? '#B99C5A' },
     brand: { logoCid: map['brand.logoCid'] ?? '' },

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -186,7 +186,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.update({ ...order, status: 'courier_found' });
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/congress/orders/1',
+      '/blue-ocean/orders/1',
       'order.updated',
       expect.objectContaining({ orderId: order.id, prevStatus: 'order_received', newStatus: 'courier_found' }),
     );
@@ -210,7 +210,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.update({ ...order, status: 'disputed' });
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/congress/orders/1',
+      '/blue-ocean/orders/1',
       'dispute.updated',
       expect.objectContaining({ orderId: order.id, prevStatus: 'delivered', newStatus: 'disputed' }),
     );
@@ -237,12 +237,12 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.releasePayment(order.id);
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/congress/orders/1',
+      '/blue-ocean/orders/1',
       'payment.received',
       expect.objectContaining({ orderId: order.id }),
     );
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/congress/orders/1',
+      '/blue-ocean/orders/1',
       'order.updated',
       expect.objectContaining({ prevStatus: 'delivered', newStatus: 'released' }),
     );
@@ -269,7 +269,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.refundPayment(order.id);
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/congress/orders/1',
+      '/blue-ocean/orders/1',
       'order.updated',
       expect.objectContaining({ prevStatus: 'delivered', newStatus: 'refunded' }),
     );


### PR DESCRIPTION
## Summary
- rename project and tenant identifiers from thecongress to blue-ocean
- update Waku topics, seed data, scripts and docs to use /blue-ocean/
- ensure manifests and copy no longer mention The Congress

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn typecheck` *(fails: TypeScript errors)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d33ff5da48326823025dbd5291051