### PR TITLE
feat: support tenant-defined Waku peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Blue Ocean is a decentralized e‑commerce demo built with React Native and the Expo Router.
 Autonomous agents communicate over the Waku peer‑to‑peer network, keep their state in
 memory, and hydrate from message history on boot. Configuration such as debug logging or
-Waku bootstrap peers is supplied through `EXPO_PUBLIC_*` environment variables.
+Waku bootstrap peers can be customized through `EXPO_PUBLIC_*` environment variables, but
+defaults are provided for a zero‑config experience.
 
 ## Quickstart
 
@@ -22,13 +23,14 @@ yarn test
    yarn install
    ```
 
-2. **Create and populate `.env`**
+2. *(Optional)* **Create a `.env` for customization**
 
    ```sh
    cp .env.example .env
    ```
 
-   Fill in each variable as described in [Environment Variables](#environment-variables).
+   Only needed for advanced overrides such as custom Waku peers. See
+   [Environment Variables](#environment-variables).
 
 3. **Start the Expo project**
 
@@ -68,9 +70,10 @@ yarn husky install
 
 ### Environment Variables
 
-The project reads configuration from a `.env` file using Expo's env support
-for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests. Copy
-`.env.example` to `.env` and set the following variables:
+The app ships with sensible defaults and runs without a `.env` file. Environment
+variables let you customize behavior or override settings for development and
+deployment. To supply overrides locally, copy `.env.example` to `.env` and set
+the desired values:
 
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
@@ -90,7 +93,7 @@ for `EXPO_PUBLIC_*` keys and `dotenv` for Node scripts and tests. Copy
  - `TON_RPC_FALLBACK_URLS` – comma-separated backup RPC endpoints (optional; overrides tenant setting)
 - `EXPO_PUBLIC_DEBUG_LOGS` – enable verbose logging (`true`/`false`, default
   `false`)
-- `EXPO_PUBLIC_WAKU_BOOTSTRAP` – comma-separated list of Waku peers (optional)
+- `EXPO_PUBLIC_WAKU_BOOTSTRAP` – comma-separated list of Waku peers (optional override)
 - `ENABLE_UNSAFE_TON_PRIVATE_KEY` – expose wallet private key for testing
   (`true`/`false`, default `false`; ignored in production builds)
 - `PINATA_JWT` – JWT used by `scripts/pinata-upload.ts` to pin assets to
@@ -115,10 +118,11 @@ on-chain settings contract. Use the **Admin → Settings** screen or
 `SettingsAgent.setAdmins()` to add or remove addresses. Only wallets in this
 allowlist can manage users, products or other system settings.
 
-The app connects to the peer-to-peer network through Waku bootstrap nodes
-provided in `EXPO_PUBLIC_WAKU_BOOTSTRAP`. Supply a comma‑separated list of Waku
-multiaddrs in the `.env` file so agents can discover peers. Leaving the value
-empty runs the app in offline mode with no Waku connectivity.
+The app connects to the peer‑to‑peer network through a built‑in list of Waku
+bootstrap nodes. Developers can override this by setting
+`EXPO_PUBLIC_WAKU_BOOTSTRAP` (for example in a `.env` file) with a
+comma‑separated list of multiaddrs. Providing an empty value disables Waku
+connectivity entirely.
 
 ### TON Smart Contracts
 

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -15,6 +15,7 @@ export interface TenantSettings {
   admins?: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
+  wakuBootstrap?: string[];
 }
 
 export let AppConfig: TenantSettings = {
@@ -26,6 +27,7 @@ export let AppConfig: TenantSettings = {
   admins: config.ADMIN_WALLET_ADDRESS ? [config.ADMIN_WALLET_ADDRESS] : [],
   rpcUrl: '',
   rpcFallbackUrls: [],
+  wakuBootstrap: [],
 };
 
 export async function loadTenantSettings(): Promise<void> {
@@ -39,21 +41,34 @@ export async function loadTenantSettings(): Promise<void> {
   const ADMINS_KEY = 'app_admins';
   const RPC_URL_KEY = 'app_rpc_url';
   const RPC_FALLBACK_KEY = 'app_rpc_fallback_urls';
+  const WAKU_BOOTSTRAP_KEY = 'app_waku_bootstrap';
 
   try {
-    const [t, name, color, logo, fiat, feeAddr, feeBps, admins, rpc, rpcFallback] =
-      await AsyncStorage.multiGet([
-        TENANT_KEY,
-        NAME_KEY,
-        COLOR_KEY,
-        LOGO_KEY,
-        FIAT_KEY,
-        FEE_ADDR_KEY,
-        FEE_BPS_KEY,
-        ADMINS_KEY,
-        RPC_URL_KEY,
-        RPC_FALLBACK_KEY,
-      ]);
+    const [
+      t,
+      name,
+      color,
+      logo,
+      fiat,
+      feeAddr,
+      feeBps,
+      admins,
+      rpc,
+      rpcFallback,
+      waku,
+    ] = await AsyncStorage.multiGet([
+      TENANT_KEY,
+      NAME_KEY,
+      COLOR_KEY,
+      LOGO_KEY,
+      FIAT_KEY,
+      FEE_ADDR_KEY,
+      FEE_BPS_KEY,
+      ADMINS_KEY,
+      RPC_URL_KEY,
+      RPC_FALLBACK_KEY,
+      WAKU_BOOTSTRAP_KEY,
+    ]);
 
     if (t?.[1]) TENANT = t[1];
     AppConfig = {
@@ -66,6 +81,7 @@ export async function loadTenantSettings(): Promise<void> {
       admins: admins?.[1] ? JSON.parse(admins[1]) : [],
       rpcUrl: rpc?.[1] || '',
       rpcFallbackUrls: rpcFallback?.[1] ? JSON.parse(rpcFallback[1]) : [],
+      wakuBootstrap: waku?.[1] ? JSON.parse(waku[1]) : [],
     };
 
     const remote = await fetchSettings();
@@ -80,6 +96,7 @@ export async function loadTenantSettings(): Promise<void> {
       admins: remote.admins ?? [],
       rpcUrl: remote.rpcUrl,
       rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
+      wakuBootstrap: remote.wakuBootstrap ?? [],
     };
 
     await AsyncStorage.multiSet([
@@ -93,6 +110,7 @@ export async function loadTenantSettings(): Promise<void> {
       [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
       [RPC_URL_KEY, remote.rpcUrl],
       [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
+      [WAKU_BOOTSTRAP_KEY, JSON.stringify(remote.wakuBootstrap ?? [])],
     ]);
   } catch (e) {
     errorLog('Error loading tenant settings:', e);

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -11,7 +11,7 @@ When production goes sideways, use this guide to restore service quickly.
 
 ## Endpoint Failover
 
-1. **Swap `EXPO_PUBLIC_WAKU_BOOTSTRAP`** in `.env` with a healthy list of peers.
+1. **Update `EXPO_PUBLIC_WAKU_BOOTSTRAP`** (e.g., via `.env`) with a healthy list of peers if overriding defaults.
 2. **Override TON RPC:** restart deployments using `--endpoint <backup-url>`.
 3. **Flush caches** with `expo start -c` to ensure new endpoints are used.
 4. **Monitor** connectivity logs from agents for successful peer discovery.

--- a/services/__mocks__/tonSettings.ts
+++ b/services/__mocks__/tonSettings.ts
@@ -30,6 +30,9 @@ export async function fetchSettings() {
     rpcFallbackUrls: store['rpcFallbackUrls']
       ? JSON.parse(store['rpcFallbackUrls'])
       : [],
+    wakuBootstrap: store['wakuBootstrap']
+      ? JSON.parse(store['wakuBootstrap'])
+      : [],
   };
 }
 

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -11,8 +11,11 @@ import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { randomUUID, createHash } from 'crypto';
 import tonAuth from './tonAuth';
 
-const DEFAULT_BOOTSTRAP =
-  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP';
+const STABLE_BOOTSTRAP = [
+  '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP',
+  '/dns4/node-01.do-ams3.wakuv2.prod.status.im/tcp/443/wss/p2p/16Uiu2HAm67ShxB2S7RMyCV2wAPYp4nX3UX77DpDhmPEwAE8XEq8y',
+  '/dns4/node-01.gc-us-central1-a.wakuv2.prod.status.im/tcp/443/wss/p2p/16Uiu2HAkwpZJYG1ChB7FAuoCd8ohgfqNynFUsBpt7NrodpAt4E7X',
+];
 const ANALYTICS_TOPIC = '/blue-ocean/analytics/1';
 const sessionId = randomUUID();
 
@@ -21,12 +24,12 @@ let node: LightNode | null = null;
 async function ensureNode(): Promise<LightNode | null> {
   if (node) return node;
   try {
-    const bootstrap = getWakuBootstrapNodes();
+    let bootstrap = getWakuBootstrapNodes();
     if (bootstrap.length === 0) {
-      debugLog(
-        'No Waku bootstrap nodes configured. Using default bootstrap. Set EXPO_PUBLIC_WAKU_BOOTSTRAP to customize.',
-      );
-      bootstrap.push(DEFAULT_BOOTSTRAP);
+      debugLog('Using built-in Waku bootstrap nodes');
+      bootstrap = STABLE_BOOTSTRAP;
+    } else {
+      debugLog('Using custom Waku bootstrap nodes');
     }
     node = await createLightNode({ libp2p: { bootstrap } });
     await node.start();

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -44,6 +44,7 @@ export interface TonSettings {
   admins: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
+  wakuBootstrap?: string[];
 }
 
 export async function getSetting(key: string): Promise<string | null> {
@@ -182,6 +183,9 @@ export async function fetchSettings(): Promise<TonSettings> {
     rpcUrl: map['rpcUrl'] ?? '',
     rpcFallbackUrls: map['rpcFallbackUrls']
       ? JSON.parse(map['rpcFallbackUrls'])
+      : [],
+    wakuBootstrap: map['wakuBootstrap']
+      ? JSON.parse(map['wakuBootstrap'])
       : [],
   };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -302,6 +302,7 @@ export interface TenantSettings {
   fiatKey?: string | null;
   rpcUrl?: string | null;
   rpcFallbackUrls?: string[] | null;
+  wakuBootstrap?: string[] | null;
   feeAddress?: string | null;
   feeBps?: number | null;
   admins?: string[] | null;

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -46,14 +46,23 @@ export function reloadConfig(): void {
 }
 
 export function getWakuBootstrapNodes(): string[] {
-  const raw =
+  const override =
     config.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
     process.env.EXPO_PUBLIC_WAKU_BOOTSTRAP;
-  if (!raw) return [];
-  return raw
-    .split(',')
-    .map((addr) => addr.trim())
-    .filter(Boolean);
+  if (override) {
+    return override
+      .split(',')
+      .map((addr) => addr.trim())
+      .filter(Boolean);
+  }
+  try {
+    const tenant = require('../constants/tenant');
+    const list = tenant.AppConfig?.wakuBootstrap || [];
+    if (Array.isArray(list) && list.length > 0) {
+      return list;
+    }
+  } catch {}
+  return [];
 }
 
 export function requireEnv(key: string): string {


### PR DESCRIPTION
## Summary
- embed stable Waku bootstrap nodes with optional override
- allow tenant settings to provide custom Waku peers
- clarify docs that `.env` overrides are optional

## Testing
- `yarn lint` *(fails: Parsing error: '}' expected and React Hooks rules-of-hooks errors)*
- `npx eslint services/eventBus.ts utils/appConfig.ts constants/tenant.ts services/tonSettings.ts types/index.ts && echo ESLINT_OK`
- `yarn typecheck` *(fails: components/ChatWidget.tsx: error TS1005: '}' expected.)*
- `npx tsc --noEmit services/eventBus.ts utils/appConfig.ts constants/tenant.ts services/tonSettings.ts types/index.ts && echo TSC_OK` *(fails: Cannot find type definition file for 'bcryptjs'.)*
- `yarn test` *(fails: Jest globalSetup lint step error)*

------
https://chatgpt.com/codex/tasks/task_e_68a47ff6a2608326990db89415ffe6b2