### PR TITLE
fix tslib default export for metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -35,6 +35,12 @@ config.resolver.extraNodeModules = {
     'node_modules/multiformats/dist/src/index.js'
   ),
   tslib: require.resolve('tslib'),
+  // Ensure Metro resolves tslib's ESM entry to a CommonJS-compatible module
+  // that includes a default export. Without this, packages that rely on the
+  // default export (e.g. rxjs) will crash at runtime because `tslib`'s
+  // generated `modules/index.js` attempts to destructure from an undefined
+  // default export.
+  'tslib/modules/index.js': path.resolve(__dirname, 'tslib-polyfill.js'),
 };
 
 module.exports = config;

--- a/tslib-polyfill.js
+++ b/tslib-polyfill.js
@@ -1,0 +1,4 @@
+const tslib = require('tslib/tslib.js');
+// Ensure tslib has a default export for environments expecting it.
+module.exports = tslib;
+module.exports.default = tslib;


### PR DESCRIPTION
## Summary
- ensure tslib exposes a default export to avoid rxjs runtime crash
- redirect Metro to patched tslib module

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*
- `yarn typecheck` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0283b4a88326a33c73d5b469fc50