### PR TITLE
feat: compute card fees and support MoonPay parameters

### DIFF
--- a/components/MoonPayModal.tsx
+++ b/components/MoonPayModal.tsx
@@ -23,12 +23,17 @@ export default function MoonPayModal({
   amountTON,
 }: MoonPayModalProps) {
   const { colors } = useTheme();
-  const { fiatKey } = useAppInfo();
+  const { fiatKey, feeAddress, feeBps } = useAppInfo();
   const [loading, setLoading] = useState(true);
 
   if (!fiatKey) return null;
 
-  const url = `https://buy.moonpay.com?apiKey=${fiatKey}&currencyCode=${coin}&walletAddress=${walletAddress}&baseCurrencyCode=usd`;
+  const feeParams =
+    feeAddress && typeof feeBps === 'number'
+      ? `&feeAddress=${encodeURIComponent(feeAddress)}&feeBps=${feeBps}`
+      : '';
+  const url =
+    `https://buy.moonpay.com?apiKey=${fiatKey}&currencyCode=${coin}&walletAddress=${walletAddress}&baseCurrencyCode=usd${feeParams}`;
 
   let injectedJavaScript: string | undefined;
   if (typeof amountTON === 'number') {

--- a/payments/card.ts
+++ b/payments/card.ts
@@ -1,0 +1,13 @@
+import { getFeeSettings } from '@/constants/tenant';
+
+export interface CardFees {
+  platformFee: number;
+  sellerPayout: number;
+}
+
+export async function calculateCardFees(total: number): Promise<CardFees> {
+  const { feeBps } = await getFeeSettings();
+  const fee = Number(((total * feeBps) / 10000).toFixed(2));
+  const payout = Number((total - fee).toFixed(2));
+  return { platformFee: fee, sellerPayout: payout };
+}

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -15,6 +15,7 @@ import { getProduct, setProduct } from './tonProducts';
 import tonAuth from './tonAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
 import config from '../utils/appConfig';
+import { calculateCardFees } from '@/payments/card';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
@@ -110,7 +111,7 @@ class OrderService {
     items: CartItem[],
     shippingAddress: ShippingAddress,
     payment?: {
-      method?: 'cash_on_delivery' | 'ton';
+      method?: 'cash_on_delivery' | 'ton' | 'card';
       contractAddress?: string;
       txHash?: string;
       buyerAddress?: string;
@@ -140,6 +141,9 @@ class OrderService {
     const itemsHash = Buffer.from(
       sha256(Buffer.from(JSON.stringify(items)))
     ).toString('hex');
+    const feeInfo =
+      pay?.method === 'card' ? await calculateCardFees(total) : undefined;
+
     const order: Order = {
       id: orderId,
       userId,
@@ -157,6 +161,8 @@ class OrderService {
       createdAt: timestamp,
       updatedAt: timestamp,
       trackingSteps: this.getTrackingSteps('order_received'),
+      platformFee: feeInfo?.platformFee,
+      sellerPayout: feeInfo?.sellerPayout,
     };
 
     await ordersAgent.add(order);
@@ -169,7 +175,7 @@ class OrderService {
     userId: string,
     cartItems: CartItem[],
     shippingAddress: ShippingAddress,
-    paymentMethod: 'cash_on_delivery' | 'ton' = 'cash_on_delivery',
+    paymentMethod: 'cash_on_delivery' | 'ton' | 'card' = 'cash_on_delivery',
   ): Promise<Order[]> {
     const grouped: Record<string, CartItem[]> = {};
     for (const item of cartItems) {
@@ -185,6 +191,12 @@ class OrderService {
         paymentMethod === 'ton'
           ? {
               method: 'ton' as const,
+              buyerAddress: tonAuth.getAddress() || undefined,
+              sellerAddress: store?.owner,
+            }
+          : paymentMethod === 'card'
+          ? {
+              method: 'card' as const,
               buyerAddress: tonAuth.getAddress() || undefined,
               sellerAddress: store?.owner,
             }

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -1,0 +1,104 @@
+import OrderService from '../services/orders';
+import { CartItem, ShippingAddress } from '../types';
+
+const mockStore: Record<string, any> = {};
+const mockProducts: Record<string, any> = {};
+
+jest.mock('../services/tonOrders', () => ({
+  setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
+  getOrder: jest.fn(async (id: string) => mockStore[id] || null),
+  listOrders: jest.fn().mockResolvedValue([]),
+  removeOrder: jest.fn(),
+  listOrdersBySeller: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../services/eventBus', () => ({ publish: jest.fn() }));
+
+jest.mock('../services/tonContract', () => ({
+  deployOrderPayment: jest.fn(),
+  releasePayment: jest.fn(),
+  refundPayment: jest.fn(),
+}));
+
+jest.mock('../services/tonStores', () => ({
+  getStore: jest.fn(async (id: string) => ({ id, name: id, owner: `seller_${id}`, nftId: id })),
+}));
+
+jest.mock('../services/tonProducts', () => ({
+  getProduct: jest.fn(async (id: string) => mockProducts[id] || null),
+  setProduct: jest.fn(async (p: any) => {
+    mockProducts[p.id] = p;
+  }),
+}));
+
+jest.mock('../services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+
+jest.mock('../agents/orders-agent', () => ({
+  subscribe: jest.fn(),
+  add: jest.fn(),
+  get: jest.fn(),
+  getAll: jest.fn().mockResolvedValue([]),
+  update: jest.fn(),
+}));
+
+jest.mock('../services/tonAuth', () => ({
+  getAddress: jest.fn().mockReturnValue('buyer_address'),
+  getTonPublicKey: jest.fn(),
+  openModal: jest.fn(),
+}));
+
+jest.mock('../constants/tenant', () => ({
+  getFeeSettings: jest.fn().mockResolvedValue({ feeAddress: 'fee_addr', feeBps: 250 }),
+}));
+
+describe('card checkout fee deduction', () => {
+  it('deducts platform fee for card payments', async () => {
+    jest
+      .spyOn<any, any>(OrderService.prototype as any, 'simulateOrderProgress')
+      .mockImplementation(() => {});
+
+    const svc = OrderService.getInstance();
+
+    const items: CartItem[] = [
+      {
+        id: 'i1',
+        productId: 'p1',
+        product: {
+          id: 'p1',
+          name: 'P1',
+          price: 100,
+          description: 'd',
+          category: 'c',
+          images: [],
+          rating: 0,
+          reviews: 0,
+          storeId: 's1',
+          stock: 10,
+        },
+        quantity: 1,
+        addedAt: '',
+      },
+    ];
+
+    mockProducts['p1'] = { ...items[0].product };
+
+    const shipping: ShippingAddress = {
+      name: 'A',
+      phone: '1',
+      street: 'st',
+      city: 'c',
+      postalCode: 'p',
+    };
+
+    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'card');
+    expect(orders).toHaveLength(1);
+    const order = orders[0];
+    expect(order.total).toBe(100);
+    expect(order.platformFee).toBeCloseTo(2.5);
+    expect(order.sellerPayout).toBeCloseTo(97.5);
+  });
+});
+
+afterAll(() => {
+  jest.resetModules();
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -236,7 +236,7 @@ export interface Order {
     cipher: string;
     from: string;
   };
-  paymentMethod: 'cash_on_delivery' | 'ton';
+  paymentMethod: 'cash_on_delivery' | 'ton' | 'card';
   buyerAddress?: string;
   sellerAddress?: string;
   driverAddress?: string;
@@ -248,6 +248,8 @@ export interface Order {
   updatedAt: string;
   trackingSteps: OrderTrackingStep[];
   paymentTxHash?: string;
+  platformFee?: number;
+  sellerPayout?: number;
 }
 
 export type OrderStatus =


### PR DESCRIPTION
## Summary
- add card payment fee helper calculating platform share and seller payout
- send fee configuration to MoonPay widget
- store fee and payout amounts on orders and enable card payments
- test card checkout fee deduction

## Testing
- `yarn test tests/cardCheckoutFee.test.ts tests/moonPayButton.test.ts` (fails: Invalid project root: /workspace/blue-ocean/lint)
- `node node_modules/jest/bin/jest.js tests/cardCheckoutFee.test.ts tests/moonPayButton.test.ts --runInBand --globalSetup=/tmp/empty.js` (fails: Cannot find module '@/utils/logger')


------
https://chatgpt.com/codex/tasks/task_e_68ae47cbba608326be43e033989d6c99