### PR TITLE
chore: remove dead user profile navigation

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -35,8 +35,6 @@ export default function ChatWidget() {
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
-  const [profileModalVisible, setProfileModalVisible] = useState(false);
-  const [profileUserId, setProfileUserId] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
   const [chatConfigOk, setChatConfigOk] = useState(true);
   const waku = useWakuClient();
@@ -731,10 +729,6 @@ const loadOrCreateDefaultRoom = async () => {
         setShowReactions(null);
       }
     }
-  };
-
-  const navigateToUserProfile = async (userId: string) => {
-    if (!isAdmin && !isDriver) return;
   };
 
   const { chatRooms, selectedRoom, setSelectedRoom } = useChatRooms(isOpen);


### PR DESCRIPTION
## Summary
- drop unused profile modal state
- delete `navigateToUserProfile` helper and references

## Testing
- `yarn test` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aab6f74c748326addbc4354cebfcd0