### PR TITLE
enforce secure config and admin checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ ADMIN_WALLET_ADDRESS=
 ORDER_PAYMENT_FACTORY_ADDRESS=
 TON_RPC_URL=
 TON_RPC_FALLBACK_URLS=
+# Enable only during local testing; ignored in production builds
+ENABLE_UNSAFE_TON_PRIVATE_KEY=false

--- a/README.md
+++ b/README.md
@@ -72,11 +72,21 @@ for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests. Copy
   `false`)
 - `EXPO_PUBLIC_WAKU_BOOTSTRAP` – comma-separated list of Waku peers (optional)
 - `ENABLE_UNSAFE_TON_PRIVATE_KEY` – expose wallet private key for testing
-  (`true`/`false`, default `false`)
+  (`true`/`false`, default `false`; ignored in production builds)
 - `EXPO_PUBLIC_MOONPAY_PUBLISHABLE_KEY` – MoonPay public API key (optional;
   enables credit card purchases)
 
 These values are read at build time and cannot be changed from the UI.
+
+### Secure Key Management
+
+Store sensitive values such as `ADMIN_WALLET_ADDRESS` and
+`ORDER_PAYMENT_FACTORY_ADDRESS` in a dedicated secrets manager (e.g., AWS
+Secrets Manager, Hashicorp Vault). Inject them as environment variables at
+runtime; the app will throw on startup if required keys are missing. Avoid
+committing secrets to source control. See
+[`docs/secure-key-management.md`](docs/secure-key-management.md) for
+additional guidance.
 
 ### Wallet Allowlist & Waku Bootstrap
 

--- a/docs/secure-key-management.md
+++ b/docs/secure-key-management.md
@@ -1,0 +1,5 @@
+# Secure Key Management
+
+Sensitive configuration values such as `ADMIN_WALLET_ADDRESS`, `ORDER_PAYMENT_FACTORY_ADDRESS`, and `TON_RPC_URL` must be supplied via environment variables. In production environments, load these variables from a dedicated secrets manager (AWS Secrets Manager, Hashicorp Vault, Docker secrets, etc.) rather than committing them to source control.
+
+At runtime the app validates that required keys are present and will throw an error if any are missing. Development-only flags like `ENABLE_UNSAFE_TON_PRIVATE_KEY` are automatically ignored when `NODE_ENV` is set to `production`.

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -13,6 +13,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from './tonStores';
 import tonAuth from './tonAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
+import { requireEnv } from '../utils/appConfig';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 
@@ -242,6 +243,11 @@ class OrderService {
   async resolveDispute(orderId: string, toSeller: boolean): Promise<void> {
     const order = await ordersAgent.get(orderId);
     if (!order || !order.escrowAddr) return;
+    const actor = tonAuth.getAddress();
+    const admin = requireEnv('ADMIN_WALLET_ADDRESS');
+    if (!actor || actor !== admin) {
+      throw new Error('Admin wallet address required');
+    }
     await adminResolve(order.escrowAddr, toSeller);
     await this.updateOrderStatus(orderId, toSeller ? 'released' : 'refunded');
   }

--- a/services/tonAuth.tsx
+++ b/services/tonAuth.tsx
@@ -80,6 +80,9 @@ export const getAddress = (): string | null =>
  * unset this function will always return `null`.
  */
 export const getTonPrivateKey = (): string | null => {
+  if (process.env.NODE_ENV === 'production') {
+    return null;
+  }
   if (config.ENABLE_UNSAFE_TON_PRIVATE_KEY !== 'true') {
     return null;
   }
@@ -94,7 +97,10 @@ const api = {
   getAddress,
 } as const;
 
-if (config.ENABLE_UNSAFE_TON_PRIVATE_KEY === 'true') {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  config.ENABLE_UNSAFE_TON_PRIVATE_KEY === 'true'
+) {
   (api as any).getTonPrivateKey = getTonPrivateKey;
 }
 

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -1,6 +1,6 @@
 import { debugLog, errorLog } from '@/utils/logger';
 import { getValue, setValue, listValues } from './tonKvStore';
-import config from '../utils/appConfig';
+import config, { requireEnv } from '../utils/appConfig';
 import {
   LightNode,
   Protocols,
@@ -22,6 +22,14 @@ const ADDRESS =
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
+
+const ADMIN_ADDRESS = requireEnv('ADMIN_WALLET_ADDRESS');
+
+function assertAdmin(actor: string): void {
+  if (actor !== ADMIN_ADDRESS) {
+    throw new Error('Admin wallet address required');
+  }
+}
 
 export interface TonSettings {
   tenantId: string;
@@ -124,6 +132,7 @@ export async function setSetting(
   value: string,
   actor: string,
 ) {
+  assertAdmin(actor);
   const res = await setValue(ADDRESS, key, value);
   await emit({
     type: 'settings.write',

--- a/tests/admin-disputes.test.tsx
+++ b/tests/admin-disputes.test.tsx
@@ -13,6 +13,9 @@ jest.mock('../services/tonContract', () => ({
 }));
 
 jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+jest.mock('../services/tonAuth', () => ({
+  getAddress: jest.fn().mockReturnValue('EQtestadmin'),
+}));
 
 describe('OrderService.resolveDispute', () => {
   const svc = OrderService.getInstance();

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,5 +1,12 @@
 import 'dotenv/config';
 import { insertConfig } from './testUtils';
+
+insertConfig({
+  TON_RPC_URL: 'https://ton.test',
+  ORDER_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
+  ADMIN_WALLET_ADDRESS: 'EQtestadmin',
+});
+
 jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
 jest.mock('../services/tonSettings');
 const { loadTenantSettings } = require('../constants/tenant');
@@ -7,6 +14,10 @@ const { loadTenantSettings } = require('../constants/tenant');
 var __DEV__ = false;
 
 beforeEach(async () => {
-  insertConfig({ TON_RPC_URL: 'https://ton.test' });
+  insertConfig({
+    TON_RPC_URL: 'https://ton.test',
+    ORDER_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
+    ADMIN_WALLET_ADDRESS: 'EQtestadmin',
+  });
   await loadTenantSettings();
 });

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,12 +1,16 @@
 // Configuration values are loaded from environment variables.
 // Only a minimal set of keys is supported at runtime.
 
-const ENV_KEYS = [
-  'EXPO_PUBLIC_DEBUG_LOGS',
-  'EXPO_PUBLIC_WAKU_BOOTSTRAP',
+const REQUIRED_ENV_KEYS = [
   'ADMIN_WALLET_ADDRESS',
   'ORDER_PAYMENT_FACTORY_ADDRESS',
   'TON_RPC_URL',
+];
+
+const ENV_KEYS = [
+  'EXPO_PUBLIC_DEBUG_LOGS',
+  'EXPO_PUBLIC_WAKU_BOOTSTRAP',
+  ...REQUIRED_ENV_KEYS,
   'TON_RPC_FALLBACK_URLS',
   'ENABLE_UNSAFE_TON_PRIVATE_KEY',
 ];
@@ -16,7 +20,15 @@ function loadConfig(): Record<string, string> {
   for (const key of ENV_KEYS) {
     const value = process.env[key];
     if (value !== undefined) {
+      if (
+        key === 'ENABLE_UNSAFE_TON_PRIVATE_KEY' &&
+        process.env.NODE_ENV === 'production'
+      ) {
+        continue;
+      }
       cfg[key] = value;
+    } else if (REQUIRED_ENV_KEYS.includes(key)) {
+      throw new Error(`Missing required environment variable: ${key}`);
     }
   }
   return cfg;


### PR DESCRIPTION
## Summary
- require critical env vars and ignore development-only private key flag in production
- gate settings changes and dispute resolution behind `ADMIN_WALLET_ADDRESS`
- document secure key management and production secrets handling

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: @waku/sdk requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689d397b0b3083268e982ad0d276cc4a