### PR TITLE
chore: remove unused Expo and React Native type references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,15 +12,16 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "types": [
-      "expo",
       "react",
-      "react-native",
       "jest",
       "node",
       "bcryptjs",
       "minimatch"
     ],
-    "typeRoots": ["./types", "./node_modules/@types"],
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- remove Expo and React Native from `compilerOptions.types` to rely on bundled type definitions

## Testing
- `yarn typecheck` *(fails: tests have syntax errors, but missing type definition errors are resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68aaae1646988326a288184a532abf55