### PR TITLE
refactor: wrap tabs with top providers

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,9 @@
 import { Tabs } from "expo-router";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Lucide from 'lucide-react-native';
+import { ThemeProvider } from "../contexts/ThemeContext";
 import { ConfigProvider } from "../contexts/ConfigContext";
 import { AuthProvider } from "../components/AuthContext";
 import { AuthModalProvider } from "../components/AuthModalContext";
@@ -9,30 +13,40 @@ import { LanguageProvider } from "../contexts/LanguageContext";
 import { CurrencyProvider } from "../contexts/CurrencyContext";
 import { NotificationProvider } from "../components/NotificationContext";
 
+const queryClient = new QueryClient();
+
 export default function RootLayout() {
   return (
-    <ConfigProvider>
-      <AuthProvider>
-        <AuthModalProvider>
-            <TenantProvider>
-              <AppInfoProvider>
-                <LanguageProvider>
-                  <CurrencyProvider>
-                    <NotificationProvider>
-                      <Tabs screenOptions={{ headerShown: false }}>
-                        <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
-                        <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
-                        <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
-                        <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
-                        <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
-                      </Tabs>
-                    </NotificationProvider>
-                  </CurrencyProvider>
-                </LanguageProvider>
-              </AppInfoProvider>
-            </TenantProvider>
-        </AuthModalProvider>
-      </AuthProvider>
-    </ConfigProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <ThemeProvider>
+          <QueryClientProvider client={queryClient}>
+            <ConfigProvider>
+              <AuthProvider>
+                <AuthModalProvider>
+                  <TenantProvider>
+                    <AppInfoProvider>
+                      <LanguageProvider>
+                        <CurrencyProvider>
+                          <NotificationProvider>
+                            <Tabs screenOptions={{ headerShown: false }}>
+                              <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
+                              <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
+                              <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
+                              <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
+                              <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
+                            </Tabs>
+                          </NotificationProvider>
+                        </CurrencyProvider>
+                      </LanguageProvider>
+                    </AppInfoProvider>
+                  </TenantProvider>
+                </AuthModalProvider>
+              </AuthProvider>
+            </ConfigProvider>
+          </QueryClientProvider>
+        </ThemeProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- add GestureHandlerRootView, SafeAreaProvider, ThemeProvider and QueryClientProvider to root tab layout
- nest existing context providers inside SafeAreaProvider and export wrapped Tabs

## Testing
- `yarn test` *(fails: constants/tenant.ts:7 comparison types "near" and "ton" have no overlap)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e2f96748326833114f911593630