### PR TITLE
chore: add near lake indexer

### DIFF
--- a/indexers/lake/.env.example
+++ b/indexers/lake/.env.example
@@ -1,0 +1,6 @@
+# Contract to index
+CONTRACT_ID=
+# Optional: block height to start from
+START_BLOCK_HEIGHT=0
+# Postgres connection string
+DATABASE_URL=postgres://postgres:password@localhost:5432/postgres

--- a/indexers/lake/Dockerfile
+++ b/indexers/lake/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json .
+COPY src ./src
+RUN npm install
+CMD ["npm", "run", "dev"]

--- a/indexers/lake/package.json
+++ b/indexers/lake/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "lake-indexer",
+  "version": "1.0.0",
+  "main": "src/main.ts",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node src/main.ts"
+  },
+  "dependencies": {
+    "near-lake-framework": "^2.0.0",
+    "pg": "^8.11.3",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3",
+    "@types/node": "^24.0.10",
+    "@types/pg": "^8.10.0"
+  }
+}

--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -1,0 +1,50 @@
+import { startStream, types } from 'near-lake-framework';
+import dotenv from 'dotenv';
+import { init, upsertListing, upsertOrder, pool } from './store';
+
+dotenv.config();
+
+const CONTRACT_ID = process.env.CONTRACT_ID as string;
+const START_BLOCK_HEIGHT = parseInt(process.env.START_BLOCK_HEIGHT || '0');
+
+async function handleMessage(streamerMessage: types.StreamerMessage) {
+  const blockHeight = streamerMessage.block.header.height;
+  for (const shard of streamerMessage.shards) {
+    for (const outcome of shard.receiptExecutionOutcomes) {
+      const receiverId = outcome.receipt?.receiverId;
+      if (receiverId !== CONTRACT_ID) continue;
+      for (const log of outcome.executionOutcome.outcome.logs) {
+        let parsed;
+        try {
+          parsed = JSON.parse(log);
+        } catch {
+          continue;
+        }
+        const receiptId = outcome.executionOutcome.id;
+        if (parsed.event === 'listing_added') {
+          await upsertListing(receiptId, blockHeight, parsed);
+        } else if (parsed.event === 'order_paid') {
+          await upsertOrder(receiptId, blockHeight, parsed);
+        }
+      }
+    }
+  }
+}
+
+async function main() {
+  await init();
+  const lakeConfig: types.LakeConfig = {
+    s3BucketName: 'near-lake-data-testnet',
+    s3RegionName: 'eu-central-1',
+    startBlockHeight: START_BLOCK_HEIGHT
+  };
+  await startStream(lakeConfig, handleMessage);
+}
+
+main()
+  .catch(err => {
+    console.error(err);
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/indexers/lake/src/store.ts
+++ b/indexers/lake/src/store.ts
@@ -1,0 +1,37 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+
+const connectionString = process.env.DATABASE_URL || '';
+export const pool = new Pool({ connectionString });
+
+export async function init() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS listing_events (
+    receipt_id TEXT PRIMARY KEY,
+    block_height BIGINT,
+    data JSONB
+  );`);
+
+  await pool.query(`CREATE TABLE IF NOT EXISTS order_events (
+    receipt_id TEXT PRIMARY KEY,
+    block_height BIGINT,
+    data JSONB
+  );`);
+}
+
+export async function upsertListing(receiptId: string, blockHeight: number, data: unknown) {
+  await pool.query(
+    `INSERT INTO listing_events (receipt_id, block_height, data)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (receipt_id) DO UPDATE SET block_height = EXCLUDED.block_height, data = EXCLUDED.data`,
+    [receiptId, blockHeight, data]
+  );
+}
+
+export async function upsertOrder(receiptId: string, blockHeight: number, data: unknown) {
+  await pool.query(
+    `INSERT INTO order_events (receipt_id, block_height, data)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (receipt_id) DO UPDATE SET block_height = EXCLUDED.block_height, data = EXCLUDED.data`,
+    [receiptId, blockHeight, data]
+  );
+}

--- a/indexers/lake/tsconfig.json
+++ b/indexers/lake/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "jest",
     "prepare": "husky install",
     "contract:build": "cargo build --manifest-path contracts/marketplace/Cargo.toml --release",
-    "contract:deploy": "bash scripts/deploy-marketplace.sh"
+    "contract:deploy": "bash scripts/deploy-marketplace.sh",
+    "indexer:dev": "yarn --cwd indexers/lake dev"
   },
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",


### PR DESCRIPTION
## Summary
- add lake indexer to stream marketplace events into Postgres
- provide .env example and Dockerfile for the indexer
- wire up dev script in root package.json

## Testing
- `yarn lint` *(fails: parserOptions.project missing for tests)*
- `yarn typecheck` *(fails: missing modules and type errors)*
- `yarn test` *(fails: Jest unexpected token and module resolution)*
- `yarn indexer:dev` *(fails: could not reach near-lake S3 ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af47a6070c8326a8854366bf3bd118