### PR TITLE
docs: document tenant scoped routes

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -4,7 +4,7 @@ This app records anonymized funnel events over Waku for basic analytics.
 
 ## Event Schema
 
-Events published on `/blue-ocean/analytics/1` follow this structure:
+Events published on `/blue-ocean/{tenantId}/analytics/1` follow this structure:
 
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,27 +1,27 @@
 # Architecture
 
 ## Service Boundaries
-- **settings-agent** – subscribes to `/blue-ocean/settings/1`, validates admin senders, and updates in-memory config.
-- **users-agent** – listens on `/blue-ocean/users/1` to register users and roles, rejecting unauthenticated or duplicate roles.
-- **products-agent** – watches `/blue-ocean/products/1` for admin-signed product changes and hydrates the catalog.
-- **orders-agent** – processes `/blue-ocean/orders/1` messages when the sender matches the order user and keeps an ephemeral history.
-- **notifications-agent** – forwards order events to `/blue-ocean/notifications/1` and persists user notifications locally.
-- **review-agent** – distributes reviews on `/blue-ocean/reviews/1`, verifies they relate to completed orders, and updates reputation.
+- **settings-agent** – subscribes to `/blue-ocean/{tenantId}/settings/1`, validates admin senders, and updates in-memory config.
+- **users-agent** – listens on `/blue-ocean/{tenantId}/users/1` to register users and roles, rejecting unauthenticated or duplicate roles.
+- **products-agent** – watches `/blue-ocean/{tenantId}/products/1` for admin-signed product changes and hydrates the catalog.
+- **orders-agent** – processes `/blue-ocean/{tenantId}/orders/1` messages when the sender matches the order user and keeps an ephemeral history.
+- **notifications-agent** – forwards order events to `/blue-ocean/{tenantId}/notifications/1` and persists user notifications locally.
+- **review-agent** – distributes reviews on `/blue-ocean/{tenantId}/reviews/1`, verifies they relate to completed orders, and updates reputation.
 
 ## Peer-to-Peer Data Flow
-Blue Ocean operates entirely peer-to-peer over the Waku network. Each domain uses a dedicated topic:
+Blue Ocean operates entirely peer-to-peer over the Waku network. Each domain uses a tenant-scoped topic:
 
 | Topic | Purpose |
 |-------|---------|
-| `/blue-ocean/settings/1` | Store configuration |
-| `/blue-ocean/users/1` | Registered users and roles |
-| `/blue-ocean/products/1` | Product catalog |
-| `/blue-ocean/stores/1` | Store registry |
-| `/blue-ocean/orders/1` | Orders and status updates |
-| `/blue-ocean/notifications/1` | System notifications |
-| `/blue-ocean/reviews/1` | Product reviews |
-| `/blue-ocean/analytics/1` | Anonymous analytics events |
-| `/blue-ocean/chat/1/<roomId>` | Encrypted buyer/seller chat |
+| `/blue-ocean/{tenantId}/settings/1` | Store configuration |
+| `/blue-ocean/{tenantId}/users/1` | Registered users and roles |
+| `/blue-ocean/{tenantId}/products/1` | Product catalog |
+| `/blue-ocean/{tenantId}/stores/1` | Store registry |
+| `/blue-ocean/{tenantId}/orders/1` | Orders and status updates |
+| `/blue-ocean/{tenantId}/notifications/1` | System notifications |
+| `/blue-ocean/{tenantId}/reviews/1` | Product reviews |
+| `/blue-ocean/{tenantId}/analytics/1` | Anonymous analytics events |
+| `/blue-ocean/{tenantId}/chat/1/<roomId>` | Encrypted buyer/seller chat |
 
 Messages on these topics are signed and may be encrypted, and agents hydrate their state from message history on boot.
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,33 +1,53 @@
-# Routes
+# Routes (v2, tenant-scoped)
 
 ## Public
 | Path | Role requirement |
 |------|------------------|
-| `/` | none |
-| `/storefront` | none |
-| `/store/[storeId]` | none |
-| `/product/[id]` | none |
-| `/category/[id]` | none |
-| `/orders/[id]` | buyer, seller, or driver to update |
-| `/driver-dashboard` | driver or admin |
+| `/t/[tenantId]` | none |
+| `/t/[tenantId]/storefront` | none |
+| `/t/[tenantId]/store/[storeId]` | none |
+| `/t/[tenantId]/product/[id]` | none |
+| `/t/[tenantId]/category/[id]` | none |
+| `/t/[tenantId]/orders/[id]` | buyer, seller, or driver to update |
+| `/t/[tenantId]/driver-dashboard` | driver or admin |
 
 ## Store
 | Path | Role requirement |
 |------|------------------|
-| `/stores/create` | wallet connection required |
-| `/store/[storeId]/dashboard` | store owner of `[storeId]` |
-| `/store/[storeId]/products` | store owner of `[storeId]` |
-| `/store/[storeId]/orders` | store owner of `[storeId]` |
+| `/t/[tenantId]/stores/create` | wallet connection required |
+| `/t/[tenantId]/store/[storeId]/dashboard` | store owner of `[storeId]` |
+| `/t/[tenantId]/store/[storeId]/products` | store owner of `[storeId]` |
+| `/t/[tenantId]/store/[storeId]/orders` | store owner of `[storeId]` |
 
 ## Admin
 | Path | Role requirement |
 |------|------------------|
-| `/admin` | admin |
-| `/admin/dashboard` | admin |
-| `/admin/kyc-approvals` | admin |
-| `/admin/user-management` | admin |
-| `/admin/pricing-tiers` | admin |
-| `/admin/deliveries` | admin |
-| `/admin/bulk-upload` | admin |
-| `/admin/disputes` | admin |
-| `/admin/settings` | admin |
+| `/t/[tenantId]/admin` | admin |
+| `/t/[tenantId]/admin/dashboard` | admin |
+| `/t/[tenantId]/admin/kyc-approvals` | admin |
+| `/t/[tenantId]/admin/user-management` | admin |
+| `/t/[tenantId]/admin/pricing-tiers` | admin |
+| `/t/[tenantId]/admin/deliveries` | admin |
+| `/t/[tenantId]/admin/bulk-upload` | admin |
+| `/t/[tenantId]/admin/disputes` | admin |
+| `/t/[tenantId]/admin/settings` | admin |
+
+### RBAC Summary
+- **Public** routes are accessible without authentication.
+- **Store** routes require the corresponding store owner and a connected wallet.
+- **Admin** routes are restricted to tenant admins.
+- **Driver** actions are limited to users with the driver role or admins.
+
+### API Namespace Summary
+| Namespace | Topic |
+|-----------|-------|
+| `settings` | `/blue-ocean/{tenantId}/settings/1` |
+| `users` | `/blue-ocean/{tenantId}/users/1` |
+| `products` | `/blue-ocean/{tenantId}/products/1` |
+| `stores` | `/blue-ocean/{tenantId}/stores/1` |
+| `orders` | `/blue-ocean/{tenantId}/orders/1` |
+| `notifications` | `/blue-ocean/{tenantId}/notifications/1` |
+| `reviews` | `/blue-ocean/{tenantId}/reviews/1` |
+| `analytics` | `/blue-ocean/{tenantId}/analytics/1` |
+| `chat` | `/blue-ocean/{tenantId}/chat/1/<roomId>` |
+


### PR DESCRIPTION
## Summary
- document tenant-scoped routes with RBAC and API namespaces
- note tenant-specific Waku topics in architecture guide
- update analytics docs for tenant-scoped event topic

## Testing
- `yarn lint` *(fails: Invalid project root: /workspace/blue-ocean/lint)*
- `yarn test` *(fails: Invalid project root: /workspace/blue-ocean/lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4b732ca883269383ff9dcf154a8f