### PR TITLE
Fix ChatWidget closing brace placement

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -730,6 +730,7 @@ const loadOrCreateDefaultRoom = async () => {
 
   const navigateToUserProfile = async (userId: string) => {
     if (!isAdmin && !isDriver) return;
+  };
 
   const { chatRooms, selectedRoom, setSelectedRoom, loadChatRooms, unreadTotal } =
     useChatRooms(isOpen);


### PR DESCRIPTION
## Summary
- close navigateToUserProfile helper and ensure ChatWidget closes before StyleSheet

## Testing
- `npm run lint components/ChatWidget.tsx` (fails: expo not found)
- `npx tsc --noEmit components/ChatWidget.tsx` (fails: missing global Promise and other modules)

------
https://chatgpt.com/codex/tasks/task_e_68aaabd0d2288326bfe86d685cd5dff8