### PR TITLE
feat: add store owner role and gating

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -31,7 +31,7 @@ export default function CategoriesScreen() {
     icon: '',
   });
   const [loading, setLoading] = useState(true);
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const NUM_COLUMNS = 2;
   const ITEM_HEIGHT = 176;
@@ -188,7 +188,7 @@ export default function CategoriesScreen() {
         {item.name}
       </Text>
 
-      {isAdmin && (
+      {isStoreOwner && (
         <View style={styles.adminActions}>
           <TouchableOpacity
             style={styles.adminActionButton}
@@ -221,7 +221,7 @@ export default function CategoriesScreen() {
             קטגוריות
           </Text>
           <View style={styles.headerActions}>
-            {isAdmin && (
+      {isStoreOwner && (
               <TouchableOpacity
                 style={[styles.addButton, { backgroundColor: colors.gold }]}
                 onPress={addCategory}
@@ -253,7 +253,7 @@ export default function CategoriesScreen() {
           קטגוריות
         </Text>
         <View style={styles.headerActions}>
-          {isAdmin && (
+          {isStoreOwner && (
             <TouchableOpacity
               style={[styles.addButton, { backgroundColor: colors.gold }]}
               onPress={addCategory}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -73,7 +73,7 @@ export default function HomeScreen() {
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
     buttonText: undefined as string | undefined,
   });
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { t } = useLanguage();
   const { colors } = useTheme();
   const bannerScrollRef = useRef<ScrollView>(null);
@@ -255,7 +255,7 @@ export default function HomeScreen() {
       <Text style={[styles.categoryName, { color: colors.text.primary }]}>
         {item.name}
       </Text>
-      {isAdmin && (
+      {isStoreOwner && (
         <View style={styles.categoryAdminActions}>
           <TouchableOpacity
             style={[
@@ -312,7 +312,7 @@ export default function HomeScreen() {
         </View>
       </TouchableOpacity>
 
-      {isAdmin && (
+      {isStoreOwner && (
         <View style={styles.bannerAdminActions}>
           <TouchableOpacity
             style={styles.bannerAdminButton}
@@ -489,7 +489,7 @@ export default function HomeScreen() {
         {/* Hero Banner Carousel */}
         <View style={styles.bannerContainer}>
           <View style={styles.bannerHeader}>
-            {isAdmin && (
+            {isStoreOwner && (
               <TouchableOpacity
                 style={[
                   styles.addBannerButton,
@@ -548,10 +548,10 @@ export default function HomeScreen() {
               icon={Plus}
               title={t('home.noBanners')}
               message={
-                isAdmin ? t('home.addBanners') : t('home.bannersComingSoon')
+                isStoreOwner ? t('home.addBanners') : t('home.bannersComingSoon')
               }
-              actionText={isAdmin ? t('banner.addBanner') : undefined}
-              onAction={isAdmin ? addBanner : undefined}
+              actionText={isStoreOwner ? t('banner.addBanner') : undefined}
+              onAction={isStoreOwner ? addBanner : undefined}
             />
           )}
         </View>
@@ -614,7 +614,7 @@ export default function HomeScreen() {
                   {getSortLabel()}
                 </Text>
               </TouchableOpacity>
-              {isAdmin && (
+              {isStoreOwner && (
                 <TouchableOpacity
                   style={[
                     styles.addProductButton,
@@ -643,7 +643,7 @@ export default function HomeScreen() {
                 >
                   <ProductCard
                     product={item}
-                    isAdmin={isAdmin}
+                    isOwner={isStoreOwner}
                     onEdit={editProduct}
 
                     subcategoryName={
@@ -665,8 +665,8 @@ export default function HomeScreen() {
                   ? t('home.tryDifferentSearch')
                   : t('home.productsComingSoon')
               }
-              actionText={isAdmin && !searchQuery ? 'הוסף מוצר' : undefined}
-              onAction={isAdmin && !searchQuery ? addProduct : undefined}
+              actionText={isStoreOwner && !searchQuery ? 'הוסף מוצר' : undefined}
+              onAction={isStoreOwner && !searchQuery ? addProduct : undefined}
             />
           )}
         </View>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -43,7 +43,7 @@ import DatabaseService from '../../services/database';
 const NOTIFICATIONS_STORAGE_KEY = 'settings_notifications';
 
 export default function ProfileScreen() {
-  const { isLoggedIn, isAdmin, isDriver, user, logout } = useAuth();
+  const { isLoggedIn, isStoreOwner, isDriver, user, logout } = useAuth();
   const { t, currentLanguage, setLanguage } = useLanguage();
   const { theme, toggleTheme, colors } = useTheme();
   const { appName } = useAppInfo();
@@ -180,12 +180,12 @@ export default function ProfileScreen() {
           </Text>
           <Text style={[styles.userEmail, { color: colors.text.secondary }]}>
             {isLoggedIn
-              ? isAdmin
+              ? isStoreOwner
                 ? t('profile.admin')
                 : t('profile.customer')
               : t('profile.guestBrowsing')}
           </Text>
-          {isAdmin && (
+          {isStoreOwner && (
             <View style={[styles.adminBadge, { backgroundColor: colors.gold }]}>
               <Shield size={16} color={colors.text.inverse} />
               <Text
@@ -271,7 +271,7 @@ export default function ProfileScreen() {
         )}
 
         {/* Admin Menu */}
-        {isLoggedIn && isAdmin && (
+        {isLoggedIn && isStoreOwner && (
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
               ניהול
@@ -333,7 +333,7 @@ export default function ProfileScreen() {
         )}
 
         {/* Driver Menu */}
-        {isLoggedIn && (isDriver || isAdmin) && (
+        {isLoggedIn && (isDriver || isStoreOwner) && (
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
               נהג

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -44,7 +44,7 @@ export default function AdminDashboardScreen() {
     storeReputation: 0
   });
   const { showNotification } = useNotifications();
-  const { isAdmin, isDriver, user } = useAuth();
+  const { isStoreOwner, user } = useAuth();
   const { openAuthModal } = useAuthModal();
   const { colors } = useTheme();
 
@@ -58,14 +58,14 @@ export default function AdminDashboardScreen() {
 
   useEffect(() => {
     // Check if user is logged in as admin
-    if (!isAdmin && !isDriver) {
+    if (!isStoreOwner) {
       openAuthModal('login');
       router.replace('/');
       return;
     }
 
     loadData();
-  }, [isAdmin, isDriver]);
+  }, [isStoreOwner]);
 
   const loadData = async () => {
     try {

--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -23,7 +23,7 @@ import commonStyles from '../../constants/styles';
 import SmartImage from '../../components/SmartImage';
 
 export default function AdminDeliveriesScreen() {
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const [jobs, setJobs] = useState<DeliveryJob[]>([]);
   const [drivers, setDrivers] = useState<User[]>([]);
@@ -39,12 +39,12 @@ export default function AdminDeliveriesScreen() {
   // const matrixService = MatrixService.getInstance(); // TODO: re-enable Matrix later
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!isStoreOwner) {
       router.replace('/');
       return;
     }
     loadData();
-  }, [isAdmin]);
+  }, [isStoreOwner]);
 
   const loadData = async () => {
     try {

--- a/app/admin/user-management.tsx
+++ b/app/admin/user-management.tsx
@@ -17,7 +17,7 @@ import { ArrowLeft, Search, User, Mail, Calendar, Shield, UserCheck, UserX, Filt
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
-import { User as UserType, CustomerTier } from '../../types';
+import { User as UserType, CustomerTier, UserRole } from '../../types';
 import { useNotifications } from '../../components/NotificationContext';
 import commonStyles from '../../constants/styles';
 
@@ -28,7 +28,7 @@ export default function UserManagementScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserType | null>(null);
-  const [editedRole, setEditedRole] = useState<'user' | 'driver' | 'admin'>('user');
+  const [editedRole, setEditedRole] = useState<UserRole>('user');
   const [editedTier, setEditedTier] = useState<CustomerTier>('new');
   const [showRoleDropdown, setShowRoleDropdown] = useState(false);
   const [showTierDropdown, setShowTierDropdown] = useState(false);
@@ -103,7 +103,7 @@ export default function UserManagementScreen() {
 
   const openEditModal = (user: UserType) => {
     setSelectedUser(user);
-    setEditedRole(user.role as 'user' | 'driver' | 'admin' || 'user');
+    setEditedRole((user.role as UserRole) || 'user');
     setEditedTier(user.customerTier || 'new');
     setShowEditModal(true);
   };
@@ -246,17 +246,22 @@ export default function UserManagementScreen() {
         
         <View style={styles.userBadges}>
           {user.role === 'admin' && (
-            <View style={[styles.roleBadge, { backgroundColor: colors.gold }]}>
+            <View style={[styles.roleBadge, { backgroundColor: colors.gold }]}> 
               <Text style={[styles.roleBadgeText, { color: colors.text.inverse }]}>מנהל</Text>
             </View>
           )}
           {user.role === 'driver' && (
-            <View style={[styles.roleBadge, { backgroundColor: colors.status.info }]}>
+            <View style={[styles.roleBadge, { backgroundColor: colors.status.info }]}> 
               <Text style={[styles.roleBadgeText, { color: colors.text.inverse }]}>נהג</Text>
             </View>
           )}
-          
-          <View style={[styles.tierBadge, { backgroundColor: getCustomerTierColor(user.customerTier) }]}>
+          {user.role === 'store-owner' && (
+            <View style={[styles.roleBadge, { backgroundColor: colors.status.warning }]}> 
+              <Text style={[styles.roleBadgeText, { color: colors.text.inverse }]}>בעל חנות</Text>
+            </View>
+          )}
+
+          <View style={[styles.tierBadge, { backgroundColor: getCustomerTierColor(user.customerTier) }]}> 
             <Text style={[styles.tierBadgeText, { color: colors.text.inverse }]}>
               {getCustomerTierLabel(user.customerTier)}
             </Text>
@@ -350,7 +355,13 @@ export default function UserManagementScreen() {
             {filterRole && (
               <View style={[styles.activeFilterChip, { backgroundColor: colors.interactive.secondary }]}>
                 <Text style={[styles.activeFilterText, { color: colors.text.primary }]}>
-                  תפקיד: {filterRole === 'admin' ? 'מנהל' : filterRole === 'driver' ? 'נהג' : 'משתמש'}
+                  תפקיד: {filterRole === 'admin'
+                    ? 'מנהל'
+                    : filterRole === 'driver'
+                    ? 'נהג'
+                    : filterRole === 'store-owner'
+                    ? 'בעל חנות'
+                    : 'משתמש'}
                 </Text>
                 <TouchableOpacity onPress={() => setFilterRole(null)}>
                   <X size={14} color={colors.text.primary} />
@@ -400,11 +411,11 @@ export default function UserManagementScreen() {
             <Text style={[styles.statLabel, { color: colors.text.secondary }]}>סה"כ משתמשים</Text>
           </View>
           
-          <View style={[styles.statCard, { 
+          <View style={[styles.statCard, {
             backgroundColor: colors.surface.primary,
-            borderColor: colors.border.primary 
-          }]}>
-            <Text style={[styles.statNumber, { color: colors.text.primary }]}>
+            borderColor: colors.border.primary
+          }]}> 
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}> 
               {users.filter(u => u.role === 'admin').length}
             </Text>
             <Text style={[styles.statLabel, { color: colors.text.secondary }]}>מנהלים</Text>
@@ -412,11 +423,20 @@ export default function UserManagementScreen() {
           <View style={[styles.statCard, {
             backgroundColor: colors.surface.primary,
             borderColor: colors.border.primary
-          }]}>
-            <Text style={[styles.statNumber, { color: colors.text.primary }]}>
+          }]}> 
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}> 
               {users.filter(u => u.role === 'driver').length}
             </Text>
             <Text style={[styles.statLabel, { color: colors.text.secondary }]}>נהגים</Text>
+          </View>
+          <View style={[styles.statCard, {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.border.primary
+          }]}> 
+            <Text style={[styles.statNumber, { color: colors.text.primary }]}> 
+              {users.filter(u => u.role === 'store-owner').length}
+            </Text>
+            <Text style={[styles.statLabel, { color: colors.text.secondary }]}>בעלי חנויות</Text>
           </View>
 
           <View style={[styles.statCard, {
@@ -527,8 +547,14 @@ export default function UserManagementScreen() {
                     }]}
                     onPress={() => setShowRoleDropdown(!showRoleDropdown)}
                   >
-                    <Text style={[styles.dropdownText, { color: colors.text.primary }]}>
-                      {editedRole === 'admin' ? 'מנהל' : editedRole === 'driver' ? 'נהג' : 'משתמש רגיל'}
+                    <Text style={[styles.dropdownText, { color: colors.text.primary }]}> 
+                      {editedRole === 'admin'
+                        ? 'מנהל'
+                        : editedRole === 'driver'
+                        ? 'נהג'
+                        : editedRole === 'store-owner'
+                        ? 'בעל חנות'
+                        : 'משתמש רגיל'}
                     </Text>
                     <ChevronDown size={20} color={colors.text.secondary} />
                   </TouchableOpacity>
@@ -573,6 +599,18 @@ export default function UserManagementScreen() {
                         }}
                       >
                         <Text style={[styles.dropdownItemText, { color: colors.text.primary }]}>מנהל</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[
+                          styles.dropdownItem,
+                          editedRole === 'store-owner' && { backgroundColor: colors.interactive.secondary }
+                        ]}
+                        onPress={() => {
+                          setEditedRole('store-owner');
+                          setShowRoleDropdown(false);
+                        }}
+                      >
+                        <Text style={[styles.dropdownItemText, { color: colors.text.primary }]}>בעל חנות</Text>
                       </TouchableOpacity>
                     </View>
                   )}
@@ -737,6 +775,17 @@ export default function UserManagementScreen() {
                 >
                   <Text style={[styles.filterOptionText, { color: colors.text.primary }]}>מנהלים</Text>
                   {filterRole === 'admin' && <View style={[styles.filterSelectedDot, { backgroundColor: colors.gold }]} />}
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.filterOption,
+                    { borderBottomColor: colors.border.secondary },
+                    filterRole === 'store-owner' && { backgroundColor: colors.interactive.secondary }
+                  ]}
+                  onPress={() => setFilterRole('store-owner')}
+                >
+                  <Text style={[styles.filterOptionText, { color: colors.text.primary }]}>בעלי חנויות</Text>
+                  {filterRole === 'store-owner' && <View style={[styles.filterSelectedDot, { backgroundColor: colors.gold }]} />}
                 </TouchableOpacity>
               </View>
 

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -35,7 +35,7 @@ export default function CategoryScreen() {
     categoryId: id || ''
   });
   const [loading, setLoading] = useState(true);
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
 
   // Modal states
@@ -194,7 +194,7 @@ export default function CategoryScreen() {
       </View>
       <Text style={[styles.subcategoryName, { color: colors.text.primary }]}>{item.name}</Text>
       
-      {isAdmin && (
+      {isStoreOwner && (
         <View style={styles.adminActions}>
           <TouchableOpacity 
             style={styles.adminActionButton}
@@ -247,7 +247,7 @@ export default function CategoryScreen() {
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{category.name}</Text>
         <View style={styles.headerActions}>
-          {isAdmin && (
+          {isStoreOwner && (
             <TouchableOpacity style={[styles.addButton, { backgroundColor: colors.gold }]} onPress={addSubcategory}>
               <Plus size={20} color={colors.text.inverse} />
             </TouchableOpacity>
@@ -269,9 +269,9 @@ export default function CategoryScreen() {
             <Text style={styles.emptyIcon}>{category.icon}</Text>
             <Text style={[styles.emptyTitle, { color: colors.text.primary }]}>אין תת-קטגוריות</Text>
             <Text style={[styles.emptyText, { color: colors.text.secondary }]}>
-              {isAdmin ? 'הוסף תת-קטגוריות כדי להתחיל' : 'תת-קטגוריות יתווספו בקרוב'}
+              {isStoreOwner ? 'הוסף תת-קטגוריות כדי להתחיל' : 'תת-קטגוריות יתווספו בקרוב'}
             </Text>
-            {isAdmin && (
+            {isStoreOwner && (
               <TouchableOpacity style={[styles.emptyButton, { backgroundColor: colors.gold }]} onPress={addSubcategory}>
                 <Plus size={20} color={colors.text.inverse} />
                 <Text style={[styles.emptyButtonText, { color: colors.text.inverse }]}>הוסף תת-קטגוריה</Text>

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -73,7 +73,7 @@ export default function ProductDetailScreen() {
   const [isFavorite, setIsFavorite] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const [videoThumbnails, setVideoThumbnails] = useState<Record<string, string>>({});
@@ -460,7 +460,7 @@ export default function ProductDetailScreen() {
                 fill={isFavorite ? colors.status.error : 'transparent'}
               />
             </TouchableOpacity>
-            {isAdmin && (
+            {isStoreOwner && (
               <TouchableOpacity
                 style={[
                   styles.headerButton,

--- a/app/store/[storeId]/products.tsx
+++ b/app/store/[storeId]/products.tsx
@@ -7,6 +7,7 @@ import { Product } from '../../../types';
 import ProductCard from '../../../components/ProductCard';
 import ProductFormModal from '../../../components/ProductFormModal';
 import { useTonAddress } from '../../../services/tonAuth';
+import { useAuth } from '../../../components/AuthContext';
 
 const ITEM_HEIGHT = 200;
 
@@ -17,15 +18,16 @@ export default function StoreProductsScreen() {
   const [formVisible, setFormVisible] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const address = useTonAddress();
+  const { isStoreOwner } = useAuth();
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || address !== storeId) return;
+      if (!storeId || !isStoreOwner || address !== storeId) return;
       const all = await listProducts();
       setProducts(all.filter((p) => p.storeId === storeId));
     };
     load();
-  }, [storeId, address]);
+  }, [storeId, address, isStoreOwner]);
 
   const openForm = (p?: Product) => {
     setEditingProduct(p || null);
@@ -44,7 +46,7 @@ export default function StoreProductsScreen() {
     setProducts((prev) => prev.filter((p) => p.id !== productId));
   };
 
-  if (address !== storeId) {
+  if (!isStoreOwner || address !== storeId) {
     return (
       <View
         style={[
@@ -76,7 +78,7 @@ export default function StoreProductsScreen() {
           <TouchableOpacity style={{ marginBottom: 12 }}>
             <ProductCard
               product={p}
-              isAdmin
+              isOwner
               onEdit={() => openForm(p)}
               onDelete={(id) => handleDeleted(id)}
             />

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -67,7 +67,7 @@ export default function SubcategoryScreen() {
   const [confirmDeleteVisible, setConfirmDeleteVisible] = useState(false);
   const [showSubcategoryEditModal, setShowSubcategoryEditModal] = useState(false);
   const [editSubcategoryData, setEditSubcategoryData] = useState<Partial<Subcategory>>({name: "", icon: ""});
-  const { isAdmin } = useAuth();
+  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
@@ -454,7 +454,7 @@ export default function SubcategoryScreen() {
         </TouchableOpacity>
 
         {/* Admin Actions */}
-        {isAdmin && (
+        {isStoreOwner && (
           <View style={styles.adminActions}>
             <TouchableOpacity 
               style={styles.adminActionButton}
@@ -540,7 +540,7 @@ export default function SubcategoryScreen() {
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{subcategory.name}</Text>
         <View style={styles.headerActions}>
-          {isAdmin && (
+          {isStoreOwner && (
             <>
               <TouchableOpacity
                 style={[styles.addButton, { backgroundColor: colors.gold }]}
@@ -573,9 +573,9 @@ export default function SubcategoryScreen() {
             <Text style={styles.emptyIcon}>{subcategory.icon}</Text>
             <Text style={[styles.emptyTitle, { color: colors.text.primary }]}>אין מוצרים עדיין</Text>
             <Text style={[styles.emptyText, { color: colors.text.secondary }]}>
-              {isAdmin ? 'הוסף מוצרים כדי להתחיל' : 'אנחנו עובדים על הוספת מוצרים לקטגוריה זו'}
+              {isStoreOwner ? 'הוסף מוצרים כדי להתחיל' : 'אנחנו עובדים על הוספת מוצרים לקטגוריה זו'}
             </Text>
-            {isAdmin && (
+            {isStoreOwner && (
               <TouchableOpacity style={[styles.emptyButton, { backgroundColor: colors.gold }]} onPress={addProduct}>
                 <Plus size={20} color={colors.text.inverse} />
                 <Text style={[styles.emptyButtonText, { color: colors.text.inverse }]}>הוסף מוצר</Text>

--- a/components/AuthContext.tsx
+++ b/components/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthContextType {
   isLoggedIn: boolean;
   isAdmin: boolean;
   isDriver: boolean;
+  isStoreOwner: boolean;
   user: User | null;
   loading: boolean;
   login: () => Promise<void>;
@@ -26,6 +27,7 @@ const AuthContext = createContext<AuthContextType>({
   isLoggedIn: false,
   isAdmin: false,
   isDriver: false,
+  isStoreOwner: false,
   user: null,
   loading: false,
   login: async () => {},
@@ -108,6 +110,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const role = user?.role;
   const isAdmin = role === 'admin';
   const isDriver = role === 'driver';
+  const isStoreOwner = role === 'store-owner';
 
   if (!connectionRestored) {
     return null;
@@ -119,6 +122,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         isLoggedIn: !!address,
         isAdmin,
         isDriver,
+        isStoreOwner,
         user,
         loading: false,
         login,

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -22,7 +22,7 @@ import Card from './Card';
 
 interface ProductCardProps {
   product: Product;
-  isAdmin?: boolean;
+  isOwner?: boolean;
   onEdit?: (product: Product) => void;
   onDelete?: (productId: string) => void;
 
@@ -33,7 +33,7 @@ interface ProductCardProps {
 
 export default function ProductCard({
   product,
-  isAdmin = false,
+  isOwner = false,
   onEdit,
   onDelete,
 
@@ -53,7 +53,7 @@ export default function ProductCard({
   const selectedVariant = variants[selectedVariantIndex];
   const stock = selectedVariant ? selectedVariant.stock : product.stock;
 
-  if (isAdmin && address && product.storeId !== address) {
+  if (isOwner && address && product.storeId !== address) {
     return null;
   }
 
@@ -203,8 +203,8 @@ export default function ProductCard({
           <ShoppingCart size={16} color={colors.text.inverse} />
         </TouchableOpacity>
 
-        {/* Admin Actions */}
-        {isAdmin && (
+        {/* Owner Actions */}
+        {isOwner && (
           <View style={styles.adminActions}>
             <TouchableOpacity style={styles.adminButton} onPress={handleEdit}>
               <Pencil size={12} color="#FFFFFF" />

--- a/services/database.ts
+++ b/services/database.ts
@@ -23,6 +23,7 @@ import {
   WishlistItem,
   CustomerTier,
   KycStatus,
+  UserRole,
 } from '../types';
 
 const CHAT_MESSAGE_LIMIT = 50;
@@ -80,7 +81,7 @@ class DatabaseService {
 
   async updateUserRole(
     userId: string,
-    role: 'user' | 'driver' | 'admin',
+    role: UserRole,
   ): Promise<void> {
     const user = await this.getUserProfile(userId);
     if (!user) return;

--- a/types/index.ts
+++ b/types/index.ts
@@ -123,6 +123,7 @@ export interface ChatRoom {
 
 export type KycStatus = 'none' | 'pending' | 'verified' | 'rejected';
 export type CustomerTier = 'new' | 'regular' | 'vip' | 'banned';
+export type UserRole = 'user' | 'driver' | 'admin' | 'store-owner';
 
 export interface User {
   id: string;
@@ -134,7 +135,7 @@ export interface User {
   passwordHash?: string;
   avatar?: string;
   email?: string;
-  role?: string;
+  role?: UserRole;
   publicKey?: string;
   chatPublicKey?: string;
   address?: string;


### PR DESCRIPTION
## Summary
- extend user roles to include `store-owner`
- expose `isStoreOwner` via `AuthContext` and use it to gate management routes
- render product and category management actions only for store owners

## Testing
- `yarn test` *(fails: Invalid project root: /workspace/blue-ocean/lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2c7749c883269294cc3d310c221e