### PR TITLE
feat: handle wallet connect errors

### DIFF
--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, ReactNode, useEffect, useState } from 'react';
+import { Alert } from 'react-native';
 import {
   useTonConnectUI,
   useTonAddress,
@@ -6,6 +7,7 @@ import {
 } from '@tonconnect/ui-react';
 import DatabaseService from '../services/database';
 import { User } from '../types';
+import { errorLog } from '../utils/logger';
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -89,7 +91,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [address, connectionRestored]);
 
   const login = async () => {
-    openModal();
+    try {
+      await openModal();
+    } catch (err: unknown) {
+      errorLog('Wallet connection failed', err);
+      Alert.alert('Error', 'Wallet connection failed. Please try again.');
+    }
   };
 
   const signup = login;


### PR DESCRIPTION
## Summary
- handle wallet connection failures in AuthContext

## Testing
- `yarn lint components/AuthContext.tsx` (fails: expo not found)
- `yarn test components/AuthContext.tsx` (fails: jest not found)
- `yarn install --frozen-lockfile` (fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")

------
https://chatgpt.com/codex/tasks/task_e_68abd94e6b508326a6e59d4c4e77b346