### PR TITLE
feat: add payment factory settings

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -17,7 +17,8 @@ type SettingKey =
   | 'feeAddress'
   | 'feeBps'
   | 'rpcUrl'
-  | 'rpcFallbackUrls';
+  | 'rpcFallbackUrls'
+  | 'paymentFactoryAddress';
 
 class SettingsAgent {
   private static instance: SettingsAgent;

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -20,6 +20,7 @@ import LanguageSettings from '../../components/settings/LanguageSettings';
 import NotificationSettings from '../../components/settings/NotificationSettings';
 import RpcSettings from '../../components/settings/RpcSettings';
 import MoonPaySettings from '../../components/settings/MoonPaySettings';
+import PaymentFactorySettings from '../../components/settings/PaymentFactorySettings';
 
 export default function SettingsScreen() {
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
@@ -27,6 +28,7 @@ export default function SettingsScreen() {
   const [logoCidInput, setLogoCidInput] = useState('');
   const [themeColor, setThemeColorState] = useState('#B99C5A');
   const [fiatKeyInput, setFiatKeyInput] = useState('');
+  const [paymentFactoryAddress, setPaymentFactoryAddress] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const { isAdmin, isDriver } = useAuth();
@@ -83,6 +85,8 @@ export default function SettingsScreen() {
       setThemeColorState(contextThemeColor);
       setLogoCidInput(logoCid || '');
       setFiatKeyInput(fiatKey || '');
+      const pf = await SettingsAgent.getInstance().getSettingValue('paymentFactoryAddress');
+      setPaymentFactoryAddress(pf || '');
     } catch (error) {
       errorLog('Error loading settings:', error);
       setInfoModal({
@@ -105,6 +109,10 @@ export default function SettingsScreen() {
       const logoUri = logoCidInput.trim();
       await setLogoCid(logoUri);
       await setFiatKey(fiatKeyInput.trim());
+      await SettingsAgent.getInstance().updateSettingValue(
+        'paymentFactoryAddress',
+        paymentFactoryAddress.trim(),
+      );
       setInfoModal({
         visible: true,
         title: 'הצלחה',
@@ -176,6 +184,11 @@ export default function SettingsScreen() {
         <MoonPaySettings
           fiatKeyInput={fiatKeyInput}
           setFiatKeyInput={setFiatKeyInput}
+          colors={colors}
+        />
+        <PaymentFactorySettings
+          paymentFactoryAddress={paymentFactoryAddress}
+          setPaymentFactoryAddress={setPaymentFactoryAddress}
           colors={colors}
         />
         <EnvironmentSettings colors={colors} admins={admins} />

--- a/components/settings/EnvironmentSettings.tsx
+++ b/components/settings/EnvironmentSettings.tsx
@@ -21,8 +21,7 @@ const EnvironmentSettings: React.FC<Props> = ({ colors, admins }) => {
         <Text style={[styles.title, { color: colors.text.primary }]}>Environment</Text>
       </View>
       <View style={styles.content}>
-        <Text style={[styles.description, { color: colors.text.primary }]}>Admin credentials and Waku details are configured via .env and cannot be edited here.</Text>
-        <Text style={[styles.label, { color: colors.text.primary, marginTop: 8 }]}>Admin Addresses: {admins.join(', ') || 'Not set'}</Text>
+        <Text style={[styles.label, { color: colors.text.primary }]}>Admin Addresses: {admins.join(', ') || 'Not set'}</Text>
       </View>
     </Card>
   );
@@ -49,10 +48,6 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: 16,
-  },
-  description: {
-    fontSize: 14,
-    textAlign: 'end',
   },
   label: {
     fontSize: 14,

--- a/components/settings/PaymentFactorySettings.tsx
+++ b/components/settings/PaymentFactorySettings.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { Settings as SettingsIcon } from 'lucide-react-native';
+import Card from '../Card';
+
+interface Props {
+  paymentFactoryAddress: string;
+  setPaymentFactoryAddress: (v: string) => void;
+  colors: any;
+}
+
+const PaymentFactorySettings: React.FC<Props> = ({
+  paymentFactoryAddress,
+  setPaymentFactoryAddress,
+  colors,
+}) => {
+  return (
+    <Card
+      style={[
+        styles.card,
+        { backgroundColor: colors.surface.primary, borderColor: colors.border.primary },
+      ]}
+    >
+      <View style={styles.header}>
+        <SettingsIcon size={20} color={colors.gold} />
+        <Text style={[styles.title, { color: colors.text.primary }]}>Payment Factory</Text>
+      </View>
+      <View style={styles.content}>
+        <View style={styles.inputContainer}>
+          <Text style={[styles.label, { color: colors.text.primary }]}>Factory Address</Text>
+          <TextInput
+            style={[
+              styles.input,
+              {
+                borderColor: colors.border.primary,
+                backgroundColor: colors.surface.secondary,
+                color: colors.text.primary,
+              },
+            ]}
+            value={paymentFactoryAddress}
+            onChangeText={setPaymentFactoryAddress}
+            placeholder="EQ..."
+            textAlign="end"
+            placeholderTextColor={colors.text.tertiary}
+          />
+        </View>
+      </View>
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    justifyContent: 'flex-end',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginRight: 8,
+  },
+  content: {
+    padding: 16,
+  },
+  inputContainer: {
+    marginBottom: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+    textAlign: 'end',
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+});
+
+export default PaymentFactorySettings;

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -16,6 +16,7 @@ export interface TenantSettings {
   rpcUrl: string;
   rpcFallbackUrls?: string[];
   wakuBootstrap?: string[];
+  paymentFactoryAddress?: string;
 }
 
 const initialAdmin =
@@ -46,6 +47,7 @@ export let AppConfig: TenantSettings = {
   rpcUrl: '',
   rpcFallbackUrls: [],
   wakuBootstrap: [],
+  paymentFactoryAddress: '',
 };
 
 export async function loadTenantSettings(): Promise<void> {
@@ -60,6 +62,7 @@ export async function loadTenantSettings(): Promise<void> {
   const RPC_URL_KEY = 'app_rpc_url';
   const RPC_FALLBACK_KEY = 'app_rpc_fallback_urls';
   const WAKU_BOOTSTRAP_KEY = 'app_waku_bootstrap';
+  const PAYMENT_FACTORY_KEY = 'app_payment_factory_address';
 
   try {
     const [
@@ -74,6 +77,7 @@ export async function loadTenantSettings(): Promise<void> {
       rpc,
       rpcFallback,
       waku,
+      paymentFactory,
     ] = await AsyncStorage.multiGet([
       TENANT_KEY,
       NAME_KEY,
@@ -86,6 +90,7 @@ export async function loadTenantSettings(): Promise<void> {
       RPC_URL_KEY,
       RPC_FALLBACK_KEY,
       WAKU_BOOTSTRAP_KEY,
+      PAYMENT_FACTORY_KEY,
     ]);
 
     if (t?.[1]) TENANT = t[1];
@@ -100,6 +105,7 @@ export async function loadTenantSettings(): Promise<void> {
       rpcUrl: rpc?.[1] || '',
       rpcFallbackUrls: rpcFallback?.[1] ? JSON.parse(rpcFallback[1]) : [],
       wakuBootstrap: waku?.[1] ? JSON.parse(waku[1]) : [],
+      paymentFactoryAddress: paymentFactory?.[1] || '',
     };
 
     const remote = await fetchSettings();
@@ -115,6 +121,7 @@ export async function loadTenantSettings(): Promise<void> {
       rpcUrl: remote.rpcUrl,
       rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
       wakuBootstrap: remote.wakuBootstrap ?? [],
+      paymentFactoryAddress: remote.paymentFactoryAddress ?? '',
     };
 
     await AsyncStorage.multiSet([
@@ -129,6 +136,7 @@ export async function loadTenantSettings(): Promise<void> {
       [RPC_URL_KEY, remote.rpcUrl],
       [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
       [WAKU_BOOTSTRAP_KEY, JSON.stringify(remote.wakuBootstrap ?? [])],
+      [PAYMENT_FACTORY_KEY, remote.paymentFactoryAddress ?? ''],
     ]);
   } catch (e) {
     errorLog('Error loading tenant settings:', e);

--- a/services/__mocks__/tonSettings.ts
+++ b/services/__mocks__/tonSettings.ts
@@ -33,6 +33,7 @@ export async function fetchSettings() {
     wakuBootstrap: store['wakuBootstrap']
       ? JSON.parse(store['wakuBootstrap'])
       : [],
+    paymentFactoryAddress: store['paymentFactoryAddress'],
   };
 }
 

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -62,6 +62,7 @@ export interface TonSettings {
   rpcUrl: string;
   rpcFallbackUrls?: string[];
   wakuBootstrap?: string[];
+  paymentFactoryAddress?: string;
 }
 
 export async function getSetting(key: string): Promise<string | null> {
@@ -204,6 +205,7 @@ export async function fetchSettings(): Promise<TonSettings> {
     wakuBootstrap: map['wakuBootstrap']
       ? JSON.parse(map['wakuBootstrap'])
       : [],
+    paymentFactoryAddress: map['paymentFactoryAddress'],
   };
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -306,6 +306,7 @@ export interface TenantSettings {
   feeAddress?: string | null;
   feeBps?: number | null;
   admins?: string[] | null;
+  paymentFactoryAddress?: string | null;
 }
 
 export interface RoadmapTask {


### PR DESCRIPTION
## Summary
- add PaymentFactorySettings component with editable address field
- load and save payment factory address in admin settings and agent
- remove read-only notice from environment settings

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn typecheck` *(fails: tsconfig base not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc307e688326a9743b954496ce91