### PR TITLE
refactor: unify loading spinners

### DIFF
--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -11,7 +11,6 @@ import {
   Modal,
   TextInput,
   Platform,
-  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';

--- a/app/store/[storeId]/admin/_UserManagementScreen.tsx
+++ b/app/store/[storeId]/admin/_UserManagementScreen.tsx
@@ -20,6 +20,7 @@ import DatabaseService from '../../../../services/database';
 import { User as UserType, CustomerTier, UserRole } from '../../../../types';
 import { useNotifications } from '../../../../components/NotificationContext';
 import commonStyles from '../../../../constants/styles';
+import Spinner from '../../../../components/ui/Spinner';
 
 export default function UserManagementScreen() {
   const [users, setUsers] = useState<UserType[]>([]);
@@ -302,10 +303,7 @@ export default function UserManagementScreen() {
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>ניהול משתמשים</Text>
           <View style={commonStyles.spacer24} />
         </View>
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.gold} />
-          <Text style={[styles.loadingText, { color: colors.text.primary }]}>טוען משתמשים...</Text>
-        </View>
+        <Spinner label="טוען משתמשים..." />
       </SafeAreaView>
     );
   }
@@ -1103,15 +1101,6 @@ const styles = StyleSheet.create({
   userDetailText: {
     fontSize: 12,
     textAlign: 'end',
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    marginTop: 12,
-    fontSize: 16,
   },
   emptyContainer: {
     alignItems: 'center',

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, ReactNode, useEffect, useState } from 'react';
-import { View, ActivityIndicator } from 'react-native';
 import { Alert } from 'react-native';
+import Spinner from '@/components/ui/Spinner';
 import DatabaseService from '@/services/database';
 import { User } from '@/types';
 import { errorLog } from '@/utils/logger';
@@ -121,11 +121,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const isPlatformAdmin = role === 'platform-admin';
 
   if (!initialized) {
-    return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <ActivityIndicator />
-      </View>
-    );
+    return <Spinner />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- use shared Spinner component for auth context loading state
- replace ActivityIndicator in user management screen with Spinner
- clean up unused ActivityIndicator import in product screen

## Testing
- `yarn test` *(fails: types '"near"' and '"ton"' have no overlap)*

------
https://chatgpt.com/codex/tasks/task_e_68b55a4bc6ec8326b390f6d24efc6144