### PR TITLE
feat: add reusable button component

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -9,6 +9,7 @@ import { Product, Category, HeroBanner } from '../types';
 import ProductCard from '../components/ProductCard';
 import { useTheme } from '../contexts/ThemeContext';
 import SmartImage from '../components/SmartImage';
+import Button from '../components/ui/Button';
 
 export default function Landing() {
   const { colors } = useTheme();
@@ -51,14 +52,14 @@ export default function Landing() {
           </View>
           <View style={{ flexDirection: 'row', gap: 12, marginTop: 16 }}>
             <Link href="/store/alpha" asChild>
-              <Pressable style={{ backgroundColor: colors.gold, paddingHorizontal: 16, paddingVertical: 10, borderRadius: 10 }}>
-                <Text style={{ color: colors.text.inverse, fontWeight: '700' }}>Open Alpha Store</Text>
-              </Pressable>
+              <Button title="Open Alpha Store" style={{ borderRadius: 10 }} />
             </Link>
             <Link href="/(tabs)" asChild>
-              <Pressable style={{ borderColor: colors.gold, borderWidth: 1, paddingHorizontal: 16, paddingVertical: 10, borderRadius: 10 }}>
-                <Text style={{ color: colors.text.primary, fontWeight: '700' }}>Browse App</Text>
-              </Pressable>
+              <Button
+                title="Browse App"
+                variant="secondary"
+                style={{ borderRadius: 10, borderColor: colors.gold, backgroundColor: 'transparent' }}
+              />
             </Link>
           </View>
         </View>

--- a/components/MoonPayButton.tsx
+++ b/components/MoonPayButton.tsx
@@ -1,7 +1,6 @@
 import { errorLog } from '@/utils/logger';
 import React, { useState } from 'react';
-import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-import { useTheme } from '../contexts/ThemeContext';
+import Button from './ui/Button';
 import { useAppInfo } from '../contexts/AppInfoContext';
 import near, { useNearAccount } from '../services/near';
 import MoonPayModal from './MoonPayModal';
@@ -11,7 +10,6 @@ interface MoonPayButtonProps {
 }
 
 export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
-  const { colors } = useTheme();
   const { fiatKey } = useAppInfo();
   const walletAddress = useNearAccount();
   const [visible, setVisible] = useState(false);
@@ -45,13 +43,12 @@ export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
 
   return (
     <>
-      <TouchableOpacity
+      <Button
         testID="moonpay-button"
-        style={[styles.button, { backgroundColor: colors.gold }]}
+        title="Buy TON"
         onPress={handlePress}
-      >
-        <Text style={[styles.text, { color: colors.text.inverse }]}>Buy TON</Text>
-      </TouchableOpacity>
+        style={{ marginTop: 16 }}
+      />
       <MoonPayModal
         visible={visible}
         onClose={() => setVisible(false)}
@@ -63,17 +60,4 @@ export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-    marginTop: 16,
-  },
-  text: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});
 

--- a/components/PayPrivatelyButton.tsx
+++ b/components/PayPrivatelyButton.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { TouchableOpacity, Text, StyleSheet, ActivityIndicator } from 'react-native';
-import { useTheme } from '../contexts/ThemeContext';
+import Button from './ui/Button';
 import { payPrivately, openModal, useNearAccount } from '../services/near';
 
 interface PayPrivatelyButtonProps {
@@ -10,7 +9,6 @@ interface PayPrivatelyButtonProps {
 }
 
 export default function PayPrivatelyButton({ listingId, amountYocto, onComplete }: PayPrivatelyButtonProps) {
-  const { colors } = useTheme();
   const accountId = useNearAccount();
   const [loading, setLoading] = useState(false);
 
@@ -29,31 +27,14 @@ export default function PayPrivatelyButton({ listingId, amountYocto, onComplete 
   };
 
   return (
-    <TouchableOpacity
+    <Button
       testID="pay-privately-button"
-      style={[styles.button, { backgroundColor: colors.interactive.primary }]}
+      title="Pay Privately"
       onPress={handlePress}
       disabled={loading}
-    >
-      {loading ? (
-        <ActivityIndicator color={colors.text.inverse} />
-      ) : (
-        <Text style={[styles.text, { color: colors.text.inverse }]}>Pay Privately</Text>
-      )}
-    </TouchableOpacity>
+      loading={loading}
+      style={{ marginTop: 16 }}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-    marginTop: 16,
-  },
-  text: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});
 

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, TouchableOpacityProps } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface ButtonProps extends TouchableOpacityProps {
+  title?: string;
+  variant?: 'primary' | 'secondary';
+  loading?: boolean;
+}
+
+export default function Button({
+  title,
+  variant = 'primary',
+  loading = false,
+  style,
+  disabled,
+  children,
+  accessibilityRole = 'button',
+  ...rest
+}: ButtonProps) {
+  const { colors } = useTheme();
+
+  const backgroundColor =
+    variant === 'primary' ? colors.interactive.primary : colors.interactive.secondary;
+  const textColor = variant === 'primary' ? colors.text.inverse : colors.text.primary;
+  const borderStyle =
+    variant === 'secondary'
+      ? { borderWidth: 1, borderColor: colors.border.primary }
+      : null;
+
+  return (
+    <TouchableOpacity
+      accessibilityRole={accessibilityRole}
+      style={[styles.button, { backgroundColor }, borderStyle, style]}
+      disabled={disabled || loading}
+      {...rest}
+    >
+      {loading ? (
+        <ActivityIndicator color={textColor} />
+      ) : children ? (
+        children
+      ) : (
+        <Text style={[styles.text, { color: textColor }]}>{title}</Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { Video as LucideIcon } from 'lucide-react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import Button from './Button';
 
 interface EmptyStateProps {
   icon: typeof LucideIcon;
@@ -26,14 +27,7 @@ export default function EmptyState({
       <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
       <Text style={[styles.message, { color: colors.text.secondary }]}>{message}</Text>
       {actionText && onAction && (
-        <TouchableOpacity
-          style={[styles.actionButton, { backgroundColor: colors.gold }]}
-          onPress={onAction}
-        >
-          <Text style={[styles.actionButtonText, { color: colors.text.inverse }]}>
-            {actionText}
-          </Text>
-        </TouchableOpacity>
+        <Button title={actionText} onPress={onAction} style={styles.actionButton} />
       )}
     </View>
   );
@@ -61,13 +55,8 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   actionButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
     borderRadius: 25,
-  },
-  actionButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
+    paddingHorizontal: 24,
   },
 });
 


### PR DESCRIPTION
## Summary
- add Button component with primary and secondary variants using theme tokens
- refactor multiple Touchables/Pressables to use new Button
- remove duplicate styles from buttons

## Testing
- `npm test` *(fails: constants/tenant.ts comparison between "near" and "ton" has no overlap)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a9a27c108326b83f3290574d508c