### PR TITLE
Use translucent backdrop in media viewer

### DIFF
--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -199,7 +199,10 @@ export default function FullScreenMediaViewer({
         <View style={styles.overlay}>
           <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
             <SafeAreaView
-              style={[styles.container, { backgroundColor: '#000000', paddingBottom: insets.bottom }]}
+              style={[
+                styles.container,
+                { backgroundColor: 'rgba(0, 0, 0, 0.8)', paddingBottom: insets.bottom }
+              ]}
             >
               <TouchableOpacity
                 style={[


### PR DESCRIPTION
## Summary
- replace hardcoded black background in FullScreenMediaViewer with semi-transparent tint
- verified overlays avoid pointerEvents="auto" when not interactive

## Testing
- `npx eslint components/FullScreenMediaViewer.tsx`
- `npx jest` *(fails: constants/tenant.ts TS2367)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3bd5ea883268bd829f36f7e8755