### PR TITLE
fix: correct ProductCard import path

### DIFF
--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useTheme } from '../../contexts/ThemeContext';
 import productsAgent from '../../agents/products-agent';
 import reviewAgent from '../../agents/review-agent';
-import ProductCard from '../@/features/products/components/ProductCard';
+import ProductCard from '@/features/products/components/ProductCard';
 import { Product } from '../../types';
 import Fuse from 'fuse.js';
 import eventBus from '../../services/eventBus';


### PR DESCRIPTION
## Summary
- fix ProductCard import path to use project alias

## Testing
- `yarn lint`
- `yarn test` *(fails: TS2367 in constants/tenant.ts)*
- `yarn typecheck` *(fails: multiple type errors in ProductFormModal.tsx and tonReviews.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b548b27ea8832697268cf79585fb4f