### PR TITLE
fix: pin tslib to root for metro

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -45,10 +45,16 @@ export default function ChatWidget() {
     useChatRooms(isOpen);
 
   useEffect(() => {
+    let mounted = true;
     SettingsAgent.getInstance()
       .getAdmins()
-      .then((a) => setAdminKey(a[0] || ''))
+      .then((a) => {
+        if (mounted) setAdminKey(a[0] || '');
+      })
       .catch((err) => errorLog('Failed to load admin key', err));
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   useEffect(() => {

--- a/metro.config.js
+++ b/metro.config.js
@@ -3,6 +3,10 @@ const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push('wasm', 'sql', 'boc');
+// Force Metro to resolve all modules from the project root so nested copies
+// of dependencies (e.g., tslib inside rxjs) are ignored. This ensures our
+// custom alias for `tslib` is respected everywhere.
+config.resolver.disableHierarchicalLookup = true;
 
 // Map the Expo HMR client to our local wrapper; polyfills are applied at app entry
 config.resolver.extraNodeModules = {
@@ -34,7 +38,7 @@ config.resolver.extraNodeModules = {
     __dirname,
     'node_modules/multiformats/dist/src/index.js'
   ),
-  tslib: require.resolve('tslib'),
+  tslib: path.resolve(__dirname, 'tslib-polyfill.js'),
   // Ensure Metro resolves tslib's ESM entry to a CommonJS-compatible module
   // that includes a default export. Without this, packages that rely on the
   // default export (e.g. rxjs) will crash at runtime because `tslib`'s

--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
     "util": "^0.12.5"
   },
   "packageManager": "yarn@1.22.22",
+  "resolutions": {
+    "tslib": "^2.8.1"
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "yarn lint"

--- a/polyfills.js
+++ b/polyfills.js
@@ -29,7 +29,9 @@ if (typeof global.process === 'undefined') {
 
 // Ensure tslib provides a default export for libraries that import it
 try {
-  const tslib = require('tslib');
+  // Load tslib via its ESM entry to ensure the runtime sees a version with a
+  // default export before any dependency (e.g., rxjs) uses it.
+  const tslib = require('tslib/modules/index.js');
   if (tslib && !('default' in tslib)) {
     // eslint-disable-next-line no-param-reassign
     tslib.default = tslib;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13127,12 +13127,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.1:
+tslib@^1.9.0, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary
- prevent Metro from searching nested node_modules so tslib maps to the project-level polyfill
- load tslib's ESM entry in polyfills to ensure a default export before any dependency uses it

## Testing
- `yarn lint` *(fails: React Hook useEffect is called conditionally in ProductCard)*
- `yarn typecheck` *(fails: TS1005 errors in tests)*
- `yarn test` *(fails: global setup failed due to lint errors)*
- `yarn web`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ba5934c83268786625fefd7bd7a