### PR TITLE
feat: add product index caching

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -4,6 +4,7 @@ import {
   getProduct,
   listProducts,
   removeProduct,
+  getProducts,
 } from '../services/tonProducts';
 import { getStore } from '../services/tonStores';
 import ensureTonWallet from '../utils/ensureTonWallet';
@@ -23,8 +24,14 @@ import { getPrivateKey, getPublicKeyHex } from '../services/localIdentity';
 import { sign } from '@noble/ed25519';
 import type { WakuMessage } from '../types/waku';
 import { errorLog } from '../utils/logger';
+import {
+  getProductCache,
+  setProductCache,
+  clearProductCache,
+} from '../services/productCache';
 
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
+const PAGE_SIZE = 50;
 
 interface ProductSummary {
   rating: number;
@@ -76,6 +83,7 @@ class ProductsAgent {
           rating: prod.rating,
           reviews: prod.reviews,
         });
+        await clearProductCache();
       } catch {
         /* ignore */
       }
@@ -162,7 +170,35 @@ class ProductsAgent {
 
   async getAll(): Promise<Product[]> {
     if (this.cache.size > 0) return Array.from(this.cache.values());
+
+    const cached = await getProductCache();
+    if (cached) {
+      const products: Product[] = [];
+      for (let i = 0; i < cached.index.length; i += PAGE_SIZE) {
+        const slice = cached.index.slice(i, i + PAGE_SIZE);
+        const batch = await getProducts(slice);
+        batch.forEach((p) => {
+          this.cache.set(p.id, p);
+          this.summaries.set(p.id, { rating: p.rating, reviews: p.reviews });
+        });
+        products.push(...batch);
+      }
+      void this.refreshAndPersist(cached.version);
+      return products;
+    }
+    return await this.refreshAndPersist();
+  }
+
+  private async refreshAndPersist(prevVersion = 0): Promise<Product[]> {
     const prods = await listProducts();
+    const version = prods.reduce((max, p) => {
+      const t = p.updatedAt ? Date.parse(p.updatedAt) : 0;
+      return t > max ? t : max;
+    }, 0);
+    if (version !== prevVersion) {
+      await clearProductCache();
+      await setProductCache({ version, index: prods.map((p) => p.id) });
+    }
     prods.forEach((p) => {
       this.cache.set(p.id, p);
       this.summaries.set(p.id, { rating: p.rating, reviews: p.reviews });

--- a/services/productCache.ts
+++ b/services/productCache.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const PRODUCT_CACHE_KEY = 'product_index_cache';
+
+export interface ProductCache {
+  version: number;
+  index: string[];
+}
+
+export async function getProductCache(): Promise<ProductCache | null> {
+  try {
+    const raw = await AsyncStorage.getItem(PRODUCT_CACHE_KEY);
+    return raw ? (JSON.parse(raw) as ProductCache) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setProductCache(cache: ProductCache): Promise<void> {
+  try {
+    await AsyncStorage.setItem(PRODUCT_CACHE_KEY, JSON.stringify(cache));
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function clearProductCache(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(PRODUCT_CACHE_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -48,6 +48,15 @@ export async function listProducts(): Promise<Product[]> {
   });
 }
 
+export async function getProducts(ids: string[]): Promise<Product[]> {
+  const res: Product[] = [];
+  for (const id of ids) {
+    const prod = await getProduct(id);
+    if (prod) res.push(prod);
+  }
+  return res;
+}
+
 export async function setProductBatch(products: Product[]) {
   for (const p of products) {
     await setProduct(p);


### PR DESCRIPTION
## Summary
- add AsyncStorage-backed product cache service
- hydrate ProductsAgent from cached index before network calls
- invalidate cache on Waku product updates or version changes

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_68a10058a3348326bd87e725cd27569f