### PR TITLE
refactor: consolidate empty state usage

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1166,14 +1166,6 @@ const styles = StyleSheet.create({
   categorySelectorItemId: {
     fontSize: 12,
   },
-  emptySubcategories: {
-    padding: 20,
-    alignItems: 'center',
-  },
-  emptySubcategoriesText: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
   buttonSpinner: {
     marginRight: 8,
   },

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -354,22 +354,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     padding: 4,
   },
-  emptyContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 32,
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 16,
-    marginBottom: 8,
-  },
-  emptyMessage: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
   loginButton: {
     marginTop: 20,
     paddingHorizontal: 24,

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   TouchableOpacity,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Package, ArrowLeft, ChevronLeft, ShoppingBag, Clock, Calendar, Truck } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
@@ -344,33 +343,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginRight: 4,
-  },
-  emptyState: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 60,
-    paddingHorizontal: 32,
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 16,
-    marginBottom: 8,
-  },
-  emptyMessage: {
-    fontSize: 16,
-    textAlign: 'center',
-    marginBottom: 24,
-    lineHeight: 24,
-  },
-  shopButton: {
-    borderRadius: 25,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-  },
-  shopButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1138,14 +1138,6 @@ const styles = StyleSheet.create({
   categorySelectorItemId: {
     fontSize: 12,
   },
-  emptySubcategories: {
-    padding: 20,
-    alignItems: 'center',
-  },
-  emptySubcategoriesText: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
   buttonSpinner: {
     marginRight: 8,
   },


### PR DESCRIPTION
## Summary
- remove legacy empty state styling from orders, notifications, and home screens
- rely on shared `EmptyState` component for consistent empty views

## Testing
- `yarn lint`
- `yarn test` *(fails: constants/tenant.ts type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b55ef5d4ac8326892651d3d33cf63b