### PR TITLE
chore: rely on default expo preset

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,5 @@ module.exports = function (api) {
     // including 'module:metro-react-native-babel-preset' causes plugins like
     // 'transform-react-jsx-self' to run twice and inject duplicate props.
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel'],
   };
 };


### PR DESCRIPTION
## Summary
- remove expo-router Babel plugin

## Testing
- `npm test` *(fails: Command failed: yarn lint)*
- `npm run lint` *(fails: 3 errors, 34 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0c57cefc83269ef8a0bb6631ab20