### PR TITLE
feat: allow tenant-configurable TON RPC endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,9 @@ EXPO_PUBLIC_MOONPAY_PUBLISHABLE_KEY=
 PINATA_JWT=
 ADMIN_WALLET_ADDRESS=
 ORDER_PAYMENT_FACTORY_ADDRESS=
+# Optional: override tenant RPC endpoint
 TON_RPC_URL=
+# Optional: comma-separated list of fallback RPC endpoints
 TON_RPC_FALLBACK_URLS=
 # Enable only during local testing; ignored in production builds
 ENABLE_UNSAFE_TON_PRIVATE_KEY=false

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests. Copy
 | -------- | -------- | ----------- |
 | `ADMIN_WALLET_ADDRESS` | yes | Wallet granted admin rights if no on-chain list exists. |
 | `ORDER_PAYMENT_FACTORY_ADDRESS` | yes | Address of the deployed OrderPayment factory contract. |
-| `TON_RPC_URL` | yes | Primary TON RPC endpoint used for blockchain calls. |
-| `TON_RPC_FALLBACK_URLS` | no | Comma-separated backup RPC endpoints. |
+| `TON_RPC_URL` | no | Primary TON RPC endpoint used for blockchain calls. Overrides tenant setting. |
+| `TON_RPC_FALLBACK_URLS` | no | Comma-separated backup RPC endpoints. Overrides tenant setting. |
 | `EXPO_PUBLIC_WAKU_BOOTSTRAP` | no | Comma-separated list of Waku peers for network bootstrap. |
 | `EXPO_PUBLIC_DEBUG_LOGS` | no | Set to `true` to enable verbose logging. |
 | `ENABLE_UNSAFE_TON_PRIVATE_KEY` | no | Exposes wallet private key for testing. Never use in production. |
@@ -87,8 +87,8 @@ for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests. Copy
   exists (required)
 - `ORDER_PAYMENT_FACTORY_ADDRESS` – address of the deployed OrderPayment
   factory contract (required)
-- `TON_RPC_URL` – primary TON RPC endpoint used for blockchain calls (required)
-- `TON_RPC_FALLBACK_URLS` – comma-separated backup RPC endpoints (optional)
+ - `TON_RPC_URL` – primary TON RPC endpoint used for blockchain calls (optional; overrides tenant setting)
+ - `TON_RPC_FALLBACK_URLS` – comma-separated backup RPC endpoints (optional; overrides tenant setting)
 - `EXPO_PUBLIC_DEBUG_LOGS` – enable verbose logging (`true`/`false`, default
   `false`)
 - `EXPO_PUBLIC_WAKU_BOOTSTRAP` – comma-separated list of Waku peers (optional)

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -15,7 +15,9 @@ type SettingKey =
   | 'brand.logoCid'
   | 'fiatKey'
   | 'feeAddress'
-  | 'feeBps';
+  | 'feeBps'
+  | 'rpcUrl'
+  | 'rpcFallbackUrls';
 
 class SettingsAgent {
   private static instance: SettingsAgent;
@@ -72,6 +74,25 @@ class SettingsAgent {
     await storeAdmins(admins, actor);
     this.admins = admins;
     this.adminsFetchedAt = Date.now();
+  }
+
+  async getRpcUrls(): Promise<{ rpcUrl: string; rpcFallbackUrls: string[] }> {
+    const rpcUrl = (await this.get('rpcUrl')) || '';
+    const fallbacksRaw = await this.get('rpcFallbackUrls');
+    let rpcFallbackUrls: string[] = [];
+    if (fallbacksRaw) {
+      try {
+        rpcFallbackUrls = JSON.parse(fallbacksRaw);
+      } catch {
+        rpcFallbackUrls = [];
+      }
+    }
+    return { rpcUrl, rpcFallbackUrls };
+  }
+
+  async setRpcUrls(rpcUrl: string, rpcFallbackUrls: string[]): Promise<void> {
+    await this.set('rpcUrl', rpcUrl);
+    await this.set('rpcFallbackUrls', JSON.stringify(rpcFallbackUrls));
   }
 
   static getInstance(): SettingsAgent {

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -18,6 +18,7 @@ import CurrencySettings from '../../components/settings/CurrencySettings';
 import EnvironmentSettings from '../../components/settings/EnvironmentSettings';
 import LanguageSettings from '../../components/settings/LanguageSettings';
 import NotificationSettings from '../../components/settings/NotificationSettings';
+import RpcSettings from '../../components/settings/RpcSettings';
 
 export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
@@ -166,6 +167,7 @@ export default function SettingsScreen() {
           colors={colors}
         />
         <EnvironmentSettings colors={colors} admins={admins} />
+        <RpcSettings colors={colors} />
         <LanguageSettings colors={colors} currentLanguage={currentLanguage} />
         <NotificationSettings colors={colors} />
 

--- a/components/settings/RpcSettings.tsx
+++ b/components/settings/RpcSettings.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { Server } from 'lucide-react-native';
+import Card from '../Card';
+import SettingsAgent from '../../agents/settings-agent';
+import { errorLog } from '@/utils/logger';
+
+interface Props {
+  colors: any;
+}
+
+const RpcSettings: React.FC<Props> = ({ colors }) => {
+  const [rpcUrl, setRpcUrl] = useState('');
+  const [fallbacks, setFallbacks] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { rpcUrl, rpcFallbackUrls } = await SettingsAgent.getInstance().getRpcUrls();
+        setRpcUrl(rpcUrl);
+        setFallbacks(rpcFallbackUrls.join(', '));
+      } catch (err) {
+        errorLog('Failed to load RPC URLs:', err);
+      }
+    })();
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const urls = fallbacks
+        .split(',')
+        .map((u) => u.trim())
+        .filter(Boolean);
+      await SettingsAgent.getInstance().setRpcUrls(rpcUrl.trim(), urls);
+    } catch (err) {
+      errorLog('Failed to save RPC URLs:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      style={[
+        styles.card,
+        { backgroundColor: colors.surface.primary, borderColor: colors.border.primary },
+      ]}
+    >
+      <View style={styles.header}>
+        <Server size={20} color={colors.gold} />
+        <Text style={[styles.title, { color: colors.text.primary }]}>RPC Settings</Text>
+      </View>
+      <View style={styles.content}>
+        <View style={styles.inputContainer}>
+          <Text style={[styles.label, { color: colors.text.primary }]}>Primary RPC URL</Text>
+          <TextInput
+            style={[
+              styles.input,
+              {
+                borderColor: colors.border.primary,
+                backgroundColor: colors.surface.secondary,
+                color: colors.text.primary,
+              },
+            ]}
+            value={rpcUrl}
+            onChangeText={setRpcUrl}
+            placeholder="https://ton.example"
+            textAlign="left"
+            placeholderTextColor={colors.text.tertiary}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={[styles.label, { color: colors.text.primary }]}>Fallback RPC URLs</Text>
+          <TextInput
+            style={[
+              styles.input,
+              {
+                borderColor: colors.border.primary,
+                backgroundColor: colors.surface.secondary,
+                color: colors.text.primary,
+              },
+            ]}
+            value={fallbacks}
+            onChangeText={setFallbacks}
+            placeholder="https://ton1.example, https://ton2.example"
+            textAlign="left"
+            placeholderTextColor={colors.text.tertiary}
+          />
+        </View>
+        <TouchableOpacity
+          style={[styles.saveButton, { backgroundColor: colors.gold }]}
+          onPress={save}
+          disabled={saving}
+        >
+          <Text style={[styles.saveButtonText, { color: colors.text.inverse }]}>Save RPC URLs</Text>
+        </TouchableOpacity>
+      </View>
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    justifyContent: 'flex-end',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginRight: 8,
+  },
+  content: {
+    padding: 16,
+  },
+  inputContainer: {
+    marginBottom: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+    textAlign: 'left',
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  saveButton: {
+    marginTop: 12,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  saveButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default RpcSettings;

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -13,6 +13,8 @@ export interface TenantSettings {
   feeAddress?: string;
   feeBps?: number;
   admins?: string[];
+  rpcUrl: string;
+  rpcFallbackUrls?: string[];
 }
 
 export let AppConfig: TenantSettings = {
@@ -22,6 +24,8 @@ export let AppConfig: TenantSettings = {
   feeAddress: '',
   feeBps: 0,
   admins: config.ADMIN_WALLET_ADDRESS ? [config.ADMIN_WALLET_ADDRESS] : [],
+  rpcUrl: '',
+  rpcFallbackUrls: [],
 };
 
 export async function loadTenantSettings(): Promise<void> {
@@ -33,9 +37,11 @@ export async function loadTenantSettings(): Promise<void> {
   const FEE_ADDR_KEY = 'app_fee_address';
   const FEE_BPS_KEY = 'app_fee_bps';
   const ADMINS_KEY = 'app_admins';
+  const RPC_URL_KEY = 'app_rpc_url';
+  const RPC_FALLBACK_KEY = 'app_rpc_fallback_urls';
 
   try {
-    const [t, name, color, logo, fiat, feeAddr, feeBps, admins] =
+    const [t, name, color, logo, fiat, feeAddr, feeBps, admins, rpc, rpcFallback] =
       await AsyncStorage.multiGet([
         TENANT_KEY,
         NAME_KEY,
@@ -45,6 +51,8 @@ export async function loadTenantSettings(): Promise<void> {
         FEE_ADDR_KEY,
         FEE_BPS_KEY,
         ADMINS_KEY,
+        RPC_URL_KEY,
+        RPC_FALLBACK_KEY,
       ]);
 
     if (t?.[1]) TENANT = t[1];
@@ -56,6 +64,8 @@ export async function loadTenantSettings(): Promise<void> {
       feeAddress: feeAddr?.[1] || '',
       feeBps: feeBps?.[1] ? parseInt(feeBps[1]) : 0,
       admins: admins?.[1] ? JSON.parse(admins[1]) : [],
+      rpcUrl: rpc?.[1] || '',
+      rpcFallbackUrls: rpcFallback?.[1] ? JSON.parse(rpcFallback[1]) : [],
     };
 
     const remote = await fetchSettings();
@@ -68,6 +78,8 @@ export async function loadTenantSettings(): Promise<void> {
       feeAddress: remote.feeAddress ?? '',
       feeBps: remote.feeBps ?? 0,
       admins: remote.admins ?? [],
+      rpcUrl: remote.rpcUrl,
+      rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
     };
 
     await AsyncStorage.multiSet([
@@ -79,6 +91,8 @@ export async function loadTenantSettings(): Promise<void> {
       [FEE_ADDR_KEY, remote.feeAddress ?? ''],
       [FEE_BPS_KEY, String(remote.feeBps ?? 0)],
       [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
+      [RPC_URL_KEY, remote.rpcUrl],
+      [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
     ]);
   } catch (e) {
     errorLog('Error loading tenant settings:', e);

--- a/services/__mocks__/tonSettings.ts
+++ b/services/__mocks__/tonSettings.ts
@@ -26,6 +26,10 @@ export async function fetchSettings() {
     feeAddress: store['feeAddress'] ?? '',
     feeBps: store['feeBps'] ? Number(store['feeBps']) : 0,
     admins: store['admins'] ? JSON.parse(store['admins']) : [],
+    rpcUrl: store['rpcUrl'] ?? '',
+    rpcFallbackUrls: store['rpcFallbackUrls']
+      ? JSON.parse(store['rpcFallbackUrls'])
+      : [],
   };
 }
 

--- a/services/tonProvider.ts
+++ b/services/tonProvider.ts
@@ -2,16 +2,15 @@ import { errorLog } from '@/utils/logger';
 import TonWeb from 'tonweb';
 import { getTonRpcUrls } from '@/utils/appConfig';
 
-const RPC_ENDPOINTS = getTonRpcUrls();
-
-export function getTonWeb(url: string = RPC_ENDPOINTS[0]): TonWeb {
-  const provider = new TonWeb.HttpProvider(url);
+export function getTonWeb(url?: string): TonWeb {
+  const endpoints = getTonRpcUrls();
+  const provider = new TonWeb.HttpProvider(url || endpoints[0]);
   return new TonWeb(provider);
 }
 
 export async function withTonWeb<T>(callback: (tonweb: TonWeb) => Promise<T>): Promise<T> {
   let lastError: unknown;
-  for (const url of RPC_ENDPOINTS) {
+  for (const url of getTonRpcUrls()) {
     try {
       const tonweb = getTonWeb(url);
       return await callback(tonweb);

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -42,6 +42,8 @@ export interface TonSettings {
   feeAddress?: string;
   feeBps?: number;
   admins: string[];
+  rpcUrl: string;
+  rpcFallbackUrls?: string[];
 }
 
 export async function getSetting(key: string): Promise<string | null> {
@@ -173,6 +175,10 @@ export async function fetchSettings(): Promise<TonSettings> {
     feeAddress: map['feeAddress'] ?? '',
     feeBps,
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
+    rpcUrl: map['rpcUrl'] ?? '',
+    rpcFallbackUrls: map['rpcFallbackUrls']
+      ? JSON.parse(map['rpcFallbackUrls'])
+      : [],
   };
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -300,6 +300,11 @@ export interface TenantSettings {
   theme?: { primary?: string | null };
   brand?: { logoCid?: string | null };
   fiatKey?: string | null;
+  rpcUrl?: string | null;
+  rpcFallbackUrls?: string[] | null;
+  feeAddress?: string | null;
+  feeBps?: number | null;
+  admins?: string[] | null;
 }
 
 export interface RoadmapTask {

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -4,7 +4,6 @@
 const REQUIRED_ENV_KEYS = [
   'ADMIN_WALLET_ADDRESS',
   'ORDER_PAYMENT_FACTORY_ADDRESS',
-  'TON_RPC_URL',
 ];
 
 const ENV_KEYS = [
@@ -12,6 +11,7 @@ const ENV_KEYS = [
   'EXPO_PUBLIC_WAKU_BOOTSTRAP',
   'EXPO_PUBLIC_MOONPAY_PUBLISHABLE_KEY',
   ...REQUIRED_ENV_KEYS,
+  'TON_RPC_URL',
   'TON_RPC_FALLBACK_URLS',
   'ENABLE_UNSAFE_TON_PRIVATE_KEY',
   'PINATA_JWT',
@@ -66,13 +66,26 @@ export function requireEnv(key: string): string {
 }
 
 export function getTonRpcUrls(): string[] {
-  const primary = requireEnv('TON_RPC_URL');
-  const fallbacks = config.TON_RPC_FALLBACK_URLS || process.env.TON_RPC_FALLBACK_URLS || '';
-  const extra = fallbacks
+  let tenantRpc = '';
+  let tenantFallbacks: string[] = [];
+  try {
+    const tenant = require('../constants/tenant');
+    tenantRpc = tenant.AppConfig?.rpcUrl || '';
+    tenantFallbacks = tenant.AppConfig?.rpcFallbackUrls || [];
+  } catch {}
+  const envPrimary = config.TON_RPC_URL || process.env.TON_RPC_URL || '';
+  const envFallbackRaw =
+    config.TON_RPC_FALLBACK_URLS || process.env.TON_RPC_FALLBACK_URLS || '';
+  const envFallbacks = envFallbackRaw
     .split(',')
     .map((u) => u.trim())
     .filter(Boolean);
-  return [primary, ...extra];
+  const primary = envPrimary || tenantRpc;
+  const fallbacks = envFallbacks.length > 0 ? envFallbacks : tenantFallbacks;
+  if (!primary) {
+    throw new Error('Missing TON RPC URL');
+  }
+  return [primary, ...fallbacks];
 }
 
 export default config;


### PR DESCRIPTION
## Summary
- add rpcUrl and rpcFallbackUrls to tenant settings and storage
- read TON RPC config from tenant settings with env overrides
- expose admin UI to edit RPC URLs and update settings agent

## Testing
- `npx expo lint` *(fails: Need to install expo)*
- `yarn typecheck` *(fails: expo/tsconfig.base missing and type errors)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47a7fb798832686c4bd9fc76627a4