### PR TITLE
refactor: centralize design tokens usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ const styles = StyleSheet.create({
 });
 ```
 
+Tokens are also available at runtime through the `useTheme()` hook, which merges the current
+light/dark mode with any overrides:
+
+```ts
+const { tokens, colors } = useTheme();
+// tokens.spacing.spacer16, colors.text.primary, ...
+```
+
 
 ## Setup Guide
 

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -4,13 +4,14 @@ import { View, Text, StyleSheet } from 'react-native';
 import NotificationService from '../services/notification';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '@/features/auth/AuthContext';
+import { spacing } from '../constants/tokens';
 
 interface NotificationBadgeProps {
   size?: number;
   style?: any;
 }
 
-export default function NotificationBadge({ size = 20, style }: NotificationBadgeProps) {
+export default function NotificationBadge({ size = spacing.spacer20, style }: NotificationBadgeProps) {
   const [unreadCount, setUnreadCount] = useState(0);
   const { colors } = useTheme();
   const { isLoggedIn, user } = useAuth();
@@ -69,10 +70,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-    top: -5,
-    end: -5,
-    minWidth: 20,
-    paddingHorizontal: 2,
+    top: -spacing.spacer4,
+    end: -spacing.spacer4,
+    minWidth: spacing.spacer20,
+    paddingHorizontal: spacing.spacer4 / 2,
   },
   badgeText: {
     fontWeight: 'bold',

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -3,7 +3,8 @@ import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native
 import { Package, Tag, MessageCircle, Info, CircleCheck as CheckCircle, CircleAlert as AlertCircle } from 'lucide-react-native';
 import { Notification } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, typography } from '../constants/styles';
+import { spacing, radius, shadows } from '../constants/tokens';
+import { typography } from '../constants/styles';
 
 interface NotificationItemProps {
   notification: Notification;
@@ -16,14 +17,14 @@ export default function NotificationItem({ notification, onPress }: Notification
   const getNotificationIcon = () => {
     switch (notification.type) {
       case 'order':
-        return <Package size={24} color="#20B2AA" />;
+        return <Package size={24} color={colors.status.success} />;
       case 'promo':
-        return <Tag size={24} color="#FF6B6B" />;
+        return <Tag size={24} color={colors.status.error} />;
       case 'message':
-        return <MessageCircle size={24} color="#4D96FF" />;
+        return <MessageCircle size={24} color={colors.status.info} />;
       case 'system':
       default:
-        return <Info size={24} color="#FFB347" />;
+        return <Info size={24} color={colors.status.warning} />;
     }
   };
 
@@ -53,8 +54,8 @@ export default function NotificationItem({ notification, onPress }: Notification
           borderColor: colors.border.primary 
         },
         !notification.read && {
-          backgroundColor: '#F0FFFF',
-          borderLeftColor: '#20B2AA'
+          backgroundColor: colors.interactive.secondary,
+          borderLeftColor: colors.status.success
         }
       ]}
       onPress={() => onPress(notification.id)}
@@ -71,9 +72,9 @@ export default function NotificationItem({ notification, onPress }: Notification
       </View>
       <View style={styles.statusContainer}>
         {notification.read ? (
-          <CheckCircle size={20} color="#20B2AA" />
+          <CheckCircle size={20} color={colors.status.success} />
         ) : (
-          <AlertCircle size={20} color="#FFB347" />
+          <AlertCircle size={20} color={colors.status.warning} />
         )}
       </View>
     </TouchableOpacity>
@@ -83,21 +84,17 @@ export default function NotificationItem({ notification, onPress }: Notification
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    borderRadius: 12,
+    borderRadius: radius.lg,
     padding: spacing.spacer16,
     marginBottom: spacing.spacer12,
     borderWidth: 1,
     borderLeftWidth: 4,
-    ...Platform.select({
-      ios: { elevation: 2 },
-      android: { elevation: 2 },
-      web: { boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.1)' }
-    }),
+    ...Platform.select(shadows.sm),
   },
   iconContainer: {
     width: spacing.spacer40,
     height: spacing.spacer40,
-    borderRadius: 20,
+    borderRadius: radius.full,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: spacing.spacer12,

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -9,6 +9,8 @@ import {
   Platform
 } from 'react-native';
 import { X } from 'lucide-react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { spacing, zIndex } from '../constants/tokens';
 
 interface NotificationPopupProps {
   title: string;
@@ -29,6 +31,7 @@ export default function NotificationPopup({
 }: NotificationPopupProps) {
   const translateY = useRef(new Animated.Value(-100)).current;
   const opacity = useRef(new Animated.Value(0)).current;
+  const { colors } = useTheme();
 
   useEffect(() => {
     // Slide in
@@ -73,14 +76,14 @@ export default function NotificationPopup({
   const getBackgroundColor = () => {
     switch (type) {
       case 'success':
-        return '#4CAF50';
+        return colors.status.success;
       case 'warning':
-        return '#FF9800';
+        return colors.status.warning;
       case 'error':
-        return '#F44336';
+        return colors.status.error;
       case 'info':
       default:
-        return '#20B2AA';
+        return colors.status.info;
     }
   };
 
@@ -97,11 +100,11 @@ export default function NotificationPopup({
     >
       <View style={styles.content}>
         <View style={styles.textContainer}>
-          <Text style={styles.title}>{title}</Text>
-          <Text style={styles.message} numberOfLines={2}>{message}</Text>
+          <Text style={[styles.title, { color: colors.text.inverse }]}>{title}</Text>
+          <Text style={[styles.message, { color: colors.text.inverse }]} numberOfLines={2}>{message}</Text>
         </View>
         <TouchableOpacity style={styles.closeButton} onPress={dismiss}>
-          <X size={20} color="#FFFFFF" />
+          <X size={20} color={colors.text.inverse} />
         </TouchableOpacity>
       </View>
     </Animated.View>
@@ -114,8 +117,8 @@ const styles = StyleSheet.create({
     top: 0,
     start: 0,
     end: 0,
-    padding: 16,
-    zIndex: 1000,
+    padding: spacing.spacer16,
+    zIndex: zIndex.modal,
     width: width,
   },
   content: {
@@ -125,19 +128,17 @@ const styles = StyleSheet.create({
   },
   textContainer: {
     flex: 1,
-    marginRight: 8,
+    marginRight: spacing.spacer8,
   },
   title: {
-    color: '#FFFFFF',
     fontWeight: 'bold',
     fontSize: 16,
-    marginBottom: 4,
+    marginBottom: spacing.spacer4,
   },
   message: {
-    color: '#FFFFFF',
     fontSize: 14,
   },
   closeButton: {
-    padding: 4,
+    padding: spacing.spacer4,
   },
 });

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,4 +1,4 @@
-import { Colors as DarkColors } from './Colors';
+import { Colors as darkColors } from './Colors';
 import { LightColors } from './LightColors';
 
 export const spacing = {
@@ -38,8 +38,7 @@ export const shadows = {
   },
 };
 
-export const colors = DarkColors;
-export const lightColors = LightColors;
+export const colors = darkColors;
 
 export const tokens = { spacing, radius, colors, zIndex, shadows };
 export const lightTokens = { ...tokens, colors: LightColors };

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -56,20 +56,23 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   const applyTheme = (mode: ThemeMode, color: string) => {
     const base = mode === 'light' ? lightTokens : darkTokens;
-    setCurrentTokens({
+    setCurrentTokens(prev => ({
+      ...prev,
       ...base,
       colors: {
+        ...prev.colors,
         ...base.colors,
         gold: color,
         interactive: {
           ...base.colors.interactive,
+          ...prev.colors.interactive,
           primary: color,
           primaryHover: color,
         },
-        tabBar: { ...base.colors.tabBar, active: color },
-        border: { ...base.colors.border, focus: color },
+        tabBar: { ...base.colors.tabBar, ...prev.colors.tabBar, active: color },
+        border: { ...base.colors.border, ...prev.colors.border, focus: color },
       },
-    });
+    }));
   };
 
   const setTheme = async (newTheme: ThemeMode) => {


### PR DESCRIPTION
## Summary
- export design tokens for spacing, radius, z-index, colors and shadows
- refactor notification components to consume tokens
- merge theme tokens when applying runtime theme changes

## Testing
- `yarn lint`
- `yarn test` *(fails: constants/tenant.ts types mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b5532d073883269cbd80f0d04f40ae