### PR TITLE
refactor(cart): move data fetching to hooks

### DIFF
--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -24,16 +24,9 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react-native';
-import CartService from '../services/cart';
-import chain from '@/services/chain';
 import { CartItem, ShippingAddress, Store } from '@/types';
-
-let getStore:
-  | ((storeId: string, id: string) => Promise<Store | null>)
-  | undefined;
-if (chain === 'ton') {
-  ({ getStore } = require('@/services/tonStores'));
-}
+import useCart from '../hooks/useCart';
+import useCartStores from '../hooks/useCartStores';
 import OrderService from '@/services/orders';
 import eventBus from '@/services/eventBus';
 const MoonPayButton = require('@/features/payments/components/MoonPayButton').default;
@@ -53,7 +46,8 @@ interface CartModalProps {
 }
 
 export default function CartModal({ visible, onClose }: CartModalProps) {
-  const [cartItems, setCartItems] = useState<CartItem[]>([]);
+  const { cartItems, updateQuantity, removeItem, clearCart, getTotal } = useCart();
+  const stores = useCartStores(cartItems);
   const [checkoutStep, setCheckoutStep] = useState<
     'cart' | 'shipping' | 'payment' | 'confirmation'
   >('cart');
@@ -68,7 +62,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const [loading, setLoading] = useState(false);
   const [orderPlaced, setOrderPlaced] = useState(false);
   const [orderIds, setOrderIds] = useState<string[]>([]);
-  const [stores, setStores] = useState<Record<string, Store>>({});
   const { isLoggedIn, user } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
@@ -95,60 +88,20 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
 
   useEffect(() => {
     if (visible) {
-      loadCartItems();
       // reset flow
       setCheckoutStep('cart');
       setOrderPlaced(false);
       setOrderIds([]);
+      if (isLoggedIn && user) {
+        setShippingAddress((prev) => ({ ...prev, name: user.displayName || '' }));
+      }
     }
-  }, [visible]);
-
-  useEffect(() => {
-    const cartService = CartService.getInstance();
-    const handleCartUpdate = () => setCartItems(cartService.getCartItems());
-    cartService.addListener(handleCartUpdate);
-    return () => cartService.removeListener(handleCartUpdate);
-  }, []);
+  }, [visible, isLoggedIn, user]);
 
   useEffect(() => {
     // Scroll to top when changing steps
     scrollViewRef.current?.scrollTo({ y: 0, animated: true });
   }, [checkoutStep]);
-
-  useEffect(() => {
-    const fetchStores = async () => {
-      const ids = Array.from(new Set(cartItems.map((i) => i.product.storeId)));
-      const entries = await Promise.all(
-        ids.map(async (id) => {
-          const store = getStore ? await getStore(id, id) : null;
-          return store ? ([id, store] as const) : null;
-        })
-      );
-      const map: Record<string, Store> = {};
-      entries.forEach((entry) => {
-        if (entry) map[entry[0]] = entry[1];
-      });
-      setStores(map);
-    };
-    fetchStores();
-  }, [cartItems]);
-
-  const loadCartItems = () => {
-    const cartService = CartService.getInstance();
-    setCartItems(cartService.getCartItems());
-    // Pre-fill shipping name if logged in
-    if (isLoggedIn && user) {
-      setShippingAddress((prev) => ({ ...prev, name: user.displayName || '' }));
-    }
-  };
-
-  const updateQuantity = async (itemId: string, newQuantity: number) => {
-    await CartService.getInstance().updateCartItemQuantity(itemId, newQuantity);
-  };
-
-  const removeItem = async (itemId: string) => {
-    await CartService.getInstance().removeFromCart(itemId);
-  };
 
   const groupedItems = useMemo(() => {
     return cartItems.reduce<Record<string, CartItem[]>>((acc, item) => {
@@ -157,13 +110,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       return acc;
     }, {});
   }, [cartItems]);
-
-  const getTotal = () =>
-    cartItems.reduce(
-      (total, item) =>
-        total + (item.unitPrice ?? item.product.price) * item.quantity,
-      0
-    );
 
   const getGroupTotal = (items: CartItem[]) =>
     items.reduce(
@@ -316,7 +262,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
 
     setLoading(true);
     try {
-      const cartService = CartService.getInstance();
       const orders = await OrderService.getInstance().createOrdersFromCart(
         user?.id || 'guest',
         cartItems,
@@ -329,7 +274,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       });
       setOrderIds(orders.map((o) => o.id));
       setOrderPlaced(true);
-      await cartService.clearCart();
+      await clearCart();
 
       showNotification(
         t('cart.orderReceived'),

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -12,17 +12,15 @@ import {
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import { ShoppingCart, X, Plus, Minus } from 'lucide-react-native';
-import CartService from '../services/cart';
-import { CartItem } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { router } from 'expo-router';
+import useCart from '../hooks/useCart';
 
 const { width } = Dimensions.get('window');
 
 export default function FloatingCartWidget() {
-  const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
   const [animatedHeight] = useState(new Animated.Value(60));
   const [animatedOpacity] = useState(new Animated.Value(0));
@@ -30,36 +28,24 @@ export default function FloatingCartWidget() {
   const { currencySymbol } = useCurrency();
   const { t } = useLanguage();
   const isRTL = I18nManager.isRTL;
+  const { cartItems, updateQuantity, removeItem, getTotal, getTotalItems } = useCart();
 
   useEffect(() => {
-    const cartService = CartService.getInstance();
-    
-    const updateCart = () => {
-      const items = cartService.getCartItems();
-      setCartItems(items);
-      
-      // Show/hide widget based on cart content
-      if (items.length > 0) {
-        Animated.timing(animatedOpacity, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: false,
-        }).start();
-      } else {
-        Animated.timing(animatedOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: false,
-        }).start();
-        setIsExpanded(false);
-      }
-    };
-
-    updateCart();
-    cartService.addListener(updateCart);
-    
-    return () => cartService.removeListener(updateCart);
-  }, []);
+    if (cartItems.length > 0) {
+      Animated.timing(animatedOpacity, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: false,
+      }).start();
+    } else {
+      Animated.timing(animatedOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: false,
+      }).start();
+      setIsExpanded(false);
+    }
+  }, [cartItems.length, animatedOpacity]);
 
   const toggleExpanded = () => {
     const newExpanded = !isExpanded;
@@ -70,27 +56,6 @@ export default function FloatingCartWidget() {
       duration: 300,
       useNativeDriver: false,
     }).start();
-  };
-
-  const updateQuantity = async (itemId: string, newQuantity: number) => {
-    const cartService = CartService.getInstance();
-    await cartService.updateCartItemQuantity(itemId, newQuantity);
-  };
-
-  const removeItem = async (itemId: string) => {
-    const cartService = CartService.getInstance();
-    await cartService.removeFromCart(itemId);
-  };
-
-  const getTotal = () => {
-    return cartItems.reduce((total, item) => {
-      const price = item.unitPrice ?? item.product.price;
-      return total + price * item.quantity;
-    }, 0);
-  };
-
-  const getTotalItems = () => {
-    return cartItems.reduce((total, item) => total + item.quantity, 0);
   };
 
     const goToCheckout = () => {

--- a/src/features/cart/components/WishlistModal.tsx
+++ b/src/features/cart/components/WishlistModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   View,
   Text,
@@ -11,10 +11,10 @@ import {
 import SmartImage from '@/components/SmartImage';
 import { X, Heart, ShoppingCart, Trash2 } from 'lucide-react-native';
 import { router } from 'expo-router';
-import CartService from '../services/cart';
 import { WishlistItem } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
+import useWishlist from '../hooks/useWishlist';
 
 interface WishlistModalProps {
   visible: boolean;
@@ -22,39 +22,12 @@ interface WishlistModalProps {
 }
 
 export default function WishlistModal({ visible, onClose }: WishlistModalProps) {
-  const [wishlistItems, setWishlistItems] = useState<WishlistItem[]>([]);
+  const { wishlistItems, removeFromWishlist, addToCart } = useWishlist(visible);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
 
-  useEffect(() => {
-    if (visible) {
-      loadWishlistItems();
-    }
-  }, [visible]);
-
-  useEffect(() => {
-    const cartService = CartService.getInstance();
-    const handleWishlistUpdate = () => {
-      setWishlistItems(cartService.getWishlistItems());
-    };
-
-    cartService.addListener(handleWishlistUpdate);
-    return () => cartService.removeListener(handleWishlistUpdate);
-  }, []);
-
-  const loadWishlistItems = () => {
-    const cartService = CartService.getInstance();
-    setWishlistItems(cartService.getWishlistItems());
-  };
-
-  const removeFromWishlist = async (productId: string) => {
-    const cartService = CartService.getInstance();
-    await cartService.removeFromWishlist(productId);
-  };
-
-  const addToCart = async (item: WishlistItem) => {
-    const cartService = CartService.getInstance();
-    await cartService.addToCart(item.product, 1);
+  const handleAddToCart = async (item: WishlistItem) => {
+    await addToCart(item);
     Alert.alert('נוסף לעגלה', `${item.product.name} נוסף לעגלה`);
   };
 
@@ -113,7 +86,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
       <View style={styles.actions}>
         <TouchableOpacity
           style={[styles.actionButton, styles.addToCartButton, { backgroundColor: colors.gold }]}
-          onPress={() => addToCart(item)}
+          onPress={() => handleAddToCart(item)}
           disabled={item.product.stock === 0}
         >
           <ShoppingCart size={16} color={colors.text.inverse} />

--- a/src/features/cart/hooks/useCart.ts
+++ b/src/features/cart/hooks/useCart.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+import CartService from '../services/cart';
+import { CartItem } from '@/types';
+
+export default function useCart() {
+  const [cartItems, setCartItems] = useState<CartItem[]>([]);
+
+  const loadCartItems = useCallback(() => {
+    const cartService = CartService.getInstance();
+    setCartItems(cartService.getCartItems());
+  }, []);
+
+  useEffect(() => {
+    const cartService = CartService.getInstance();
+    const handleUpdate = () => setCartItems(cartService.getCartItems());
+    handleUpdate();
+    cartService.addListener(handleUpdate);
+    return () => cartService.removeListener(handleUpdate);
+  }, []);
+
+  const updateQuantity = useCallback(async (itemId: string, newQuantity: number) => {
+    await CartService.getInstance().updateCartItemQuantity(itemId, newQuantity);
+  }, []);
+
+  const removeItem = useCallback(async (itemId: string) => {
+    await CartService.getInstance().removeFromCart(itemId);
+  }, []);
+
+  const clearCart = useCallback(async () => {
+    await CartService.getInstance().clearCart();
+  }, []);
+
+  const getTotal = useCallback(() => {
+    return cartItems.reduce((total, item) => {
+      const price = item.unitPrice ?? item.product.price;
+      return total + price * item.quantity;
+    }, 0);
+  }, [cartItems]);
+
+  const getTotalItems = useCallback(() => {
+    return cartItems.reduce((total, item) => total + item.quantity, 0);
+  }, [cartItems]);
+
+  return {
+    cartItems,
+    loadCartItems,
+    updateQuantity,
+    removeItem,
+    clearCart,
+    getTotal,
+    getTotalItems,
+  };
+}

--- a/src/features/cart/hooks/useCartStores.ts
+++ b/src/features/cart/hooks/useCartStores.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import chain from '@/services/chain';
+import { CartItem, Store } from '@/types';
+
+let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
+if (chain === 'ton') {
+  ({ getStore } = require('@/services/tonStores'));
+}
+
+export default function useCartStores(cartItems: CartItem[]) {
+  const [stores, setStores] = useState<Record<string, Store>>({});
+
+  useEffect(() => {
+    const fetchStores = async () => {
+      const ids = Array.from(new Set(cartItems.map((i) => i.product.storeId)));
+      const entries = await Promise.all(
+        ids.map(async (id) => {
+          const store = getStore ? await getStore(id, id) : null;
+          return store ? ([id, store] as const) : null;
+        })
+      );
+      const map: Record<string, Store> = {};
+      entries.forEach((entry) => {
+        if (entry) map[entry[0]] = entry[1];
+      });
+      setStores(map);
+    };
+    fetchStores();
+  }, [cartItems]);
+
+  return stores;
+}

--- a/src/features/cart/hooks/useWishlist.ts
+++ b/src/features/cart/hooks/useWishlist.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+import CartService from '../services/cart';
+import { WishlistItem } from '@/types';
+
+export default function useWishlist(visible: boolean) {
+  const [wishlistItems, setWishlistItems] = useState<WishlistItem[]>([]);
+
+  const loadWishlistItems = useCallback(() => {
+    const cartService = CartService.getInstance();
+    setWishlistItems(cartService.getWishlistItems());
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const cartService = CartService.getInstance();
+    const handleUpdate = () => setWishlistItems(cartService.getWishlistItems());
+    handleUpdate();
+    cartService.addListener(handleUpdate);
+    return () => cartService.removeListener(handleUpdate);
+  }, [visible]);
+
+  const removeFromWishlist = useCallback(async (productId: string) => {
+    await CartService.getInstance().removeFromWishlist(productId);
+  }, []);
+
+  const addToCart = useCallback(async (item: WishlistItem) => {
+    await CartService.getInstance().addToCart(item.product, 1);
+  }, []);
+
+  return {
+    wishlistItems,
+    loadWishlistItems,
+    removeFromWishlist,
+    addToCart,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize cart state and actions in `useCart`
- manage wishlist updates via `useWishlist`
- fetch store metadata for cart items with `useCartStores`
- update cart components to consume new hooks

## Testing
- `yarn lint src/features/cart/hooks src/features/cart/components/WishlistModal.tsx src/features/cart/components/FloatingCartWidget.tsx src/features/cart/components/CartModal.tsx`
- `yarn test` *(fails: constants/tenant.ts comparison type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b55452bc208326afcae1f4b6ce389d