### PR TITLE
Add payment factory address setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ PINATA_JWT=
 TON_NETWORK=mainnet
 ADMIN_WALLET_ADDRESS_MAINNET=
 ADMIN_WALLET_ADDRESS_TESTNET=
-ORDER_PAYMENT_FACTORY_ADDRESS=
 # Optional: override tenant RPC endpoint
 TON_RPC_URL=
 # Optional: comma-separated list of fallback RPC endpoints

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ the desired values:
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
 | `ADMIN_WALLET_ADDRESS` | yes | Wallet granted admin rights if no on-chain list exists. |
-| `ORDER_PAYMENT_FACTORY_ADDRESS` | yes | Address of the deployed OrderPayment factory contract. |
 | `TON_RPC_URL` | no | Primary TON RPC endpoint used for blockchain calls. Overrides tenant setting. |
 | `TON_RPC_FALLBACK_URLS` | no | Comma-separated backup RPC endpoints. Overrides tenant setting. |
 | `EXPO_PUBLIC_WAKU_BOOTSTRAP` | no | Comma-separated list of Waku peers for network bootstrap. |
@@ -87,10 +86,8 @@ the desired values:
 | `PINATA_JWT` | no | JWT for pinning assets to Pinata via `scripts/pinata-upload.ts`. |
 - `ADMIN_WALLET_ADDRESS` – wallet granted admin rights if no on-chain list
   exists (required)
-- `ORDER_PAYMENT_FACTORY_ADDRESS` – address of the deployed OrderPayment
-  factory contract (required)
- - `TON_RPC_URL` – primary TON RPC endpoint used for blockchain calls (optional; overrides tenant setting)
- - `TON_RPC_FALLBACK_URLS` – comma-separated backup RPC endpoints (optional; overrides tenant setting)
+- `TON_RPC_URL` – primary TON RPC endpoint used for blockchain calls (optional; overrides tenant setting)
+- `TON_RPC_FALLBACK_URLS` – comma-separated backup RPC endpoints (optional; overrides tenant setting)
 - `EXPO_PUBLIC_DEBUG_LOGS` – enable verbose logging (`true`/`false`, default
   `false`)
 - `EXPO_PUBLIC_WAKU_BOOTSTRAP` – comma-separated list of Waku peers (optional override)
@@ -103,11 +100,10 @@ These values are read at build time and cannot be changed from the UI.
 
 ### Secure Key Management
 
-Store sensitive values such as `ADMIN_WALLET_ADDRESS` and
-`ORDER_PAYMENT_FACTORY_ADDRESS` in a dedicated secrets manager (e.g., AWS
-Secrets Manager, Hashicorp Vault). Inject them as environment variables at
-runtime; the app will throw on startup if required keys are missing. Avoid
-committing secrets to source control. See
+Store sensitive values such as `ADMIN_WALLET_ADDRESS` in a dedicated secrets
+manager (e.g., AWS Secrets Manager, Hashicorp Vault). Inject them as
+environment variables at runtime; the app will throw on startup if required
+keys are missing. Avoid committing secrets to source control. See
 [`docs/secure-key-management.md`](docs/secure-key-management.md) for
 additional guidance.
 

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -16,6 +16,7 @@ type SettingKey =
   | 'fiatKey'
   | 'feeAddress'
   | 'feeBps'
+  | 'paymentFactoryAddress'
   | 'rpcUrl'
   | 'rpcFallbackUrls';
 
@@ -93,6 +94,14 @@ class SettingsAgent {
   async setRpcUrls(rpcUrl: string, rpcFallbackUrls: string[]): Promise<void> {
     await this.set('rpcUrl', rpcUrl);
     await this.set('rpcFallbackUrls', JSON.stringify(rpcFallbackUrls));
+  }
+
+  async getPaymentFactoryAddress(): Promise<string | null> {
+    return await this.get('paymentFactoryAddress');
+  }
+
+  async setPaymentFactoryAddress(address: string): Promise<void> {
+    await this.set('paymentFactoryAddress', address);
   }
 
   static getInstance(): SettingsAgent {

--- a/docs/secure-key-management.md
+++ b/docs/secure-key-management.md
@@ -1,5 +1,5 @@
 # Secure Key Management
 
-Sensitive configuration values such as `ADMIN_WALLET_ADDRESS`, `ORDER_PAYMENT_FACTORY_ADDRESS`, and `TON_RPC_URL` must be supplied via environment variables. In production environments, load these variables from a dedicated secrets manager (AWS Secrets Manager, Hashicorp Vault, Docker secrets, etc.) rather than committing them to source control.
+Sensitive configuration values such as `ADMIN_WALLET_ADDRESS` and `TON_RPC_URL` must be supplied via environment variables. In production environments, load these variables from a dedicated secrets manager (AWS Secrets Manager, Hashicorp Vault, Docker secrets, etc.) rather than committing them to source control.
 
 At runtime the app validates that required keys are present and will throw an error if any are missing. Development-only flags like `ENABLE_UNSAFE_TON_PRIVATE_KEY` are automatically ignored when `NODE_ENV` is set to `production`.

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -7,8 +7,7 @@ import { getTonConnect } from './tonAuth';
 import { fetchSettings } from './tonSettings';
 
 const DEFAULT_FACTORY_ADDRESS = 'EQtestfactory';
-export let ORDER_PAYMENT_FACTORY_ADDRESS =
-  process.env.ORDER_PAYMENT_FACTORY_ADDRESS || '';
+export let ORDER_PAYMENT_FACTORY_ADDRESS = '';
 
 async function deployTemporaryFactory(): Promise<string> {
   // Placeholder for actual factory deployment logic
@@ -17,11 +16,12 @@ async function deployTemporaryFactory(): Promise<string> {
 
 export async function getOrderPaymentFactoryAddress(): Promise<string> {
   if (!ORDER_PAYMENT_FACTORY_ADDRESS) {
-    if (process.env.NODE_ENV === 'test') {
-      ORDER_PAYMENT_FACTORY_ADDRESS = DEFAULT_FACTORY_ADDRESS;
-    } else {
-      ORDER_PAYMENT_FACTORY_ADDRESS = await deployTemporaryFactory();
-    }
+    const settings = await fetchSettings();
+    ORDER_PAYMENT_FACTORY_ADDRESS =
+      settings.paymentFactoryAddress ||
+      (process.env.NODE_ENV === 'test'
+        ? DEFAULT_FACTORY_ADDRESS
+        : await deployTemporaryFactory());
   }
   return ORDER_PAYMENT_FACTORY_ADDRESS;
 }

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -58,6 +58,7 @@ export interface TonSettings {
   fiatKey?: string;
   feeAddress?: string;
   feeBps?: number;
+  paymentFactoryAddress?: string;
   admins: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
@@ -196,6 +197,7 @@ export async function fetchSettings(): Promise<TonSettings> {
     fiatKey: map['fiatKey'],
     feeAddress: map['feeAddress'] ?? '',
     feeBps,
+    paymentFactoryAddress: map['paymentFactoryAddress'] ?? '',
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
     rpcUrl: map['rpcUrl'] ?? '',
     rpcFallbackUrls: map['rpcFallbackUrls']
@@ -228,4 +230,15 @@ export async function getAdmins(): Promise<string[]> {
 
 export async function setAdmins(admins: string[], actor: string): Promise<void> {
   await setSetting('admins', JSON.stringify(admins), actor);
+}
+
+export async function getPaymentFactoryAddress(): Promise<string> {
+  return (await getSetting('paymentFactoryAddress')) || '';
+}
+
+export async function setPaymentFactoryAddress(
+  address: string,
+  actor: string,
+): Promise<void> {
+  await setSetting('paymentFactoryAddress', address, actor);
 }

--- a/tests/bulkProductUploader.test.ts
+++ b/tests/bulkProductUploader.test.ts
@@ -29,7 +29,6 @@ describe('BulkProductUploader processRecords', () => {
     setProductBatchMock.mockClear();
     estimateSetProductBatchMock.mockClear();
     insertConfig({
-      ORDER_PAYMENT_FACTORY_ADDRESS: 'test',
       TON_RPC_URL: 'http://localhost',
       ADMIN_WALLET_ADDRESS_MAINNET: undefined,
       ADMIN_WALLET_ADDRESS_TESTNET: undefined,

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -5,7 +5,6 @@ import PinataService from '../services/pinata';
 describe('PinataService', () => {
   beforeEach(async () => {
     insertConfig({
-      ORDER_PAYMENT_FACTORY_ADDRESS: '0x0',
       TON_RPC_URL: 'https://ton.example',
       ADMIN_WALLET_ADDRESS_MAINNET: undefined,
       ADMIN_WALLET_ADDRESS_TESTNET: undefined,

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -3,7 +3,6 @@ import { insertConfig } from './testUtils';
 
 insertConfig({
   TON_RPC_URL: 'https://ton.test',
-  ORDER_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
   ADMIN_WALLET_ADDRESS_MAINNET: 'EQtestadmin',
   ADMIN_WALLET_ADDRESS_TESTNET: 'EQtestadmin',
 });
@@ -17,7 +16,6 @@ var __DEV__ = false;
 beforeEach(async () => {
   insertConfig({
     TON_RPC_URL: 'https://ton.test',
-    ORDER_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
     ADMIN_WALLET_ADDRESS_MAINNET: 'EQtestadmin',
     ADMIN_WALLET_ADDRESS_TESTNET: 'EQtestadmin',
   });

--- a/tests/tonAuthContract.test.ts
+++ b/tests/tonAuthContract.test.ts
@@ -8,8 +8,6 @@ jest.mock('../services/tonSettings', () => ({
   }),
 }));
 
-import { insertConfig } from './testUtils';
-
 let deployOrderPayment: any;
 let releasePayment: any;
 let refundPayment: any;
@@ -41,7 +39,6 @@ describe('Ton contract flows', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    insertConfig({ ORDER_PAYMENT_FACTORY_ADDRESS: undefined });
     ({
       deployOrderPayment,
       releasePayment,
@@ -64,7 +61,12 @@ describe('Ton contract flows', () => {
 
   it('uses configured factory address when provided', async () => {
     jest.resetModules();
-    insertConfig({ ORDER_PAYMENT_FACTORY_ADDRESS: 'EQcustomfactory' });
+    const tonSettings = require('../services/tonSettings');
+    tonSettings.fetchSettings.mockResolvedValue({
+      feeAddress: 'feeAddr',
+      feeBps: 500,
+      paymentFactoryAddress: 'EQcustomfactory',
+    });
     ({ getOrderPaymentFactoryAddress } = require('../services/tonContract'));
     const addr = await getOrderPaymentFactoryAddress();
     expect(addr).toBe('EQcustomfactory');

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,7 +1,7 @@
 // Configuration values are loaded from environment variables.
 // Only a minimal set of keys is supported at runtime.
 
-const REQUIRED_ENV_KEYS = ['ORDER_PAYMENT_FACTORY_ADDRESS'];
+const REQUIRED_ENV_KEYS: string[] = [];
 
 const ENV_KEYS = [
   'EXPO_PUBLIC_DEBUG_LOGS',


### PR DESCRIPTION
## Summary
- allow payment factory address to be stored in on-chain settings instead of env var
- use Ton settings when resolving order payment factory
- expose paymentFactoryAddress helpers in settings agent

## Testing
- `yarn test` *(fails: Cannot find type definition file for 'minimatch')*
- `yarn lint` *(fails: React hook useEffect is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc2fc7f88326a886c149da310607