### PR TITLE
Add tslib dependency and bundler aliases

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -27,6 +27,7 @@ config.resolver.extraNodeModules = {
     __dirname,
     'node_modules/@waku/sdk/bundle/index.js'
   ),
+  tslib: require.resolve('tslib/tslib.es6.js'),
   multiformats: path.join(multiformatsPath, 'dist/index.min.js'),
 };
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
     "tonweb": "^0.0.66",
+    "tslib": "^2.8.1",
     "tweetnacl": "^1.0.3",
     "web-push": "^3.6.7",
     "zod": "^3.22.4"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = async function (env, argv) {
       __dirname,
       'node_modules/@waku/sdk/bundle/index.js'
     ),
+    tslib: require.resolve('tslib/tslib.es6.js'),
     multiformats: path.join(multiformatsPath, 'dist/index.min.js'),
   };
 


### PR DESCRIPTION
## Summary
- add tslib as direct dependency
- alias tslib to its ES module build for Metro and Webpack

## Testing
- `yarn build`
- `yarn lint` *(fails: React Hooks rule violations)*
- `yarn test` *(fails: Jest setup running `yarn lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68aae2180be483268a3073cadf618243