### PR TITLE
refactor: extract data fetching hooks

### DIFF
--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -1,9 +1,6 @@
-import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Bell, Package, Tag, MessageCircle, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info } from 'lucide-react-native';
-import NotificationService from '../../services/notification';
 import { Notification } from '../../types';
 import { useAuth } from '../../components/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -13,17 +10,23 @@ import Spinner from '../../components/ui/Spinner';
 import EmptyState from '../../components/ui/EmptyState';
 import InfoModal from '../../components/InfoModal';
 import { useAuthModal } from '../../components/AuthModalContext';
+import { useNotifications } from '../../src/features/notifications/hooks/useNotifications';
 
 
 
 export default function NotificationsScreen() {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<'all' | 'unread'>('all');
   const { openAuthModal } = useAuthModal();
-  const { isLoggedIn, isAdmin, user } = useAuth();
+  const { isLoggedIn, isAdmin } = useAuth();
   const { colors } = useTheme();
   const { t } = useLanguage();
+  const {
+    notifications,
+    loading,
+    error,
+    markAsRead,
+    markAllAsRead,
+  } = useNotifications();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -34,108 +37,24 @@ export default function NotificationsScreen() {
   });
 
   useEffect(() => {
-    if (isLoggedIn && user) {
-      loadNotifications();
-    } else {
-      setLoading(false);
-      setNotifications([]);
-    }
-  }, [isLoggedIn, user]);
-
-  const loadNotifications = async () => {
-    if (!user) return;
-    
-    setLoading(true);
-    try {
-      const notificationService = NotificationService.getInstance();
-      const data = await notificationService.getNotifications(user.id);
-      setNotifications(data);
-    } catch (error) {
-      errorLog('Error loading notifications:', error);
+    if (error) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'טעינת ההתראות נכשלה',
-        type: 'error'
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const markAsRead = async (id: string) => {
-    try {
-      const notificationService = NotificationService.getInstance();
-      const success = await notificationService.markAsRead(id);
-      
-      if (success) {
-        // Update local state
-        setNotifications(prev => 
-          prev.map(notification => 
-            notification.id === id 
-              ? { ...notification, read: true } 
-              : notification
-          )
-        );
-      }
-    } catch (error) {
-      errorLog('Error marking notification as read:', error);
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'סימון ההתראה כנקראה נכשל',
-        type: 'error'
+        title: t('common.error'),
+        message: t('notifications.loadError'),
+        type: 'error',
       });
     }
-  };
+  }, [error, t]);
 
-  const markAllAsRead = async () => {
-    if (!user) return;
-    
-    try {
-      const notificationService = NotificationService.getInstance();
-      const success = await notificationService.markAllAsRead(user.id);
-      
-      if (success) {
-        // Update local state
-        setNotifications(prev => 
-          prev.map(notification => ({ ...notification, read: true }))
-        );
-        
-        setInfoModal({
-          visible: true,
-          title: 'הצלחה',
-          message: 'כל ההתראות סומנו כנקראו',
-          type: 'success'
-        });
-      }
-    } catch (error) {
-      errorLog('Error marking all notifications as read:', error);
+  const handleMarkAllAsRead = async () => {
+    const success = await markAllAsRead();
+    if (success) {
       setInfoModal({
         visible: true,
-        title: 'שגיאה',
-        message: 'סימון כל ההתראות כנקראו נכשל',
-        type: 'error'
-      });
-    }
-  };
-
-  const deleteNotification = async (id: string) => {
-    try {
-      const notificationService = NotificationService.getInstance();
-      const success = await notificationService.deleteNotification(id);
-      
-      if (success) {
-        // Update local state
-        setNotifications(prev => prev.filter(notification => notification.id !== id));
-      }
-    } catch (error) {
-      errorLog('Error deleting notification:', error);
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'מחיקת ההתראה נכשלה',
-        type: 'error'
+        title: 'הצלחה',
+        message: 'כל ההתראות סומנו כנקראו',
+        type: 'success',
       });
     }
   };
@@ -229,7 +148,7 @@ export default function NotificationsScreen() {
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{t('notifications.notifications')}</Text>
         {notifications.length > 0 && (
-          <TouchableOpacity onPress={markAllAsRead}>
+          <TouchableOpacity onPress={handleMarkAllAsRead}>
             <Text style={[styles.markAllRead, { color: colors.gold }]}>{t('notifications.markAllRead')}</Text>
           </TouchableOpacity>
         )}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,3 @@
-import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
@@ -23,14 +22,8 @@ import {
   Filter,
   ArrowUpDown,
 } from 'lucide-react-native';
-import DatabaseService from '../services/database';
 import { Product, Category, HeroBanner } from '../types';
-import chain from '../services/chain';
-
-let listCategories: (() => Promise<Category[]>) | undefined;
-if (chain === 'ton') {
-  ({ listCategories } = require('../services/tonCategories'));
-}
+import { useHome } from '../src/features/home/hooks/useHome';
 import { useAuth } from '../components/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -51,10 +44,21 @@ const BANNER_HEIGHT = (BANNER_WIDTH * 9) / 16;
 export default function HomeScreen() {
   const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
-  const [products, setProducts] = useState<Product[]>([]);
+  const {
+    products,
+    categories,
+    heroBanners,
+    loading,
+    refreshing,
+    error,
+    reload,
+    refresh,
+    upsertBanner,
+    removeBanner,
+    upsertProduct,
+    removeProduct,
+  } = useHome();
   const [filteredProducts, setFilteredProducts] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [minPrice, setMinPrice] = useState('');
@@ -62,8 +66,6 @@ export default function HomeScreen() {
   const [currentBannerIndex, setCurrentBannerIndex] = useState(0);
   const [bannerFormVisible, setBannerFormVisible] = useState(false);
   const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
   const [sortBy, setSortBy] = useState<
     'newest' | 'price-low' | 'price-high' | 'rating'
   >('newest');
@@ -98,10 +100,6 @@ export default function HomeScreen() {
   ];
 
   useEffect(() => {
-    loadData();
-  }, []);
-
-  useEffect(() => {
     // Check if we should show the cart modal from URL params
     if (params.showCart === 'true') {
       setShowCartModal(true);
@@ -130,20 +128,8 @@ export default function HomeScreen() {
     filterAndSortProducts();
   }, [products, searchQuery, sortBy, selectedCategory, minPrice, maxPrice]);
 
-  const loadData = async () => {
-    try {
-      setLoading(true);
-      const db = DatabaseService.getInstance();
-      const [productsData, categoriesData, bannersData] = await Promise.all([
-        db.getProducts(),
-        listCategories ? listCategories() : Promise.resolve([]),
-        db.getHeroBanners(),
-      ]);
-      setProducts(productsData);
-      setCategories(categoriesData);
-      setHeroBanners(bannersData);
-    } catch (error) {
-      errorLog('HomeScreen loadData error:', error);
+  useEffect(() => {
+    if (error) {
       setInfoModal({
         visible: true,
         title: t('common.error'),
@@ -151,16 +137,8 @@ export default function HomeScreen() {
         type: 'error',
         buttonText: t('common.reload'),
       });
-    } finally {
-      setLoading(false);
     }
-  };
-
-  const onRefresh = async () => {
-    setRefreshing(true);
-    await loadData();
-    setRefreshing(false);
-  };
+  }, [error, t]);
 
   const filterAndSortProducts = () => {
     let filtered = products;
@@ -222,15 +200,11 @@ export default function HomeScreen() {
   };
 
   const handleBannerSaved = (b: HeroBanner, isNew: boolean) => {
-    if (isNew) {
-      setHeroBanners((prev) => [...prev, b]);
-    } else {
-      setHeroBanners((prev) => prev.map((h) => (h.id === b.id ? b : h)));
-    }
+    upsertBanner(b, isNew);
   };
 
   const handleBannerDeleted = (id: string) => {
-    setHeroBanners((prev) => prev.filter((b) => b.id !== id));
+    removeBanner(id);
   };
 
   const addProduct = () => {
@@ -244,15 +218,11 @@ export default function HomeScreen() {
   };
 
   const handleProductSaved = (p: Product, isNew: boolean) => {
-    if (isNew) {
-      setProducts((prev) => [...prev, p]);
-    } else {
-      setProducts((prev) => prev.map((prod) => (prod.id === p.id ? p : prod)));
-    }
+    upsertProduct(p, isNew);
   };
 
   const handleProductDeleted = (id: string) => {
-    setProducts((prev) => prev.filter((p) => p.id !== id));
+    removeProduct(id);
   };
 
   const renderCategory = ({ item }: { item: Category }) => (
@@ -374,7 +344,7 @@ export default function HomeScreen() {
 
   const handleReload = () => {
     setInfoModal((prev) => ({ ...prev, visible: false }));
-    loadData();
+    reload();
   };
 
   if (loading) {
@@ -405,7 +375,7 @@ export default function HomeScreen() {
       <ScrollView
         showsVerticalScrollIndicator={false}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          <RefreshControl refreshing={refreshing} onRefresh={refresh} />
         }
       >
         <View style={styles.filtersContainer}>

--- a/services/tonProducts.ts
+++ b/services/tonProducts.ts
@@ -3,6 +3,8 @@ import { Product } from '../types';
 import { requireEnv } from '../utils/appConfig';
 import { assertTonChain } from './chain';
 import { requireStoreId } from '@blue-ocean/utils';
+import { errorLog } from '@/utils/logger';
+import { productSchema } from '../schemas/waku';
 
 assertTonChain();
 
@@ -35,25 +37,31 @@ export async function getProduct(storeId: string, id: string): Promise<Product |
   const sid = requireStoreId(storeId);
   const res = await getValue(ADDRESS, `${sid}:${id}`);
   if (!res) return null;
-  const parsed = JSON.parse(res) as Product;
-  return {
-    ...parsed,
-    pricingTier: parsed.pricingTier,
-    variants: parsed.variants || [],
-    colors: parsed.colors || [],
-  };
+  try {
+    const parsed = productSchema.parse(JSON.parse(res));
+    return {
+      ...parsed,
+      pricingTier: parsed.pricingTier,
+      variants: parsed.variants || [],
+      colors: parsed.colors || [],
+    };
+  } catch (err) {
+    errorLog('Invalid product data', err);
+    return null;
+  }
 }
 
 export async function setProduct(storeId: string, product: Product) {
   const sid = requireStoreId(storeId);
+  const validated = productSchema.parse(product);
   await setValue(
     ADDRESS,
-    `${sid}:${product.id}`,
+    `${sid}:${validated.id}`,
     JSON.stringify({
-      ...product,
-      pricingTier: product.pricingTier,
-      variants: product.variants || [],
-      colors: product.colors || [],
+      ...validated,
+      pricingTier: validated.pricingTier,
+      variants: validated.variants || [],
+      colors: validated.colors || [],
     })
   );
 }
@@ -66,17 +74,22 @@ export async function listProducts(storeId: string): Promise<Product[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);
   const items = await listValues(ADDRESS);
-  return items
-    .filter((i) => i.key.startsWith(`${sid}:`))
-    .map((i) => {
-      const parsed = JSON.parse(i.value) as Product;
-      return {
+  const res: Product[] = [];
+  for (const i of items) {
+    if (!i.key.startsWith(`${sid}:`)) continue;
+    try {
+      const parsed = productSchema.parse(JSON.parse(i.value));
+      res.push({
         ...parsed,
         pricingTier: parsed.pricingTier,
         variants: parsed.variants || [],
         colors: parsed.colors || [],
-      };
-    });
+      });
+    } catch (err) {
+      errorLog('Invalid product in list', err);
+    }
+  }
+  return res;
 }
 
 export async function getProducts(storeId: string, ids: string[]): Promise<Product[]> {
@@ -92,7 +105,8 @@ export async function getProducts(storeId: string, ids: string[]): Promise<Produ
 export async function setProductBatch(storeId: string, products: Product[]) {
   const sid = requireStoreId(storeId);
   for (const p of products) {
-    await setProduct(sid, p);
+    const validated = productSchema.parse(p);
+    await setProduct(sid, validated);
   }
 }
 

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useCallback } from 'react';
+import DatabaseService from '@/services/database';
+import chain from '@/services/chain';
+import { Product, Category, HeroBanner } from '@/types';
+
+let listCategories: (() => Promise<Category[]>) | undefined;
+if (chain === 'ton') {
+  ({ listCategories } = require('@/services/tonCategories'));
+}
+
+export function useHome() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const db = DatabaseService.getInstance();
+      const [productsData, categoriesData, bannersData] = await Promise.all([
+        db.getProducts(),
+        listCategories ? listCategories() : Promise.resolve([]),
+        db.getHeroBanners(),
+      ]);
+      setProducts(productsData);
+      setCategories(categoriesData);
+      setHeroBanners(bannersData);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadData();
+    setRefreshing(false);
+  }, [loadData]);
+
+  const upsertBanner = useCallback((b: HeroBanner, isNew: boolean) => {
+    setHeroBanners((prev) =>
+      isNew ? [...prev, b] : prev.map((h) => (h.id === b.id ? b : h)),
+    );
+  }, []);
+
+  const removeBanner = useCallback((id: string) => {
+    setHeroBanners((prev) => prev.filter((b) => b.id !== id));
+  }, []);
+
+  const upsertProduct = useCallback((p: Product, isNew: boolean) => {
+    setProducts((prev) =>
+      isNew ? [...prev, p] : prev.map((prod) => (prod.id === p.id ? p : prod)),
+    );
+  }, []);
+
+  const removeProduct = useCallback((id: string) => {
+    setProducts((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  return {
+    products,
+    categories,
+    heroBanners,
+    loading,
+    refreshing,
+    error,
+    reload: loadData,
+    refresh,
+    upsertBanner,
+    removeBanner,
+    upsertProduct,
+    removeProduct,
+  };
+}
+
+export type UseHomeReturn = ReturnType<typeof useHome>;

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect, useCallback } from 'react';
+import NotificationService from '@/services/notification';
+import { Notification } from '@/types';
+import { useAuth } from '@/components/AuthContext';
+
+export function useNotifications() {
+  const { isLoggedIn, user } = useAuth();
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadNotifications = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const notificationService = NotificationService.getInstance();
+      const data = await notificationService.getNotifications(user.id);
+      setNotifications(data);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  const markAsRead = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const service = NotificationService.getInstance();
+      const success = await service.markAsRead(id);
+      if (success) {
+        setNotifications((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+        );
+      }
+      return success;
+    } catch (err) {
+      setError(err as Error);
+      return false;
+    }
+  }, []);
+
+  const markAllAsRead = useCallback(async (): Promise<boolean> => {
+    if (!user) return false;
+    try {
+      const service = NotificationService.getInstance();
+      const success = await service.markAllAsRead(user.id);
+      if (success) {
+        setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      }
+      return success;
+    } catch (err) {
+      setError(err as Error);
+      return false;
+    }
+  }, [user]);
+
+  const deleteNotification = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const service = NotificationService.getInstance();
+      const success = await service.deleteNotification(id);
+      if (success) {
+        setNotifications((prev) => prev.filter((n) => n.id !== id));
+      }
+      return success;
+    } catch (err) {
+      setError(err as Error);
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isLoggedIn && user) {
+      void loadNotifications();
+    } else {
+      setLoading(false);
+      setNotifications([]);
+    }
+  }, [isLoggedIn, user, loadNotifications]);
+
+  return {
+    notifications,
+    loading,
+    error,
+    reload: loadNotifications,
+    markAsRead,
+    markAllAsRead,
+    deleteNotification,
+  };
+}
+
+export type UseNotificationsReturn = ReturnType<typeof useNotifications>;


### PR DESCRIPTION
## Summary
- add reusable `useHome` hook for home screen data
- centralize notification data logic in `useNotifications` hook
- validate TON product service responses with zod

## Testing
- `npm test` *(fails: constants/tenant.ts:7:5 - error TS2367)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eb3e23048326b85e494198019680