### PR TITLE
Subscribe to Waku order status updates

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { Order, OrderStatus, Notification } from '../types';
+import { Order, OrderStatus, Notification, OrderTrackingStep } from '../types';
 import tonAuth from '../services/tonAuth';
 import notificationsAgent from './notifications-agent';
 import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
@@ -18,6 +18,17 @@ import { logOrderEvent } from '../services/eventLog';
 import ensureTonWallet from '../utils/ensureTonWallet';
 import eventBus from '../services/eventBus';
 import { errorLog, warnLog } from '../utils/logger';
+import {
+  LightNode,
+  createLightNode,
+  waitForRemotePeer,
+  createDecoder,
+  Protocols,
+  bytesToUtf8,
+} from '@waku/sdk';
+import { getWakuBootstrapNodes } from '../utils/appConfig';
+import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
+import { orderStatusMessageSchema } from '../schemas/waku/order.status';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 
@@ -35,6 +46,11 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
   private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};
+  private node: LightNode | null = null;
+
+  constructor() {
+    void this.subscribeWaku();
+  }
 
   private buildBaseEvent(order: Order) {
     return {
@@ -69,6 +85,85 @@ class OrdersAgent {
 
   getSellerMetrics(address: string) {
     return this.sellerMetrics[address] || { completed: 0, refunds: 0 };
+  }
+
+  private async ensureNode(): Promise<LightNode | null> {
+    if (this.node) return this.node;
+    try {
+      const bootstrap = getWakuBootstrapNodes();
+      if (bootstrap.length === 0) return null;
+      this.node = await createLightNode({ libp2p: { bootstrap } as any });
+      await this.node.start();
+      await waitForRemotePeer(this.node, [Protocols.Relay]);
+      return this.node;
+    } catch (err) {
+      errorLog('Failed to start Waku node', err);
+      this.node = null;
+      return null;
+    }
+  }
+
+  private async subscribeWaku() {
+    const n = await this.ensureNode();
+    if (!n) return;
+    const decoder = createDecoder(ORDER_TOPIC);
+    const handler = async (wakuMsg: any) => {
+      if (!wakuMsg.payload) return;
+      try {
+        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const signed = await verifyBeforeWrite(raw, orderStatusMessageSchema);
+        if (!signed) return;
+        const { orderId, status } = signed.payload;
+        await this.applyRemoteStatus(orderId, status);
+      } catch (err) {
+        errorLog('Failed to process order status update', err);
+      }
+    };
+    (n.relay as any).addObserver(handler, [decoder]);
+  }
+
+  private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
+    const allSteps: OrderTrackingStep[] = [
+      { status: 'order_received', title: 'הזמנה התקבלה', timestamp: new Date().toISOString(), completed: false },
+      { status: 'courier_found', title: 'נמצא שליח מתאים', timestamp: '', completed: false },
+      { status: 'courier_picked_up', title: 'שליח אסף את ההזמנה', timestamp: '', completed: false },
+      { status: 'courier_on_way', title: 'שליח בדרך אלייך', timestamp: '', completed: false },
+      { status: 'delivered', title: 'הזמנה התקבלה (השאר ביקורת)', timestamp: '', completed: false },
+    ];
+    const statusOrder: OrderStatus[] = [
+      'order_received',
+      'courier_found',
+      'courier_picked_up',
+      'courier_on_way',
+      'delivered',
+    ];
+    const currentIndex = statusOrder.indexOf(status);
+    for (let i = 0; i <= currentIndex; i++) {
+      allSteps[i].completed = true;
+      if (!allSteps[i].timestamp) {
+        const now = new Date();
+        const minutesAgo = (currentIndex - i) * 10;
+        allSteps[i].timestamp = new Date(now.getTime() - minutesAgo * 60000).toISOString();
+      }
+    }
+    return allSteps;
+  }
+
+  private async applyRemoteStatus(orderId: string, status: OrderStatus) {
+    const order = await this.get(orderId);
+    if (!order) return;
+    if (order.status === status) return;
+    const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
+    if (!allowed.includes(status)) return;
+    const updated: Order = {
+      ...order,
+      status,
+      trackingSteps: this.getTrackingSteps(status),
+      updatedAt: new Date().toISOString(),
+    };
+    await setOrder(updated);
+    this.subscribers.forEach((cb) => cb(updated));
+    await this.notifyStatusChange(updated);
   }
 
   private async ensureWallet() {

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -2,3 +2,4 @@ export * from './message';
 export * from './settings';
 export * from './notification';
 export * from './product.updated';
+export * from './order.status';

--- a/schemas/waku/order.status.ts
+++ b/schemas/waku/order.status.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+const orderStatuses = [
+  'order_received',
+  'courier_found',
+  'courier_picked_up',
+  'courier_on_way',
+  'delivered',
+  'disputed',
+  'released',
+  'refunded',
+] as const;
+
+export const orderStatusMessageSchema = wakuMessageSchema.extend({
+  type: z.literal('order.status'),
+  payload: z.object({
+    orderId: z.string(),
+    status: z.enum(orderStatuses),
+  }),
+});
+
+export type OrderStatusMessage = z.infer<typeof orderStatusMessageSchema>;

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -158,7 +158,6 @@ class OrderService {
 
     await ordersAgent.add(order);
     this.notifyListeners();
-    this.simulateOrderProgress(orderId);
     return order;
   }
 
@@ -200,21 +199,6 @@ class OrderService {
       orders.push(order);
     }
     return orders;
-  }
-
-  private simulateOrderProgress(orderId: string) {
-    const statusProgression: OrderStatus[] = [
-      'courier_found',
-      'courier_picked_up',
-      'courier_on_way',
-      'delivered',
-    ];
-    const delays = [30000, 60000, 120000, 180000];
-    for (let i = 0; i < statusProgression.length; i++) {
-      setTimeout(async () => {
-        await this.updateOrderStatus(orderId, statusProgression[i]);
-      }, delays[i]);
-    }
   }
 
   async getOrder(id: string): Promise<Order | null> {

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -4,4 +4,5 @@ export {
   type NotificationEvent,
   type NotificationWakuPayload,
   type ProductUpdatedMessage,
+  type OrderStatusMessage,
 } from '../schemas/waku';


### PR DESCRIPTION
## Summary
- remove simulated order progress logic
- subscribe orders agent to `/blue-ocean/orders/1` Waku topic and apply signed status changes
- add schema definition for signed order status messages

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn typecheck` *(fails: TS config and syntax errors)*
- `yarn test` *(fails: jest not found; installing deps requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ac02429c8326806ead27e19c36b6