### PR TITLE
fix: remove duplicate useChatRooms call

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -731,7 +731,6 @@ const loadOrCreateDefaultRoom = async () => {
     }
   };
 
-  const { chatRooms, selectedRoom, setSelectedRoom } = useChatRooms(isOpen);
   const {
     messages,
     newMessage,


### PR DESCRIPTION
## Summary
- remove redundant useChatRooms invocation in ChatWidget
- use existing selected room to initialize useChatMessages

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*
- `yarn install` *(fails: @waku/sdk requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68aabca0193c8326878177df4d8d98d5