### PR TITLE
chore: alias expo router

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -20,12 +20,17 @@ config.resolver.extraNodeModules = {
     __dirname,
     'EmptyHMRClient.ts'
   ),
-  '@noble/hashes': require.resolve('@noble/hashes'),
+  '@noble/hashes': path.resolve(__dirname, 'node_modules/@noble/hashes'),
   '@noble/hashes/hkdf': require.resolve('@noble/hashes/hkdf'),
   '@noble/hashes/sha256': require.resolve('@noble/hashes/sha256'),
   '@noble/hashes/sha512': require.resolve('@noble/hashes/sha512'),
   '@noble/hashes/crypto': require.resolve('@noble/hashes/crypto'),
   '@noble/hashes/crypto.js': require.resolve('@noble/hashes/crypto'),
+  'expo-router': path.resolve(__dirname, 'node_modules/expo-router'),
+  'react-native-url-polyfill': path.resolve(
+    __dirname,
+    'node_modules/react-native-url-polyfill'
+  ),
   '@waku/utils': path.resolve(
     __dirname,
     'node_modules/@waku/utils/dist/index.js'

--- a/types/expo-router-entry.d.ts
+++ b/types/expo-router-entry.d.ts
@@ -1,1 +1,0 @@
-declare module 'expo-router/entry';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,11 @@ module.exports = async function (env, argv) {
       __dirname,
       'node_modules/multiformats/dist/src/index.js'
     ),
+    'expo-router/entry': require.resolve('expo-router/entry'),
+    'react-native-url-polyfill': path.resolve(
+      __dirname,
+      'node_modules/react-native-url-polyfill'
+    ),
     tslib: require.resolve('tslib'),
   };
 


### PR DESCRIPTION
## Summary
- remove custom expo-router type stub
- resolve expo-router and polyfill modules through explicit Metro/Webpack aliases

## Testing
- `yarn typecheck` *(fails: TS1005 errors in tests)*
- `npx expo export --platform web --output-dir web-build` *(fails: @noble/ed25519 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf929635883268e007bd92f4f11ad