### PR TITLE
Refactor lazy fallbacks to use Spinner with route labels

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -5,7 +5,7 @@ const ProductScreen = React.lazy(() => import('./_ProductScreen'));
 
 export default function ProductScreenRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Product" />}>
       <ProductScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/bulk-upload.tsx
+++ b/app/store/[storeId]/admin/bulk-upload.tsx
@@ -5,7 +5,7 @@ const BulkUploadScreen = React.lazy(() => import('./_BulkUploadScreen'));
 
 export default function BulkUploadRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Bulk Upload" />}>
       <BulkUploadScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -5,7 +5,7 @@ const DashboardScreen = React.lazy(() => import('./_DashboardScreen'));
 
 export default function DashboardRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Dashboard" />}>
       <DashboardScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/deliveries.tsx
+++ b/app/store/[storeId]/admin/deliveries.tsx
@@ -5,7 +5,7 @@ const DeliveriesScreen = React.lazy(() => import('./_DeliveriesScreen'));
 
 export default function DeliveriesRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Deliveries" />}>
       <DeliveriesScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/disputes.tsx
+++ b/app/store/[storeId]/admin/disputes.tsx
@@ -5,7 +5,7 @@ const DisputesScreen = React.lazy(() => import('./_DisputesScreen'));
 
 export default function DisputesRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Disputes" />}>
       <DisputesScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/kyc-approvals.tsx
+++ b/app/store/[storeId]/admin/kyc-approvals.tsx
@@ -5,7 +5,7 @@ const KycApprovalsScreen = React.lazy(() => import('./_KycApprovalsScreen'));
 
 export default function KycApprovalsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="KYC Approvals" />}>
       <KycApprovalsScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/orders.tsx
+++ b/app/store/[storeId]/admin/orders.tsx
@@ -5,7 +5,7 @@ const OrdersScreen = React.lazy(() => import('./_OrdersScreen'));
 
 export default function OrdersRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Orders" />}>
       <OrdersScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/pricing-tiers.tsx
+++ b/app/store/[storeId]/admin/pricing-tiers.tsx
@@ -5,7 +5,7 @@ const PricingTiersScreen = React.lazy(() => import('./_PricingTiersScreen'));
 
 export default function PricingTiersRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Pricing Tiers" />}>
       <PricingTiersScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/products.tsx
+++ b/app/store/[storeId]/admin/products.tsx
@@ -5,7 +5,7 @@ const ProductsScreen = React.lazy(() => import('./_ProductsScreen'));
 
 export default function ProductsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Products" />}>
       <ProductsScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/settings.tsx
+++ b/app/store/[storeId]/admin/settings.tsx
@@ -5,7 +5,7 @@ const SettingsScreen = React.lazy(() => import('./_SettingsScreen'));
 
 export default function SettingsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="Settings" />}>
       <SettingsScreen {...props} />
     </Suspense>
   );

--- a/app/store/[storeId]/admin/user-management.tsx
+++ b/app/store/[storeId]/admin/user-management.tsx
@@ -5,7 +5,7 @@ const UserManagementScreen = React.lazy(() => import('./_UserManagementScreen'))
 
 export default function UserManagementRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback={<Spinner label="User Management" />}>
       <UserManagementScreen {...props} />
     </Suspense>
   );

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
+import {
+  View,
+  ActivityIndicator,
+  Text,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 
 interface SpinnerProps {
   size?: 'small' | 'large';
   color?: string;
   label?: string;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
 }
 
 export default function Spinner({
@@ -19,7 +26,7 @@ export default function Spinner({
   const spinnerColor = color || colors.gold;
 
   return (
-    <View style={[styles.container, style]}> 
+    <View style={[styles.container, { backgroundColor: colors.background }, style]}>
       <ActivityIndicator size={size} color={spinnerColor} />
       {label ? (
         <Text style={[styles.label, { color: colors.text.primary }]}>{label}</Text>
@@ -30,6 +37,7 @@ export default function Spinner({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,


### PR DESCRIPTION
## Summary
- make Spinner cover full screen with themed background and optional label
- use Spinner in lazy route fallbacks to show route names

## Testing
- `yarn lint`
- `yarn test` *(fails: TS2367 in constants/tenant.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b54c0b0e788326bc8d52601de14c73