### PR TITLE
fix: ensure tslib default export in polyfills

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -26,3 +26,14 @@ if (typeof global.Buffer === 'undefined') {
 if (typeof global.process === 'undefined') {
   global.process = require('process/browser');
 }
+
+// Ensure tslib provides a default export for libraries that import it
+try {
+  const tslib = require('tslib');
+  if (tslib && !('default' in tslib)) {
+    // eslint-disable-next-line no-param-reassign
+    tslib.default = tslib;
+  }
+} catch (err) {
+  debugLog('❌ tslib polyfill failed:', err);
+}


### PR DESCRIPTION
## Summary
- ensure tslib exposes a default export for libraries using default imports

## Testing
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4".)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aafe8a6c7883269fdef3e6d713d3c3