### PR TITLE
feat: validate waku events

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -18,11 +18,12 @@ import {
   bytesToUtf8,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
-import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { getPrivateKey, getPublicKeyHex } from '../services/localIdentity';
 import { sign } from '@noble/ed25519';
 import type { WakuMessage } from '../types/waku';
 import { errorLog } from '../utils/logger';
+import { productUpdatedSchema } from '../schemas/waku/product.updated';
 
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
 
@@ -64,20 +65,16 @@ class ProductsAgent {
       if (!wakuMsg.payload) return;
       try {
         const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
-        const signed = raw as WakuMessage<Product>;
-        if (signed.type !== 'product.updated') return;
-        if (
-          !(await verifyMessageSignature(signed, signed.sender.publicKey))
-        )
-          return;
+        const signed = await verifyBeforeWrite(raw, productUpdatedSchema);
+        if (!signed) return;
         const prod = signed.payload;
         this.cache.set(prod.id, prod);
         this.summaries.set(prod.id, {
           rating: prod.rating,
           reviews: prod.reviews,
         });
-      } catch {
-        /* ignore */
+      } catch (err) {
+        errorLog('Failed to process product update', err);
       }
     };
     (n.relay as any).addObserver(handler, [decoder]);

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -14,8 +14,8 @@ import { encryptMessage, decryptMessage } from '../utils/chatCrypto';
 import DatabaseService from '../services/database';
 import { ChatMessage } from '../types';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
-import { verifyMessageSignature } from '../utils/verifyMessageSignature';
-import { parseWakuMessage } from '../schemas/waku';
+import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
+import { wakuMessageSchema } from '../schemas/waku';
 import { z } from 'zod';
 
 const DEFAULT_BOOTSTRAP =
@@ -120,12 +120,9 @@ export function useWakuClient(): WakuClient {
       if (!wakuMsg.payload) return;
       try {
         const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
-        const signed = parseWakuMessage(raw, z.string());
+        const schema = wakuMessageSchema.extend({ payload: z.string() });
+        const signed = await verifyBeforeWrite(raw, schema);
         if (!signed) return;
-        if (
-          !(await verifyMessageSignature(signed, signed.sender.publicKey))
-        )
-          return;
         const text = await decryptMessage(
           signed.payload,
           roomId,
@@ -181,12 +178,9 @@ export function useWakuClient(): WakuClient {
         if (!wakuMsg.payload) continue;
         try {
           const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
-          const signed = parseWakuMessage(raw, z.string());
+          const schema = wakuMessageSchema.extend({ payload: z.string() });
+          const signed = await verifyBeforeWrite(raw, schema);
           if (!signed) continue;
-          if (
-            !(await verifyMessageSignature(signed, signed.sender.publicKey))
-          )
-            continue;
           const text = await decryptMessage(
             signed.payload,
             roomId,

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -1,3 +1,4 @@
 export * from './message';
 export * from './settings';
 export * from './notification';
+export * from './product.updated';

--- a/schemas/waku/product.updated.ts
+++ b/schemas/waku/product.updated.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import type { Product } from '../../types';
+import { wakuMessageSchema } from './message';
+
+export const productSchema: z.ZodType<Product> = z.object({
+  id: z.string(),
+  tenant_id: z.string().optional(),
+  name: z.string(),
+  name_en: z.string().optional(),
+  name_he: z.string().optional(),
+  price: z.number(),
+  originalPrice: z.number().optional(),
+  description: z.string(),
+  description_en: z.string().optional(),
+  description_he: z.string().optional(),
+  category: z.string(),
+  subcategory: z.string().optional(),
+  images: z.array(z.string()),
+  videos: z.array(z.string()).optional(),
+  colors: z.array(z.string()).optional(),
+  variants: z
+    .array(
+      z.object({
+        color: z.string(),
+        stock: z.number(),
+      }),
+    )
+    .optional(),
+  rating: z.number(),
+  reviews: z.number(),
+  badges: z.array(z.string()).optional(),
+  pricingTier: z.string().optional(),
+  mixGroupId: z.string().optional(),
+  storeId: z.string(),
+  stock: z.number(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const productUpdatedSchema = wakuMessageSchema.extend({
+  type: z.literal('product.updated'),
+  payload: productSchema,
+});
+
+export type ProductUpdatedMessage = z.infer<typeof productUpdatedSchema>;
+
+export function parseProductUpdatedMessage(
+  data: unknown,
+): ProductUpdatedMessage | null {
+  const res = productUpdatedSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -12,9 +12,10 @@ import {
   bytesToUtf8,
 } from '@waku/sdk';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
-import { verifyMessageSignature } from '../utils/verifyMessageSignature';
 import type { SettingsWriteEvent, WakuMessage } from '../types/waku';
-import { parseWakuMessage, settingsWriteEventSchema } from '../schemas/waku';
+import { settingsWriteEventSchema, wakuMessageSchema } from '../schemas/waku';
+import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
+import { z } from 'zod';
 import { sign } from '@noble/ed25519';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
@@ -102,15 +103,15 @@ export async function subscribeToSettingsWrites(
     if (!wakuMsg.payload) return;
     try {
       const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
-      const signed = parseWakuMessage(raw, settingsWriteEventSchema);
+      const schema = wakuMessageSchema.extend({
+        type: z.literal('settings.write'),
+        payload: settingsWriteEventSchema,
+      });
+      const signed = await verifyBeforeWrite(raw, schema);
       if (!signed) return;
-      if (
-        !(await verifyMessageSignature(signed, signed.sender.publicKey))
-      )
-        return;
       cb(signed.payload);
-    } catch {
-      /* ignore malformed events */
+    } catch (err) {
+      errorLog('Failed to process settings.write', err);
     }
   };
   const maybeUnsub = (n.relay as any).addObserver(handler, [decoder]) as

--- a/tests/productUpdatedSchema.test.ts
+++ b/tests/productUpdatedSchema.test.ts
@@ -1,0 +1,38 @@
+import { productUpdatedSchema, parseProductUpdatedMessage } from '../schemas/waku/product.updated';
+
+describe('product.updated schema', () => {
+  const product = {
+    id: 'p1',
+    name: 'Widget',
+    price: 10,
+    description: 'A great widget',
+    category: 'tools',
+    images: ['ipfs://img'],
+    rating: 5,
+    reviews: 1,
+    storeId: 's1',
+    stock: 3,
+  };
+
+  test('valid message parses', () => {
+    const msg = {
+      type: 'product.updated',
+      payload: product,
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    };
+    expect(productUpdatedSchema.parse(msg)).toEqual(msg);
+    expect(parseProductUpdatedMessage(msg)).toEqual(msg);
+  });
+
+  test('invalid message fails', () => {
+    const bad = {
+      type: 'product.updated',
+      payload: { id: 'p1' },
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    };
+    expect(() => productUpdatedSchema.parse(bad)).toThrow();
+    expect(parseProductUpdatedMessage(bad)).toBeNull();
+  });
+});

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -3,4 +3,5 @@ export {
   type SettingsWriteEvent,
   type NotificationEvent,
   type NotificationWakuPayload,
+  type ProductUpdatedMessage,
 } from '../schemas/waku';

--- a/utils/verifyBeforeWrite.ts
+++ b/utils/verifyBeforeWrite.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import type { WakuMessage } from '../types/waku';
+import { errorLog } from './logger';
+import { verifyMessageSignature } from './verifyMessageSignature';
+
+export async function verifyBeforeWrite<T>(
+  data: unknown,
+  schema: z.ZodType<WakuMessage<T>>,
+): Promise<WakuMessage<T> | null> {
+  const res = schema.safeParse(data);
+  if (!res.success) {
+    errorLog('Invalid Waku message', res.error.flatten());
+    return null;
+  }
+  const msg = res.data;
+  const ok = await verifyMessageSignature(msg, msg.sender.publicKey);
+  if (!ok) {
+    errorLog('Invalid message signature', msg);
+    return null;
+  }
+  return msg;
+}


### PR DESCRIPTION
## Summary
- add utility to validate and log Waku messages before processing
- define `product.updated` schema and accompanying tests
- use verification helper in agents and Waku client

## Testing
- `npm test` *(fails: Command failed with exit code 1: lintTypeCheck.js runs yarn lint)*


------
https://chatgpt.com/codex/tasks/task_e_68a10027c13c83269501063f455cd22c