### PR TITLE
Log dropped Waku messages

### DIFF
--- a/docs/waku-signing.md
+++ b/docs/waku-signing.md
@@ -21,4 +21,5 @@ using the standard Waku message envelope:
 - **sender.publicKey** – identity of the signer.
 - **signature** – signature produced by the sender's key over the message content.
 
-Clients verify signatures and drop any message that fails validation.
+Clients verify signatures (e.g. via `verifyBeforeWrite`) and drop or log
+any message that fails validation.

--- a/hooks/useWakuClient.ts
+++ b/hooks/useWakuClient.ts
@@ -229,7 +229,10 @@ export function useWakuClient(): WakuClient {
         const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
         const signed = await verifyBeforeWrite(raw, schema);
-        if (!signed) return;
+        if (!signed) {
+          errorLog('Dropping unverified system message', raw);
+          return;
+        }
         cb(signed.payload);
       } catch (err) {
         errorLog('Malformed system message', err);
@@ -257,7 +260,10 @@ export function useWakuClient(): WakuClient {
         const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
         const signed = await verifyBeforeWrite(raw, schema);
-        if (!signed) return;
+        if (!signed) {
+          errorLog('Dropping unverified order message', raw);
+          return;
+        }
         cb(signed.payload);
       } catch (err) {
         errorLog('Malformed order message', err);


### PR DESCRIPTION
## Summary
- Log when unverified system or order messages are dropped
- Document expected signing envelope for system and order topics

## Testing
- `yarn lint hooks/useWakuClient.ts docs/waku-signing.md` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a6d763d88326b06990defbccc2e2