### PR TITLE
feat: stub private checkout button

### DIFF
--- a/components/PayPrivatelyButton.tsx
+++ b/components/PayPrivatelyButton.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { TouchableOpacity, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { payPrivately, openModal, useNearAccount } from '../services/near';
+
+interface PayPrivatelyButtonProps {
+  listingId: number;
+  amountYocto: string;
+  onComplete?: () => void;
+}
+
+export default function PayPrivatelyButton({ listingId, amountYocto, onComplete }: PayPrivatelyButtonProps) {
+  const { colors } = useTheme();
+  const accountId = useNearAccount();
+  const [loading, setLoading] = useState(false);
+
+  const handlePress = async () => {
+    if (!accountId) {
+      await openModal();
+      return;
+    }
+    try {
+      setLoading(true);
+      await payPrivately({ id: listingId, buyer: accountId, amountYocto });
+      onComplete?.();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      testID="pay-privately-button"
+      style={[styles.button, { backgroundColor: colors.interactive.primary }]}
+      onPress={handlePress}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color={colors.text.inverse} />
+      ) : (
+        <Text style={[styles.text, { color: colors.text.inverse }]}>Pay Privately</Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/packages/sdk-near/src/index.ts
+++ b/packages/sdk-near/src/index.ts
@@ -80,5 +80,13 @@ export async function buyListing(args: BuyListingArgs): Promise<any> {
   return json;
 }
 
-export default { getListings, addListing, buyListing };
+/**
+ * Pay for a listing while attempting to preserve privacy.
+ * TODO: integrate with mixer for on-chain privacy once available.
+ */
+export async function payPrivately(args: BuyListingArgs): Promise<any> {
+  return buyListing(args);
+}
+
+export default { getListings, addListing, buyListing, payPrivately };
 

--- a/services/near.ts
+++ b/services/near.ts
@@ -3,7 +3,7 @@ import { setupWalletSelector, WalletSelector } from '@near-wallet-selector/core'
 import { setupModal, WalletSelectorModal } from '@near-wallet-selector/modal-ui';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import { useEffect, useState } from 'react';
-import { getListings, addListing, buyListing } from '@blue-ocean/sdk-near';
+import { getListings, addListing, buyListing, payPrivately } from '@blue-ocean/sdk-near';
 
 let selector: WalletSelector | null = null;
 let modal: WalletSelectorModal | null = null;
@@ -58,7 +58,7 @@ export function getModal() {
   return modal;
 }
 
-export { getListings, addListing, buyListing };
+export { getListings, addListing, buyListing, payPrivately };
 
 export default {
   initNear,
@@ -68,4 +68,5 @@ export default {
   getListings,
   addListing,
   buyListing,
+  payPrivately,
 };


### PR DESCRIPTION
## Summary
- add payPrivately helper delegating to buyListing
- expose PayPrivatelyButton for private checkout flows

## Testing
- `npx eslint packages/sdk-near/src/index.ts services/near.ts components/PayPrivatelyButton.tsx`
- `yarn test --passWithNoTests packages/sdk-near`


------
https://chatgpt.com/codex/tasks/task_e_68af73fd6e448326b00b9495840bcfd3