### PR TITLE
refactor: initialize chat rooms earlier

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -23,7 +23,6 @@ export default function ChatWidget() {
   const { t } = useLanguage();
   const recordingTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const messagesEndRef = useRef<FlatList<ChatMessage>>(null);
-  const [unreadTotal, setUnreadTotal] = useState(0);
   const [defaultRoomId, setDefaultRoomId] = useState<string | null>(null);
   const messageSoundRef = useRef<Audio.AudioPlayer | null>(null);
   const lastTimestampRef = useRef(0);
@@ -42,6 +41,10 @@ export default function ChatWidget() {
   const [chatConfigOk, setChatConfigOk] = useState(true);
   const waku = useWakuClient();
   const [adminKey, setAdminKey] = useState('');
+  const { user, isAdmin, isDriver, isLoggedIn } = useAuth();
+
+  const { chatRooms, setChatRooms, selectedRoom, setSelectedRoom, unreadTotal } =
+    useChatRooms(isOpen);
 
   useEffect(() => {
     SettingsAgent.getInstance()
@@ -99,10 +102,6 @@ export default function ChatWidget() {
 
     init();
   }, [isLoggedIn, isAdmin, isDriver, adminKey]);
-
-  useEffect(() => {
-    setUnreadTotal(chatRooms.reduce((sum, r) => sum + r.unreadCount, 0));
-  }, [chatRooms]);
 
   useEffect(() => {
     if (!isLoggedIn) return;
@@ -738,8 +737,6 @@ const loadOrCreateDefaultRoom = async () => {
     if (!isAdmin && !isDriver) return;
   };
 
-  const { chatRooms, selectedRoom, setSelectedRoom, loadChatRooms, unreadTotal } =
-    useChatRooms(isOpen);
   const {
     messages,
     newMessage,

--- a/hooks/useChatRooms.ts
+++ b/hooks/useChatRooms.ts
@@ -28,6 +28,13 @@ export function useChatRooms(isOpen: boolean) {
     [chatRooms],
   );
 
-  return { chatRooms, selectedRoom, setSelectedRoom, loadChatRooms, unreadTotal };
+  return {
+    chatRooms,
+    setChatRooms,
+    selectedRoom,
+    setSelectedRoom,
+    loadChatRooms,
+    unreadTotal,
+  };
 }
 export default useChatRooms;


### PR DESCRIPTION
## Summary
- expose `setChatRooms` from `useChatRooms`
- call `useChatRooms` at start of `ChatWidget`
- update `ChatWidget` to use exported `setChatRooms`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab46b372083268c29a41e13b27e14