### PR TITLE
fix: resolve duplicate identifiers in chat widget

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -412,7 +412,7 @@ const loadOrCreateDefaultRoom = async () => {
     return ok;
   };
 
-  const sendMessage = async () => {
+  const handleSendMessage = async () => {
     if (!newMessage.trim() || isSending) return;
       if (!(await ensureChatConfigured())) return;
       setIsSending(true);
@@ -735,10 +735,10 @@ const loadOrCreateDefaultRoom = async () => {
     messages,
     newMessage,
     setNewMessage,
-    sendMessage,
     loadOlderMessages,
     hasMore,
     loadingMore,
+    setMessages,
   } = useChatMessages(selectedRoom, user, isAdmin);
 
   const toggleOpen = () => {
@@ -792,7 +792,7 @@ const loadOrCreateDefaultRoom = async () => {
               <MessageInput
                 value={newMessage}
                 onChange={setNewMessage}
-                onSend={sendMessage}
+                onSend={handleSendMessage}
                 colors={colors}
               />
             </View>

--- a/hooks/useChatMessages.ts
+++ b/hooks/useChatMessages.ts
@@ -86,6 +86,7 @@ export function useChatMessages(selectedRoom: ChatRoom | null, user: User | null
     loadOlderMessages,
     hasMore,
     loadingMore,
+    setMessages,
   };
 }
 export default useChatMessages;


### PR DESCRIPTION
## Summary
- rename `sendMessage` handler to `handleSendMessage` to prevent duplicate declarations
- expose `setMessages` from `useChatMessages` and consume it in `ChatWidget`

## Testing
- `npm run --silent typecheck` *(fails: tests/reputation.test.ts(96,53): error TS1005: '>' expected.)*
- `npm test --silent` *(fails: Command failed: yarn lint)*

------
https://chatgpt.com/codex/tasks/task_e_68aac81deea08326a5b831f7186fa459