### PR TITLE
feat: add design tokens and theme merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ yarn start      # web
 yarn test
 ```
 
+## Design Tokens
+
+Shared design tokens live in `constants/tokens.ts`. Import `spacing`, `radius`, `colors`, `zIndex`, and `shadows` to keep styles consistent across components.
+
+```ts
+import { spacing, radius } from '../constants/tokens';
+
+const styles = StyleSheet.create({
+  button: {
+    padding: spacing.spacer16,
+    borderRadius: radius.md,
+  },
+});
+```
+
+
 ## Setup Guide
 
 1. **Install dependencies**

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Platform, ViewStyle, StyleProp } from 'react-native';
+import { radius, shadows } from '../constants/tokens';
 
 interface CardProps {
   children?: React.ReactNode;
@@ -29,11 +30,14 @@ export default function Card({
   Component = View,
   ...rest
 }: CardProps) {
-  const shadowStyle = Platform.select({
-    ios: { elevation },
-    android: { elevation },
-    web: { boxShadow: getBoxShadow(elevation) },
-  });
+  const shadowStyle =
+    elevation === 5
+      ? Platform.select(shadows.md)
+      : Platform.select({
+          ios: { elevation },
+          android: { elevation },
+          web: { boxShadow: getBoxShadow(elevation) },
+        });
 
   return (
     <Component style={[styles.card, shadowStyle, style]} {...rest}>
@@ -44,7 +48,7 @@ export default function Card({
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 12,
+    borderRadius: radius.lg,
   },
 });
 

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
+import { spacing, radius, zIndex, shadows } from '../constants/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 
 type InfoType = 'success' | 'error' | 'info' | 'warning';
@@ -73,23 +74,23 @@ export default function InfoModal({
   const getIconAndColor = () => {
     switch (type) {
       case 'success':
-        return { 
+        return {
           icon: <CheckCircle size={32} color={colors.status.success} />,
           color: colors.status.success
         };
       case 'error':
-        return { 
+        return {
           icon: <AlertCircle size={32} color={colors.status.error} />,
           color: colors.status.error
         };
       case 'warning':
-        return { 
+        return {
           icon: <AlertTriangle size={32} color={colors.status.warning} />,
           color: colors.status.warning
         };
       case 'info':
       default:
-        return { 
+        return {
           icon: <Info size={32} color={colors.status.info} />,
           color: colors.status.info
         };
@@ -108,10 +109,10 @@ export default function InfoModal({
       <TouchableWithoutFeedback onPress={onClose}>
         <View style={styles.overlay}>
           <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-            <Animated.View 
+            <Animated.View
               style={[
-                styles.modalContainer, 
-                { 
+                styles.modalContainer,
+                {
                   backgroundColor: colors.surface.elevated,
                   transform: [{ scale: scaleAnim }],
                   opacity: opacityAnim,
@@ -121,19 +122,19 @@ export default function InfoModal({
               <TouchableOpacity style={styles.closeButton} onPress={onClose}>
                 <X size={20} color={colors.text.secondary} />
               </TouchableOpacity>
-              
+
               <View style={styles.iconContainer}>
                 {icon}
               </View>
-              
+
               <Text style={[styles.title, { color: colors.text.primary }]}>
                 {title}
               </Text>
-              
-              <Text style={[styles.message, { color: colors.text.secondary }]}>
+
+              <Text style={[styles.message, { color: colors.text.secondary }]}> 
                 {message}
               </Text>
-              
+
               <TouchableOpacity
                 style={[styles.button, { backgroundColor: color }]}
                 onPress={onClose}
@@ -156,46 +157,42 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 20,
+    padding: spacing.spacer20,
   },
   modalContainer: {
     width: '100%',
     maxWidth: 340,
-    borderRadius: 16,
-    padding: 24,
+    borderRadius: radius.xl,
+    padding: spacing.spacer24,
     alignItems: 'center',
-    ...Platform.select({
-      ios: { elevation: 5 },
-      android: { elevation: 5 },
-      web: { boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.15)' },
-    }),
+    ...Platform.select(shadows.md),
   },
   closeButton: {
     position: 'absolute',
-    top: 12,
-    end: 12,
-    padding: 4,
-    zIndex: 1,
+    top: spacing.spacer12,
+    end: spacing.spacer12,
+    padding: spacing.spacer4,
+    zIndex: zIndex.dropdown,
   },
   iconContainer: {
-    marginBottom: 16,
+    marginBottom: spacing.spacer16,
   },
   title: {
     fontSize: 18,
     fontWeight: 'bold',
     textAlign: 'center',
-    marginBottom: 8,
+    marginBottom: spacing.spacer8,
   },
   message: {
     fontSize: 16,
     textAlign: 'center',
-    marginBottom: 24,
+    marginBottom: spacing.spacer24,
     lineHeight: 24,
   },
   button: {
-    paddingVertical: 12,
-    paddingHorizontal: 24,
-    borderRadius: 12,
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer24,
+    borderRadius: radius.lg,
     minWidth: 120,
     alignItems: 'center',
   },

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, TouchableOpacityProps } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import { spacing, radius } from '../../constants/tokens';
 
 interface ButtonProps extends TouchableOpacityProps {
   title?: string;
@@ -48,9 +49,9 @@ export default function Button({
 
 const styles = StyleSheet.create({
   button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 8,
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer16,
+    borderRadius: radius.md,
     alignItems: 'center',
   },
   text: {

--- a/constants/styles.ts
+++ b/constants/styles.ts
@@ -1,14 +1,7 @@
 import { StyleSheet } from 'react-native';
+import { spacing } from './tokens';
 
-export const spacing = {
-  spacer4: 4,
-  spacer8: 8,
-  spacer12: 12,
-  spacer16: 16,
-  spacer20: 20,
-  spacer24: 24,
-  spacer40: 40,
-};
+export { spacing };
 
 export const typography = StyleSheet.create({
   heading1: {

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,0 +1,47 @@
+import { Colors as DarkColors } from './Colors';
+import { LightColors } from './LightColors';
+
+export const spacing = {
+  spacer4: 4,
+  spacer8: 8,
+  spacer12: 12,
+  spacer16: 16,
+  spacer20: 20,
+  spacer24: 24,
+  spacer40: 40,
+};
+
+export const radius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  full: 9999,
+};
+
+export const zIndex = {
+  dropdown: 100,
+  modal: 1000,
+  overlay: 2000,
+};
+
+export const shadows = {
+  sm: {
+    ios: { elevation: 2 },
+    android: { elevation: 2 },
+    web: { boxShadow: '0px 2px 4px rgba(0,0,0,0.1)' },
+  },
+  md: {
+    ios: { elevation: 5 },
+    android: { elevation: 5 },
+    web: { boxShadow: '0px 4px 12px rgba(0,0,0,0.15)' },
+  },
+};
+
+export const colors = DarkColors;
+export const lightColors = LightColors;
+
+export const tokens = { spacing, radius, colors, zIndex, shadows };
+export const lightTokens = { ...tokens, colors: LightColors };
+
+export type Tokens = typeof tokens;

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,8 +1,7 @@
 import { errorLog } from '@/utils/logger';
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Colors as DarkColors } from '../constants/Colors';
-import { LightColors } from '../constants/LightColors';
+import { tokens as darkTokens, lightTokens, Tokens } from '../constants/tokens';
 import { useAppInfo } from './AppInfoContext';
 
 const THEME_STORAGE_KEY = 'app_theme';
@@ -11,14 +10,16 @@ type ThemeMode = 'light' | 'dark';
 
 interface ThemeContextType {
   theme: ThemeMode;
-  colors: typeof DarkColors;
+  colors: Tokens['colors'];
+  tokens: Tokens;
   setTheme: (theme: ThemeMode) => Promise<void>;
   toggleTheme: () => Promise<void>;
 }
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: 'dark',
-  colors: DarkColors,
+  colors: darkTokens.colors,
+  tokens: darkTokens,
   setTheme: async () => {},
   toggleTheme: async () => {},
 });
@@ -31,7 +32,7 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<ThemeMode>('dark');
-  const [colors, setColors] = useState(DarkColors);
+  const [currentTokens, setCurrentTokens] = useState<Tokens>(darkTokens);
   const { themeColor } = useAppInfo();
 
   useEffect(() => {
@@ -54,17 +55,20 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   };
 
   const applyTheme = (mode: ThemeMode, color: string) => {
-    const base = mode === 'light' ? LightColors : DarkColors;
-    setColors({
+    const base = mode === 'light' ? lightTokens : darkTokens;
+    setCurrentTokens({
       ...base,
-      gold: color,
-      interactive: {
-        ...base.interactive,
-        primary: color,
-        primaryHover: color,
+      colors: {
+        ...base.colors,
+        gold: color,
+        interactive: {
+          ...base.colors.interactive,
+          primary: color,
+          primaryHover: color,
+        },
+        tabBar: { ...base.colors.tabBar, active: color },
+        border: { ...base.colors.border, focus: color },
       },
-      tabBar: { ...base.tabBar, active: color },
-      border: { ...base.border, focus: color },
     });
   };
 
@@ -84,12 +88,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   };
 
   return (
-    <ThemeContext.Provider 
-      value={{ 
-        theme, 
-        colors,
-        setTheme, 
-        toggleTheme
+    <ThemeContext.Provider
+      value={{
+        theme,
+        colors: currentTokens.colors,
+        tokens: currentTokens,
+        setTheme,
+        toggleTheme,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add centralized design tokens for spacing, radius, colors, z-index and shadows
- refactor components to use tokens and expose them through ThemeContext
- document token usage in README

## Testing
- `yarn lint`
- `yarn test` *(fails: constants/tenant.ts types mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eb38db2083269f5371498d8a1371