### PR TITLE
feat(auth): verify and refresh wallet session

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -45,27 +45,41 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const checkAuthState = async () => {
     const walletAddress = tonConnectUI.account?.address || address;
+
     if (!walletAddress) {
+      // Wallet not connected – ensure we clear any stale user data
       setUser(null);
       return;
     }
 
     const db = DatabaseService.getInstance();
-    const profile = await db.getUserProfile(walletAddress);
 
-    setUser(
-      profile || {
-        id: walletAddress,
-        username: walletAddress,
-        displayName: walletAddress,
-        isAdmin: false,
-        address: walletAddress,
-        role: 'user',
-      }
-    );
+    try {
+      const profile = await db.getUserProfile(walletAddress);
+      setUser(
+        profile || {
+          id: walletAddress,
+          username: walletAddress,
+          displayName: walletAddress,
+          isAdmin: false,
+          address: walletAddress,
+          role: 'user',
+        },
+      );
+    } catch {
+      // In case of any failure, fall back to clearing the user state
+      setUser(null);
+    }
   };
 
   const refreshSession = async () => {
+    // Re-check the authentication state when recovering from a lost
+    // connection or after the wallet reconnects.
+    if (!tonConnectUI.account?.address && !address) {
+      setUser(null);
+      return;
+    }
+
     await checkAuthState();
   };
 


### PR DESCRIPTION
## Summary
- handle TON wallet connection state and pull user profile from DatabaseService
- expose refreshSession helper for rehydrating auth state
- check auth on startup and address changes

## Testing
- `yarn test` *(fails: jest: not found)*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" )*


------
https://chatgpt.com/codex/tasks/task_e_68a38277e91c83268c0418ab47c22a8a