### PR TITLE
fix: correct tonProducts import path

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -12,7 +12,7 @@ import {
 } from '../types';
 import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from './tonStores';
-import { getProduct, setProduct } from './tonProducts';
+import { getProduct, setProduct } from '@/features/products/services/tonProducts';
 import nearAuth from '@/features/auth/services/nearAuth';
 import { adminResolve, deployOrderPayment } from './tonContract';
 import config from '../utils/appConfig';


### PR DESCRIPTION
## Summary
- fix import path for tonProducts in order service so bundler resolves

## Testing
- `yarn test` *(fails: constants/tenant.ts:7:5 - TS2367: This comparison appears to be unintentional because the types '"near"' and '"ton"' have no overlap)*

------
https://chatgpt.com/codex/tasks/task_e_68b54a16b1488326825b4c3b95ce2dd4