### PR TITLE
docs: outline architecture and route roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ memory, and hydrate from message history on boot. Configuration such as debug lo
 Waku bootstrap peers can be customized through `EXPO_PUBLIC_*` environment variables, but
 defaults are provided for a zero‑config experience.
 
+See [docs/architecture.md](docs/architecture.md) for a high-level architecture overview and [docs/routes.md](docs/routes.md) for route and role details.
+
 ## Quickstart
 
 Use **Yarn** for dependency management and running scripts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,30 @@
+# Architecture
+
+## Service Boundaries
+- **settings-agent** – subscribes to `/blue-ocean/settings/1`, validates admin senders, and updates in-memory config.
+- **users-agent** – listens on `/blue-ocean/users/1` to register users and roles, rejecting unauthenticated or duplicate roles.
+- **products-agent** – watches `/blue-ocean/products/1` for admin-signed product changes and hydrates the catalog.
+- **orders-agent** – processes `/blue-ocean/orders/1` messages when the sender matches the order user and keeps an ephemeral history.
+- **notifications-agent** – forwards order events to `/blue-ocean/notifications/1` and persists user notifications locally.
+- **review-agent** – distributes reviews on `/blue-ocean/reviews/1`, verifies they relate to completed orders, and updates reputation.
+
+## Peer-to-Peer Data Flow
+Blue Ocean operates entirely peer-to-peer over the Waku network. Each domain uses a dedicated topic:
+
+| Topic | Purpose |
+|-------|---------|
+| `/blue-ocean/settings/1` | Store configuration |
+| `/blue-ocean/users/1` | Registered users and roles |
+| `/blue-ocean/products/1` | Product catalog |
+| `/blue-ocean/stores/1` | Store registry |
+| `/blue-ocean/orders/1` | Orders and status updates |
+| `/blue-ocean/notifications/1` | System notifications |
+| `/blue-ocean/reviews/1` | Product reviews |
+| `/blue-ocean/analytics/1` | Anonymous analytics events |
+| `/blue-ocean/chat/1/<roomId>` | Encrypted buyer/seller chat |
+
+Messages on these topics are signed and may be encrypted, and agents hydrate their state from message history on boot.
+
+## Fee Handling
+Network settings store a fee address and basis points (`feeBps`) that define the protocol fee.
+The `OrderPayment` smart contract calculates `fee = amount * feeBps / 10000` when releasing funds, sending the fee to the configured address and the remainder to the seller.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,33 @@
+# Routes
+
+## Public
+| Path | Role requirement |
+|------|------------------|
+| `/` | none |
+| `/storefront` | none |
+| `/store/[storeId]` | none |
+| `/product/[id]` | none |
+| `/category/[id]` | none |
+| `/orders/[id]` | buyer, seller, or driver to update |
+| `/driver-dashboard` | driver or admin |
+
+## Store
+| Path | Role requirement |
+|------|------------------|
+| `/stores/create` | wallet connection required |
+| `/store/[storeId]/dashboard` | store owner of `[storeId]` |
+| `/store/[storeId]/products` | store owner of `[storeId]` |
+| `/store/[storeId]/orders` | store owner of `[storeId]` |
+
+## Admin
+| Path | Role requirement |
+|------|------------------|
+| `/admin` | admin |
+| `/admin/dashboard` | admin |
+| `/admin/kyc-approvals` | admin |
+| `/admin/user-management` | admin |
+| `/admin/pricing-tiers` | admin |
+| `/admin/deliveries` | admin |
+| `/admin/bulk-upload` | admin |
+| `/admin/disputes` | admin |
+| `/admin/settings` | admin |


### PR DESCRIPTION
## Summary
- add architecture overview detailing agent boundaries, Waku data flow, and fee handling
- document public, store, and admin routes with role requirements
- link new docs from the README for quick discovery

## Testing
- `yarn lint` *(fails: Invalid project root: /workspace/blue-ocean/lint)*
- `yarn typecheck` *(fails: TS1005 '>' expected in tests/reputation.test.ts:96)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47df24f88326a9102664ed11b491