### PR TITLE
feat: add ErrorBoundary and wrap entry screens

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'expo-router';
 import FloatingCartWidget from '@/features/cart/components/FloatingCartWidget';
 import { getTabsForAuth } from '../../config/navigation/tabs';
 import { useAuth } from '@/features/auth/AuthContext';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function TabLayout() {
   const { t } = useLanguage();
@@ -28,11 +29,12 @@ export default function TabLayout() {
   }, [pathname]);
 
   return (
-    <>
-      <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarActiveTintColor: colors.tabBar.active,
+    <ErrorBoundary>
+      <>
+        <Tabs
+          screenOptions={{
+            headerShown: false,
+            tabBarActiveTintColor: colors.tabBar.active,
           tabBarInactiveTintColor: colors.tabBar.inactive,
           tabBarStyle: {
             position: 'absolute',
@@ -66,10 +68,11 @@ export default function TabLayout() {
             />
           );
         })}
-      </Tabs>
+        </Tabs>
 
-      {showCartWidget && <FloatingCartWidget />}
-    </>
+        {showCartWidget && <FloatingCartWidget />}
+      </>
+    </ErrorBoundary>
   );
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import { AppInfoProvider } from "../contexts/AppInfoContext";
 import { LanguageProvider } from "../contexts/LanguageContext";
 import { CurrencyProvider } from "../contexts/CurrencyContext";
 import { NotificationProvider } from "../components/NotificationContext";
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 const queryClient = new QueryClient();
 
@@ -29,13 +30,15 @@ export default function RootLayout() {
                       <LanguageProvider>
                         <CurrencyProvider>
                           <NotificationProvider>
-                            <Tabs screenOptions={{ headerShown: false }}>
-                              <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
-                              <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
-                              <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
-                              <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
-                              <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
-                            </Tabs>
+                            <ErrorBoundary>
+                              <Tabs screenOptions={{ headerShown: false }}>
+                                <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
+                                <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
+                                <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
+                                <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
+                                <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
+                              </Tabs>
+                            </ErrorBoundary>
                           </NotificationProvider>
                         </CurrencyProvider>
                       </LanguageProvider>

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,18 +1,21 @@
 import { Stack } from 'expo-router';
 import chain from '../../services/chain';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function AdminLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="index" />
-      <Stack.Screen name="overview" />
-      <Stack.Screen name="stores" />
-      <Stack.Screen name="stores/[storeId]" />
-      <Stack.Screen name="user-directory" />
-      <Stack.Screen name="fees" />
-      {chain === 'ton' && <Stack.Screen name="ton" />}
-      <Stack.Screen name="compliance" />
-      <Stack.Screen name="settings" />
-    </Stack>
+    <ErrorBoundary>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="overview" />
+        <Stack.Screen name="stores" />
+        <Stack.Screen name="stores/[storeId]" />
+        <Stack.Screen name="user-directory" />
+        <Stack.Screen name="fees" />
+        {chain === 'ton' && <Stack.Screen name="ton" />}
+        <Stack.Screen name="compliance" />
+        <Stack.Screen name="settings" />
+      </Stack>
+    </ErrorBoundary>
   );
 }

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -23,6 +23,7 @@ import ProofUploader from '../components/ProofUploader';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import DatabaseService from '../services/database';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import { DeliveryJob } from '../types';
 import commonStyles from '../constants/styles';
 
@@ -83,9 +84,10 @@ export default function DriverDashboardScreen() {
   };
 
   return (
-    <SafeAreaView
-      style={[styles.container, { backgroundColor: colors.background }]}
-    >
+    <ErrorBoundary>
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: colors.background }]}
+      >
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
         <TouchableOpacity onPress={goBack}>
           <ArrowLeft size={24} color={colors.text.primary} />
@@ -93,7 +95,7 @@ export default function DriverDashboardScreen() {
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>לוח נהג</Text>
         <View style={commonStyles.spacer24} />
       </View>
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {jobs.map((job) => (
           <View
             key={job.id}
@@ -182,8 +184,9 @@ export default function DriverDashboardScreen() {
             </Text>
           </View>
         )}
-      </ScrollView>
-    </SafeAreaView>
+        </ScrollView>
+      </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -36,6 +36,7 @@ import CartModal from '@/features/cart/components/CartModal';
 import ProductFormModal from '@/features/products/components/ProductFormModal';
 import SmartImage from '../components/SmartImage';
 import InfoModal from '../components/InfoModal';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 const { width } = Dimensions.get('window');
 const BANNER_WIDTH = width - 32;
@@ -349,6 +350,23 @@ export default function HomeScreen() {
 
   if (loading) {
     return (
+      <ErrorBoundary>
+        <SafeAreaView
+          style={[styles.container, { backgroundColor: colors.background }]}
+        >
+          <GlobalHeader
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            showSearch={true}
+          />
+          <Spinner label="Loading home" />
+        </SafeAreaView>
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <ErrorBoundary>
       <SafeAreaView
         style={[styles.container, { backgroundColor: colors.background }]}
       >
@@ -357,20 +375,6 @@ export default function HomeScreen() {
           onSearchChange={setSearchQuery}
           showSearch={true}
         />
-        <Spinner label="Loading home" />
-      </SafeAreaView>
-    );
-  }
-
-  return (
-    <SafeAreaView
-      style={[styles.container, { backgroundColor: colors.background }]}
-    >
-      <GlobalHeader
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        showSearch={true}
-      />
 
       <ScrollView
         showsVerticalScrollIndicator={false}
@@ -770,6 +774,7 @@ export default function HomeScreen() {
         onClose={() => setShowCartModal(false)}
       />
     </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -6,6 +6,7 @@ import ProofUploader from '../../components/ProofUploader';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import usersAgent from '../../agents/users-agent';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function KycScreen() {
   const { user } = useAuth();
@@ -22,20 +23,22 @@ export default function KycScreen() {
   };
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={styles.content}>
-        <Text style={[styles.title, { color: colors.text.primary }]}>KYC Verification</Text>
-        <Text style={[styles.description, { color: colors.text.secondary }]}>Upload a document for verification.</Text>
-        <ProofUploader jobId={`kyc_${user?.id || 'unknown'}`} onUploaded={setDocUri} />
-        <TouchableOpacity
-          style={[styles.button, { backgroundColor: colors.gold }]}
-          onPress={submit}
-          disabled={!docUri}
-        >
-          <Text style={[styles.buttonText, { color: colors.text.inverse }]}>Submit</Text>
-        </TouchableOpacity>
-      </View>
-    </SafeAreaView>
+    <ErrorBoundary>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={styles.content}>
+          <Text style={[styles.title, { color: colors.text.primary }]}>KYC Verification</Text>
+          <Text style={[styles.description, { color: colors.text.secondary }]}>Upload a document for verification.</Text>
+          <ProofUploader jobId={`kyc_${user?.id || 'unknown'}`} onUploaded={setDocUri} />
+          <TouchableOpacity
+            style={[styles.button, { backgroundColor: colors.gold }]}
+            onPress={submit}
+            disabled={!docUri}
+          >
+            <Text style={[styles.buttonText, { color: colors.text.inverse }]}>Submit</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -10,6 +10,7 @@ import ProductCard from '@/features/products/components/ProductCard';
 import { useTheme } from '../contexts/ThemeContext';
 import SmartImage from '../components/SmartImage';
 import Button from '../components/ui/Button';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function Landing() {
   const { colors } = useTheme();
@@ -37,9 +38,10 @@ export default function Landing() {
   }, []);
 
   return (
-    <AppShell>
-      <ScrollView showsVerticalScrollIndicator={false}>
-        {/* Hero */}
+    <ErrorBoundary>
+      <AppShell>
+        <ScrollView showsVerticalScrollIndicator={false}>
+          {/* Hero */}
         <View style={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 12, alignItems: 'center' }}>
           <Text style={{ color: colors.text.primary, fontSize: 28, fontWeight: '800', textAlign: 'center' }}>
             Blue Ocean Marketplace
@@ -134,6 +136,7 @@ export default function Landing() {
           )}
         </Section>
       </ScrollView>
-    </AppShell>
+      </AppShell>
+    </ErrorBoundary>
   );
 }

--- a/app/store/[storeId]/admin/_layout.tsx
+++ b/app/store/[storeId]/admin/_layout.tsx
@@ -1,18 +1,21 @@
 import { Stack } from 'expo-router';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function StoreAdminLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="dashboard" />
-      <Stack.Screen name="products" />
-      <Stack.Screen name="orders" />
-      <Stack.Screen name="kyc-approvals" />
-      <Stack.Screen name="user-management" />
-      <Stack.Screen name="pricing-tiers" />
-      <Stack.Screen name="deliveries" />
-      <Stack.Screen name="bulk-upload" />
-      <Stack.Screen name="disputes" />
-      <Stack.Screen name="settings" />
-    </Stack>
+    <ErrorBoundary>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="dashboard" />
+        <Stack.Screen name="products" />
+        <Stack.Screen name="orders" />
+        <Stack.Screen name="kyc-approvals" />
+        <Stack.Screen name="user-management" />
+        <Stack.Screen name="pricing-tiers" />
+        <Stack.Screen name="deliveries" />
+        <Stack.Screen name="bulk-upload" />
+        <Stack.Screen name="disputes" />
+        <Stack.Screen name="settings" />
+      </Stack>
+    </ErrorBoundary>
   );
 }

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import React, { ReactNode } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { spacing } from '@/constants/tokens';
+import Button from './Button';
+import { usePathname, router } from 'expo-router';
+import { errorLog } from '@/utils/logger';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    errorLog('ErrorBoundary caught error:', error, info);
+  }
+
+  private reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback onRetry={this.reset} />;
+    }
+    return this.props.children;
+  }
+}
+
+function ErrorFallback({ onRetry }: { onRetry: () => void }) {
+  const { colors } = useTheme();
+  const pathname = usePathname();
+
+  const handleRetry = () => {
+    onRetry();
+    try {
+      router.replace(pathname);
+    } catch {}
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <Text style={[styles.title, { color: colors.text.primary }]}>Something went wrong</Text>
+      <Text style={[styles.route, { color: colors.text.secondary }]}>Route: {pathname}</Text>
+      <Button title="Retry" onPress={handleRetry} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.spacer16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: spacing.spacer8,
+    textAlign: 'center',
+  },
+  route: {
+    marginBottom: spacing.spacer16,
+    textAlign: 'center',
+  },
+});
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add themed `ErrorBoundary` component with retry support
- wrap major layouts and standalone screens with the error boundary

## Testing
- `yarn lint`
- `yarn test` *(fails: TS2367 comparison appears to be unintentional)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f11d2cd88326b52062565e240121