### PR TITLE
feat(tokens): add design tokens and theme integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Install the Git hooks after cloning:
 yarn husky install
 ```
 
+### Design Tokens
+
+Shared spacing, radius, z-index and shadow values along with color palettes are defined in `constants/tokens.ts`. Components should import these tokens rather than hard-coding numbers so the UI stays consistent. `ThemeContext` merges the active theme with these tokens and exposes them via `useTheme()`.
+
 ### Environment Variables
 
 The app ships with sensible defaults and runs without a `.env` file. Environment

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -19,6 +19,7 @@ import MediaService from '../services/media';
 import { useAccountId } from '../services/nearAuth';
 import productsAgent from '../agents/products-agent';
 import Card from './Card';
+import { spacing, radius } from '../constants/tokens';
 
 interface ProductCardProps {
   product: Product;
@@ -306,7 +307,7 @@ export default function ProductCard({
 
 const styles = StyleSheet.create({
   container: {
-    borderRadius: 12,
+    borderRadius: radius.lg,
     borderWidth: 1,
     overflow: 'hidden',
   },
@@ -331,8 +332,8 @@ const styles = StyleSheet.create({
   },
   favoriteButton: {
     position: 'absolute',
-    top: 8,
-    start: 8,
+    top: spacing.sm,
+    start: spacing.sm,
     width: 28,
     height: 28,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -342,33 +343,33 @@ const styles = StyleSheet.create({
   },
   cartButton: {
     position: 'absolute',
-    bottom: 8,
-    end: 8,
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    bottom: spacing.sm,
+    end: spacing.sm,
+    width: spacing.xxxl,
+    height: spacing.xxxl,
+    borderRadius: radius.xl,
     justifyContent: 'center',
     alignItems: 'center',
   },
   adminActions: {
     position: 'absolute',
-    top: 8,
-    end: 8,
+    top: spacing.sm,
+    end: spacing.sm,
     flexDirection: 'row',
   },
   adminButton: {
     backgroundColor: 'rgba(0,0,0,0.7)',
-    borderRadius: 12,
-    width: 24,
-    height: 24,
+    borderRadius: radius.lg,
+    width: spacing.xxl,
+    height: spacing.xxl,
     justifyContent: 'center',
     alignItems: 'center',
-    marginLeft: 4,
+    marginLeft: spacing.xs,
   },
   badgesContainer: {
     position: 'absolute',
-    bottom: 8,
-    start: 8,
+    bottom: spacing.sm,
+    start: spacing.sm,
     flexDirection: 'row',
     flexWrap: 'wrap',
     maxWidth: '70%',
@@ -376,21 +377,21 @@ const styles = StyleSheet.create({
   badge: {
     paddingHorizontal: 6,
     paddingVertical: 2,
-    borderRadius: 8,
-    marginRight: 4,
-    marginBottom: 4,
+    borderRadius: radius.md,
+    marginRight: spacing.xs,
+    marginBottom: spacing.xs,
   },
   badgeText: {
     fontSize: 10,
     fontWeight: '600',
   },
   content: {
-    padding: 12,
+    padding: spacing.md,
   },
   name: {
     fontSize: 14,
     fontWeight: '500',
-    marginBottom: 8,
+    marginBottom: spacing.sm,
     lineHeight: 18,
     textAlign: 'end',
   },
@@ -398,12 +399,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
-    marginBottom: 4,
+    marginBottom: spacing.xs,
   },
   currentPrice: {
     fontSize: 16,
     fontWeight: 'bold',
-    marginLeft: 8,
+    marginLeft: spacing.sm,
   },
   originalPrice: {
     fontSize: 12,
@@ -418,7 +419,7 @@ const styles = StyleSheet.create({
   tieredPricingText: {
     fontSize: 12,
     fontWeight: '500',
-    marginRight: 4,
+    marginRight: spacing.xs,
   },
   ratingContainer: {
     flexDirection: 'row',
@@ -432,7 +433,7 @@ const styles = StyleSheet.create({
   },
   reviews: {
     fontSize: 12,
-    marginLeft: 4,
+    marginLeft: spacing.xs,
   },
   variantContainer: {
     flexDirection: 'row',
@@ -441,15 +442,15 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   variantDot: {
-    width: 16,
-    height: 16,
-    borderRadius: 8,
+    width: spacing.lg,
+    height: spacing.lg,
+    borderRadius: radius.md,
     marginLeft: 6,
     borderWidth: 1,
   },
   selectedVariantText: {
     fontSize: 12,
-    marginBottom: 4,
+    marginBottom: spacing.xs,
     textAlign: 'end',
   },
   stockContainer: {

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Video as LucideIcon } from 'lucide-react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import { spacing, radius } from '../../constants/tokens';
 
 interface EmptyStateProps {
   icon: typeof LucideIcon;
@@ -44,26 +45,26 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingHorizontal: 32,
-    paddingVertical: 60,
+    paddingHorizontal: spacing.xxxl,
+    paddingVertical: spacing.giant,
   },
   title: {
     fontSize: 20,
     fontWeight: 'bold',
-    marginTop: 16,
-    marginBottom: 8,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
     textAlign: 'center',
   },
   message: {
     fontSize: 16,
     textAlign: 'center',
-    marginBottom: 24,
-    lineHeight: 24,
+    marginBottom: spacing.xxl,
+    lineHeight: spacing.xxl,
   },
   actionButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 25,
+    paddingHorizontal: spacing.xxl,
+    paddingVertical: spacing.md,
+    borderRadius: radius.pill,
   },
   actionButtonText: {
     fontSize: 16,

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import GoldDivider from './GoldDivider';
 import { useTheme } from '../../contexts/ThemeContext';
+import { spacing } from '../../constants/tokens';
 
 export default function Section({
   title,
@@ -14,7 +15,7 @@ export default function Section({
 }) {
   const { colors } = useTheme();
   return (
-    <View style={{ paddingHorizontal: 16, paddingVertical: 16 }}>
+    <View style={{ paddingHorizontal: spacing.lg, paddingVertical: spacing.lg }}>
       <Text
         style={{
           color: colors.text.primary,
@@ -25,10 +26,10 @@ export default function Section({
       >
         {title}
       </Text>
-      <View style={{ alignItems: center ? 'center' : 'flex-start', marginTop: 8 }}>
+      <View style={{ alignItems: center ? 'center' : 'flex-start', marginTop: spacing.sm }}>
         <GoldDivider width={center ? 160 : 120} />
       </View>
-      <View style={{ marginTop: 12 }}>{children}</View>
+      <View style={{ marginTop: spacing.md }}>{children}</View>
     </View>
   );
 }

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import { spacing } from '../../constants/tokens';
 
 interface SpinnerProps {
   size?: 'small' | 'large';
@@ -32,9 +33,9 @@ const styles = StyleSheet.create({
   container: {
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 20,
+    padding: spacing.xl,
   },
   label: {
-    marginTop: 12,
+    marginTop: spacing.md,
   },
 });

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,0 +1,64 @@
+import { Colors as DarkColors } from './Colors';
+import { LightColors } from './LightColors';
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+  huge: 40,
+  giant: 60,
+};
+
+export const radius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  xxl: 20,
+  pill: 25,
+  full: 9999,
+};
+
+export const zIndex = {
+  base: 0,
+  dropdown: 1000,
+  modal: 1100,
+  toast: 1200,
+};
+
+export const shadows = {
+  sm: {
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  md: {
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+};
+
+export const darkTokens = {
+  spacing,
+  radius,
+  zIndex,
+  shadows,
+  colors: DarkColors,
+};
+
+export const lightTokens = {
+  spacing,
+  radius,
+  zIndex,
+  shadows,
+  colors: LightColors,
+};
+
+export type Tokens = typeof darkTokens;

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Colors as DarkColors } from '../constants/Colors';
-import { LightColors } from '../constants/LightColors';
+import { darkTokens, lightTokens, Tokens } from '../constants/tokens';
 import { useAppInfo } from './AppInfoContext';
 
 const THEME_STORAGE_KEY = 'app_theme';
@@ -12,13 +12,15 @@ type ThemeMode = 'light' | 'dark';
 interface ThemeContextType {
   theme: ThemeMode;
   colors: typeof DarkColors;
+  tokens: Tokens;
   setTheme: (theme: ThemeMode) => Promise<void>;
   toggleTheme: () => Promise<void>;
 }
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: 'dark',
-  colors: DarkColors,
+  colors: darkTokens.colors,
+  tokens: darkTokens,
   setTheme: async () => {},
   toggleTheme: async () => {},
 });
@@ -31,7 +33,7 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<ThemeMode>('dark');
-  const [colors, setColors] = useState(DarkColors);
+  const [tokens, setTokens] = useState<Tokens>(darkTokens);
   const { themeColor } = useAppInfo();
 
   useEffect(() => {
@@ -54,18 +56,22 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   };
 
   const applyTheme = (mode: ThemeMode, color: string) => {
-    const base = mode === 'light' ? LightColors : DarkColors;
-    setColors({
+    const base = mode === 'light' ? lightTokens : darkTokens;
+    const merged = {
       ...base,
-      gold: color,
-      interactive: {
-        ...base.interactive,
-        primary: color,
-        primaryHover: color,
+      colors: {
+        ...base.colors,
+        gold: color,
+        interactive: {
+          ...base.colors.interactive,
+          primary: color,
+          primaryHover: color,
+        },
+        tabBar: { ...base.colors.tabBar, active: color },
+        border: { ...base.colors.border, focus: color },
       },
-      tabBar: { ...base.tabBar, active: color },
-      border: { ...base.border, focus: color },
-    });
+    };
+    setTokens(merged);
   };
 
   const setTheme = async (newTheme: ThemeMode) => {
@@ -85,10 +91,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   return (
     <ThemeContext.Provider 
-      value={{ 
-        theme, 
-        colors,
-        setTheme, 
+      value={{
+        theme,
+        colors: tokens.colors,
+        tokens,
+        setTheme,
         toggleTheme
       }}
     >


### PR DESCRIPTION
## Summary
- add design tokens for spacing, radius, z-index, shadows and colors
- consume tokens in UI components and product card
- merge tokens in ThemeContext and document usage

## Testing
- `yarn lint`
- `yarn test` (fails: constants/tenant.ts TS2367 etc.)
- `yarn typecheck` (fails: TS errors across repo)


------
https://chatgpt.com/codex/tasks/task_e_68b4a9a558548326bee47055e76bdfd0