### PR TITLE
Show reload modal on Home data load error

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -37,6 +37,7 @@ import BannerFormModal from '../../components/BannerFormModal';
 import CartModal from '../../components/CartModal';
 import ProductFormModal from '../../components/ProductFormModal';
 import SmartImage from '../../components/SmartImage';
+import InfoModal from '../../components/InfoModal';
 
 const { width } = Dimensions.get('window');
 const BANNER_WIDTH = width - 32;
@@ -65,6 +66,13 @@ export default function HomeScreen() {
   const [productFormVisible, setProductFormVisible] = useState(false);
   const [productToEdit, setProductToEdit] = useState<Product | null>(null);
   const [showCartModal, setShowCartModal] = useState(false);
+  const [infoModal, setInfoModal] = useState({
+    visible: false,
+    title: '',
+    message: '',
+    type: 'info' as 'success' | 'error' | 'info' | 'warning',
+    buttonText: undefined as string | undefined,
+  });
   const { isAdmin } = useAuth();
   const { t } = useLanguage();
   const { colors } = useTheme();
@@ -116,7 +124,14 @@ export default function HomeScreen() {
       setCategories(categoriesData);
       setHeroBanners(bannersData);
     } catch (error) {
-      errorLog('Error loading data:', error);
+      errorLog('HomeScreen loadData error:', error);
+      setInfoModal({
+        visible: true,
+        title: t('common.error'),
+        message: t('home.loadErrorMessage'),
+        type: 'error',
+        buttonText: t('common.reload'),
+      });
     } finally {
       setLoading(false);
     }
@@ -336,6 +351,11 @@ export default function HomeScreen() {
       default:
         return t('home.newest');
     }
+  };
+
+  const handleReload = () => {
+    setInfoModal((prev) => ({ ...prev, visible: false }));
+    loadData();
   };
 
   if (loading) {
@@ -744,6 +764,16 @@ export default function HomeScreen() {
           </View>
         </View>
       </Modal>
+
+      <InfoModal
+        visible={infoModal.visible}
+        title={infoModal.title}
+        message={infoModal.message}
+        type={infoModal.type}
+        buttonText={infoModal.buttonText}
+        onClose={handleReload}
+        autoClose={false}
+      />
 
       {/* Cart Modal */}
       <CartModal

--- a/translations/en.json
+++ b/translations/en.json
@@ -22,7 +22,8 @@
     "free": "Free",
     "premium": "Premium",
     "info": "Information",
-    "understood": "Understood"
+    "understood": "Understood",
+    "reload": "Reload"
   },
   "navigation": {
     "home": "Home",
@@ -85,7 +86,8 @@
     "newest": "Newest",
     "priceLowHigh": "Price: Low to High",
     "priceHighLow": "Price: High to Low",
-    "highRating": "High Rating"
+    "highRating": "High Rating",
+    "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload."
   },
   "product": {
     "inStock": "In Stock ({count})",

--- a/translations/he.json
+++ b/translations/he.json
@@ -22,7 +22,8 @@
     "free": "חינם",
     "premium": "פרימיום",
     "info": "מידע",
-    "understood": "הבנתי"
+    "understood": "הבנתי",
+    "reload": "טען מחדש"
   },
   "navigation": {
     "home": "בית",
@@ -85,7 +86,8 @@
     "newest": "החדשים ביותר",
     "priceLowHigh": "מחיר: נמוך לגבוה",
     "priceHighLow": "מחיר: גבוה לנמוך",
-    "highRating": "דירוג גבוה"
+    "highRating": "דירוג גבוה",
+    "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש."
   },
   "product": {
     "inStock": "במלאי ({count})",


### PR DESCRIPTION
## Summary
- show InfoModal with Reload button if `loadData` fails on Home tab
- log errors with context and let users retry
- add translations for reload action and error message

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn typecheck` *(fails: TS errors and missing expo config)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d0e3b948326a810e951366f54f9