### PR TITLE
Document NEAR environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,64 @@
-EXPO_PUBLIC_DEBUG_LOGS=false
-EXPO_PUBLIC_WAKU_BOOTSTRAP=
+# Web App (Expo)
+# Must be set to "near" for web builds
 EXPO_PUBLIC_CHAIN=near
+
+# NEAR contract account for the UI
+EXPO_PUBLIC_CONTRACT_ID=marketplace.<you>.testnet
+
+# Relayer endpoint used by the UI (defaults to http://localhost:3000)
+EXPO_PUBLIC_RELAYER_URL=http://localhost:3000
+
+# Indexer endpoint used by the UI (defaults to http://localhost:4000)
+EXPO_PUBLIC_INDEXER_URL=http://localhost:4000
+
+# Optional: enable verbose logging
+EXPO_PUBLIC_DEBUG_LOGS=false
+
+# Optional: comma-separated list of Waku peers
+EXPO_PUBLIC_WAKU_BOOTSTRAP=
+
+# Pinata credentials (optional for file uploads)
 EXPO_PUBLIC_PINATA_API_KEY=
 EXPO_PUBLIC_PINATA_SECRET_API_KEY=
 EXPO_PUBLIC_PINATA_JWT=
+
+
+# Relayer service
+# Defaults: testnet network and rpc node https://rpc.testnet.near.org
+RELAYER_NETWORK_ID=testnet
+RELAYER_NODE_URL=https://rpc.testnet.near.org
+
+RELAYER_ACCOUNT_ID=
+RELAYER_PRIVATE_KEY=
+
+# Shared contract account used by relayer & indexer
+CONTRACT_ID=marketplace.<you>.testnet
+
+# Port and gas limits for the relayer service
+PORT=3000
+MAX_GAS=30000000000000
+
+
+# Indexer service
+LAKE_BUCKET=
+
+# Start streaming from this block height (default 0)
+START_BLOCK=0
+
+# Path to the local SQLite database (default ./lake.db)
+DB_PATH=./lake.db
+
+
+# TON chain (only needed when EXPO_PUBLIC_CHAIN=ton)
 TON_NETWORK=mainnet
 ADMIN_WALLET_ADDRESS_MAINNET=
 ADMIN_WALLET_ADDRESS_TESTNET=
+
 # Optional: override tenant RPC endpoint
 TON_RPC_URL=
+
 # Optional: comma-separated list of fallback RPC endpoints
 TON_RPC_FALLBACK_URLS=
+
 # Enable only during local testing; ignored in production builds
 ENABLE_UNSAFE_TON_PRIVATE_KEY=false
-
-# Relayer configuration
-RELAYER_NETWORK_ID=testnet
-RELAYER_NODE_URL=https://rpc.testnet.near.org
-RELAYER_ACCOUNT_ID=
-RELAYER_PRIVATE_KEY=
-CONTRACT_ID=
-PORT=3000
-MAX_GAS=30000000000000

--- a/docs/near-dev-packet.md
+++ b/docs/near-dev-packet.md
@@ -2,6 +2,15 @@
 
 This guide shows how to build, deploy, initialize, and test the marketplace contract on NEAR testnet.
 
+## Environment Variables
+
+Copy `.env.example` to `.env` and populate the required values before running
+the web app, relayer, or indexer. The example file groups variables by service
+and documents default values such as `RELAYER_NODE_URL` (defaults to
+`https://rpc.testnet.near.org`), `PORT` (3000), `START_BLOCK` (0), and
+`DB_PATH` (`./lake.db`). For web builds you **must** set
+`EXPO_PUBLIC_CHAIN=near`.
+
 ## Contract Commands
 
 Replace `<you>` with your own testnet account name. The following account IDs must be adjusted before running the commands:


### PR DESCRIPTION
## Summary
- add grouped `.env.example` covering web app, relayer, and indexer variables
- highlight required `EXPO_PUBLIC_CHAIN=near` and defaults like RPC URL and ports
- note new environment file in NEAR dev packet docs

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af73f31d1c83268706e6012339d649