### PR TITLE
Verify Waku system and order messages

### DIFF
--- a/docs/waku-signing.md
+++ b/docs/waku-signing.md
@@ -1,0 +1,24 @@
+# Signed System & Order Messages
+
+Messages on `/blue-ocean/notifications/1` and `/blue-ocean/orders/1` must be signed
+using the standard Waku message envelope:
+
+```json
+{
+  "type": "event.type",
+  "payload": "string",
+  "sender": {
+    "publicKey": "hex",
+    "role": "admin" | "user"
+  },
+  "signature": "0x..."
+}
+```
+
+- **type** – event identifier (`system.message`, `order.notification`, etc.).
+- **payload** – UTF-8 string delivered to subscribers. For orders this should be a
+  serialized `NotificationWakuPayload`.
+- **sender.publicKey** – identity of the signer.
+- **signature** – signature produced by the sender's key over the message content.
+
+Clients verify signatures and drop any message that fails validation.

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -223,9 +223,17 @@ export function useWakuClient(): WakuClient {
   const subscribeSystem = async (cb: (msg: string) => void) => {
     if (!nodeRef.current) return () => {};
     const decoder = createDecoder(SYSTEM_TOPIC);
-    const handler = (wakuMsg: any) => {
+    const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
-      cb(bytesToUtf8(wakuMsg.payload));
+      try {
+        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const schema = wakuMessageSchema.extend({ payload: z.string() });
+        const signed = await verifyBeforeWrite(raw, schema);
+        if (!signed) return;
+        cb(signed.payload);
+      } catch (err) {
+        errorLog('Malformed system message', err);
+      }
     };
     const maybeUnsub = (nodeRef.current.relay as any).addObserver(
       handler,
@@ -243,9 +251,17 @@ export function useWakuClient(): WakuClient {
   const subscribeOrders = async (cb: (msg: string) => void) => {
     if (!nodeRef.current) return () => {};
     const decoder = createDecoder(ORDER_TOPIC);
-    const handler = (wakuMsg: any) => {
+    const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
-      cb(bytesToUtf8(wakuMsg.payload));
+      try {
+        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const schema = wakuMessageSchema.extend({ payload: z.string() });
+        const signed = await verifyBeforeWrite(raw, schema);
+        if (!signed) return;
+        cb(signed.payload);
+      } catch (err) {
+        errorLog('Malformed order message', err);
+      }
     };
     const maybeUnsub = (nodeRef.current.relay as any).addObserver(
       handler,


### PR DESCRIPTION
## Summary
- verify signatures on system and order topics before invoking callbacks
- log malformed or unsigned Waku messages
- document signed message schema for notification and order topics

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn typecheck` *(fails: missing tsconfig base, parsing errors)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d1a66448326897eda1f4c3b9d85