### PR TITLE
refactor: scope store admin routes

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -36,6 +36,7 @@ import { useAuthModal } from '../../components/AuthModalContext';
 import OrderService from '../../services/orders';
 import CartService from '../../services/cart';
 import DatabaseService from '../../services/database';
+import { listStores } from '../../services/tonStores';
 
 
 
@@ -56,6 +57,7 @@ export default function ProfileScreen() {
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const scrollViewRef = useRef<ScrollView>(null);
   const { openAuthModal } = useAuthModal();
+  const [storeId, setStoreId] = useState<string | null>(null);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -93,6 +95,20 @@ export default function ProfileScreen() {
     };
     fetchData();
   }, [isLoggedIn, user]);
+
+  useEffect(() => {
+    const loadStore = async () => {
+      if (!user?.address) return;
+      try {
+        const stores = await listStores();
+        const store = stores.find((s) => s.owner === user.address);
+        if (store) setStoreId(store.id);
+      } catch (err) {
+        errorLog('Failed to load store for user', err);
+      }
+    };
+    loadStore();
+  }, [user?.address]);
 
   const loadSettings = async () => {
     try {
@@ -284,7 +300,9 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() => router.push('/admin/dashboard')}
+              onPress={() =>
+                storeId && router.push(`/store/${storeId}/admin/dashboard`)
+              }
             >
               <View style={styles.menuItemContent}>
                 <Shield size={24} color={colors.gold} />
@@ -301,7 +319,9 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() => router.push('/admin/deliveries')}
+              onPress={() =>
+                storeId && router.push(`/store/${storeId}/admin/deliveries`)
+              }
             >
               <View style={styles.menuItemContent}>
                 <Package size={24} color={colors.gold} />

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -15,6 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2, Heart } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
+import { listStores } from '../../services/tonStores';
 import { Product, Subcategory, Category, PricingTier } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -67,7 +68,8 @@ export default function SubcategoryScreen() {
   const [confirmDeleteVisible, setConfirmDeleteVisible] = useState(false);
   const [showSubcategoryEditModal, setShowSubcategoryEditModal] = useState(false);
   const [editSubcategoryData, setEditSubcategoryData] = useState<Partial<Subcategory>>({name: "", icon: ""});
-  const { isStoreOwner } = useAuth();
+  const { isStoreOwner, user } = useAuth();
+  const [storeId, setStoreId] = useState<string | null>(null);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
@@ -83,6 +85,20 @@ export default function SubcategoryScreen() {
     loadSubcategoryData();
     loadPricingTiers();
   }, [id]);
+
+  useEffect(() => {
+    const loadStore = async () => {
+      if (!user?.address) return;
+      try {
+        const stores = await listStores();
+        const store = stores.find((s) => s.owner === user.address);
+        if (store) setStoreId(store.id);
+      } catch (err) {
+        errorLog('Failed to load store for user', err);
+      }
+    };
+    loadStore();
+  }, [user?.address]);
 
   useEffect(() => {
     // When category changes, update available subcategories
@@ -1054,7 +1070,9 @@ export default function SubcategoryScreen() {
                 }]}
                 onPress={() => {
                   setShowPricingTierSelector(false);
-                  router.push('/admin/pricing-tiers');
+                  if (storeId) {
+                    router.push(`/store/${storeId}/admin/pricing-tiers`);
+                  }
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -1,5 +1,5 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -17,6 +17,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { router } from 'expo-router';
 import { useAuthModal } from './AuthModalContext';
 import ConfirmationModal from './ConfirmationModal';
+import { listStores } from '../services/tonStores';
 
 const { width } = Dimensions.get('window');
 
@@ -28,6 +29,7 @@ export default function UserAvatar() {
   const { currentLanguage, setLanguage, t } = useLanguage();
   const { theme, toggleTheme, colors } = useTheme();
   const fadeAnim = useRef(new Animated.Value(0)).current;
+  const [storeId, setStoreId] = useState<string | null>(null);
 
   const getInitials = () => {
     if (!user?.displayName && !user?.username) return 'G';
@@ -87,14 +89,32 @@ export default function UserAvatar() {
     }
   };
 
+  useEffect(() => {
+    const loadStore = async () => {
+      if (!user?.address) return;
+      try {
+        const stores = await listStores();
+        const store = stores.find((s) => s.owner === user.address);
+        if (store) setStoreId(store.id);
+      } catch (err) {
+        errorLog('Failed to load store for user', err);
+      }
+    };
+    loadStore();
+  }, [user?.address]);
+
   const handleAdminDashboard = () => {
     hideDropdown();
-    router.push('/admin/dashboard');
+    if (storeId) {
+      router.push(`/store/${storeId}/admin/dashboard`);
+    }
   };
 
   const handleUserManagement = () => {
     hideDropdown();
-    router.push('/admin/user-management');
+    if (storeId) {
+      router.push(`/store/${storeId}/admin/user-management`);
+    }
   };
 
   const handleProfile = () => {


### PR DESCRIPTION
## Summary
- load and use store-specific admin links in profile
- scope user avatar admin links to store context
- connect subcategory pricing tier route to store admin

## Testing
- `npm test` *(fails: Invalid project root: /workspace/blue-ocean/lint)*

------
https://chatgpt.com/codex/tasks/task_e_68af2479a37c83269e374e8d4bd1fe80