### PR TITLE
feat: integrate router app container

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { ThemeProvider } from './contexts/ThemeContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Router } from 'expo-router';
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,5 @@
 import { Tabs } from "expo-router";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { SafeAreaProvider } from "react-native-safe-area-context";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Lucide from 'lucide-react-native';
-import { ThemeProvider } from "../contexts/ThemeContext";
 import { ConfigProvider } from "../contexts/ConfigContext";
 import { AuthProvider } from "@/features/auth/AuthContext";
 import { AuthModalProvider } from "@/features/auth/AuthModalContext";
@@ -14,42 +10,32 @@ import { CurrencyProvider } from "../contexts/CurrencyContext";
 import { NotificationProvider } from "../components/NotificationContext";
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
-const queryClient = new QueryClient();
-
 export default function RootLayout() {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider>
-        <ThemeProvider>
-          <QueryClientProvider client={queryClient}>
-            <ConfigProvider>
-              <AuthProvider>
-                <AuthModalProvider>
-                  <TenantProvider>
-                    <AppInfoProvider>
-                      <LanguageProvider>
-                        <CurrencyProvider>
-                          <NotificationProvider>
-                            <ErrorBoundary>
-                              <Tabs screenOptions={{ headerShown: false }}>
-                                <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
-                                <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
-                                <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
-                                <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
-                                <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
-                              </Tabs>
-                            </ErrorBoundary>
-                          </NotificationProvider>
-                        </CurrencyProvider>
-                      </LanguageProvider>
-                    </AppInfoProvider>
-                  </TenantProvider>
-                </AuthModalProvider>
-              </AuthProvider>
-            </ConfigProvider>
-          </QueryClientProvider>
-        </ThemeProvider>
-      </SafeAreaProvider>
-    </GestureHandlerRootView>
+    <ConfigProvider>
+      <AuthProvider>
+        <AuthModalProvider>
+          <TenantProvider>
+            <AppInfoProvider>
+              <LanguageProvider>
+                <CurrencyProvider>
+                  <NotificationProvider>
+                    <ErrorBoundary>
+                      <Tabs screenOptions={{ headerShown: false }}>
+                        <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
+                        <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
+                        <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
+                        <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
+                        <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
+                      </Tabs>
+                    </ErrorBoundary>
+                  </NotificationProvider>
+                </CurrencyProvider>
+              </LanguageProvider>
+            </AppInfoProvider>
+          </TenantProvider>
+        </AuthModalProvider>
+      </AuthProvider>
+    </ConfigProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap app entry with gesture, safe area, theme and query providers before rendering Router
- move root layout providers under ConfigProvider and show tab navigation

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Cannot find module './tonKvStore'... and numerous TS2322 etc)*
- `yarn test` *(fails: constants/tenant.ts:7:5 - error TS2367: This comparison appears to be unintentional because the types '"near"' and '"ton"' have no overlap.)*

------
https://chatgpt.com/codex/tasks/task_e_68b54903050883269ac05bbc7251e3c6