### PR TITLE
feat: tenant-scoped topics and agent tests

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -17,38 +17,7 @@ import {
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import ensureTonWallet from '../utils/ensureTonWallet';
 import { errorLog } from '../utils/logger';
-
-const ORDER_TOPIC = '/blue-ocean/orders/1';
-
-type NotificationTemplate = (
-  item: Notification,
-) => {
-  contentTopic: string;
-  payload: any;
-};
-
-export const notificationTemplates: Record<NotificationEvent, NotificationTemplate> = {
-  'order.created': (item) => ({
-    contentTopic: ORDER_TOPIC,
-    payload: { type: 'order.created', notification: item },
-  }),
-  'payment.received': (item) => ({
-    contentTopic: ORDER_TOPIC,
-    payload: { type: 'payment.received', notification: item },
-  }),
-  'status.updated': (item) => ({
-    contentTopic: ORDER_TOPIC,
-    payload: { type: 'status.updated', notification: item },
-  }),
-  'dispute.updated': (item) => ({
-    contentTopic: ORDER_TOPIC,
-    payload: { type: 'dispute.updated', notification: item },
-  }),
-  'escrow.deployed': (item) => ({
-    contentTopic: ORDER_TOPIC,
-    payload: { type: 'escrow.deployed', notification: item },
-  }),
-};
+import { buildTopic } from '../utils/wakuTopics';
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
@@ -58,18 +27,18 @@ class NotificationsAgent {
     await ensureTonWallet('Please connect your TON wallet to send notifications.');
   }
 
-  async add(item: Notification): Promise<void> {
+  async add(item: Notification, storeId = 'default'): Promise<void> {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item);
+    await this.broadcastWaku(item, undefined, storeId);
   }
 
-  async update(item: Notification): Promise<void> {
+  async update(item: Notification, storeId = 'default'): Promise<void> {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item);
+    await this.broadcastWaku(item, undefined, storeId);
   }
 
   async remove(id: string): Promise<void> {
@@ -85,11 +54,11 @@ class NotificationsAgent {
     return await listNotifications();
   }
 
-  async broadcast(event: NotificationEvent, item: Notification): Promise<void> {
+  async broadcast(event: NotificationEvent, item: Notification, storeId: string): Promise<void> {
     await this.ensureWallet();
     await setNotification(item);
     this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item, event);
+    await this.broadcastWaku(item, event, storeId);
   }
 
   subscribe(cb: (n: Notification) => void) {
@@ -118,24 +87,22 @@ class NotificationsAgent {
     }
   }
 
-  private async broadcastWaku(item: Notification, event?: NotificationEvent) {
+  private async broadcastWaku(
+    item: Notification,
+    event?: NotificationEvent,
+    storeId = 'default',
+  ) {
     const node = await this.ensureNode();
     if (!node) return;
     try {
-      if (event) {
-        const template = notificationTemplates[event];
-        if (!template) return;
-        const { contentTopic, payload } = template(item);
-        const encoder = createEncoder({ contentTopic });
-        await node.lightPush.send(encoder, {
-          payload: utf8ToBytes(JSON.stringify(payload)),
-        });
-      } else {
-        const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
-        await node.lightPush.send(encoder, {
-          payload: utf8ToBytes(JSON.stringify(item)),
-        });
-      }
+      const topic = buildTopic('orders', storeId);
+      const encoder = createEncoder({ contentTopic: topic });
+      const payload = event
+        ? { type: event, notification: item }
+        : item;
+      await node.lightPush.send(encoder, {
+        payload: utf8ToBytes(JSON.stringify(payload)),
+      });
     } catch (err) {
       errorLog('Failed to broadcast notification', err);
     }

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -2,7 +2,13 @@ import { randomUUID } from 'crypto';
 import { Order, OrderStatus, Notification, OrderTrackingStep } from '../types';
 import tonAuth from '../services/tonAuth';
 import notificationsAgent from './notifications-agent';
-import { setOrder, getOrder, listOrders, removeOrder, listOrdersBySeller } from '../services/tonOrders';
+import {
+  setOrder,
+  getOrder,
+  listOrders,
+  removeOrder,
+  listOrdersBySeller,
+} from '../services/tonOrders';
 import storesAgent from './stores-agent';
 import SettingsAgent from './settings-agent';
 import {
@@ -29,8 +35,7 @@ import {
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { orderStatusMessageSchema } from '../schemas/waku/order.status';
-
-const ORDER_TOPIC = '/blue-ocean/orders/1';
+import { buildTopic } from '../utils/wakuTopics';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -49,10 +54,9 @@ class OrdersAgent {
   private node: LightNode | null = null;
   private storeMap: Map<string, string> = new Map();
   private knownStores: Set<string> = new Set();
+  private subscribedStores: Set<string> = new Set();
 
-  constructor() {
-    void this.subscribeWaku();
-  }
+  constructor() {}
 
   private buildBaseEvent(order: Order) {
     return {
@@ -105,10 +109,11 @@ class OrdersAgent {
     }
   }
 
-  private async subscribeWaku() {
+  private async subscribeStore(storeId: string) {
+    if (this.subscribedStores.has(storeId)) return;
     const n = await this.ensureNode();
     if (!n) return;
-    const decoder = createDecoder(ORDER_TOPIC);
+    const decoder = createDecoder(buildTopic('orders', storeId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
@@ -122,6 +127,7 @@ class OrdersAgent {
       }
     };
     (n.relay as any).addObserver(handler, [decoder]);
+    this.subscribedStores.add(storeId);
   }
 
   private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
@@ -235,6 +241,7 @@ class OrdersAgent {
       this.storeMap.set(toStore.id, sid);
       this.knownStores.add(sid);
       await setOrder(sid, toStore);
+      await this.subscribeStore(sid);
     }
     await logOrderEvent({
       tenant: enriched.items?.[0]?.product?.storeId || '',
@@ -270,6 +277,7 @@ class OrdersAgent {
       this.storeMap.set(order.id, sid);
       this.knownStores.add(sid);
       await setOrder(sid, order);
+      await this.subscribeStore(sid);
     }
     await logOrderEvent({
       tenant: order.items?.[0]?.product?.storeId || '',
@@ -282,7 +290,8 @@ class OrdersAgent {
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
-    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+    const sid = order.items?.[0]?.product?.storeId || '';
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
       ...this.buildBaseEvent(order),
       prevStatus: current.status,
       newStatus: order.status,
@@ -296,7 +305,7 @@ class OrdersAgent {
         await this.recordSellerMetric(order.sellerAddress, 'refunded');
       }
       if (order.status === 'disputed' || current.status === 'disputed') {
-        await eventBus.publish(ORDER_TOPIC, 'dispute.updated', {
+        await eventBus.publish(buildTopic('orders', sid), 'dispute.updated', {
           ...this.buildBaseEvent(order),
           prevStatus: current.status,
           newStatus: order.status,
@@ -377,6 +386,7 @@ class OrdersAgent {
       this.storeMap.set(updated.id, sid);
       this.knownStores.add(sid);
       await setOrder(sid, updated);
+      await this.subscribeStore(sid);
     }
     await logOrderEvent({
       tenant: updated.items?.[0]?.product?.storeId || '',
@@ -389,12 +399,13 @@ class OrdersAgent {
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
-    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+    const sid = updated.items?.[0]?.product?.storeId || '';
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
       ...this.buildBaseEvent(updated),
       prevStatus: order.status,
       newStatus: updated.status,
     });
-    await eventBus.publish(ORDER_TOPIC, 'payment.received', {
+    await eventBus.publish(buildTopic('orders', sid), 'payment.received', {
       ...this.buildBaseEvent(updated),
     });
     await Promise.all(
@@ -436,6 +447,7 @@ class OrdersAgent {
       this.storeMap.set(updated.id, sid);
       this.knownStores.add(sid);
       await setOrder(sid, updated);
+      await this.subscribeStore(sid);
     }
     await logOrderEvent({
       tenant: updated.items?.[0]?.product?.storeId || '',
@@ -448,7 +460,8 @@ class OrdersAgent {
       actor: tonAuth.getAddress() || '',
       timestamp: Date.now(),
     });
-    await eventBus.publish(ORDER_TOPIC, 'order.updated', {
+    const sid = updated.items?.[0]?.product?.storeId || '';
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
       ...this.buildBaseEvent(updated),
       prevStatus: order.status,
       newStatus: updated.status,
@@ -478,7 +491,8 @@ class OrdersAgent {
       timestamp: Date.now(),
     };
     try {
-      await notificationsAgent.broadcast('status.updated', notification);
+      const sid = order.items?.[0]?.product?.storeId || '';
+      await notificationsAgent.broadcast('status.updated', notification, sid);
     } catch (err) {
       errorLog('Failed to send notification', err);
     }
@@ -495,7 +509,8 @@ class OrdersAgent {
       timestamp: Date.now(),
     };
     try {
-      await notificationsAgent.broadcast('order.created', notification);
+      const sid = order.items?.[0]?.product?.storeId || '';
+      await notificationsAgent.broadcast('order.created', notification, sid);
     } catch (err) {
       errorLog('Failed to send notification', err);
     }
@@ -512,7 +527,8 @@ class OrdersAgent {
       timestamp: Date.now(),
     };
     try {
-      await notificationsAgent.broadcast('payment.received', notification);
+      const sid = order.items?.[0]?.product?.storeId || '';
+      await notificationsAgent.broadcast('payment.received', notification, sid);
     } catch (err) {
       errorLog('Failed to send notification', err);
     }
@@ -529,7 +545,8 @@ class OrdersAgent {
       timestamp: Date.now(),
     };
     try {
-      await notificationsAgent.broadcast('dispute.updated', notification);
+      const sid = order.items?.[0]?.product?.storeId || '';
+      await notificationsAgent.broadcast('dispute.updated', notification, sid);
     } catch (err) {
       errorLog('Failed to send notification', err);
     }

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -26,6 +26,7 @@ import { getPrivateKey, getPublicKeyHex } from '../services/localIdentity';
 import { sign } from '@noble/ed25519';
 import type { WakuMessage } from '../types/waku';
 import { errorLog } from '../utils/logger';
+import { buildTopic } from '../utils/wakuTopics';
 
 import {
   getProductCache,
@@ -33,7 +34,7 @@ import {
   clearProductCache,
 } from '../services/productCache';
 
-const PRODUCT_TOPIC = '/blue-ocean/products/1';
+const buildProductTopic = (storeId: string) => buildTopic('products', storeId);
 const PAGE_SIZE = 50;
 
 interface ProductSummary {
@@ -47,10 +48,9 @@ class ProductsAgent {
   private node: LightNode | null = null;
   private version = 0;
   private loading: Promise<void> | null = null;
+  private subscribedStores: Set<string> = new Set();
 
-  constructor() {
-    void this.subscribe();
-  }
+  constructor() {}
 
   private async ensureNode(): Promise<LightNode | null> {
     if (this.node) return this.node;
@@ -68,10 +68,11 @@ class ProductsAgent {
     }
   }
 
-  private async subscribe() {
+  private async subscribeStore(storeId: string) {
+    if (this.subscribedStores.has(storeId)) return;
     const n = await this.ensureNode();
     if (!n) return;
-    const decoder = createDecoder(PRODUCT_TOPIC);
+    const decoder = createDecoder(buildProductTopic(storeId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
@@ -84,6 +85,7 @@ class ProductsAgent {
       }
     };
     (n.relay as any).addObserver(handler, [decoder]);
+    this.subscribedStores.add(storeId);
   }
 
   private async invalidateCache() {
@@ -146,7 +148,7 @@ class ProductsAgent {
       );
       const sig = await sign(msgBytes, priv);
       msg.signature = Buffer.from(sig).toString('hex');
-      const encoder = createEncoder({ contentTopic: PRODUCT_TOPIC });
+      const encoder = createEncoder({ contentTopic: buildProductTopic(product.storeId) });
       await n.lightPush.send(encoder, {
         payload: utf8ToBytes(JSON.stringify(msg)),
       });
@@ -175,6 +177,7 @@ class ProductsAgent {
     await setProduct(item.storeId, item);
     this.cache.set(item.id, item);
     this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
+    await this.subscribeStore(item.storeId);
     await this.broadcast(item);
   }
 
@@ -183,6 +186,7 @@ class ProductsAgent {
     await setProduct(item.storeId, item);
     this.cache.set(item.id, item);
     this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
+    await this.subscribeStore(item.storeId);
     await this.broadcast(item);
   }
 

--- a/services/notification.ts
+++ b/services/notification.ts
@@ -1,10 +1,7 @@
 import { debugLog, errorLog } from '@/utils/logger';
 import { randomUUID } from 'crypto';
 import { Notification } from '../types';
-import notificationsAgent, {
-  notificationTemplates,
-  NotificationEvent,
-} from '../agents/notifications-agent';
+import notificationsAgent, { NotificationEvent } from '../agents/notifications-agent';
 
 class NotificationService {
   private static instance: NotificationService;
@@ -129,4 +126,4 @@ class NotificationService {
 
 export default NotificationService;
 
-export { notificationTemplates, NotificationEvent };
+export { NotificationEvent };

--- a/tests/notificationsAgent.test.ts
+++ b/tests/notificationsAgent.test.ts
@@ -29,9 +29,7 @@ jest.mock(
   { virtual: true },
 );
 
-const agentModule = require('../agents/notifications-agent');
-const notificationsAgent = agentModule.default;
-const { notificationTemplates } = agentModule;
+const notificationsAgent = require('../agents/notifications-agent').default;
 
 describe('notificationsAgent.broadcast', () => {
   beforeEach(() => {
@@ -39,9 +37,7 @@ describe('notificationsAgent.broadcast', () => {
     (notificationsAgent as any).node = null;
   });
 
-  const events = Object.keys(notificationTemplates) as Array<keyof typeof notificationTemplates>;
-
-  test.each(events)('encodes %s with correct topic and payload', async (event) => {
+  it('encodes event with tenant topic and payload', async () => {
     const item = {
       id: 'id1',
       userId: 'u1',
@@ -52,15 +48,14 @@ describe('notificationsAgent.broadcast', () => {
       timestamp: 1,
     };
 
-    await notificationsAgent.broadcast(event, item);
+    await notificationsAgent.broadcast('order.created', item, 's1');
 
-    const template = notificationTemplates[event](item);
-    expect(createEncoderMock).toHaveBeenCalledWith({ contentTopic: template.contentTopic });
+    expect(createEncoderMock).toHaveBeenCalledWith({ contentTopic: '/blue-ocean/orders/s1' });
     expect(sendMock).toHaveBeenCalledTimes(1);
     const [encoderArg, { payload }] = sendMock.mock.calls[0];
-    expect(encoderArg).toEqual({ contentTopic: template.contentTopic });
+    expect(encoderArg).toEqual({ contentTopic: '/blue-ocean/orders/s1' });
     const decoded = JSON.parse(Buffer.from(payload).toString());
-    expect(decoded).toEqual(template.payload);
+    expect(decoded).toEqual({ type: 'order.created', notification: item });
   });
 
   it('generates unique IDs and timestamps under concurrent broadcasts', async () => {
@@ -76,7 +71,9 @@ describe('notificationsAgent.broadcast', () => {
 
     const count = 5;
     await Promise.all(
-      Array.from({ length: count }, (_, i) => notificationsAgent.broadcast('order.created', makeNotification(i))),
+      Array.from({ length: count }, (_, i) =>
+        notificationsAgent.broadcast('order.created', makeNotification(i), 's1'),
+      ),
     );
 
     const ids = setNotificationMock.mock.calls.map((c) => c[0].id);

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -172,7 +172,7 @@ describe('ordersAgent event emission', () => {
     const order: Order = {
       id: 'evt1',
       userId: 'u1',
-      items: [],
+      items: [{ product: { storeId: 's' } } as any],
       total: 0,
       status: 'order_received',
       itemsHash: '',
@@ -186,7 +186,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.update({ ...order, status: 'courier_found' });
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/1',
+      '/blue-ocean/orders/s',
       'order.updated',
       expect.objectContaining({ orderId: order.id, prevStatus: 'order_received', newStatus: 'courier_found' }),
     );
@@ -196,7 +196,7 @@ describe('ordersAgent event emission', () => {
     const order: Order = {
       id: 'evt2',
       userId: 'u1',
-      items: [],
+      items: [{ product: { storeId: 's' } } as any],
       total: 0,
       status: 'delivered',
       itemsHash: '',
@@ -210,7 +210,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.update({ ...order, status: 'disputed' });
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/1',
+      '/blue-ocean/orders/s',
       'dispute.updated',
       expect.objectContaining({ orderId: order.id, prevStatus: 'delivered', newStatus: 'disputed' }),
     );
@@ -220,7 +220,7 @@ describe('ordersAgent event emission', () => {
     const order: Order = {
       id: 'evt3',
       userId: 'u1',
-      items: [],
+      items: [{ product: { storeId: 's' } } as any],
       total: 0,
       status: 'delivered',
       itemsHash: '',
@@ -237,12 +237,12 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.releasePayment(order.id);
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/1',
+      '/blue-ocean/orders/s',
       'payment.received',
       expect.objectContaining({ orderId: order.id }),
     );
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/1',
+      '/blue-ocean/orders/s',
       'order.updated',
       expect.objectContaining({ prevStatus: 'delivered', newStatus: 'released' }),
     );
@@ -252,7 +252,7 @@ describe('ordersAgent event emission', () => {
     const order: Order = {
       id: 'evt4',
       userId: 'u1',
-      items: [],
+      items: [{ product: { storeId: 's' } } as any],
       total: 0,
       status: 'delivered',
       itemsHash: '',
@@ -269,7 +269,7 @@ describe('ordersAgent event emission', () => {
     mockStore[order.id] = order;
     await ordersAgent.refundPayment(order.id);
     expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/1',
+      '/blue-ocean/orders/s',
       'order.updated',
       expect.objectContaining({ prevStatus: 'delivered', newStatus: 'refunded' }),
     );

--- a/utils/wakuTopics.ts
+++ b/utils/wakuTopics.ts
@@ -1,0 +1,3 @@
+export function buildTopic(domain: string, storeId: string): string {
+  return `/blue-ocean/${domain}/${storeId}`;
+}


### PR DESCRIPTION
## Summary
- use tenant-specific Waku topics for orders, products and notifications
- add Waku topic builder util
- cover tenant topics in notification and order agent tests

## Testing
- `npm test` *(fails: Invalid project root: /workspace/blue-ocean/lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47dbe2608326acf489d8da1a23f3