### PR TITLE
feat: wrap feature screens with error boundary

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -38,6 +38,7 @@ import GlobalHeader from '@/components/GlobalHeader';
 import ProductCard from '@/features/products/components/ProductCard';
 import Spinner from '@/components/ui/Spinner';
 import EmptyState from '@/components/ui/EmptyState';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import BannerFormModal from '@/components/BannerFormModal';
 import CartModal from '@/features/cart/components/CartModal';
 import ProductFormModal from '@/features/products/components/ProductFormModal';
@@ -393,9 +394,10 @@ export default function HomeScreen() {
   }
 
   return (
-    <SafeAreaView
-      style={[styles.container, { backgroundColor: colors.background }]}
-    >
+    <ErrorBoundary>
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: colors.background }]}
+      >
       <GlobalHeader
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
@@ -799,7 +801,8 @@ export default function HomeScreen() {
         visible={showCartModal}
         onClose={() => setShowCartModal(false)}
       />
-    </SafeAreaView>
+      </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,7 +1,12 @@
 import { Redirect } from 'expo-router';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function AdminIndex() {
   useRequirePlatformAdmin();
-  return <Redirect href="/admin/overview" />;
+  return (
+    <ErrorBoundary>
+      <Redirect href="/admin/overview" />
+    </ErrorBoundary>
+  );
 }

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,7 +1,12 @@
 import { Redirect } from 'expo-router';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function CategoriesAlias() {
   // Web-safe alias so navigating to '/categories' mounts the Tabs group child
-  return <Redirect href="/(tabs)/categories" />;
+  return (
+    <ErrorBoundary>
+      <Redirect href="/(tabs)/categories" />
+    </ErrorBoundary>
+  );
 }
 

--- a/app/ping.tsx
+++ b/app/ping.tsx
@@ -1,10 +1,22 @@
-import { View, Text } from "react-native";
+import { View, Text } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function Ping() {
+  const { colors } = useTheme();
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-      <Text style={{ fontSize: 24 }}>PING ✅</Text>
-    </View>
+    <ErrorBoundary>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: colors.background,
+        }}
+      >
+        <Text style={{ fontSize: 24, color: colors.text.primary }}>PING ✅</Text>
+      </View>
+    </ErrorBoundary>
   );
 }
 

--- a/app/probe.tsx
+++ b/app/probe.tsx
@@ -1,13 +1,35 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { Link } from 'expo-router';
+import { useTheme } from '../contexts/ThemeContext';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function Probe() {
+  const { colors } = useTheme();
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0b0b0b', gap: 12 }}>
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: '700' }}>PROBE OK</Text>
-      <Link href="/(tabs)/categories" style={{ color: '#4ade80', fontWeight: '700' }}>Open Tabs → Categories</Link>
-    </View>
+    <ErrorBoundary>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: colors.background,
+          gap: 12,
+        }}
+      >
+        <Text
+          style={{ color: colors.text.primary, fontSize: 24, fontWeight: '700' }}
+        >
+          PROBE OK
+        </Text>
+        <Link
+          href="/(tabs)/categories"
+          style={{ color: colors.gold, fontWeight: '700' }}
+        >
+          Open Tabs → Categories
+        </Link>
+      </View>
+    </ErrorBoundary>
   );
 }
 

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -24,6 +24,7 @@ import { useAuthModal } from '@/features/auth/AuthModalContext';
 import commonStyles from '../../constants/styles';
 import Card from '../../components/Card';
 import SmartImage from '../../components/SmartImage';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 
 
@@ -478,7 +479,8 @@ export default function ReviewsScreen() {
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+    <ErrorBoundary>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
         <TouchableOpacity onPress={goBack} style={[styles.backButton, { 
           backgroundColor: colors.surface.primary, 
@@ -862,7 +864,8 @@ export default function ReviewsScreen() {
         onCancel={() => setDeleteModal({ visible: false, reviewId: '' })}
         destructive
       />
-    </SafeAreaView>
+      </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -15,6 +15,7 @@ import ProductCard from '@/features/products/components/ProductCard';
 import { Product } from '../../types';
 import Fuse from 'fuse.js';
 import eventBus from '../../services/eventBus';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 interface ReviewMap {
   [productId: string]: { rating: number; count: number };
@@ -162,25 +163,27 @@ export default function StorefrontScreen({ initialCategory }: Props) {
   });
 
   return (
-    <FlatList
-      data={filtered}
-      keyExtractor={(item) => item.id}
-      renderItem={renderItem}
-      ListHeaderComponent={renderHeader}
-      ListEmptyComponent={() => (
-        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
-          אין מוצרים זמינים
-        </Text>
-      )}
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={[
-        styles.content,
-        { direction: I18nManager.isRTL ? 'rtl' : 'ltr' },
-      ]}
-      initialNumToRender={8}
-      windowSize={5}
-      getItemLayout={getItemLayout}
-    />
+    <ErrorBoundary>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListHeaderComponent={renderHeader}
+        ListEmptyComponent={() => (
+          <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+            אין מוצרים זמינים
+          </Text>
+        )}
+        style={[styles.container, { backgroundColor: colors.background }]}
+        contentContainerStyle={[
+          styles.content,
+          { direction: I18nManager.isRTL ? 'rtl' : 'ltr' },
+        ]}
+        initialNumToRender={8}
+        windowSize={5}
+        getItemLayout={getItemLayout}
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/app/stores/index.tsx
+++ b/app/stores/index.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function StoresScreen() {
+  const { colors } = useTheme();
   return (
-    <View style={styles.container}>
-      <Text>Stores</Text>
-    </View>
+    <ErrorBoundary>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>Stores</Text>
+      </View>
+    </ErrorBoundary>
   );
 }
 

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  error?: Error;
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
@@ -20,27 +21,28 @@ class ErrorBoundary extends React.Component<Props, State> {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     errorLog('ErrorBoundary caught error:', error, info);
+    this.setState({ error });
   }
 
   private reset = () => {
-    this.setState({ hasError: false });
+    this.setState({ hasError: false, error: undefined });
   };
 
   render() {
     if (this.state.hasError) {
-      return <ErrorFallback onRetry={this.reset} />;
+      return <ErrorFallback error={this.state.error} onRetry={this.reset} />;
     }
     return this.props.children;
   }
 }
 
-function ErrorFallback({ onRetry }: { onRetry: () => void }) {
+function ErrorFallback({ error, onRetry }: { error?: Error; onRetry: () => void }) {
   const { colors } = useTheme();
   const pathname = usePathname();
 
@@ -54,6 +56,9 @@ function ErrorFallback({ onRetry }: { onRetry: () => void }) {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}> 
       <Text style={[styles.title, { color: colors.text.primary }]}>Something went wrong</Text>
+      {error?.message && (
+        <Text style={[styles.message, { color: colors.text.secondary }]}>{error.message}</Text>
+      )}
       <Text style={[styles.route, { color: colors.text.secondary }]}>Route: {pathname}</Text>
       <Button title="Retry" onPress={handleRetry} />
     </View>
@@ -75,6 +80,10 @@ const styles = StyleSheet.create({
   },
   route: {
     marginBottom: spacing.spacer16,
+    textAlign: 'center',
+  },
+  message: {
+    marginBottom: spacing.spacer8,
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
## Summary
- improve ErrorBoundary to display error details and retry routing
- wrap feature entry screens with themed ErrorBoundary

## Testing
- `npm test` *(fails: constants/tenant.ts type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b557b0393083269b51911effac2268