### PR TITLE
chore: support boc assets

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
-config.resolver.assetExts.push('wasm', 'sql');
+config.resolver.assetExts.push('wasm', 'sql', 'boc');
 
 // Resolve package roots to avoid Node's fallbacks to non-browser builds
 const nobleHashesPath = path.resolve(__dirname, 'node_modules/@noble/hashes');


### PR DESCRIPTION
## Summary
- allow Metro to load `.boc` contract artifacts

## Testing
- `yarn lint` *(fails: Parsing error in components/ChatWidget.tsx and React hook rule violations)*
- `yarn typecheck` *(fails: TypeScript errors in components/ChatWidget.tsx and tests)*
- `yarn test` *(fails: lint in global setup)*
- `npx expo start --offline`

------
https://chatgpt.com/codex/tasks/task_e_68aaabd3dfe88326a8aba8fe1b65fe22