### PR TITLE
feat: generate TonConnect manifest from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "expo start",
     "web": "expo start --web",
-    "build": "expo export --platform web --output-dir dist",
+    "build": "expo export --platform web --output-dir dist && node scripts/inject-tonconnect-manifest.js",
     "docker:dev": "docker compose up",
     "docker:build:web": "docker compose run --rm app yarn build",
     "docker:preview": "docker compose run --rm -p 4173:4173 app npx serve@14.2.0 dist -l 4173",

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://blue-ocean.app",
+  "url": "__DOMAIN__",
   "name": "Blue Ocean",
   "iconUrl": "https://red-definite-wolf-677.mypinata.cloud/ipfs/bafybeicl42ot7h3itsvxrzp4qv6t7t2f4n657jxilei65ni3nemv7ykony",
-  "termsOfUseUrl": "https://blue-ocean.app/terms",
-  "privacyPolicyUrl": "https://blue-ocean.app/privacy"
+  "termsOfUseUrl": "__TERMS_URL__",
+  "privacyPolicyUrl": "__PRIVACY_URL__"
 }

--- a/scripts/inject-tonconnect-manifest.js
+++ b/scripts/inject-tonconnect-manifest.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const domain = process.env.TONCONNECT_DOMAIN;
+const terms = process.env.TONCONNECT_TERMS_URL;
+const privacy = process.env.TONCONNECT_PRIVACY_URL;
+
+if (!domain || !terms || !privacy) {
+  console.error(
+    'Missing required env variables TONCONNECT_DOMAIN, TONCONNECT_TERMS_URL, TONCONNECT_PRIVACY_URL'
+  );
+  process.exit(1);
+}
+
+const templatePath = path.join(__dirname, '..', 'public', 'tonconnect-manifest.json');
+const manifest = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+
+manifest.url = domain;
+manifest.termsOfUseUrl = terms;
+manifest.privacyPolicyUrl = privacy;
+
+const distPath = path.join(__dirname, '..', 'dist');
+if (!fs.existsSync(distPath)) {
+  fs.mkdirSync(distPath, { recursive: true });
+}
+
+const outputPath = path.join(distPath, 'tonconnect-manifest.json');
+fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+console.log(`TonConnect manifest written to ${outputPath}`);


### PR DESCRIPTION
## Summary
- replace hard-coded TonConnect manifest URLs with placeholders
- inject deployment-specific URLs into the manifest via a build script
- include manifest generation in the build pipeline

## Testing
- ⚠️ `yarn lint` (expo: not found)
- ⚠️ `yarn typecheck` (TS errors: missing expo/tsconfig base)
- ⚠️ `yarn test` (jest: not found)
- ✅ `TONCONNECT_DOMAIN=https://example.com TONCONNECT_TERMS_URL=https://example.com/terms TONCONNECT_PRIVACY_URL=https://example.com/privacy node scripts/inject-tonconnect-manifest.js`

------
https://chatgpt.com/codex/tasks/task_e_68abd95057f48326b0f1f72368288589