### PR TITLE
Add SQLite-backed NEAR Lake indexer

### DIFF
--- a/indexers/lake/.env.example
+++ b/indexers/lake/.env.example
@@ -1,6 +1,5 @@
-# Contract to index
 CONTRACT_ID=
-# Optional: block height to start from
-START_BLOCK_HEIGHT=0
-# Postgres connection string
-DATABASE_URL=postgres://postgres:password@localhost:5432/postgres
+LAKE_BUCKET=near-lake-data-testnet
+DB_PATH=./lake.db
+START_BLOCK=0
+

--- a/indexers/lake/package.json
+++ b/indexers/lake/package.json
@@ -8,14 +8,15 @@
     "dev": "ts-node src/main.ts"
   },
   "dependencies": {
-    "near-lake-framework": "^2.0.0",
-    "pg": "^8.11.3",
-    "dotenv": "^16.4.5"
+    "better-sqlite3": "^12.2.0",
+    "dotenv": "^16.4.5",
+    "near-lake-framework": "^2.0.0"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.0.10",
-    "@types/pg": "^8.10.0"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   }
 }

--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -1,18 +1,19 @@
 import { startStream, types } from 'near-lake-framework';
 import dotenv from 'dotenv';
-import { init, upsertListing, upsertOrder, pool } from './store';
+import { init, upsertEvent, db } from './store';
 
 dotenv.config();
 
 const CONTRACT_ID = process.env.CONTRACT_ID as string;
-const START_BLOCK_HEIGHT = parseInt(process.env.START_BLOCK_HEIGHT || '0');
+const LAKE_BUCKET = process.env.LAKE_BUCKET as string;
+const START_BLOCK = parseInt(process.env.START_BLOCK || '0', 10);
 
 async function handleMessage(streamerMessage: types.StreamerMessage) {
   const blockHeight = streamerMessage.block.header.height;
   for (const shard of streamerMessage.shards) {
     for (const outcome of shard.receiptExecutionOutcomes) {
-      const receiverId = outcome.receipt?.receiverId;
-      if (receiverId !== CONTRACT_ID) continue;
+      if (outcome.receipt?.receiverId !== CONTRACT_ID) continue;
+      const receiptId = outcome.executionOutcome.id;
       for (const log of outcome.executionOutcome.outcome.logs) {
         let parsed;
         try {
@@ -20,23 +21,18 @@ async function handleMessage(streamerMessage: types.StreamerMessage) {
         } catch {
           continue;
         }
-        const receiptId = outcome.executionOutcome.id;
-        if (parsed.event === 'listing_added') {
-          await upsertListing(receiptId, blockHeight, parsed);
-        } else if (parsed.event === 'order_paid') {
-          await upsertOrder(receiptId, blockHeight, parsed);
-        }
+        upsertEvent(parsed.event, receiptId, blockHeight, parsed);
       }
     }
   }
 }
 
 async function main() {
-  await init();
+  init();
   const lakeConfig: types.LakeConfig = {
-    s3BucketName: 'near-lake-data-testnet',
+    s3BucketName: LAKE_BUCKET,
     s3RegionName: 'eu-central-1',
-    startBlockHeight: START_BLOCK_HEIGHT
+    startBlockHeight: START_BLOCK,
   };
   await startStream(lakeConfig, handleMessage);
 }
@@ -45,6 +41,7 @@ main()
   .catch(err => {
     console.error(err);
   })
-  .finally(async () => {
-    await pool.end();
+  .finally(() => {
+    db.close();
   });
+

--- a/indexers/lake/src/store.ts
+++ b/indexers/lake/src/store.ts
@@ -1,37 +1,46 @@
 import 'dotenv/config';
-import { Pool } from 'pg';
+import Database from 'better-sqlite3';
 
-const connectionString = process.env.DATABASE_URL || '';
-export const pool = new Pool({ connectionString });
+const dbPath = process.env.DB_PATH || './lake.db';
 
-export async function init() {
-  await pool.query(`CREATE TABLE IF NOT EXISTS listing_events (
+export const db = new Database(dbPath);
+
+export function init() {
+  db.exec(`CREATE TABLE IF NOT EXISTS listings (
     receipt_id TEXT PRIMARY KEY,
-    block_height BIGINT,
-    data JSONB
+    block_height INTEGER,
+    data TEXT
   );`);
 
-  await pool.query(`CREATE TABLE IF NOT EXISTS order_events (
+  db.exec(`CREATE TABLE IF NOT EXISTS orders (
     receipt_id TEXT PRIMARY KEY,
-    block_height BIGINT,
-    data JSONB
+    block_height INTEGER,
+    data TEXT
   );`);
 }
 
-export async function upsertListing(receiptId: string, blockHeight: number, data: unknown) {
-  await pool.query(
-    `INSERT INTO listing_events (receipt_id, block_height, data)
-     VALUES ($1, $2, $3)
-     ON CONFLICT (receipt_id) DO UPDATE SET block_height = EXCLUDED.block_height, data = EXCLUDED.data`,
-    [receiptId, blockHeight, data]
+export function upsertEvent(
+  event: string,
+  receiptId: string,
+  blockHeight: number,
+  data: unknown
+) {
+  let table: 'listings' | 'orders' | undefined;
+  if (event === 'listing_added') {
+    table = 'listings';
+  } else if (event === 'order_paid') {
+    table = 'orders';
+  }
+
+  if (!table) return;
+
+  const stmt = db.prepare(
+    `INSERT INTO ${table} (receipt_id, block_height, data)
+     VALUES (?, ?, ?)
+     ON CONFLICT(receipt_id) DO UPDATE SET
+       block_height = excluded.block_height,
+       data = excluded.data`
   );
+  stmt.run(receiptId, blockHeight, JSON.stringify(data));
 }
 
-export async function upsertOrder(receiptId: string, blockHeight: number, data: unknown) {
-  await pool.query(
-    `INSERT INTO order_events (receipt_id, block_height, data)
-     VALUES ($1, $2, $3)
-     ON CONFLICT (receipt_id) DO UPDATE SET block_height = EXCLUDED.block_height, data = EXCLUDED.data`,
-    [receiptId, blockHeight, data]
-  );
-}


### PR DESCRIPTION
## Summary
- Use SQLite to store listing and order events from NEAR Lake
- Stream contract logs and upsert events by type
- Document env vars for contract, bucket, DB path and start block

## Testing
- `npx tsc -p indexers/lake/tsconfig.json --noEmit && echo tsc_completed`

------
https://chatgpt.com/codex/tasks/task_e_68af6e20e0088326a92ee5768d397676