### PR TITLE
feat: add Waku message validation schemas

### DIFF
--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -13,6 +13,7 @@ import { Notification } from '../types';
 import NotificationPopup from './NotificationPopup';
 import { useAuth } from './AuthContext';
 import { useWakuClient } from '../hooks/useWakuClient';
+import { parseNotificationWakuPayload } from '../schemas/waku';
 
 interface NotificationState {
   unreadCount: number;
@@ -165,7 +166,9 @@ function NotificationCountProvider({ children }: { children: ReactNode }) {
     }
     wakuUnsub.current = await waku.subscribeOrders((message) => {
       try {
-        const n: Notification = JSON.parse(message);
+        const payload = parseNotificationWakuPayload(JSON.parse(message));
+        if (!payload) return;
+        const n = payload.notification;
         if (n.userId !== user.id) return;
         setUnreadCount((prev) => prev + 1);
         showNotification(

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -15,7 +15,8 @@ import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyMessageSignature } from '../utils/verifyMessageSignature';
-import { WakuMessage } from '../types/waku';
+import { parseWakuMessage } from '../schemas/waku';
+import { z } from 'zod';
 
 const DEFAULT_BOOTSTRAP =
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
@@ -118,9 +119,9 @@ export function useWakuClient(): WakuClient {
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const signed: WakuMessage<string> = JSON.parse(
-          bytesToUtf8(wakuMsg.payload),
-        );
+        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const signed = parseWakuMessage(raw, z.string());
+        if (!signed) return;
         if (
           !(await verifyMessageSignature(signed, signed.sender.publicKey))
         )
@@ -179,9 +180,9 @@ export function useWakuClient(): WakuClient {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
         try {
-          const signed: WakuMessage<string> = JSON.parse(
-            bytesToUtf8(wakuMsg.payload),
-          );
+          const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+          const signed = parseWakuMessage(raw, z.string());
+          if (!signed) continue;
           if (
             !(await verifyMessageSignature(signed, signed.sender.publicKey))
           )

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "node scripts/web-clean.js",
     "seed": "node scripts/seed.js",
     "lint": "expo lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit --types expo --types react --types react-native --types jest --types node --types bcryptjs --types minimatch",
     "test": "jest",
     "prepare": "husky install"
   },
@@ -48,11 +48,11 @@
     "expo-document-picker": "~13.1.6",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.3",
+    "expo-image": "~2.4.0",
     "expo-image-picker": "~16.1.0",
     "expo-jwt": "^1.8.2",
     "expo-linear-gradient": "~14.1.3",
     "expo-linking": "~7.1.3",
-    "expo-image": "~2.4.0",
     "expo-router": "~5.1.3",
     "expo-secure-store": "^14.2.3",
     "expo-splash-screen": "~0.30.6",
@@ -85,7 +85,8 @@
     "react-native-webview": "13.13.5",
     "tonweb": "^0.0.66",
     "tweetnacl": "^1.0.3",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/core": "^7.27.7",

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -1,0 +1,3 @@
+export * from './message';
+export * from './settings';
+export * from './notification';

--- a/schemas/waku/message.ts
+++ b/schemas/waku/message.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const wakuMessageSchema = z.object({
+  type: z.string(),
+  payload: z.unknown(),
+  sender: z.object({
+    publicKey: z.string(),
+    role: z.string().optional(),
+  }),
+  signature: z.string(),
+});
+
+export type WakuMessage<T = unknown> = z.infer<typeof wakuMessageSchema> & {
+  payload: T;
+};
+
+export function parseWakuMessage<T>(
+  data: unknown,
+  payloadSchema: z.ZodType<T>,
+): WakuMessage<T> | null {
+  const schema = wakuMessageSchema.extend({ payload: payloadSchema });
+  const res = schema.safeParse(data);
+  return res.success ? res.data : null;
+}
+
+export function isWakuMessage<T>(
+  data: unknown,
+  payloadSchema: z.ZodType<T>,
+): data is WakuMessage<T> {
+  return wakuMessageSchema.extend({ payload: payloadSchema }).safeParse(data)
+    .success;
+}

--- a/schemas/waku/notification.ts
+++ b/schemas/waku/notification.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { Notification } from '../../types';
+
+export const notificationSchema: z.ZodType<Notification> = z.object({
+  id: z.string(),
+  userId: z.string(),
+  title: z.string(),
+  message: z.string(),
+  type: z.enum(['order', 'promo', 'message', 'system']),
+  read: z.boolean(),
+  timestamp: z.number(),
+});
+
+export const notificationEventSchema = z.enum([
+  'order.created',
+  'payment.received',
+  'status.updated',
+  'dispute.updated',
+  'escrow.deployed',
+]);
+
+export type NotificationEvent = z.infer<typeof notificationEventSchema>;
+
+export const notificationWakuPayloadSchema = z.object({
+  type: notificationEventSchema,
+  notification: notificationSchema,
+});
+
+export type NotificationWakuPayload = z.infer<typeof notificationWakuPayloadSchema>;
+
+export function parseNotificationWakuPayload(
+  data: unknown,
+): NotificationWakuPayload | null {
+  const res = notificationWakuPayloadSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/schemas/waku/settings.ts
+++ b/schemas/waku/settings.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const settingsWriteEventSchema = z.object({
+  type: z.literal('settings.write'),
+  key: z.string(),
+  value: z.string(),
+  actor: z.string(),
+  timestamp: z.number(),
+});
+
+export type SettingsWriteEvent = z.infer<typeof settingsWriteEventSchema>;
+
+export function parseSettingsWriteEvent(data: unknown): SettingsWriteEvent | null {
+  const res = settingsWriteEventSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -13,7 +13,8 @@ import {
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyMessageSignature } from '../utils/verifyMessageSignature';
-import { WakuMessage, SettingsWriteEvent } from '../types/waku';
+import type { SettingsWriteEvent, WakuMessage } from '../types/waku';
+import { parseWakuMessage, settingsWriteEventSchema } from '../schemas/waku';
 import { sign } from '@noble/ed25519';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
@@ -100,17 +101,14 @@ export async function subscribeToSettingsWrites(
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
-      const signed: WakuMessage<SettingsWriteEvent> = JSON.parse(
-        bytesToUtf8(wakuMsg.payload),
-      );
+      const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+      const signed = parseWakuMessage(raw, settingsWriteEventSchema);
+      if (!signed) return;
       if (
         !(await verifyMessageSignature(signed, signed.sender.publicKey))
       )
         return;
-      const evt = signed.payload;
-      if (evt && evt.type === 'settings.write') {
-        cb(evt);
-      }
+      cb(signed.payload);
     } catch {
       /* ignore malformed events */
     }

--- a/tests/wakuSchemas.test.ts
+++ b/tests/wakuSchemas.test.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import {
+  parseWakuMessage,
+  settingsWriteEventSchema,
+  parseNotificationWakuPayload,
+} from '../schemas/waku';
+
+describe('Waku schemas', () => {
+  test('parseWakuMessage accepts valid message', () => {
+    const msg = {
+      type: 'test',
+      payload: 'hello',
+      sender: { publicKey: '0xabc' },
+      signature: '0xdef',
+    };
+    const parsed = parseWakuMessage(msg, z.string());
+    expect(parsed).toEqual(msg);
+  });
+
+  test('parseWakuMessage rejects invalid message', () => {
+    const msg = { type: 'test', payload: 'hi', sender: {}, signature: '0x' };
+    const parsed = parseWakuMessage(msg, z.string());
+    expect(parsed).toBeNull();
+  });
+
+  test('parseNotificationWakuPayload validates structure', () => {
+    const payload = {
+      type: 'order.created',
+      notification: {
+        id: '1',
+        userId: 'u',
+        title: 't',
+        message: 'm',
+        type: 'order',
+        read: false,
+        timestamp: 1,
+      },
+    };
+    expect(parseNotificationWakuPayload(payload)).toEqual(payload);
+  });
+
+  test('parseNotificationWakuPayload rejects bad data', () => {
+    const payload = { type: 'order.created', notification: { id: '1' } };
+    expect(parseNotificationWakuPayload(payload)).toBeNull();
+  });
+
+  test('settingsWriteEventSchema validates payload', () => {
+    const evt = {
+      type: 'settings.write',
+      key: 'k',
+      value: 'v',
+      actor: 'a',
+      timestamp: 1,
+    };
+    expect(settingsWriteEventSchema.parse(evt)).toEqual(evt);
+  });
+});

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -1,31 +1,6 @@
-import type { Notification } from './index';
-
-export interface WakuMessage<T = any> {
-  type: string;
-  payload: T;
-  sender: {
-    publicKey: string;
-    role?: string;
-  };
-  signature: string;
-}
-
-export interface SettingsWriteEvent {
-  type: 'settings.write';
-  key: string;
-  value: string;
-  actor: string;
-  timestamp: number;
-}
-
-export type NotificationEvent =
-  | 'order.created'
-  | 'payment.received'
-  | 'status.updated'
-  | 'dispute.updated'
-  | 'escrow.deployed';
-
-export interface NotificationWakuPayload {
-  type: NotificationEvent;
-  notification: Notification;
-}
+export {
+  type WakuMessage,
+  type SettingsWriteEvent,
+  type NotificationEvent,
+  type NotificationWakuPayload,
+} from '../schemas/waku';


### PR DESCRIPTION
## Summary
- add zod schemas for Waku messages, settings, and notifications
- validate incoming Waku payloads in hooks and services
- cover message parsing with unit tests

## Testing
- `yarn lint` *(fails: React hooks and other warnings)*
- `yarn typecheck` *(fails: missing type definitions)*
- `yarn test tests/wakuSchemas.test.ts` *(fails: lint/typecheck pre-test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c63b02cc83268bef70bacb94a6bd