### PR TITLE
feat: persist cart per user

### DIFF
--- a/services/cart.ts
+++ b/services/cart.ts
@@ -45,7 +45,8 @@ class CartService {
 
       if (uid) {
         try {
-          this.cartItems = await cartAgent.getAll();
+          const all = await cartAgent.getAll();
+          this.cartItems = all.filter((it) => it.id.startsWith(`${uid}_`));
         } catch (err) {
           errorLog('Error fetching cart from storage:', err);
         }
@@ -181,8 +182,9 @@ class CartService {
       this.cartItems[existingItemIndex].quantity += quantity;
       await cartAgent.update(this.cartItems[existingItemIndex]);
     } else {
+      const uid = await this.getCurrentUserId();
       const cartItem: CartItem = {
-        id: `${product.id}_${Date.now()}`,
+        id: `${uid ? uid + '_' : ''}${product.id}_${Date.now()}`,
         productId: product.id,
         product,
         quantity,
@@ -223,9 +225,13 @@ class CartService {
   }
 
   public async clearCart(): Promise<void> {
+    const uid = await this.getCurrentUserId();
     this.cartItems = [];
-    for (const item of cartAgent.getAll()) {
-      await cartAgent.remove(item.id);
+    const allItems = await cartAgent.getAll();
+    for (const item of allItems) {
+      if (!uid || item.id.startsWith(`${uid}_`)) {
+        await cartAgent.remove(item.id);
+      }
     }
     eventBus.track('cart.clear');
     await this.recalcPricing();

--- a/tests/cartService.test.ts
+++ b/tests/cartService.test.ts
@@ -44,7 +44,15 @@ const product: Product = {
   stock: 1,
 };
 
-const cartItem: CartItem = {
+const userCartItem: CartItem = {
+  id: 'user1_ci1',
+  productId: 'p1',
+  product,
+  quantity: 1,
+  addedAt: new Date().toISOString(),
+};
+
+const anonCartItem: CartItem = {
   id: 'ci1',
   productId: 'p1',
   product,
@@ -71,7 +79,7 @@ describe('CartService storage', () => {
 
   it('loads user cart and wishlist when logged in', async () => {
     (tonAuth.getAddress as jest.Mock).mockReturnValue('user1');
-    (cartAgent.getAll as jest.Mock).mockResolvedValue([cartItem]);
+    (cartAgent.getAll as jest.Mock).mockResolvedValue([userCartItem]);
     (DatabaseService.getInstance as jest.Mock).mockReturnValue({
       getWishlistItems: jest.fn().mockResolvedValue([wishItem]),
     });
@@ -79,7 +87,7 @@ describe('CartService storage', () => {
     const svc = CartService.getInstance();
     await new Promise(r => setTimeout(r, 0));
 
-    expect(svc.getCartItems()).toEqual([cartItem]);
+    expect(svc.getCartItems()).toEqual([userCartItem]);
     expect(svc.getWishlistItems()).toEqual([wishItem]);
     expect(AsyncStorage.getItem).not.toHaveBeenCalled();
   });
@@ -87,7 +95,7 @@ describe('CartService storage', () => {
   it('falls back to anonymous storage when no user', async () => {
     (tonAuth.getAddress as jest.Mock).mockReturnValue(null);
     (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-      if (key === 'cart_items') return Promise.resolve(JSON.stringify([cartItem]));
+      if (key === 'cart_items') return Promise.resolve(JSON.stringify([anonCartItem]));
       if (key === 'wishlist_items') return Promise.resolve(JSON.stringify([wishItem]));
       return Promise.resolve(null);
     });
@@ -95,7 +103,7 @@ describe('CartService storage', () => {
     const svc = CartService.getInstance();
     await new Promise(r => setTimeout(r, 0));
 
-    expect(svc.getCartItems()).toEqual([cartItem]);
+    expect(svc.getCartItems()).toEqual([anonCartItem]);
     expect(svc.getWishlistItems()).toEqual([wishItem]);
     expect(cartAgent.getAll).not.toHaveBeenCalled();
     expect(DatabaseService.getInstance).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- derive user ID from connected wallet
- filter cart storage and item IDs by user
- adjust tests for user-scoped cart persistence

## Testing
- `yarn install --ignore-scripts --ignore-engines` *(fails: @waku/sdk requires node >=22)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38277f6a08326a6c60f41581e03e4