### PR TITLE
feat: add babel runtime plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,5 +5,6 @@ module.exports = function (api) {
     // including 'module:metro-react-native-babel-preset' causes plugins like
     // 'transform-react-jsx-self' to run twice and inject duplicate props.
     presets: ['babel-preset-expo'],
+    plugins: ['@babel/plugin-transform-runtime'],
   };
 };


### PR DESCRIPTION
## Summary
- enable `@babel/plugin-transform-runtime` in Babel config to pull helpers from `@babel/runtime`

## Testing
- `yarn lint` (fails: React hook errors)
- `yarn typecheck` (fails: TS1005 in tests)
- `yarn test` (fails: lint step)
- `npx expo export --clear --platform web` (fails: missing @babel/runtime helper)


------
https://chatgpt.com/codex/tasks/task_e_68ada1ad50e083269395ec097458fb8e