### PR TITLE
fix: resolve features path alias

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '^expo-file-system$': '<rootDir>/tests/__mocks__/expo-file-system.js',
     '^expo-asset$': '<rootDir>/tests/__mocks__/expo-asset.js',
     '^react-native$': '<rootDir>/tests/__mocks__/react-native.js',
+    '^@/features/(.*)$': '<rootDir>/src/features/$1',
     '^@/(.*)$': '<rootDir>/$1',
   },
   testMatch: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@/features/*": [
+        "src/features/*"
+      ],
       "@/*": [
         "./*"
       ],


### PR DESCRIPTION
## Summary
- map `@/features/*` to `src/features/*` in TypeScript config
- update Jest moduleNameMapper for feature paths

## Testing
- `npm test` *(fails: constants/tenant.ts TS2367)*
- `npm run typecheck` *(fails: ProductFormModal.tsx typing issues, missing modules in tonReviews.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5477c05a08326b5e8f5b2ea68bd90