### PR TITLE
feat: default TON RPC endpoint

### DIFF
--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -91,10 +91,14 @@ export function getTonRpcUrls(): string[] {
     .split(',')
     .map((u) => u.trim())
     .filter(Boolean);
-  const primary = envPrimary || tenantRpc;
+  let primary = envPrimary || tenantRpc;
   const fallbacks = envFallbacks.length > 0 ? envFallbacks : tenantFallbacks;
   if (!primary) {
-    throw new Error('Missing TON RPC URL');
+    primary = 'https://testnet.toncenter.com/api/v2/jsonRPC';
+    // eslint-disable-next-line no-console
+    console.warn(
+      'TON_RPC_URL not set, defaulting to https://testnet.toncenter.com/api/v2/jsonRPC',
+    );
   }
   return [primary, ...fallbacks];
 }


### PR DESCRIPTION
## Summary
- default TON RPC URL to a testnet endpoint if none is configured
- warn when TON_RPC_URL is missing rather than throwing

## Testing
- `yarn lint` *(fails: expo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd94e959083269c66a0067d5cf5ee