### PR TITLE
refactor: replace categories scrollview with flatlist

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
+  FlatList,
   Modal,
   TextInput,
 } from 'react-native';
@@ -32,6 +33,13 @@ export default function CategoriesScreen() {
   const [loading, setLoading] = useState(true);
   const { isAdmin } = useAuth();
   const { colors } = useTheme();
+  const NUM_COLUMNS = 2;
+  const ITEM_HEIGHT = 176;
+  const getItemLayout = (_: Category[] | null | undefined, index: number) => ({
+    length: ITEM_HEIGHT,
+    offset: ITEM_HEIGHT * Math.floor(index / NUM_COLUMNS),
+    index,
+  });
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -256,19 +264,19 @@ export default function CategoriesScreen() {
         </View>
       </View>
 
-      <ScrollView
+      <FlatList
+        data={categories}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.categoryWrapper}>{renderCategory({ item })}</View>
+        )}
+        numColumns={NUM_COLUMNS}
         style={styles.scrollContainer}
         contentContainerStyle={styles.categoriesContainer}
+        columnWrapperStyle={styles.categoriesGrid}
         showsVerticalScrollIndicator={false}
-      >
-        <View style={styles.categoriesGrid}>
-          {categories.map((item, index) => (
-            <View key={item.id} style={styles.categoryWrapper}>
-              {renderCategory({ item })}
-            </View>
-          ))}
-        </View>
-      </ScrollView>
+        getItemLayout={getItemLayout}
+      />
 
       {/* Category Edit/Add Modal */}
       <Modal


### PR DESCRIPTION
## Summary
- use FlatList grid for categories instead of ScrollView to improve large list performance
- add stable keyExtractor and getItemLayout for predictable virtualization

## Testing
- `yarn lint` *(fails: Parsing error in ChatWidget.tsx)*
- `yarn typecheck` *(fails: missing type definitions for bcryptjs and minimatch)*
- `yarn test` *(fails: globalSetup lint step)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bfeea3008326be1d1a5982328066