### PR TITLE
fix: add expo-router Babel plugin to resolve router entry

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,5 +5,6 @@ module.exports = function (api) {
     // including 'module:metro-react-native-babel-preset' causes plugins like
     // 'transform-react-jsx-self' to run twice and inject duplicate props.
     presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
   };
 };


### PR DESCRIPTION
## Summary
- ensure expo-router/entry resolves by adding expo-router Babel plugin

## Testing
- `npm test` *(fails: React Hook warnings & lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68abe347e6988326a670f114b83287f2