### PR TITLE
docs: add app structure overview

### DIFF
--- a/docs/app-structure.md
+++ b/docs/app-structure.md
@@ -1,0 +1,30 @@
+# BlueOcean v2 App Structure
+
+This document captures the high-level directory tree for the BlueOcean v2 Expo application. Update it whenever the project structure changes so that it remains current.
+
+```text
+blue-ocean/
+├─ app/                         App shell and routes
+│  ├─ admin/                    Global admin console
+│  ├─ store/                    Store owner dashboard
+│  │  └─ [storeId]/admin/       Store-specific admin
+│  ├─ stores/                   Store creation & listing
+│  ├─ storefront/               Public storefront pages
+│  ├─ category/
+│  ├─ product/
+│  ├─ orders/
+│  ├─ reviews/
+│  ├─ user/
+│  └─ …
+├─ public/                      Static web assets
+└─ …
+```
+
+## Major Sections
+
+- **App Shell** – [`app/`](../app)
+- **Public** – [`public/`](../public) & [`app/storefront`](../app/storefront)
+- **Store Owner** – [`app/stores`](../app/stores) & [`app/store`](../app/store)
+- **Admin** – [`app/admin`](../app/admin) & [`app/store/[storeId]/admin`](../app/store/%5BstoreId%5D/admin)
+
+*Keep this file in sync with the repository’s evolving structure.*


### PR DESCRIPTION
## Summary
- document top-level app directories and major sections with links for BlueOcean v2

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', 'react'; missing expo/tsconfig.base)*
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af73fe0c84832694e3718d90e77de8