### PR TITLE
feat: gate TON paths behind chain flag

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,6 +1,9 @@
 import { CartItem } from '../types';
+import { assertTonChain } from '../services/chain';
 import { setCartItem, getCartItem, listCartItems, removeCartItem } from '../services/tonCart';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 class CartAgent {
   private async ensureWallet() {

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -1,6 +1,9 @@
 import { Category } from '../types';
+import { assertTonChain } from '../services/chain';
 import { setCategory, getCategory, listCategories, removeCategory } from '../services/tonCategories';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 class CategoriesAgent {
   private async ensureWallet() {

--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'crypto';
 import { Report } from '../types';
+import { assertTonChain } from '../services/chain';
 import { addReport, listReports, removeReport } from '../services/tonReports';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 class ModerationAgent {
   private async ensureWallet() {

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,11 +1,14 @@
 import { Notification } from '../types';
 import { NotificationEvent } from '../types/waku';
+import { assertTonChain } from '../services/chain';
 import {
   setNotification,
   getNotification,
   listNotifications,
   removeNotification,
 } from '../services/tonNotifications';
+
+assertTonChain();
 import {
   LightNode,
   createLightNode,

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { Order, OrderStatus, Notification, OrderTrackingStep } from '../types';
 import nearAuth from '../services/nearAuth';
 import notificationsAgent from './notifications-agent';
+import { assertTonChain } from '../services/chain';
 import {
   setOrder,
   getOrder,
@@ -18,6 +19,8 @@ import {
 } from '../services/tonContract';
 import productsAgent from './products-agent';
 import { getSellerPublicKey } from '../services/sellerRegistry';
+
+assertTonChain();
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '../services/eventLog';

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,4 +1,5 @@
 import { Product } from '../types';
+import { assertTonChain } from '../services/chain';
 import {
   setProduct,
   getProduct,
@@ -9,6 +10,8 @@ import {
 } from '../services/tonProducts';
 import { getStore } from '../services/tonStores';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 import {
   LightNode,
   createLightNode,

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -1,9 +1,12 @@
 import { Review } from '../types';
+import { assertTonChain } from '../services/chain';
 import { addReview, getReviews } from '../services/tonReviews';
 import ordersAgent from './orders-agent';
 import productsAgent from './products-agent';
 import storesAgent from './stores-agent';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 const TOPIC = '/blue-ocean/reviews/1';
 

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -1,4 +1,5 @@
 import nearAuth from '../services/nearAuth';
+import { assertTonChain } from '../services/chain';
 import {
   getSetting,
   setSetting,
@@ -7,6 +8,8 @@ import {
   subscribeToSettingsWrites,
 } from '../services/tonSettings';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 type SettingKey =
   | 'tenantId'

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,6 +1,9 @@
 import { Store } from '../types';
+import { assertTonChain } from '../services/chain';
 import { setStore, getStore, listStores, removeStore } from '../services/tonStores';
 import ensureTonWallet from '../utils/ensureTonWallet';
+
+assertTonChain();
 
 interface Metrics {
   reviewSum: number;

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,4 +1,5 @@
 import { User } from '../types';
+import { assertTonChain } from '../services/chain';
 import { getUser, setUser, listUsers, removeUser } from '../services/tonUsers';
 import { getPublicKeyHex } from '../services/localIdentity';
 import SettingsAgent from './settings-agent';
@@ -6,6 +7,8 @@ import ensureTonWallet from '../utils/ensureTonWallet';
 import validateNearAddress from '../utils/validateNearAddress';
 import { verifyMessageSignature } from '../utils/verifyMessageSignature';
 import type { WakuMessage } from '../types/waku';
+
+assertTonChain();
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -25,7 +25,12 @@ import {
 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import { Product, Category, HeroBanner } from '../../types';
-import { listCategories } from '../../services/tonCategories';
+import chain from '../../services/chain';
+
+let listCategories: (() => Promise<Category[]>) | undefined;
+if (chain === 'ton') {
+  ({ listCategories } = require('../../services/tonCategories'));
+}
 import { useAuth } from '../../components/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -117,7 +122,7 @@ export default function HomeScreen() {
       const db = DatabaseService.getInstance();
       const [productsData, categoriesData, bannersData] = await Promise.all([
         db.getProducts(),
-        listCategories(),
+        listCategories ? listCategories() : Promise.resolve([]),
         db.getHeroBanners(),
       ]);
       setProducts(productsData);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -36,7 +36,12 @@ import { useAuthModal } from '../../components/AuthModalContext';
 import OrderService from '../../services/orders';
 import CartService from '../../services/cart';
 import DatabaseService from '../../services/database';
-import { listStores } from '../../services/tonStores';
+import chain from '../../services/chain';
+
+let listStores: (() => Promise<any[]>) | undefined;
+if (chain === 'ton') {
+  ({ listStores } = require('../../services/tonStores'));
+}
 
 
 
@@ -98,7 +103,7 @@ export default function ProfileScreen() {
 
   useEffect(() => {
     const loadStore = async () => {
-      if (!user?.address) return;
+      if (!user?.address || !listStores) return;
       try {
         const stores = await listStores();
         const store = stores.find((s) => s.owner === user.address);

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from 'expo-router';
+import chain from '../../services/chain';
 
 export default function AdminLayout() {
   return (
@@ -9,7 +10,7 @@ export default function AdminLayout() {
       <Stack.Screen name="stores/[storeId]" />
       <Stack.Screen name="user-directory" />
       <Stack.Screen name="fees" />
-      <Stack.Screen name="ton" />
+      {chain === 'ton' && <Stack.Screen name="ton" />}
       <Stack.Screen name="compliance" />
       <Stack.Screen name="settings" />
     </Stack>

--- a/app/admin/stores.tsx
+++ b/app/admin/stores.tsx
@@ -3,8 +3,13 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { router } from 'expo-router';
 import { useTheme } from '../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
-import { listStores } from '../../services/tonStores';
+import chain from '../../services/chain';
 import { Store } from '../../types';
+
+let listStores: (() => Promise<Store[]>) | undefined;
+if (chain === 'ton') {
+  ({ listStores } = require('../../services/tonStores'));
+}
 
 export default function AdminStores() {
   useRequirePlatformAdmin();
@@ -12,7 +17,9 @@ export default function AdminStores() {
   const [stores, setStores] = useState<Store[]>([]);
 
   useEffect(() => {
-    listStores().then(setStores).catch(() => {});
+    if (listStores) {
+      listStores().then(setStores).catch(() => {});
+    }
   }, []);
 
   return (

--- a/app/admin/stores/[storeId]/index.tsx
+++ b/app/admin/stores/[storeId]/index.tsx
@@ -3,8 +3,15 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { useTheme } from '../../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../../hooks/useRequirePlatformAdmin';
-import { getStore } from '../../../services/tonStores';
+import chain from '../../../services/chain';
 import { Store } from '../../../types';
+
+let getStore:
+  | ((tenantId: string, id: string) => Promise<Store | null>)
+  | undefined;
+if (chain === 'ton') {
+  ({ getStore } = require('../../../services/tonStores'));
+}
 
 export default function StoreDetail() {
   useRequirePlatformAdmin();
@@ -13,7 +20,7 @@ export default function StoreDetail() {
   const [store, setStore] = useState<Store | null>(null);
 
   useEffect(() => {
-    if (storeId) {
+    if (storeId && getStore) {
       getStore('', storeId).then(setStore).catch(() => {});
     }
   }, [storeId]);

--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -2,8 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
-import { listUsers } from '../../services/tonUsers';
+import chain from '../../services/chain';
 import { User } from '../../types';
+
+let listUsers: (() => Promise<User[]>) | undefined;
+if (chain === 'ton') {
+  ({ listUsers } = require('../../services/tonUsers'));
+}
 
 export default function UserDirectory() {
   useRequirePlatformAdmin();
@@ -11,7 +16,9 @@ export default function UserDirectory() {
   const [users, setUsers] = useState<User[]>([]);
 
   useEffect(() => {
-    listUsers().then(setUsers).catch(() => {});
+    if (listUsers) {
+      listUsers().then(setUsers).catch(() => {});
+    }
   }, []);
 
   return (

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -2,10 +2,16 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../../contexts/ThemeContext';
-import { listProducts } from '../../../../services/tonProducts';
-import { getStore } from '../../../../services/tonStores';
+import chain from '../../../../services/chain';
 import OrderRevenueMetrics from '../../../../components/OrderRevenueMetrics';
 import { useAuth } from '../../../../components/AuthContext';
+
+let listProducts: (() => Promise<any[]>) | undefined;
+let getStore: ((tenant: string, id: string) => Promise<any>) | undefined;
+if (chain === 'ton') {
+  ({ listProducts } = require('../../../../services/tonProducts'));
+  ({ getStore } = require('../../../../services/tonStores'));
+}
 
 export default function StoreDashboardScreen() {
   const { storeId, impersonate } = useLocalSearchParams<{ storeId: string; impersonate?: string }>();
@@ -16,8 +22,8 @@ export default function StoreDashboardScreen() {
 
   useEffect(() => {
     const loadStats = async () => {
-      if (!storeId) return;
-      const store = await getStore(storeId);
+      if (!storeId || !getStore || !listProducts) return;
+      const store = await getStore('', storeId);
       const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
       if (!store || (store.owner !== user?.address && !isAdmin)) {
         router.replace(`/store/${storeId}`);

--- a/app/store/[storeId]/admin/orders.tsx
+++ b/app/store/[storeId]/admin/orders.tsx
@@ -3,9 +3,16 @@ import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native
 import { debugLog } from '@/utils/logger';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../../contexts/ThemeContext';
-import { listOrdersBySeller } from '../../../../services/tonOrders';
+import chain from '../../../../services/chain';
 import { Order } from '../../../../types';
 import { useAccountId } from '../../../../services/nearAuth';
+
+let listOrdersBySeller:
+  | ((sellerId: string) => Promise<Order[]>)
+  | undefined;
+if (chain === 'ton') {
+  ({ listOrdersBySeller } = require('../../../../services/tonOrders'));
+}
 
 export default function StoreOrdersScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
@@ -23,7 +30,7 @@ export default function StoreOrdersScreen() {
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || address !== storeId) return;
+      if (!storeId || address !== storeId || !listOrdersBySeller) return;
       const all = await listOrdersBySeller(storeId);
       setOrders(all);
     };

--- a/app/store/[storeId]/admin/products.tsx
+++ b/app/store/[storeId]/admin/products.tsx
@@ -2,8 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '../../../../contexts/ThemeContext';
-import { listProducts } from '../../../../services/tonProducts';
+import chain from '../../../../services/chain';
 import { Product } from '../../../../types';
+
+let listProducts: (() => Promise<Product[]>) | undefined;
+if (chain === 'ton') {
+  ({ listProducts } = require('../../../../services/tonProducts'));
+}
 import ProductCard from '../../../../components/ProductCard';
 import ProductFormModal from '../../../../components/ProductFormModal';
 import { useAccountId } from '../../../../services/nearAuth';
@@ -22,7 +27,7 @@ export default function StoreProductsScreen() {
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || !isStoreOwner || address !== storeId) return;
+      if (!storeId || !isStoreOwner || address !== storeId || !listProducts) return;
       const all = await listProducts();
       setProducts(all.filter((p) => p.storeId === storeId));
     };

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -15,8 +15,13 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2, Heart } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
-import { listStores } from '../../services/tonStores';
-import { Product, Subcategory, Category, PricingTier } from '../../types';
+import chain from '../../services/chain';
+import { Product, Subcategory, Category, PricingTier, Store } from '../../types';
+
+let listStores: (() => Promise<Store[]>) | undefined;
+if (chain === 'ton') {
+  ({ listStores } = require('../../services/tonStores'));
+}
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
@@ -88,7 +93,7 @@ export default function SubcategoryScreen() {
 
   useEffect(() => {
     const loadStore = async () => {
-      if (!user?.address) return;
+      if (!user?.address || !listStores) return;
       try {
         const stores = await listStores();
         const store = stores.find((s) => s.owner === user.address);

--- a/components/BulkProductUploader.tsx
+++ b/components/BulkProductUploader.tsx
@@ -5,7 +5,13 @@ import pLimit from 'p-limit';
 import { useTheme } from '../contexts/ThemeContext';
 import MediaService from '../services/media';
 import { Product } from '../types';
-import { setProductBatch, estimateSetProductBatch } from '../services/tonProducts';
+import chain from '../services/chain';
+
+let setProductBatch: ((items: Product[]) => Promise<void>) | undefined;
+let estimateSetProductBatch: ((items: Product[]) => number) | undefined;
+if (chain === 'ton') {
+  ({ setProductBatch, estimateSetProductBatch } = require('../services/tonProducts'));
+}
 
 interface Summary {
   success: number;
@@ -38,6 +44,9 @@ export async function processRecords(
 
   const BATCH_SIZE = 25;
   const gasEstimates: number[] = [];
+  if (!estimateSetProductBatch || !setProductBatch) {
+    return { success, failed, gas: gasEstimates };
+  }
   for (let i = 0; i < records.length; i += BATCH_SIZE) {
     const batch = records.slice(i, i + BATCH_SIZE);
     const g = await estimateSetProductBatch(batch);

--- a/components/CartModal.tsx
+++ b/components/CartModal.tsx
@@ -25,8 +25,15 @@ import {
   ChevronRight,
 } from 'lucide-react-native';
 import CartService from '../services/cart';
-import { getStore } from '../services/tonStores';
+import chain from '../services/chain';
 import { CartItem, ShippingAddress, Store } from '../types';
+
+let getStore:
+  | ((storeId: string, id: string) => Promise<Store | null>)
+  | undefined;
+if (chain === 'ton') {
+  ({ getStore } = require('../services/tonStores'));
+}
 import OrderService from '../services/orders';
 import eventBus from '../services/eventBus';
 import { useAuth } from './AuthContext';
@@ -113,7 +120,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       const ids = Array.from(new Set(cartItems.map((i) => i.product.storeId)));
       const entries = await Promise.all(
         ids.map(async (id) => {
-          const store = await getStore(id);
+          const store = getStore ? await getStore('', id) : null;
           return store ? ([id, store] as const) : null;
         })
       );

--- a/components/OrderRevenueMetrics.tsx
+++ b/components/OrderRevenueMetrics.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { listOrdersBySeller } from '../services/tonOrders';
+import chain from '../services/chain';
 import { Order } from '../types';
+
+let listOrdersBySeller:
+  | ((sellerId: string) => Promise<Order[]>)
+  | undefined;
+if (chain === 'ton') {
+  ({ listOrdersBySeller } = require('../services/tonOrders'));
+}
 
 interface Props {
   sellerId: string;
@@ -14,7 +21,7 @@ export default function OrderRevenueMetrics({ sellerId }: Props) {
 
   useEffect(() => {
     const load = async () => {
-      if (!sellerId) return;
+      if (!sellerId || !listOrdersBySeller) return;
       const list = await listOrdersBySeller(sellerId);
       setOrders(list);
     };

--- a/components/ProductFormModal.tsx
+++ b/components/ProductFormModal.tsx
@@ -20,7 +20,14 @@ import { useCurrency } from '../contexts/CurrencyContext';
 import DatabaseService from '../services/database';
 import PinataService from '../services/pinata';
 import ipfsService from '../services/ipfsService';
-import { setProductBatch } from '../services/tonProductIndex';
+import chain from '../services/chain';
+
+let setProductBatch:
+  | ((items: ProductIndexItem[]) => Promise<void>)
+  | undefined;
+if (chain === 'ton') {
+  ({ setProductBatch } = require('../services/tonProductIndex'));
+}
 import { Video } from 'expo-video';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
@@ -253,7 +260,9 @@ export default function ProductFormModal({
         metadataUri: metadataCid,
         image: pinnedImages[0] || '',
       };
-      await setProductBatch([indexItem]);
+      if (setProductBatch) {
+        await setProductBatch([indexItem]);
+      }
 
       setInfoModal({
         visible: true,

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -17,7 +17,12 @@ import { useTheme } from '../contexts/ThemeContext';
 import { router } from 'expo-router';
 import { useAuthModal } from './AuthModalContext';
 import ConfirmationModal from './ConfirmationModal';
-import { listStores } from '../services/tonStores';
+import chain from '../services/chain';
+
+let listStores: (() => Promise<any[]>) | undefined;
+if (chain === 'ton') {
+  ({ listStores } = require('../services/tonStores'));
+}
 
 const { width } = Dimensions.get('window');
 
@@ -91,7 +96,7 @@ export default function UserAvatar() {
 
   useEffect(() => {
     const loadStore = async () => {
-      if (!user?.address) return;
+      if (!user?.address || !listStores) return;
       try {
         const stores = await listStores();
         const store = stores.find((s) => s.owner === user.address);

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -1,7 +1,12 @@
 import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { fetchSettings } from '../services/tonSettings';
+import chain from '../services/chain';
 import config from '../utils/appConfig';
+
+let fetchSettings: (() => Promise<any>) | undefined;
+if (chain === 'ton') {
+  ({ fetchSettings } = require('../services/tonSettings'));
+}
 
 export let TENANT = 'blue-ocean';
 
@@ -108,36 +113,38 @@ export async function loadTenantSettings(): Promise<void> {
       paymentFactoryAddress: paymentFactory?.[1] || '',
     };
 
-    const remote = await fetchSettings();
-    TENANT = remote.tenantId;
-    AppConfig = {
-      appName: remote.appName,
-      primaryColor: remote.theme.primary,
-      logoCid: remote.brand.logoCid,
-      fiatKey: remote.fiatKey,
-      feeAddress: remote.feeAddress ?? '',
-      feeBps: remote.feeBps ?? 0,
-      admins: remote.admins ?? [],
-      rpcUrl: remote.rpcUrl,
-      rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
-      wakuBootstrap: remote.wakuBootstrap ?? [],
-      paymentFactoryAddress: remote.paymentFactoryAddress ?? '',
-    };
+    if (fetchSettings) {
+      const remote = await fetchSettings();
+      TENANT = remote.tenantId;
+      AppConfig = {
+        appName: remote.appName,
+        primaryColor: remote.theme.primary,
+        logoCid: remote.brand.logoCid,
+        fiatKey: remote.fiatKey,
+        feeAddress: remote.feeAddress ?? '',
+        feeBps: remote.feeBps ?? 0,
+        admins: remote.admins ?? [],
+        rpcUrl: remote.rpcUrl,
+        rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
+        wakuBootstrap: remote.wakuBootstrap ?? [],
+        paymentFactoryAddress: remote.paymentFactoryAddress ?? '',
+      };
 
-    await AsyncStorage.multiSet([
-      [TENANT_KEY, remote.tenantId],
-      [NAME_KEY, remote.appName],
-      [COLOR_KEY, remote.theme.primary],
-      [LOGO_KEY, remote.brand.logoCid],
-      [FIAT_KEY, remote.fiatKey ?? ''],
-      [FEE_ADDR_KEY, remote.feeAddress ?? ''],
-      [FEE_BPS_KEY, String(remote.feeBps ?? 0)],
-      [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
-      [RPC_URL_KEY, remote.rpcUrl],
-      [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
-      [WAKU_BOOTSTRAP_KEY, JSON.stringify(remote.wakuBootstrap ?? [])],
-      [PAYMENT_FACTORY_KEY, remote.paymentFactoryAddress ?? ''],
-    ]);
+      await AsyncStorage.multiSet([
+        [TENANT_KEY, remote.tenantId],
+        [NAME_KEY, remote.appName],
+        [COLOR_KEY, remote.theme.primary],
+        [LOGO_KEY, remote.brand.logoCid],
+        [FIAT_KEY, remote.fiatKey ?? ''],
+        [FEE_ADDR_KEY, remote.feeAddress ?? ''],
+        [FEE_BPS_KEY, String(remote.feeBps ?? 0)],
+        [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
+        [RPC_URL_KEY, remote.rpcUrl],
+        [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
+        [WAKU_BOOTSTRAP_KEY, JSON.stringify(remote.wakuBootstrap ?? [])],
+        [PAYMENT_FACTORY_KEY, remote.paymentFactoryAddress ?? ''],
+      ]);
+    }
   } catch (e) {
     errorLog('Error loading tenant settings:', e);
   }

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -10,7 +10,12 @@ import React, {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert } from 'react-native';
 import SettingsAgent from '../agents/settings-agent';
-import { fetchSettings } from '../services/tonSettings';
+import chain from '../services/chain';
+
+let fetchSettings: (() => Promise<any>) | undefined;
+if (chain === 'ton') {
+  ({ fetchSettings } = require('../services/tonSettings'));
+}
 
 interface AppInfoContextType {
   tenantId: string;
@@ -81,37 +86,42 @@ export function AppInfoProvider({ children }: AppInfoProviderProps) {
       if (storedFiat) setFiatKey(storedFiat || undefined);
 
       try {
-        const remote = await fetchSettings();
-        setTenantId(remote.tenantId);
-        await AsyncStorage.setItem(TENANT_KEY, remote.tenantId);
-        if (remote.appName) {
-          setAppNameState(remote.appName);
-          await AsyncStorage.setItem(`app_name_${remote.tenantId}`, remote.appName);
+        if (fetchSettings) {
+          const remote = await fetchSettings();
+          setTenantId(remote.tenantId);
+          await AsyncStorage.setItem(TENANT_KEY, remote.tenantId);
+          if (remote.appName) {
+            setAppNameState(remote.appName);
+            await AsyncStorage.setItem(
+              `app_name_${remote.tenantId}`,
+              remote.appName,
+            );
+          }
+          if (remote.brand.logoCid) {
+            setLogoCidState(remote.brand.logoCid);
+            await AsyncStorage.setItem(
+              `app_logo_${remote.tenantId}`,
+              remote.brand.logoCid,
+            );
+          }
+          if (remote.theme.primary) {
+            setThemeColorState(remote.theme.primary);
+            await AsyncStorage.setItem(
+              `app_theme_primary_${remote.tenantId}`,
+              remote.theme.primary,
+            );
+          }
+          if (remote.fiatKey) {
+            setFiatKey(remote.fiatKey);
+            await AsyncStorage.setItem(
+              `app_fiat_key_${remote.tenantId}`,
+              remote.fiatKey,
+            );
+          }
+          if (remote.feeAddress) setFeeAddress(remote.feeAddress);
+          if (remote.feeBps !== undefined) setFeeBps(remote.feeBps);
+          if (remote.admins) setAdmins(remote.admins);
         }
-        if (remote.brand.logoCid) {
-          setLogoCidState(remote.brand.logoCid);
-          await AsyncStorage.setItem(
-            `app_logo_${remote.tenantId}`,
-            remote.brand.logoCid,
-          );
-        }
-        if (remote.theme.primary) {
-          setThemeColorState(remote.theme.primary);
-          await AsyncStorage.setItem(
-            `app_theme_primary_${remote.tenantId}`,
-            remote.theme.primary,
-          );
-        }
-        if (remote.fiatKey) {
-          setFiatKey(remote.fiatKey);
-          await AsyncStorage.setItem(
-            `app_fiat_key_${remote.tenantId}`,
-            remote.fiatKey,
-          );
-        }
-        if (remote.feeAddress) setFeeAddress(remote.feeAddress);
-        if (remote.feeBps !== undefined) setFeeBps(remote.feeBps);
-        if (remote.admins) setAdmins(remote.admins);
       } catch (err) {
         Alert.alert('שגיאה', 'טעינת הגדרות מהשרת נכשלה');
         errorLog('Failed fetching branding from server:', err);

--- a/services/chain.ts
+++ b/services/chain.ts
@@ -2,8 +2,16 @@ import { requireEnv } from '../utils/appConfig';
 
 const chain = requireEnv('EXPO_PUBLIC_CHAIN');
 
-if (chain !== 'near') {
+if (!['near', 'ton'].includes(chain)) {
   throw new Error(`Unsupported chain: ${chain}`);
+}
+
+export function assertTonChain(): void {
+  if (chain !== 'ton') {
+    throw new Error(
+      `TON helpers are disabled when EXPO_PUBLIC_CHAIN is "${chain}"`,
+    );
+  }
 }
 
 export default chain;

--- a/services/chatConfig.ts
+++ b/services/chatConfig.ts
@@ -1,6 +1,13 @@
-import { getAdmins } from './tonSettings';
+import chain from './chain';
+
+let getAdmins: (() => Promise<string[]>) | undefined;
+
+if (chain === 'ton') {
+  ({ getAdmins } = require('./tonSettings'));
+}
 
 export async function isChatConfigured(): Promise<boolean> {
+  if (!getAdmins) return false;
   const admins = await getAdmins();
   return admins.length > 0;
 }

--- a/services/database.ts
+++ b/services/database.ts
@@ -7,7 +7,12 @@ import productsAgent from '../agents/products-agent';
 import ordersAgent from '../agents/orders-agent';
 import SettingsAgent from '../agents/settings-agent';
 import reviewAgent from '../agents/review-agent';
-import { listAllReviews } from '../services/tonReviews';
+import chain from '../services/chain';
+
+let listAllReviews: (() => Promise<Review[]>) | undefined;
+if (chain === 'ton') {
+  ({ listAllReviews } = require('../services/tonReviews'));
+}
 import {
   User,
   Category,
@@ -245,7 +250,7 @@ class DatabaseService {
 
   // Reviews
   async getReviews(): Promise<Review[]> {
-    if (this.reviews.size === 0) {
+    if (this.reviews.size === 0 && listAllReviews) {
       const all = await listAllReviews();
       all.forEach((r) => this.reviews.set(r.id, r));
     }

--- a/services/tonCart.ts
+++ b/services/tonCart.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { CartItem } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_CART_ADDRESS');
 

--- a/services/tonCategories.ts
+++ b/services/tonCategories.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { Category } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_CATEGORIES_ADDRESS');
 

--- a/services/tonContract.ts
+++ b/services/tonContract.ts
@@ -2,6 +2,9 @@ import { errorLog } from '@/utils/logger';
 import nearAuth from './nearAuth';
 import { fetchSettings } from './tonSettings';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 export let ORDER_PAYMENT_FACTORY_ADDRESS = '';
 

--- a/services/tonKvStore.ts
+++ b/services/tonKvStore.ts
@@ -1,3 +1,7 @@
+import { assertTonChain } from './chain';
+
+assertTonChain();
+
 const store: Map<string, Map<string, string>> = new Map();
 
 export async function setValue(address: string, key: string, value: string) {

--- a/services/tonNotifications.ts
+++ b/services/tonNotifications.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { Notification } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_NOTIFICATIONS_ADDRESS');
 

--- a/services/tonOrders.ts
+++ b/services/tonOrders.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { Order } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_ORDERS_ADDRESS');
 

--- a/services/tonProductIndex.ts
+++ b/services/tonProductIndex.ts
@@ -1,6 +1,9 @@
 import { Buffer } from 'buffer';
 import { ProductIndexItem } from '../types';
 import nearAuth from './nearAuth';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 export function encodeProductIndexItem(item: ProductIndexItem): string {
   return JSON.stringify(item);

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { Product } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_PRODUCTS_ADDRESS');
 

--- a/services/tonReports.ts
+++ b/services/tonReports.ts
@@ -1,6 +1,9 @@
 import { setValue, listValues, removeValue } from './tonKvStore';
 import { Report } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_REPORTS_ADDRESS');
 

--- a/services/tonReviews.ts
+++ b/services/tonReviews.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues } from './tonKvStore';
 import { Review } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_REVIEWS_ADDRESS');
 

--- a/services/tonSettings.ts
+++ b/services/tonSettings.ts
@@ -1,5 +1,8 @@
 import { debugLog, errorLog } from '@/utils/logger';
+import { assertTonChain } from './chain';
 import { getValue, setValue, listValues } from './tonKvStore';
+
+assertTonChain();
 import config, { getWakuBootstrapNodes, requireEnv } from '../utils/appConfig';
 import {
   LightNode,

--- a/services/tonStores.ts
+++ b/services/tonStores.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { Store } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_STORES_ADDRESS');
 

--- a/services/tonUsers.ts
+++ b/services/tonUsers.ts
@@ -1,6 +1,9 @@
 import { getValue, setValue, listValues, removeValue } from './tonKvStore';
 import { User } from '../types';
 import { requireEnv } from '../utils/appConfig';
+import { assertTonChain } from './chain';
+
+assertTonChain();
 
 const ADDRESS = requireEnv('TON_USERS_ADDRESS');
 

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -18,6 +18,7 @@ insertConfig({
   TON_PRODUCTS_ADDRESS: 'EQtestproducts',
   TON_USERS_ADDRESS: 'EQtestusers',
   TON_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
+  EXPO_PUBLIC_CHAIN: 'ton',
 });
 
 jest.mock('../services/tonKvStore', () => require('./tonKvMock'));
@@ -31,6 +32,7 @@ beforeEach(async () => {
     TON_RPC_URL: 'https://ton.test',
     ADMIN_WALLET_ADDRESS_MAINNET: 'EQtestadmin',
     ADMIN_WALLET_ADDRESS_TESTNET: 'EQtestadmin',
+    EXPO_PUBLIC_CHAIN: 'ton',
   });
   await loadTenantSettings();
 });


### PR DESCRIPTION
## Summary
- add `assertTonChain` helper and guard TON service modules
- conditionally load TON routes and settings when `EXPO_PUBLIC_CHAIN` is "ton"
- update tests to set chain and block TON helpers on other chains

## Testing
- `yarn lint` *(fails: Invalid package.json)*
- `yarn test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af60c57e0483268132df543cf73a98