### PR TITLE
feat: add near relayer service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ TON_RPC_URL=
 TON_RPC_FALLBACK_URLS=
 # Enable only during local testing; ignored in production builds
 ENABLE_UNSAFE_TON_PRIVATE_KEY=false
+
+# Relayer configuration
+RELAYER_NETWORK_ID=testnet
+RELAYER_NODE_URL=https://rpc.testnet.near.org
+RELAYER_ACCOUNT_ID=
+RELAYER_PRIVATE_KEY=
+RELAYER_CONTRACT_ID=

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "jest",
     "prepare": "husky install",
     "contract:build": "cargo build --manifest-path contracts/marketplace/Cargo.toml --release",
-    "contract:deploy": "bash scripts/deploy-marketplace.sh"
+    "contract:deploy": "bash scripts/deploy-marketplace.sh",
+    "relayer:dev": "yarn --cwd relayer dev"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",

--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN yarn install --production
+COPY src ./src
+RUN yarn build
+CMD ["node", "dist/server.js"]

--- a/relayer/package.json
+++ b/relayer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "blue-ocean-relayer",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/server.ts",
+  "scripts": {
+    "dev": "ts-node src/server.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "near-api-js": "^6.2.6",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.8.3"
+  }
+}

--- a/relayer/src/server.ts
+++ b/relayer/src/server.ts
@@ -1,0 +1,77 @@
+import express, { Request, Response } from 'express';
+import * as nearAPI from 'near-api-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const ALLOWED_METHODS = new Set(['add_listing', 'buy_listing']);
+
+async function initAccount() {
+  const networkId = process.env.RELAYER_NETWORK_ID || 'testnet';
+  const nodeUrl = process.env.RELAYER_NODE_URL || `https://rpc.${networkId}.near.org`;
+  const accountId = process.env.RELAYER_ACCOUNT_ID as string;
+  const privateKey = process.env.RELAYER_PRIVATE_KEY as string;
+  const keyStore = new nearAPI.keyStores.InMemoryKeyStore();
+  const keyPair = nearAPI.KeyPair.fromString(privateKey as any);
+  await keyStore.setKey(networkId, accountId, keyPair);
+  const near = await nearAPI.connect({ networkId, nodeUrl, deps: { keyStore } });
+  return new nearAPI.Account(accountId, near.connection.provider, near.connection.signer);
+}
+
+async function main() {
+  const app = express();
+  app.use(express.json());
+  let account: nearAPI.Account | null = null;
+  try {
+    account = await initAccount();
+  } catch (err) {
+    console.error('Failed to initialize relayer account', err);
+  }
+
+  app.post('/meta-tx', async (req: Request, res: Response) => {
+    const { signerId, receiverId, methodName, args, publicKey, signature, gas, deposit } = req.body;
+
+    if (!ALLOWED_METHODS.has(methodName)) {
+      return res.status(400).json({ error: 'Method not allowed' });
+    }
+
+    try {
+      const pk = nearAPI.utils.PublicKey.fromString(publicKey);
+      const message = Buffer.from(JSON.stringify({ signerId, receiverId, methodName, args }));
+      const sig = Buffer.from(signature, 'base64');
+      if (!pk.verify(message, sig)) {
+        return res.status(401).json({ error: 'Invalid signature' });
+      }
+    } catch (err) {
+      return res.status(400).json({ error: 'Signature verification failed' });
+    }
+
+    try {
+      if (!account) {
+        return res.status(500).json({ error: 'Relayer account not configured' });
+      }
+
+      const result = await account.functionCall({
+        contractId: receiverId,
+        methodName,
+        args,
+        gas: gas || '30000000000000',
+        attachedDeposit: deposit || '0'
+      });
+      return res.json({ transaction: result.transaction.hash });
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Failed to submit transaction' });
+    }
+  });
+
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Relayer listening on port ${port}`);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/relayer/tsconfig.json
+++ b/relayer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+    ,"types": []
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add relayer service using express and near-api-js
- support meta-tx endpoint with signature validation
- provide Dockerfile, env example, and root script for dev server

## Testing
- `yarn lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*
- `yarn typecheck` *(fails: Property 'label' is incompatible with index signature)*
- `yarn test` *(fails: Test suite failed to run)*
- `yarn --cwd relayer build`
- `RELAYER_ACCOUNT_ID=relayer.testnet RELAYER_PRIVATE_KEY=ed25519:1111111111111111111111111111111111111111111111111111111111111111 PORT=3333 yarn relayer:dev`

------
https://chatgpt.com/codex/tasks/task_e_68af47a3bbe88326911589c4a6f94933