### PR TITLE
chore: alias noble ed25519

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -21,6 +21,7 @@ config.resolver.extraNodeModules = {
     'EmptyHMRClient.ts'
   ),
   '@noble/hashes': path.resolve(__dirname, 'node_modules/@noble/hashes'),
+  '@noble/ed25519': path.resolve(__dirname, 'node_modules/@noble/ed25519'),
   '@noble/hashes/hkdf': require.resolve('@noble/hashes/hkdf'),
   '@noble/hashes/sha256': require.resolve('@noble/hashes/sha256'),
   '@noble/hashes/sha512': require.resolve('@noble/hashes/sha512'),


### PR DESCRIPTION
## Summary
- map `@noble/ed25519` to local package for Metro resolver

## Testing
- `npm test` *(fails: Command failed: yarn lint)*
- `yarn lint` *(fails: React Hooks useEffect dependency warnings and rules-of-hooks errors)*
- `npm run dev` (start Expo bundler)

------
https://chatgpt.com/codex/tasks/task_e_68ac0c58c5388326b2bb9657bca01925