### PR TITLE
feat: add themed button component

### DIFF
--- a/components/AgeVerificationModal.tsx
+++ b/components/AgeVerificationModal.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   StyleSheet,
   Modal,
-  TouchableOpacity,
   ScrollView,
   Platform,
 } from 'react-native';
@@ -17,6 +16,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useAppInfo } from '../contexts/AppInfoContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { spacing, typography } from '../constants/styles';
+import Button from './ui/Button';
 
 const AGE_VERIFICATION_KEY = 'age_verified';
 
@@ -159,36 +159,19 @@ export default function AgeVerificationModal() {
 
             {/* Action Buttons */}
             <View style={styles.buttonContainer}>
-              <TouchableOpacity
-                style={[styles.confirmButton, { backgroundColor: colors.gold }]}
+              <Button
+                title={t('ageVerification.yes18Plus')}
                 onPress={handleConfirm}
-              >
-                <Text
-                  style={[
-                    styles.confirmButtonText,
-                    { color: colors.text.inverse },
-                  ]}
-                >
-                   {t('ageVerification.yes18Plus')}
-                </Text>
-              </TouchableOpacity>
+                accessibilityRole="button"
+              />
 
-              <TouchableOpacity
-                style={[
-                  styles.denyButton,
-                  { borderColor: colors.interactive.disabled },
-                ]}
+              <Button
+                title={t('ageVerification.noUnder18')}
+                variant="secondary"
                 onPress={handleDeny}
-              >
-                <Text
-                  style={[
-                    styles.denyButtonText,
-                    { color: colors.text.primary },
-                  ]}
-                >
-                   {t('ageVerification.noUnder18')}
-                </Text>
-              </TouchableOpacity>
+                style={{ borderColor: colors.interactive.disabled }}
+                accessibilityRole="button"
+              />
             </View>
 
             {/* Footer */}
@@ -305,28 +288,6 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 400,
     alignSelf: 'center',
-  },
-  confirmButton: {
-    borderRadius: 16,
-    paddingVertical: spacing.spacer16,
-    paddingHorizontal: spacing.spacer24,
-    alignItems: 'center',
-  },
-  confirmButtonText: {
-    ...typography.bodyText,
-    fontWeight: 'bold',
-  },
-  denyButton: {
-    backgroundColor: 'transparent',
-    borderWidth: 2,
-    borderRadius: 16,
-    paddingVertical: spacing.spacer16,
-    paddingHorizontal: spacing.spacer24,
-    alignItems: 'center',
-  },
-  denyButtonText: {
-    ...typography.bodyText,
-    fontWeight: '600',
   },
   footer: {
     alignItems: 'center',

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { X } from 'lucide-react-native';
+import Button from './ui/Button';
 
 interface ConfirmationModalProps {
   visible: boolean;
@@ -49,7 +50,11 @@ export default function ConfirmationModal({
             <View style={[styles.modalContainer, { backgroundColor: colors.surface.elevated }]}>
               <View style={styles.header}>
                 <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
-                <TouchableOpacity onPress={onCancel} style={styles.closeButton}>
+                <TouchableOpacity
+                  onPress={onCancel}
+                  style={styles.closeButton}
+                  accessibilityRole="button"
+                >
                   <X size={20} color={colors.text.secondary} />
                 </TouchableOpacity>
               </View>
@@ -61,33 +66,25 @@ export default function ConfirmationModal({
               </View>
               
               <View style={styles.actions}>
-                <TouchableOpacity
-                  style={[
-                    styles.button,
-                    styles.cancelButton,
-                    { borderColor: colors.border.primary }
-                  ]}
+                <Button
+                  title={cancelText}
+                  variant="secondary"
                   onPress={onCancel}
-                >
-                  <Text style={[styles.buttonText, { color: colors.text.primary }]}>
-                    {cancelText}
-                  </Text>
-                </TouchableOpacity>
-                
-                <TouchableOpacity
-                  style={[
-                    styles.button,
-                    styles.confirmButton,
-                    { backgroundColor: destructive ? colors.status.error : colors.gold }
-                  ]}
-                  onPress={() => {
-                    onConfirm();
+                  style={{ flex: 1 }}
+                  accessibilityRole="button"
+                />
+
+                <Button
+                  title={confirmText}
+                  onPress={onConfirm}
+                  style={{
+                    flex: 1,
+                    backgroundColor: destructive
+                      ? colors.status.error
+                      : colors.interactive.primary,
                   }}
-                >
-                  <Text style={[styles.buttonText, { color: colors.text.inverse }]}>
-                    {confirmText}
-                  </Text>
-                </TouchableOpacity>
+                  accessibilityRole="button"
+                />
               </View>
             </View>
           </TouchableWithoutFeedback>
@@ -146,21 +143,5 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: 16,
     gap: 12,
-  },
-  button: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cancelButton: {
-    backgroundColor: 'transparent',
-    borderWidth: 1,
-  },
-  confirmButton: {},
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/components/admin/AdminList.tsx
+++ b/components/admin/AdminList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { View, Text } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import Button from '../ui/Button';
 
 export type AdminListItem = {
   id: string;
@@ -21,16 +22,22 @@ export default function AdminList({ items, emptyText = 'Nothing yet.' }: { items
   return (
     <View style={{ padding: 16 }}>
       {items.map((it) => (
-        <Pressable
+        <Button
           key={it.id}
           onPress={it.onPress}
-          style={{ padding: 12, borderWidth: 1, borderColor: colors.border.primary, borderRadius: 10, marginBottom: 10, backgroundColor: colors.surface.primary }}
+          variant="secondary"
+          style={{
+            marginBottom: 10,
+            alignItems: 'flex-start',
+            backgroundColor: colors.surface.primary,
+          }}
+          accessibilityRole="button"
         >
           <Text style={{ color: colors.text.primary, fontWeight: '600' }}>{it.title}</Text>
           {it.subtitle ? (
             <Text style={{ color: colors.text.secondary, marginTop: 4 }}>{it.subtitle}</Text>
           ) : null}
-        </Pressable>
+        </Button>
       ))}
     </View>
   );

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, TouchableOpacityProps } from 'react-native';
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  PressableProps,
+} from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing, radius } from '../../constants/tokens';
 
-interface ButtonProps extends TouchableOpacityProps {
+interface ButtonProps extends PressableProps {
   title?: string;
   variant?: 'primary' | 'secondary';
   loading?: boolean;
@@ -19,7 +24,8 @@ export default function Button({
   accessibilityRole = 'button',
   ...rest
 }: ButtonProps) {
-  const { colors } = useTheme();
+  const { tokens } = useTheme();
+  const { colors, spacing, radius } = tokens;
 
   const backgroundColor =
     variant === 'primary' ? colors.interactive.primary : colors.interactive.secondary;
@@ -29,10 +35,18 @@ export default function Button({
       ? { borderWidth: 1, borderColor: colors.border.primary }
       : null;
 
+  const buttonStyle = {
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer16,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as const;
+
   return (
-    <TouchableOpacity
+    <Pressable
       accessibilityRole={accessibilityRole}
-      style={[styles.button, { backgroundColor }, borderStyle, style]}
+      style={[buttonStyle, { backgroundColor }, borderStyle, style]}
       disabled={disabled || loading}
       {...rest}
     >
@@ -43,17 +57,11 @@ export default function Button({
       ) : (
         <Text style={[styles.text, { color: textColor }]}>{title}</Text>
       )}
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
-  button: {
-    paddingVertical: spacing.spacer12,
-    paddingHorizontal: spacing.spacer16,
-    borderRadius: radius.md,
-    alignItems: 'center',
-  },
   text: {
     fontSize: 16,
     fontWeight: '600',


### PR DESCRIPTION
## Summary
- create reusable Button with primary/secondary variants from theme tokens
- use Button in modal and admin list screens to reduce duplicate TouchableOpacity/Pressable usage
- clean up redundant style blocks

## Testing
- `yarn test` *(fails: constants/tenant.ts TS2367)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b553270d948326afec4a78bdbb674d