### PR TITLE
feat: namespace store data

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -47,6 +47,8 @@ class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
   private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};
   private node: LightNode | null = null;
+  private storeMap: Map<string, string> = new Map();
+  private knownStores: Set<string> = new Set();
 
   constructor() {
     void this.subscribeWaku();
@@ -161,7 +163,10 @@ class OrdersAgent {
       trackingSteps: this.getTrackingSteps(status),
       updatedAt: new Date().toISOString(),
     };
-    await setOrder(updated);
+    const sid = updated.items?.[0]?.product?.storeId || '';
+    this.storeMap.set(updated.id, sid);
+    this.knownStores.add(sid);
+    await setOrder(sid, updated);
     this.subscribers.forEach((cb) => cb(updated));
     await this.notifyStatusChange(updated);
   }
@@ -225,7 +230,12 @@ class OrdersAgent {
         warnLog('Failed to encrypt shipping address', err);
       }
     }
-    await setOrder(toStore);
+    {
+      const sid = toStore.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(toStore.id, sid);
+      this.knownStores.add(sid);
+      await setOrder(sid, toStore);
+    }
     await logOrderEvent({
       tenant: enriched.items?.[0]?.product?.storeId || '',
       type: 'order.created',
@@ -255,7 +265,12 @@ class OrdersAgent {
       }
       statusChanged = true;
     }
-    await setOrder(order);
+    {
+      const sid = order.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(order.id, sid);
+      this.knownStores.add(sid);
+      await setOrder(sid, order);
+    }
     await logOrderEvent({
       tenant: order.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
@@ -297,7 +312,9 @@ class OrdersAgent {
       throw new Error('Order not found');
     }
     await this.ensureAuthorized(order);
-    await removeOrder(id);
+    const sid = order.items?.[0]?.product?.storeId || '';
+    await removeOrder(sid, id);
+    this.storeMap.delete(id);
     await logOrderEvent({
       tenant: order.items?.[0]?.product?.storeId || '',
       type: 'order.deleted',
@@ -312,15 +329,28 @@ class OrdersAgent {
   }
 
   async get(id: string): Promise<Order | null> {
-    return await getOrder(id);
+    const sid = this.storeMap.get(id) || '';
+    return await getOrder(sid, id);
   }
 
   async getAll(): Promise<Order[]> {
-    return await listOrders();
+    const all: Order[] = [];
+    for (const sid of this.knownStores) {
+      const list = await listOrders(sid);
+      list.forEach((o) => this.storeMap.set(o.id, sid));
+      all.push(...list);
+    }
+    return all;
   }
 
   async getBySeller(address: string): Promise<Order[]> {
-    return await listOrdersBySeller(address);
+    const all: Order[] = [];
+    for (const sid of this.knownStores) {
+      const list = await listOrdersBySeller(sid, address);
+      list.forEach((o) => this.storeMap.set(o.id, sid));
+      all.push(...list);
+    }
+    return all;
   }
 
   async releasePayment(orderId: string): Promise<string> {
@@ -342,7 +372,12 @@ class OrdersAgent {
       status: 'released',
       updatedAt: new Date().toISOString(),
     };
-    await setOrder(updated);
+    {
+      const sid = updated.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(updated.id, sid);
+      this.knownStores.add(sid);
+      await setOrder(sid, updated);
+    }
     await logOrderEvent({
       tenant: updated.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
@@ -396,7 +431,12 @@ class OrdersAgent {
       status: 'refunded',
       updatedAt: new Date().toISOString(),
     };
-    await setOrder(updated);
+    {
+      const sid = updated.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(updated.id, sid);
+      this.knownStores.add(sid);
+      await setOrder(sid, updated);
+    }
     await logOrderEvent({
       tenant: updated.items?.[0]?.product?.storeId || '',
       type: 'order.updated',

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -96,7 +96,7 @@ class ProductsAgent {
   private async loadFromIndex(index: string[]): Promise<void> {
     for (let i = 0; i < index.length; i += PAGE_SIZE) {
       const slice = index.slice(i, i + PAGE_SIZE);
-      const batch = await getProducts(slice);
+      const batch = await getProducts('default', slice);
       batch.forEach((p) => {
         this.cache.set(p.id, p);
         this.summaries.set(p.id, { rating: p.rating, reviews: p.reviews });
@@ -118,7 +118,7 @@ class ProductsAgent {
         this.version = chainVersion;
       } else {
         await this.invalidateCache();
-        const products = await listProducts();
+        const products = await listProducts('default');
         const ids = products.map((p) => p.id);
         await this.loadFromIndex(ids);
         await setProductCache({ version: chainVersion, index: ids });
@@ -164,7 +164,7 @@ class ProductsAgent {
 
   private async assertStoreOwner(storeId: string) {
     const { address } = await this.ensureWallet();
-    const store = await getStore(storeId);
+    const store = await getStore(storeId, storeId);
     if (!store || store.owner !== address) {
       throw new Error('Only the store owner can manage products');
     }
@@ -172,7 +172,7 @@ class ProductsAgent {
 
   async add(item: Product): Promise<void> {
     await this.assertStoreOwner(item.storeId);
-    await setProduct(item);
+    await setProduct(item.storeId, item);
     this.cache.set(item.id, item);
     this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
     await this.broadcast(item);
@@ -180,17 +180,17 @@ class ProductsAgent {
 
   async update(item: Product): Promise<void> {
     await this.assertStoreOwner(item.storeId);
-    await setProduct(item);
+    await setProduct(item.storeId, item);
     this.cache.set(item.id, item);
     this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
     await this.broadcast(item);
   }
 
   async remove(id: string): Promise<void> {
-    const prod = await getProduct(id);
+    const prod = this.cache.get(id);
     if (!prod) return;
     await this.assertStoreOwner(prod.storeId);
-    await removeProduct(id);
+    await removeProduct(prod.storeId, id);
     this.cache.delete(id);
     this.summaries.delete(id);
   }
@@ -199,7 +199,7 @@ class ProductsAgent {
     await this.ensureCache();
     const cached = this.cache.get(id);
     if (cached) return cached;
-    const prod = await getProduct(id);
+    const prod = await getProduct('default', id);
     if (prod) {
       this.cache.set(id, prod);
       this.summaries.set(id, { rating: prod.rating, reviews: prod.reviews });
@@ -220,11 +220,11 @@ class ProductsAgent {
   }
 
   async decrementStock(productId: string, quantity: number): Promise<void> {
-    const prod = await getProduct(productId);
+    const prod = this.cache.get(productId) || (await getProduct('default', productId));
     if (!prod) return;
     await this.assertStoreOwner(prod.storeId);
     const newStock = Math.max((prod.stock || 0) - quantity, 0);
-    await setProduct({ ...prod, stock: newStock });
+    await setProduct(prod.storeId, { ...prod, stock: newStock });
   }
 }
 

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -37,14 +37,14 @@ class StoresAgent {
     m.reviewSum += rating;
     m.reviewCount += 1;
     this.computeScore(storeId);
-    const store = await getStore(storeId);
+    const store = await getStore(storeId, storeId);
     if (store) {
-      await setStore(this.toRecord({ ...store, reputation: m.score }));
+      await setStore(storeId, this.toRecord({ ...store, reputation: m.score }));
     }
   }
 
   async updateReputationByOwner(owner: string, reliability: number): Promise<void> {
-    const stores = await listStores();
+    const stores = await listStores('default');
     const store = stores.find((s) => s.owner === owner);
     if (store) {
       const id = store.id;
@@ -53,7 +53,7 @@ class StoresAgent {
       }
       this.reputation[id].reliability = reliability;
       this.computeScore(id);
-      await setStore(this.toRecord({ ...store, reputation: this.reputation[id].score }));
+      await setStore('default', this.toRecord({ ...store, reputation: this.reputation[id].score }));
     }
   }
 
@@ -71,25 +71,25 @@ class StoresAgent {
 
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore(this.toRecord(item));
+    await setStore(item.id, this.toRecord(item));
   }
 
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore(this.toRecord(item));
+    await setStore(item.id, this.toRecord(item));
   }
 
   async remove(id: string): Promise<void> {
     await this.ensureWallet();
-    await removeStore(id);
+    await removeStore(id, id);
   }
 
   async get(id: string): Promise<Store | null> {
-    return await getStore(id);
+    return await getStore(id, id);
   }
 
   async getAll(): Promise<Store[]> {
-    return await listStores();
+    return await listStores('default');
   }
 }
 

--- a/services/tonOrders.ts
+++ b/services/tonOrders.ts
@@ -6,27 +6,33 @@ const ADDRESS =
   config.TON_ORDERS_ADDRESS ??
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 
-export async function getOrder(id: string): Promise<Order | null> {
-  const res = await getValue(ADDRESS, id);
+export async function getOrder(storeId: string = '', id: string): Promise<Order | null> {
+  const res = await getValue(ADDRESS, `${storeId}:${id}`);
   return res ? (JSON.parse(res) as Order) : null;
 }
 
-export async function setOrder(order: Order) {
-  await setValue(ADDRESS, order.id, JSON.stringify(order));
+export async function setOrder(storeId: string = '', order: Order) {
+  await setValue(ADDRESS, `${storeId}:${order.id}`, JSON.stringify(order));
 }
 
-export async function removeOrder(id: string) {
-  await removeValue(ADDRESS, id);
+export async function removeOrder(storeId: string = '', id: string) {
+  await removeValue(ADDRESS, `${storeId}:${id}`);
 }
 
-export async function listOrders(): Promise<Order[]> {
-  const items = await listValues(ADDRESS);
-  return items.map((i) => JSON.parse(i.value) as Order);
-}
-
-export async function listOrdersBySeller(sellerAddress: string): Promise<Order[]> {
+export async function listOrders(storeId: string = ''): Promise<Order[]> {
   const items = await listValues(ADDRESS);
   return items
+    .filter((i) => i.key.startsWith(`${storeId}:`))
+    .map((i) => JSON.parse(i.value) as Order);
+}
+
+export async function listOrdersBySeller(
+  storeId: string = '',
+  sellerAddress: string,
+): Promise<Order[]> {
+  const items = await listValues(ADDRESS);
+  return items
+    .filter((i) => i.key.startsWith(`${storeId}:`))
     .map((i) => JSON.parse(i.value) as Order)
     .filter((o) => o.sellerAddress === sellerAddress);
 }

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -7,8 +7,8 @@ const ADDRESS =
   config.TON_PRODUCTS_ADDRESS ??
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 
-export async function getProduct(id: string): Promise<Product | null> {
-  const res = await getValue(ADDRESS, id);
+export async function getProduct(storeId: string = '', id: string): Promise<Product | null> {
+  const res = await getValue(ADDRESS, `${storeId}:${id}`);
   if (!res) return null;
   const parsed = JSON.parse(res) as Product;
   return {
@@ -19,10 +19,10 @@ export async function getProduct(id: string): Promise<Product | null> {
   };
 }
 
-export async function setProduct(product: Product) {
+export async function setProduct(storeId: string = '', product: Product) {
   await setValue(
     ADDRESS,
-    product.id,
+    `${storeId}:${product.id}`,
     JSON.stringify({
       ...product,
       pricingTier: product.pricingTier,
@@ -32,35 +32,37 @@ export async function setProduct(product: Product) {
   );
 }
 
-export async function removeProduct(id: string) {
-  await removeValue(ADDRESS, id);
+export async function removeProduct(storeId: string = '', id: string) {
+  await removeValue(ADDRESS, `${storeId}:${id}`);
 }
 
-export async function listProducts(): Promise<Product[]> {
+export async function listProducts(storeId: string = ''): Promise<Product[]> {
   const items = await listValues(ADDRESS);
-  return items.map((i) => {
-    const parsed = JSON.parse(i.value) as Product;
-    return {
-      ...parsed,
-      pricingTier: parsed.pricingTier,
-      variants: parsed.variants || [],
-      colors: parsed.colors || [],
-    };
-  });
+  return items
+    .filter((i) => i.key.startsWith(`${storeId}:`))
+    .map((i) => {
+      const parsed = JSON.parse(i.value) as Product;
+      return {
+        ...parsed,
+        pricingTier: parsed.pricingTier,
+        variants: parsed.variants || [],
+        colors: parsed.colors || [],
+      };
+    });
 }
 
-export async function getProducts(ids: string[]): Promise<Product[]> {
+export async function getProducts(storeId: string = '', ids: string[]): Promise<Product[]> {
   const res: Product[] = [];
   for (const id of ids) {
-    const prod = await getProduct(id);
+    const prod = await getProduct(storeId, id);
     if (prod) res.push(prod);
   }
   return res;
 }
 
-export async function setProductBatch(products: Product[]) {
+export async function setProductBatch(storeId: string = '', products: Product[]) {
   for (const p of products) {
-    await setProduct(p);
+    await setProduct(storeId, p);
   }
 }
 

--- a/services/tonStores.ts
+++ b/services/tonStores.ts
@@ -6,20 +6,22 @@ const ADDRESS =
   config.TON_STORES_ADDRESS ??
   'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 
-export async function getStore(id: string): Promise<Store | null> {
-  const res = await getValue(ADDRESS, id);
+export async function getStore(storeId: string = '', id: string): Promise<Store | null> {
+  const res = await getValue(ADDRESS, `${storeId}:${id}`);
   return res ? (JSON.parse(res) as Store) : null;
 }
 
-export async function setStore(store: Store) {
-  await setValue(ADDRESS, store.id, JSON.stringify(store));
+export async function setStore(storeId: string = '', store: Store) {
+  await setValue(ADDRESS, `${storeId}:${store.id}`, JSON.stringify(store));
 }
 
-export async function removeStore(id: string) {
-  await removeValue(ADDRESS, id);
+export async function removeStore(storeId: string = '', id: string) {
+  await removeValue(ADDRESS, `${storeId}:${id}`);
 }
 
-export async function listStores(): Promise<Store[]> {
+export async function listStores(storeId: string = ''): Promise<Store[]> {
   const items = await listValues(ADDRESS);
-  return items.map((i) => JSON.parse(i.value) as Store);
+  return items
+    .filter((i) => i.key.startsWith(`${storeId}:`))
+    .map((i) => JSON.parse(i.value) as Store);
 }

--- a/tests/storeIsolation.test.ts
+++ b/tests/storeIsolation.test.ts
@@ -1,0 +1,51 @@
+import { setProduct, listProducts } from '../services/tonProducts';
+import { setOrder, listOrders } from '../services/tonOrders';
+import { setStore, listStores } from '../services/tonStores';
+import { Product, Order, Store, ShippingAddress } from '../types';
+
+jest.mock('../services/tonKvStore', () => {
+  const store = new Map<string, string>();
+  return {
+    setValue: async (_addr: string, key: string, value: string) => {
+      if (value) store.set(key, value); else store.delete(key);
+    },
+    getValue: async (_addr: string, key: string) => store.get(key) || null,
+    listValues: async (_addr: string) => Array.from(store.entries()).map(([key, value]) => ({ key, value })),
+    removeValue: async (_addr: string, key: string) => { store.delete(key); },
+  };
+});
+
+describe('store data isolation', () => {
+  it('separates products by storeId', async () => {
+    const base: Omit<Product, 'id'> = { name: '', price: 1, description: '', category: '', images: [], rating: 0, reviews: 0, stock: 1, storeId: '' };
+    await setProduct('s1', { ...base, id: 'p1', storeId: 's1' });
+    await setProduct('s2', { ...base, id: 'p2', storeId: 's2' });
+    const s1 = await listProducts('s1');
+    const s2 = await listProducts('s2');
+    expect(s1.map(p => p.id)).toEqual(['p1']);
+    expect(s2.map(p => p.id)).toEqual(['p2']);
+  });
+
+  it('separates orders by storeId', async () => {
+    const addr: ShippingAddress = { name: 'n', phone: 'p', street: 's', city: 'c', postalCode: 'z' };
+    const o1: Order = { id: 'o1', userId: 'u', items: [], total: 0, status: 'order_received', shippingAddress: addr, itemsHash: '', createdAt: '', updatedAt: '', trackingSteps: [] } as Order;
+    const o2: Order = { ...o1, id: 'o2' };
+    await setOrder('s1', o1);
+    await setOrder('s2', o2);
+    const l1 = await listOrders('s1');
+    const l2 = await listOrders('s2');
+    expect(l1.map(o => o.id)).toEqual(['o1']);
+    expect(l2.map(o => o.id)).toEqual(['o2']);
+  });
+
+  it('separates stores by storeId', async () => {
+    const s1: Store = { id: 'a', name: 'A', owner: '', nftId: '' };
+    const s2: Store = { id: 'b', name: 'B', owner: '', nftId: '' };
+    await setStore('s1', s1);
+    await setStore('s2', s2);
+    const l1 = await listStores('s1');
+    const l2 = await listStores('s2');
+    expect(l1.map(s => s.id)).toEqual(['a']);
+    expect(l2.map(s => s.id)).toEqual(['b']);
+  });
+});


### PR DESCRIPTION
## Summary
- namespace product, order and store entries by storeId
- propagate storeId through agents
- add tests verifying per-store isolation

## Testing
- `npm test` *(fails: Invalid project root: /workspace/blue-ocean/lint)*

------
https://chatgpt.com/codex/tasks/task_e_68adffc5cc708326b17746e8e67b68b5