### PR TITLE
refactor: centralize auth role checks

### DIFF
--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,6 +1,22 @@
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { isPlatformAdmin } from '../../utils/authRoles';
 
 export default function AdminLayout() {
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      if (!(await isPlatformAdmin())) {
+        router.replace('/');
+        return;
+      }
+      setAuthorized(true);
+    })();
+  }, []);
+
+  if (!authorized) return null;
+
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/app/admin/bulk-upload.tsx
+++ b/app/admin/bulk-upload.tsx
@@ -1,21 +1,6 @@
-import React, { useEffect } from 'react';
-import { Alert } from 'react-native';
-import { router } from 'expo-router';
+import React from 'react';
 import AdminBulkUploader from '../../components/AdminBulkUploader';
-import { useAuth } from '../../components/AuthContext';
 
 export default function BulkUploadScreen() {
-  const { isAdmin } = useAuth();
-
-  useEffect(() => {
-    if (!isAdmin) {
-      Alert.alert('Access denied', 'Admins only', [
-        { text: 'OK', onPress: () => router.replace('/') },
-      ]);
-    }
-  }, [isAdmin]);
-
-  if (!isAdmin) return null;
-
   return <AdminBulkUploader />;
 }

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -16,6 +16,7 @@ import { Product, ChatRoom, Notification, Review, Report } from '../../types';
 import { useNotifications } from '../../components/NotificationContext';
 import { useAuth } from '../../components/AuthContext';
 import { useAuthModal } from '../../components/AuthModalContext';
+import { isPlatformAdmin } from '../../utils/authRoles';
 import { useTheme } from '../../contexts/ThemeContext';
 import InfoModal from '../../components/InfoModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -44,7 +45,7 @@ export default function AdminDashboardScreen() {
     storeReputation: 0
   });
   const { showNotification } = useNotifications();
-  const { isStoreOwner, user } = useAuth();
+  const { user } = useAuth();
   const { openAuthModal } = useAuthModal();
   const { colors } = useTheme();
 
@@ -57,15 +58,15 @@ export default function AdminDashboardScreen() {
   });
 
   useEffect(() => {
-    // Check if user is logged in as admin
-    if (!isStoreOwner) {
-      openAuthModal('login');
-      router.replace('/');
-      return;
-    }
-
-    loadData();
-  }, [isStoreOwner]);
+    (async () => {
+      if (!(await isPlatformAdmin())) {
+        openAuthModal('login');
+        router.replace('/');
+        return;
+      }
+      loadData();
+    })();
+  }, []);
 
   const loadData = async () => {
     try {

--- a/app/admin/deliveries.tsx
+++ b/app/admin/deliveries.tsx
@@ -15,7 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Plus, Truck, ChevronDown } from 'lucide-react-native';
 import FullScreenMediaViewer from '../../components/FullScreenMediaViewer';
-import { useAuth } from '../../components/AuthContext';
+import { isPlatformAdmin } from '../../utils/authRoles';
 import { useTheme } from '../../contexts/ThemeContext';
 import DatabaseService from '../../services/database';
 import { DeliveryJob, User } from '../../types';
@@ -23,7 +23,6 @@ import commonStyles from '../../constants/styles';
 import SmartImage from '../../components/SmartImage';
 
 export default function AdminDeliveriesScreen() {
-  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const [jobs, setJobs] = useState<DeliveryJob[]>([]);
   const [drivers, setDrivers] = useState<User[]>([]);
@@ -39,12 +38,14 @@ export default function AdminDeliveriesScreen() {
   // const matrixService = MatrixService.getInstance(); // TODO: re-enable Matrix later
 
   useEffect(() => {
-    if (!isStoreOwner) {
-      router.replace('/');
-      return;
-    }
-    loadData();
-  }, [isStoreOwner]);
+    (async () => {
+      if (!(await isPlatformAdmin())) {
+        router.replace('/');
+        return;
+      }
+      loadData();
+    })();
+  }, []);
 
   const loadData = async () => {
     try {

--- a/app/admin/stores/[storeId]/impersonate.tsx
+++ b/app/admin/stores/[storeId]/impersonate.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { router, useLocalSearchParams } from 'expo-router';
+import { isPlatformAdmin } from '../../../../utils/authRoles';
+
+export default function ImpersonateStore() {
+  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+
+  useEffect(() => {
+    (async () => {
+      if (!storeId || !(await isPlatformAdmin())) {
+        router.replace('/');
+        return;
+      }
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.setItem('asStoreId', storeId);
+      }
+      router.replace(`/store/${storeId}/admin/dashboard`);
+    })();
+  }, [storeId]);
+
+  return null;
+}

--- a/app/store/[storeId]/admin/_layout.tsx
+++ b/app/store/[storeId]/admin/_layout.tsx
@@ -1,6 +1,23 @@
-import { Stack } from 'expo-router';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { isStoreOwner } from '../../../../utils/authRoles';
 
 export default function StoreAdminLayout() {
+  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      if (!storeId || !(await isStoreOwner(storeId))) {
+        router.replace('/');
+        return;
+      }
+      setAuthorized(true);
+    })();
+  }, [storeId]);
+
+  if (!authorized) return null;
+
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="dashboard" />

--- a/app/store/[storeId]/admin/bulk-upload.tsx
+++ b/app/store/[storeId]/admin/bulk-upload.tsx
@@ -1,21 +1,6 @@
-import React, { useEffect } from 'react';
-import { Alert } from 'react-native';
-import { router } from 'expo-router';
+import React from 'react';
 import AdminBulkUploader from '../../../../components/AdminBulkUploader';
-import { useAuth } from '../../../../components/AuthContext';
 
 export default function BulkUploadScreen() {
-  const { isAdmin } = useAuth();
-
-  useEffect(() => {
-    if (!isAdmin) {
-      Alert.alert('Access denied', 'Admins only', [
-        { text: 'OK', onPress: () => router.replace('/') },
-      ]);
-    }
-  }, [isAdmin]);
-
-  if (!isAdmin) return null;
-
   return <AdminBulkUploader />;
 }

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -3,37 +3,22 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { listProducts } from '../../../../services/tonProducts';
-import { getStore } from '../../../../services/tonStores';
 import OrderRevenueMetrics from '../../../../components/OrderRevenueMetrics';
-import { useAuth } from '../../../../components/AuthContext';
 
 export default function StoreDashboardScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
-  const { user } = useAuth();
   const [productCount, setProductCount] = useState(0);
-  const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
     const loadStats = async () => {
       if (!storeId) return;
-      const store = await getStore(storeId);
-      if (!store || store.owner !== user?.address) {
-        router.replace(`/store/${storeId}`);
-        return;
-      }
-      setAuthorized(true);
       const products = await listProducts();
       setProductCount(products.filter((p) => p.storeId === storeId).length);
     };
 
     loadStats();
-  }, [storeId, user?.address]);
-  
-
-  if (!authorized) {
-    return null;
-  }
+  }, [storeId]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>

--- a/app/store/[storeId]/admin/deliveries.tsx
+++ b/app/store/[storeId]/admin/deliveries.tsx
@@ -15,7 +15,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Plus, Truck, ChevronDown } from 'lucide-react-native';
 import FullScreenMediaViewer from '../../../../components/FullScreenMediaViewer';
-import { useAuth } from '../../../../components/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { DeliveryJob, User } from '../../../../types';
@@ -23,7 +22,6 @@ import commonStyles from '../../../../constants/styles';
 import SmartImage from '../../../../components/SmartImage';
 
 export default function AdminDeliveriesScreen() {
-  const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const [jobs, setJobs] = useState<DeliveryJob[]>([]);
   const [drivers, setDrivers] = useState<User[]>([]);
@@ -39,12 +37,8 @@ export default function AdminDeliveriesScreen() {
   // const matrixService = MatrixService.getInstance(); // TODO: re-enable Matrix later
 
   useEffect(() => {
-    if (!isStoreOwner) {
-      router.replace('/');
-      return;
-    }
     loadData();
-  }, [isStoreOwner]);
+  }, []);
 
   const loadData = async () => {
     try {

--- a/app/store/[storeId]/admin/disputes.tsx
+++ b/app/store/[storeId]/admin/disputes.tsx
@@ -3,7 +3,6 @@ import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowLeft } from 'lucide-react-native';
 import { useTheme } from '../../../../contexts/ThemeContext';
-import { useAuth } from '../../../../components/AuthContext';
 import { router } from 'expo-router';
 import ordersAgent from '../../../../agents/orders-agent';
 import { Order } from '../../../../types';
@@ -13,14 +12,9 @@ import commonStyles from '../../../../constants/styles';
 
 export default function AdminDisputesScreen() {
   const { colors } = useTheme();
-  const { isAdmin } = useAuth();
   const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
-    if (!isAdmin) {
-      router.replace('/');
-      return;
-    }
     const load = async () => {
       const all = await ordersAgent.getAll();
       setOrders(all.filter(o => o.status === 'disputed'));
@@ -35,7 +29,7 @@ export default function AdminDisputesScreen() {
     };
     ordersAgent.subscribe(sub);
     return () => ordersAgent.unsubscribe(sub);
-  }, [isAdmin]);
+  }, []);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>

--- a/app/store/[storeId]/admin/kyc-approvals.tsx
+++ b/app/store/[storeId]/admin/kyc-approvals.tsx
@@ -11,32 +11,25 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, CircleCheck as CheckCircle, Circle as XCircle, Clock, User, Mail, FileText, Calendar } from 'lucide-react-native';
-import { useAuth } from '../../../../components/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { User as UserType } from '../../../../types';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import commonStyles from '../../../../constants/styles';
 import SmartImage from '../../../../components/SmartImage';
+import { useAuth } from '../../../../components/AuthContext';
 
 
 
 export default function KycApprovalsScreen() {
   const [pendingRequests, setPendingRequests] = useState<UserType[]>([]);
   const [loading, setLoading] = useState(true);
-  const { isAdmin, isDriver, user } = useAuth();
+  const { user } = useAuth();
   const { colors } = useTheme();
 
   useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => router.replace('/') }
-      ]);
-      return;
-    }
-
     loadPendingRequests();
-  }, [isAdmin, isDriver]);
+  }, []);
 
   const loadPendingRequests = async () => {
     setLoading(true);

--- a/app/store/[storeId]/admin/orders.tsx
+++ b/app/store/[storeId]/admin/orders.tsx
@@ -1,17 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 import { debugLog } from '@/utils/logger';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { listOrdersBySeller } from '../../../../services/tonOrders';
 import { Order } from '../../../../types';
-import { useTonAddress } from '../../../../services/tonAuth';
 
 export default function StoreOrdersScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
   const [orders, setOrders] = useState<Order[]>([]);
-  const address = useTonAddress();
 
   const handlePress = (order: Order) => {
     debugLog('Pressed order', order.id);
@@ -23,26 +21,12 @@ export default function StoreOrdersScreen() {
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || address !== storeId) return;
+      if (!storeId) return;
       const all = await listOrdersBySeller(storeId);
       setOrders(all);
     };
     load();
-  }, [storeId, address]);
-
-  if (address !== storeId) {
-    return (
-      <View
-        style={[
-          styles.container,
-          styles.content,
-          { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>יש להתחבר לארנק המתאים</Text>
-      </View>
-    );
-  }
+  }, [storeId]);
 
   return (
     <FlatList

--- a/app/store/[storeId]/admin/pricing-tiers.tsx
+++ b/app/store/[storeId]/admin/pricing-tiers.tsx
@@ -18,7 +18,6 @@ import {
   Percent,
   Package,
 } from 'lucide-react-native';
-import { useAuth } from '../../../../components/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useCurrency } from '../../../../contexts/CurrencyContext';
 import DatabaseService from '../../../../services/database';
@@ -29,7 +28,6 @@ import PricingTierFormModal from '../../../../components/PricingTierFormModal';
 import Card from '../../../../components/Card';
 
 export default function PricingTiersScreen() {
-  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
@@ -45,12 +43,8 @@ export default function PricingTiersScreen() {
   });
 
   useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      router.replace('/');
-      return;
-    }
     loadPricingTiers();
-  }, [isAdmin, isDriver]);
+  }, []);
 
   const loadPricingTiers = async () => {
     setLoading(true);

--- a/app/store/[storeId]/admin/products.tsx
+++ b/app/store/[storeId]/admin/products.tsx
@@ -6,8 +6,6 @@ import { listProducts } from '../../../../services/tonProducts';
 import { Product } from '../../../../types';
 import ProductCard from '../../../../components/ProductCard';
 import ProductFormModal from '../../../../components/ProductFormModal';
-import { useTonAddress } from '../../../../services/tonAuth';
-import { useAuth } from '../../../../components/AuthContext';
 
 const ITEM_HEIGHT = 200;
 
@@ -17,17 +15,15 @@ export default function StoreProductsScreen() {
   const [products, setProducts] = useState<Product[]>([]);
   const [formVisible, setFormVisible] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
-  const address = useTonAddress();
-  const { isStoreOwner } = useAuth();
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || !isStoreOwner || address !== storeId) return;
+      if (!storeId) return;
       const all = await listProducts();
       setProducts(all.filter((p) => p.storeId === storeId));
     };
     load();
-  }, [storeId, address, isStoreOwner]);
+  }, [storeId]);
 
   const openForm = (p?: Product) => {
     setEditingProduct(p || null);
@@ -45,23 +41,6 @@ export default function StoreProductsScreen() {
   const handleDeleted = (productId: string) => {
     setProducts((prev) => prev.filter((p) => p.id !== productId));
   };
-
-  if (!isStoreOwner || address !== storeId) {
-    return (
-      <View
-        style={[
-          styles.container,
-          {
-            backgroundColor: colors.background,
-            justifyContent: 'center',
-            alignItems: 'center',
-          },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>יש להתחבר לארנק המתאים</Text>
-      </View>
-    );
-  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}> 

--- a/app/store/[storeId]/admin/settings.tsx
+++ b/app/store/[storeId]/admin/settings.tsx
@@ -4,7 +4,6 @@ import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-nati
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
-import { useAuth } from '../../../../components/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useCurrency } from '../../../../contexts/CurrencyContext';
 import { useLanguage } from '../../../../contexts/LanguageContext';
@@ -31,7 +30,6 @@ export default function SettingsScreen() {
   const [paymentFactoryAddress, setPaymentFactoryAddress] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { currentLanguage, t } = useLanguage();
@@ -55,12 +53,8 @@ export default function SettingsScreen() {
   });
 
   useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      router.replace('/');
-      return;
-    }
     loadSettings();
-  }, [isAdmin, isDriver]);
+  }, []);
 
   useEffect(() => {
     SettingsAgent.getInstance()

--- a/app/store/[storeId]/admin/user-management.tsx
+++ b/app/store/[storeId]/admin/user-management.tsx
@@ -14,7 +14,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Search, User, Mail, Calendar, Shield, UserCheck, UserX, Filter, X, Save, ChevronDown } from 'lucide-react-native';
-import { useAuth } from '../../../../components/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { User as UserType, CustomerTier, UserRole } from '../../../../types';
@@ -37,20 +36,13 @@ export default function UserManagementScreen() {
   const [filterKyc, setFilterKyc] = useState<string | null>(null);
   const [showFilterModal, setShowFilterModal] = useState(false);
   
-  const { isAdmin, isDriver, user } = useAuth();
+  const { user } = useAuth();
   const { colors } = useTheme();
   const { showNotification } = useNotifications();
 
   useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => router.replace('/') }
-      ]);
-      return;
-    }
-
     loadUsers();
-  }, [isAdmin, isDriver]);
+  }, []);
 
   useEffect(() => {
     applyFilters();

--- a/utils/authRoles.ts
+++ b/utils/authRoles.ts
@@ -1,0 +1,50 @@
+import tonAuth from '../services/tonAuth';
+import SettingsAgent from '../agents/settings-agent';
+import ordersAgent from '../agents/orders-agent';
+
+export async function isPlatformAdmin(): Promise<boolean> {
+  const address = tonAuth.getAddress();
+  if (!address) return false;
+  const admins = await SettingsAgent.getInstance().getAdmins();
+  return admins.includes(address);
+}
+
+export async function isStoreOwner(storeId: string): Promise<boolean> {
+  const address = tonAuth.getAddress();
+  if (!address) return false;
+  if (address === storeId) return true;
+  if (await isPlatformAdmin()) {
+    if (typeof sessionStorage !== 'undefined') {
+      return sessionStorage.getItem('asStoreId') === storeId;
+    }
+  }
+  return false;
+}
+
+export async function canAccessOrder(orderId: string): Promise<boolean> {
+  const address = tonAuth.getAddress();
+  if (!address) return false;
+  const order = await ordersAgent.get(orderId);
+  if (!order) return false;
+  if (
+    order.buyerAddress === address ||
+    order.sellerAddress === address ||
+    order.driverAddress === address
+  ) {
+    return true;
+  }
+  if (await isPlatformAdmin()) return true;
+  if (typeof sessionStorage !== 'undefined') {
+    const asStoreId = sessionStorage.getItem('asStoreId');
+    if (asStoreId && (order.sellerAddress === asStoreId || order.items?.[0]?.product?.storeId === asStoreId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export default {
+  isPlatformAdmin,
+  isStoreOwner,
+  canAccessOrder,
+};

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,9 +1,2 @@
-import tonAuth from '../services/tonAuth';
-import SettingsAgent from '../agents/settings-agent';
-
-export default async function isAdmin(): Promise<boolean> {
-  const address = tonAuth.getAddress();
-  if (!address) return false;
-  const admins = await SettingsAgent.getInstance().getAdmins();
-  return admins.includes(address);
-}
+import { isPlatformAdmin } from './authRoles';
+export default isPlatformAdmin;


### PR DESCRIPTION
## Summary
- add unified auth helpers for admin, store owners, and order access
- protect admin and store admin routes with new role guards
- allow platform admins to impersonate stores via session storage

## Testing
- `yarn lint` *(fails: Invalid project root)*
- `yarn test` *(fails: Command failed: yarn lint)*

------
https://chatgpt.com/codex/tasks/task_e_68af2675c0908326a95cde515b449778