### PR TITLE
feat: add NEAR SDK for marketplace listings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "expo start",
     "web": "expo start --web",
     "build": "expo export --platform web --output-dir dist",
+    "build:web": "expo export --platform web --output-dir dist",
     "docker:dev": "docker compose up",
     "docker:build:web": "docker compose run --rm app yarn build",
     "docker:preview": "docker compose run --rm -p 4173:4173 app npx serve@14.2.0 dist -l 4173",
@@ -22,6 +23,7 @@
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/runtime": "^7.27.6",
+    "@blue-ocean/sdk-near": "file:packages/sdk-near",
     "@expo/metro-runtime": "^5",
     "@expo/vector-icons": "^14.1.0",
     "@expo/webpack-config": "^19.0.1",

--- a/packages/sdk-near/package.json
+++ b/packages/sdk-near/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@blue-ocean/sdk-near",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "buffer": "^6.0.3"
+  }
+}

--- a/packages/sdk-near/src/config.ts
+++ b/packages/sdk-near/src/config.ts
@@ -1,0 +1,5 @@
+export const relayerUrl = process.env.EXPO_PUBLIC_RELAYER_URL || '';
+export const indexerUrl = process.env.EXPO_PUBLIC_INDEXER_URL || '';
+export const contractId = process.env.EXPO_PUBLIC_CONTRACT_ID || '';
+
+export default { relayerUrl, indexerUrl, contractId };

--- a/packages/sdk-near/src/index.ts
+++ b/packages/sdk-near/src/index.ts
@@ -1,0 +1,101 @@
+import { Buffer } from 'buffer';
+import config, { relayerUrl, indexerUrl, contractId } from './config';
+
+export interface Listing {
+  id: number;
+  seller: string;
+  price: number;
+}
+
+async function fetchFromIndexer(): Promise<Listing[]> {
+  if (!indexerUrl) {
+    throw new Error('Indexer URL not configured');
+  }
+  const res = await fetch(`${indexerUrl}/listings`);
+  if (!res.ok) {
+    throw new Error(`Indexer error: ${res.status}`);
+  }
+  return (await res.json()) as Listing[];
+}
+
+async function fetchFromContract(): Promise<Listing[]> {
+  if (!contractId) {
+    throw new Error('Contract ID not configured');
+  }
+  const body = {
+    jsonrpc: '2.0',
+    id: 'dontcare',
+    method: 'query',
+    params: {
+      request_type: 'call_function',
+      finality: 'final',
+      account_id: contractId,
+      method_name: 'get_listings',
+      args_base64: Buffer.from('{}').toString('base64'),
+    },
+  };
+  const res = await fetch('https://rpc.testnet.near.org', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`RPC error: ${res.status}`);
+  }
+  const json = await res.json();
+  if (json.error) {
+    throw new Error(json.error.message || 'RPC error');
+  }
+  const result = Buffer.from(json.result.result).toString();
+  return JSON.parse(result) as Listing[];
+}
+
+export async function getListings(): Promise<Listing[]> {
+  try {
+    return await fetchFromIndexer();
+  } catch {
+    return fetchFromContract();
+  }
+}
+
+export async function addListing(listing: Listing): Promise<any> {
+  if (!relayerUrl) {
+    throw new Error('Relayer URL not configured');
+  }
+  const res = await fetch(`${relayerUrl}/meta-tx`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contractId,
+      methodName: 'create_listing',
+      args: listing,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Relayer error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function buyListing(id: number, buyer: string, amount: number): Promise<any> {
+  if (!relayerUrl) {
+    throw new Error('Relayer URL not configured');
+  }
+  const res = await fetch(`${relayerUrl}/meta-tx`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contractId,
+      methodName: 'buy_listing',
+      args: { id, buyer, amount },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Relayer error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export { config };
+
+export default { getListings, addListing, buyListing, config };

--- a/services/near.ts
+++ b/services/near.ts
@@ -3,6 +3,7 @@ import { setupWalletSelector, WalletSelector } from '@near-wallet-selector/core'
 import { setupModal, WalletSelectorModal } from '@near-wallet-selector/modal-ui';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import { useEffect, useState } from 'react';
+import { getListings, addListing, buyListing } from '@blue-ocean/sdk-near';
 
 let selector: WalletSelector | null = null;
 let modal: WalletSelectorModal | null = null;
@@ -57,4 +58,14 @@ export function getModal() {
   return modal;
 }
 
-export default { initNear, openModal, getSelector, getModal };
+export { getListings, addListing, buyListing };
+
+export default {
+  initNear,
+  openModal,
+  getSelector,
+  getModal,
+  getListings,
+  addListing,
+  buyListing,
+};


### PR DESCRIPTION
## Summary
- add `@blue-ocean/sdk-near` package with listing helpers
- expose environment-driven config for indexer, relayer and contract id
- wire web `near` service through new SDK

## Testing
- `yarn typecheck` *(fails: Argument of type...)*
- `yarn build:web` *(fails: Unable to resolve module @babel/runtime/helpers/interopRequireDefault)*

------
https://chatgpt.com/codex/tasks/task_e_68af47ac29a48326b41976485e50f1d5