### PR TITLE
feat: add root providers to tabs layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,41 +1,92 @@
-import { Tabs } from "expo-router";
+import { Tabs } from 'expo-router';
 import * as Lucide from 'lucide-react-native';
-import { ConfigProvider } from "../contexts/ConfigContext";
-import { AuthProvider } from "@/features/auth/AuthContext";
-import { AuthModalProvider } from "@/features/auth/AuthModalContext";
-import { TenantProvider } from "../contexts/TenantContext";
-import { AppInfoProvider } from "../contexts/AppInfoContext";
-import { LanguageProvider } from "../contexts/LanguageContext";
-import { CurrencyProvider } from "../contexts/CurrencyContext";
-import { NotificationProvider } from "../components/NotificationContext";
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ConfigProvider } from '../contexts/ConfigContext';
+import { AuthProvider } from '@/features/auth/AuthContext';
+import { AuthModalProvider } from '@/features/auth/AuthModalContext';
+import { TenantProvider } from '../contexts/TenantContext';
+import { AppInfoProvider } from '../contexts/AppInfoContext';
+import { LanguageProvider } from '../contexts/LanguageContext';
+import { CurrencyProvider } from '../contexts/CurrencyContext';
+import { NotificationProvider } from '../components/NotificationContext';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+
+const queryClient = new QueryClient();
 
 export default function RootLayout() {
   return (
-    <ConfigProvider>
-      <AuthProvider>
-        <AuthModalProvider>
-          <TenantProvider>
-            <AppInfoProvider>
-              <LanguageProvider>
-                <CurrencyProvider>
-                  <NotificationProvider>
-                    <ErrorBoundary>
-                      <Tabs screenOptions={{ headerShown: false }}>
-                        <Tabs.Screen name="index" options={{ title: 'Home', tabBarIcon: ({ size, color }) => <Lucide.Home size={size} color={color} /> }} />
-                        <Tabs.Screen name="categories" options={{ title: 'Categories', tabBarIcon: ({ size, color }) => <Lucide.Grid3x3 size={size} color={color} /> }} />
-                        <Tabs.Screen name="orders" options={{ title: 'Orders', tabBarIcon: ({ size, color }) => <Lucide.Package size={size} color={color} /> }} />
-                        <Tabs.Screen name="notifications" options={{ title: 'Notifications', tabBarIcon: ({ size, color }) => <Lucide.Bell size={size} color={color} /> }} />
-                        <Tabs.Screen name="profile" options={{ title: 'Profile', tabBarIcon: ({ size, color }) => <Lucide.User size={size} color={color} /> }} />
-                      </Tabs>
-                    </ErrorBoundary>
-                  </NotificationProvider>
-                </CurrencyProvider>
-              </LanguageProvider>
-            </AppInfoProvider>
-          </TenantProvider>
-        </AuthModalProvider>
-      </AuthProvider>
-    </ConfigProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <ConfigProvider>
+          <AuthProvider>
+            <AuthModalProvider>
+              <TenantProvider>
+                <AppInfoProvider>
+                  <LanguageProvider>
+                    <CurrencyProvider>
+                      <NotificationProvider>
+                        <ErrorBoundary>
+                          <QueryClientProvider client={queryClient}>
+                            <Tabs screenOptions={{ headerShown: false }}>
+                              <Tabs.Screen
+                                name="index"
+                                options={{
+                                  title: 'Home',
+                                  tabBarIcon: ({ size, color }) => (
+                                    <Lucide.Home size={size} color={color} />
+                                  ),
+                                }}
+                              />
+                              <Tabs.Screen
+                                name="categories"
+                                options={{
+                                  title: 'Categories',
+                                  tabBarIcon: ({ size, color }) => (
+                                    <Lucide.Grid3x3 size={size} color={color} />
+                                  ),
+                                }}
+                              />
+                              <Tabs.Screen
+                                name="orders"
+                                options={{
+                                  title: 'Orders',
+                                  tabBarIcon: ({ size, color }) => (
+                                    <Lucide.Package size={size} color={color} />
+                                  ),
+                                }}
+                              />
+                              <Tabs.Screen
+                                name="notifications"
+                                options={{
+                                  title: 'Notifications',
+                                  tabBarIcon: ({ size, color }) => (
+                                    <Lucide.Bell size={size} color={color} />
+                                  ),
+                                }}
+                              />
+                              <Tabs.Screen
+                                name="profile"
+                                options={{
+                                  title: 'Profile',
+                                  tabBarIcon: ({ size, color }) => (
+                                    <Lucide.User size={size} color={color} />
+                                  ),
+                                }}
+                              />
+                            </Tabs>
+                          </QueryClientProvider>
+                        </ErrorBoundary>
+                      </NotificationProvider>
+                    </CurrencyProvider>
+                  </LanguageProvider>
+                </AppInfoProvider>
+              </TenantProvider>
+            </AuthModalProvider>
+          </AuthProvider>
+        </ConfigProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- add gesture handler, safe area, and query client providers to tabs layout
- export Tabs wrapped with app providers

## Testing
- `npx eslint app/_layout.tsx`
- `npx jest app/_layout.tsx --passWithNoTests`
- `npx tsc --noEmit app/_layout.tsx` *(fails: Cannot find type definition file for 'bcryptjs')*


------
https://chatgpt.com/codex/tasks/task_e_68b54a5070948326a6ab8bbf28bb8c29