### PR TITLE
fix: default web background to white

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -30,7 +30,7 @@ export default function Document({ children }: { children: React.ReactNode }) {
             __html: `
               html, body { height: 100% !important; margin: 0 !important; padding: 0 !important; }
               #root, #app-root { height: 100% !important; min-height: 100vh !important; min-width: 100vw !important; }
-              body { background: #0b0b0b; color: #fff; }
+              body { background: #fff; }
             `,
           }}
         />

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 try {
   if (typeof document !== 'undefined') {
     const style = document.createElement('style');
-    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: #0b0b0b; }`;
+    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: #fff; }`;
     document.head.appendChild(style);
     let root = document.getElementById('root') || document.getElementById('app-root');
     if (!root) {

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,9 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https:; connect-src 'self' http: https: ws: wss: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; worker-src 'self' blob:; child-src 'self' blob:;"
     />
+    <style>
+      html, body, #root { height:100%; background:#fff; }
+    </style>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- set default white background in index.html for full-height root
- remove dark background overrides from runtime and Document CSS

## Testing
- `npm test` (fails: constants/tenant.ts comparison of 'near' and 'ton')
- `npm run lint`
- `npm run build:web` *(aborted after starting Metro Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3a924688326af8914e42040abe1