### PR TITLE
feat(cart): scope cart and wishlist to user

### DIFF
--- a/services/cart.ts
+++ b/services/cart.ts
@@ -4,6 +4,7 @@ import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup
 import DatabaseService from './database';
 import cartAgent from '../agents/cart-agent';
 import eventBus from './eventBus';
+import tonAuth from './tonAuth';
  
 
 const CART_STORAGE_KEY = 'cart_items';
@@ -18,7 +19,13 @@ class CartService {
   private groupCache: Record<string, MixGroup> = {};
 
   private async getCurrentUserId(): Promise<string | null> {
-    return null;
+    try {
+      const addr = tonAuth.getAddress?.();
+      return addr ?? null;
+    } catch (err) {
+      errorLog('Failed to get current user', err);
+      return null;
+    }
   }
 
   public static getInstance(): CartService {
@@ -34,27 +41,27 @@ class CartService {
 
   private async loadFromStorage() {
     try {
-      const cartData = await AsyncStorage.getItem(CART_STORAGE_KEY);
-      if (cartData) {
-        this.cartItems = JSON.parse(cartData);
-      }
-
       const uid = await this.getCurrentUserId();
+
       if (uid) {
+        try {
+          this.cartItems = await cartAgent.getAll();
+        } catch (err) {
+          errorLog('Error fetching cart from storage:', err);
+        }
+
         const db = DatabaseService.getInstance();
         try {
           this.wishlistItems = await db.getWishlistItems(uid);
         } catch (err) {
-          if (err instanceof Error && err.message === 'WISHLIST_TABLE_MISSING') {
-            const wishlistData = await AsyncStorage.getItem(WISHLIST_STORAGE_KEY);
-            if (wishlistData) {
-              this.wishlistItems = JSON.parse(wishlistData);
-            }
-          } else {
-            errorLog('Error fetching wishlist from DB:', err);
-          }
+          errorLog('Error fetching wishlist from DB:', err);
         }
       } else {
+        const cartData = await AsyncStorage.getItem(CART_STORAGE_KEY);
+        if (cartData) {
+          this.cartItems = JSON.parse(cartData);
+        }
+
         const wishlistData = await AsyncStorage.getItem(WISHLIST_STORAGE_KEY);
         if (wishlistData) {
           this.wishlistItems = JSON.parse(wishlistData);
@@ -70,10 +77,12 @@ class CartService {
 
   private async saveToStorage() {
     try {
-      await AsyncStorage.setItem(CART_STORAGE_KEY, JSON.stringify(this.cartItems));
-
       const uid = await this.getCurrentUserId();
       if (!uid) {
+        await AsyncStorage.setItem(
+          CART_STORAGE_KEY,
+          JSON.stringify(this.cartItems)
+        );
         await AsyncStorage.setItem(
           WISHLIST_STORAGE_KEY,
           JSON.stringify(this.wishlistItems)

--- a/tests/cartService.test.ts
+++ b/tests/cartService.test.ts
@@ -1,0 +1,103 @@
+import CartService from '../services/cart';
+import cartAgent from '../agents/cart-agent';
+import DatabaseService from '../services/database';
+import tonAuth from '../services/tonAuth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { CartItem, WishlistItem, Product } from '../types';
+
+jest.mock('../agents/cart-agent', () => ({
+  __esModule: true,
+  default: {
+    getAll: jest.fn(),
+    add: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('../services/database', () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn() },
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  __esModule: true,
+  default: { getAddress: jest.fn() },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const product: Product = {
+  id: 'p1',
+  name: 'Prod',
+  price: 1,
+  description: 'd',
+  category: 'c',
+  images: [],
+  rating: 0,
+  reviews: 0,
+  storeId: 's',
+  stock: 1,
+};
+
+const cartItem: CartItem = {
+  id: 'ci1',
+  productId: 'p1',
+  product,
+  quantity: 1,
+  addedAt: new Date().toISOString(),
+};
+
+const wishItem: WishlistItem = {
+  id: 'wi1',
+  productId: 'p1',
+  product,
+  addedAt: new Date().toISOString(),
+};
+
+describe('CartService storage', () => {
+  beforeEach(() => {
+    (CartService as any).instance = undefined;
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+    (cartAgent.getAll as jest.Mock).mockReset();
+    (DatabaseService.getInstance as jest.Mock).mockReset();
+    (tonAuth.getAddress as jest.Mock).mockReset();
+  });
+
+  it('loads user cart and wishlist when logged in', async () => {
+    (tonAuth.getAddress as jest.Mock).mockReturnValue('user1');
+    (cartAgent.getAll as jest.Mock).mockResolvedValue([cartItem]);
+    (DatabaseService.getInstance as jest.Mock).mockReturnValue({
+      getWishlistItems: jest.fn().mockResolvedValue([wishItem]),
+    });
+
+    const svc = CartService.getInstance();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(svc.getCartItems()).toEqual([cartItem]);
+    expect(svc.getWishlistItems()).toEqual([wishItem]);
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it('falls back to anonymous storage when no user', async () => {
+    (tonAuth.getAddress as jest.Mock).mockReturnValue(null);
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'cart_items') return Promise.resolve(JSON.stringify([cartItem]));
+      if (key === 'wishlist_items') return Promise.resolve(JSON.stringify([wishItem]));
+      return Promise.resolve(null);
+    });
+
+    const svc = CartService.getInstance();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(svc.getCartItems()).toEqual([cartItem]);
+    expect(svc.getWishlistItems()).toEqual([wishItem]);
+    expect(cartAgent.getAll).not.toHaveBeenCalled();
+    expect(DatabaseService.getInstance).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- track current user via TON wallet
- load cart and wishlist from user sources; fall back to local only when anonymous
- add tests for logged-in vs anonymous storage paths

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn typecheck` *(fails: components/ChatWidget.tsx(859,1): error TS1005: '}' expected, tests/reputation.test.ts(96,53): error TS1005: '>' expected, tests/reputation.test.ts(102,57): error TS1005: '>' expected, tsconfig.json(54,14): error TS6053: File 'expo/tsconfig.base' not found)*
- `yarn lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a239019e14832684b0eebb5c07320c