### PR TITLE
chore: dedupe tslib and route metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -34,7 +34,7 @@ config.resolver.extraNodeModules = {
     __dirname,
     'node_modules/multiformats/dist/src/index.js'
   ),
-  tslib: require.resolve('tslib'),
+  tslib: path.resolve(__dirname, 'tslib-polyfill.js'),
   // Ensure Metro resolves tslib's ESM entry to a CommonJS-compatible module
   // that includes a default export. Without this, packages that rely on the
   // default export (e.g. rxjs) will crash at runtime because `tslib`'s

--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
     "util": "^0.12.5"
   },
   "packageManager": "yarn@1.22.22",
+  "resolutions": {
+    "tslib": "^2.8.1"
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "yarn lint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13127,12 +13127,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.1:
+tslib@^1.9.0, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary
- dedupe tslib across dependencies using yarn resolutions
- direct metro to the tslib polyfill for all imports

## Testing
- `yarn lint` *(fails: React Hooks warnings and errors)*
- `yarn typecheck` *(fails: TS1005 in tests)*
- `yarn test` *(fails: global setup lint step)*
- `yarn web`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ba5934c83268786625fefd7bd7a