### PR TITLE
feat: migrate services to near

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,13 +1,13 @@
 import { CartItem } from '../types';
-import { assertTonChain } from '../services/chain';
-import { setCartItem, getCartItem, listCartItems, removeCartItem } from '@/features/cart/services/tonCart';
+import { assertNearChain } from '../services/chain';
+import { setCartItem, getCartItem, listCartItems, removeCartItem } from '@/features/cart/services/nearCart';
 import ensureTonWallet from '../utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 class CartAgent {
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage your cart.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage your cart.');
   }
 
   async add(item: CartItem): Promise<void> {

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -1,18 +1,18 @@
 import { Category } from '@/types';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
   setCategory,
   getCategory,
   listCategories,
   removeCategory,
-} from '@/features/products/services/tonCategories';
+} from '@/features/products/services/nearCategories';
 import ensureTonWallet from '@/utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 class CategoriesAgent {
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage categories.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage categories.');
   }
 
   async add(item: Category): Promise<void> {

--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -1,19 +1,19 @@
 import { uuid } from '@/utils/uuid';
 import { Report } from '@/types';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
   addReport,
   listReports,
   removeReport,
-} from '@/features/reviews/services/tonReports';
+} from '@/features/reviews/services/nearReports';
 import ensureTonWallet from '@/utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 class ModerationAgent {
   private async ensureWallet() {
     const { address } = await ensureTonWallet(
-      'Please connect your TON wallet to report items.',
+      'Please connect your NEAR wallet to report items.',
     );
     return { address };
   }

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -1,14 +1,14 @@
 import { Notification } from '../types';
 import { NotificationEvent } from '../types/waku';
-import { assertTonChain } from '../services/chain';
+import { assertNearChain } from '../services/chain';
 import {
   setNotification,
   getNotification,
   listNotifications,
   removeNotification,
-} from '../services/tonNotifications';
+} from '../services/nearNotifications';
 
-assertTonChain();
+assertNearChain();
 import {
   LightNode,
   createLightNode,
@@ -27,7 +27,7 @@ class NotificationsAgent {
   private node: LightNode | null = null;
 
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to send notifications.');
+    await ensureTonWallet('Please connect your NEAR wallet to send notifications.');
   }
 
   async add(item: Notification, storeId = 'default'): Promise<void> {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -2,25 +2,25 @@ import { uuid } from '../utils/uuid';
 import { Order, OrderStatus, Notification, OrderTrackingStep } from '../types';
 import nearAuth from '@/features/auth/services/nearAuth';
 import notificationsAgent from './notifications-agent';
-import { assertTonChain } from '../services/chain';
+import { assertNearChain } from '../services/chain';
 import {
   setOrder,
   getOrder,
   listOrders,
   removeOrder,
   listOrdersBySeller,
-} from '../services/tonOrders';
+} from '../services/nearOrders';
 import storesAgent from './stores-agent';
 import SettingsAgent from './settings-agent';
 import {
   deployOrderPayment,
   releasePayment,
   refundPayment,
-} from '../services/tonContract';
+} from '../services/nearContract';
 import productsAgent from './products-agent';
 import { getSellerPublicKey } from '@/features/stores/services/sellerRegistry';
 
-assertTonChain();
+assertNearChain();
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '../services/eventLog';
@@ -181,7 +181,7 @@ class OrdersAgent {
   }
 
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage orders.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage orders.');
   }
 
   private async ensureAuthorized(order: Order) {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -1,5 +1,5 @@
 import { Product } from '@/types';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
   setProduct,
   getProduct,
@@ -7,8 +7,8 @@ import {
   removeProduct,
   getProducts,
   getVersion,
-} from '@/features/products/services/tonProducts';
-import { getStore } from '@/features/stores/services/tonStores';
+} from '@/features/products/services/nearProducts';
+import { getStore } from '@/features/stores/services/nearStores';
 import ensureTonWallet from '@/utils/ensureTonWallet';
 import {
   LightNode,
@@ -37,6 +37,8 @@ import {
 
 const buildProductTopic = (storeId: string) => buildTopic('products', storeId);
 const PAGE_SIZE = 50;
+
+assertNearChain();
 
 interface ProductSummary {
   rating: number;
@@ -160,7 +162,7 @@ class ProductsAgent {
 
   private async ensureWallet() {
     const { address } = await ensureTonWallet(
-      'Please connect your TON wallet to manage products.',
+      'Please connect your NEAR wallet to manage products.',
     );
     return { address };
   }

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -1,12 +1,12 @@
 import { Review } from '../types';
-import { assertTonChain } from '../services/chain';
+import { assertNearChain } from '../services/chain';
 import { addReview, getReviews } from '@/features/reviews/services/nearReviews';
 import ordersAgent from './orders-agent';
 import productsAgent from './products-agent';
 import storesAgent from './stores-agent';
 import ensureTonWallet from '../utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 const TOPIC = '/blue-ocean/reviews/1';
 
@@ -14,7 +14,7 @@ class ReviewAgent {
   private subscribers: Set<(r: Review) => void> = new Set();
 
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage reviews.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage reviews.');
   }
 
   async add(review: Review): Promise<void> {

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -1,15 +1,15 @@
 import nearAuth from '@/features/auth/services/nearAuth';
-import { assertTonChain } from '../services/chain';
+import { assertNearChain } from '../services/chain';
 import {
   getSetting,
   setSetting,
   getAdmins as fetchAdmins,
   setAdmins as storeAdmins,
   subscribeToSettingsWrites,
-} from '../services/tonSettings';
+} from '../services/nearSettings';
 import ensureTonWallet from '../utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 type SettingKey =
   | 'tenantId'
@@ -40,7 +40,7 @@ class SettingsAgent {
   }
 
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage settings.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage settings.');
   }
 
   async set(key: string, value: string): Promise<void> {

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,14 +1,14 @@
 import { Store } from '@/types';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
   setStore,
   getStore,
   listStores,
   removeStore,
-} from '@/features/stores/services/tonStores';
+} from '@/features/stores/services/nearStores';
 import ensureTonWallet from '@/utils/ensureTonWallet';
 
-assertTonChain();
+assertNearChain();
 
 interface Metrics {
   reviewSum: number;
@@ -22,7 +22,7 @@ class StoresAgent {
   private subscribers: Set<(id: string, score: number) => void> = new Set();
 
   private async ensureWallet() {
-    await ensureTonWallet('Please connect your TON wallet to manage stores.');
+    await ensureTonWallet('Please connect your NEAR wallet to manage stores.');
   }
 
   private toRecord(item: Store) {

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,11 +1,11 @@
 import { User } from '@/types';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
   getUser,
   setUser,
   listUsers,
   removeUser,
-} from '@/features/auth/services/tonUsers';
+} from '@/features/auth/services/nearUsers';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import SettingsAgent from './settings-agent';
 import ensureTonWallet from '@/utils/ensureTonWallet';
@@ -13,7 +13,7 @@ import validateNearAddress from '@/utils/validateNearAddress';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 import type { WakuMessage } from '@/types/waku';
 
-assertTonChain();
+assertNearChain();
 
 export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
@@ -27,7 +27,7 @@ export type UsersAgentMessage =
 
 class UsersAgent {
   private async ensureWallet() {
-    return ensureTonWallet('Please connect your TON wallet to manage users.');
+    return ensureTonWallet('Please connect your NEAR wallet to manage users.');
   }
 
   async add(user: User): Promise<void> {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -28,8 +28,8 @@ import { Product, Category, HeroBanner } from '@/types';
 import chain from '@/services/chain';
 
 let listCategories: (() => Promise<Category[]>) | undefined;
-if (chain === 'ton') {
-  ({ listCategories } = require('@/features/products/services/tonCategories'));
+if (chain === 'near') {
+  ({ listCategories } = require('@/features/products/services/nearCategories'));
 }
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -39,8 +39,8 @@ import DatabaseService from '@/services/database';
 import chain from '@/services/chain';
 
 let listStores: (() => Promise<any[]>) | undefined;
-if (chain === 'ton') {
-  ({ listStores } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ listStores } = require('@/features/stores/services/nearStores'));
 }
 
 

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -12,7 +12,7 @@ export default function AdminLayout() {
         <Stack.Screen name="stores/[storeId]" />
         <Stack.Screen name="user-directory" />
         <Stack.Screen name="fees" />
-        {chain === 'ton' && <Stack.Screen name="ton" />}
+        {chain === 'near' && <Stack.Screen name="ton" />}
         <Stack.Screen name="compliance" />
         <Stack.Screen name="settings" />
       </Stack>

--- a/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
+++ b/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
@@ -10,8 +10,8 @@ import { Store } from '@/types';
 let getStore:
   | ((tenantId: string, id: string) => Promise<Store | null>)
   | undefined;
-if (chain === 'ton') {
-  ({ getStore } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ getStore } = require('@/features/stores/services/nearStores'));
 }
 
 export default function StoreDetail() {

--- a/app/admin/stores/_StoresScreen.tsx
+++ b/app/admin/stores/_StoresScreen.tsx
@@ -9,8 +9,8 @@ import AdminShell from '@/components/admin/AdminShell';
 import AdminList, { AdminListItem } from '@/components/admin/AdminList';
 
 let listStores: (() => Promise<Store[]>) | undefined;
-if (chain === 'ton') {
-  ({ listStores } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ listStores } = require('@/features/stores/services/nearStores'));
 }
 
 export default function AdminStores() {

--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -6,8 +6,8 @@ import chain from '@/services/chain';
 import { User } from '@/types';
 
 let listUsers: (() => Promise<User[]>) | undefined;
-if (chain === 'ton') {
-  ({ listUsers } = require('@/features/auth/services/tonUsers'));
+if (chain === 'near') {
+  ({ listUsers } = require('@/features/auth/services/nearUsers'));
 }
 
 export default function UserDirectory() {

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -8,9 +8,9 @@ import { useAuth } from '@/features/auth/AuthContext';
 
 let listProducts: (() => Promise<any[]>) | undefined;
 let getStore: ((tenant: string, id: string) => Promise<any>) | undefined;
-if (chain === 'ton') {
-  ({ listProducts } = require('@/features/products/services/tonProducts'));
-  ({ getStore } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ listProducts } = require('@/features/products/services/nearProducts'));
+  ({ getStore } = require('@/features/stores/services/nearStores'));
 }
 
 export default function StoreDashboardScreen() {

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -10,8 +10,8 @@ import { useAccountId } from '@/features/auth/services/nearAuth';
 let listOrdersBySeller:
   | ((storeId: string, sellerId: string) => Promise<Order[]>)
   | undefined;
-if (chain === 'ton') {
-  ({ listOrdersBySeller } = require('../../../../services/tonOrders'));
+if (chain === 'near') {
+  ({ listOrdersBySeller } = require('../../../../services/nearOrders'));
 }
 
 export default function StoreOrdersScreen() {

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -6,8 +6,8 @@ import chain from '../../../../services/chain';
 import { Product } from '../../../../types';
 
 let listProducts: (() => Promise<Product[]>) | undefined;
-if (chain === 'ton') {
-  ({ listProducts } = require('@/features/products/services/tonProducts'));
+if (chain === 'near') {
+  ({ listProducts } = require('@/features/products/services/nearProducts'));
 }
 import ProductCard from '@/features/products/components/ProductCard';
 import ProductFormModal from '@/features/products/components/ProductFormModal';

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -19,8 +19,8 @@ import chain from '@/services/chain';
 import { Product, Subcategory, Category, PricingTier, Store } from '@/types';
 
 let listStores: (() => Promise<Store[]>) | undefined;
-if (chain === 'ton') {
-  ({ listStores } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ listStores } = require('@/features/stores/services/nearStores'));
 }
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/components/OrderRevenueMetrics.tsx
+++ b/components/OrderRevenueMetrics.tsx
@@ -7,8 +7,8 @@ import { Order } from '../types';
 let listOrdersBySeller:
   | ((storeId: string, sellerId: string) => Promise<Order[]>)
   | undefined;
-if (chain === 'ton') {
-  ({ listOrdersBySeller } = require('../services/tonOrders'));
+if (chain === 'near') {
+  ({ listOrdersBySeller } = require('../services/nearOrders'));
 }
 
 interface Props {

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -20,8 +20,8 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import chain from '@/services/chain';
 
 let listStores: (() => Promise<any[]>) | undefined;
-if (chain === 'ton') {
-  ({ listStores } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ listStores } = require('@/features/stores/services/nearStores'));
 }
 
 const { width } = Dimensions.get('window');

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -4,8 +4,8 @@ import chain from '../services/chain';
 import config from '../utils/appConfig';
 
 let fetchSettings: (() => Promise<any>) | undefined;
-if (chain === 'ton') {
-  ({ fetchSettings } = require('../services/tonSettings'));
+if (chain === 'near') {
+  ({ fetchSettings } = require('../services/nearSettings'));
 }
 
 export let TENANT = 'blue-ocean';
@@ -27,7 +27,7 @@ export interface TenantSettings {
 const initialAdmin =
   (() => {
     const network =
-      (config.TON_NETWORK || process.env.TON_NETWORK || 'mainnet').toLowerCase();
+      (config.NEAR_NETWORK || process.env.NEAR_NETWORK || 'mainnet').toLowerCase();
     const legacy =
       config.ADMIN_WALLET_ADDRESS || process.env.ADMIN_WALLET_ADDRESS || '';
     const main =

--- a/contexts/AppInfoContext.tsx
+++ b/contexts/AppInfoContext.tsx
@@ -13,8 +13,8 @@ import SettingsAgent from '../agents/settings-agent';
 import chain from '../services/chain';
 
 let fetchSettings: (() => Promise<any>) | undefined;
-if (chain === 'ton') {
-  ({ fetchSettings } = require('../services/tonSettings'));
+if (chain === 'near') {
+  ({ fetchSettings } = require('../services/nearSettings'));
 }
 
 interface AppInfoContextType {

--- a/services/__mocks__/nearSettings.ts
+++ b/services/__mocks__/nearSettings.ts
@@ -1,0 +1,44 @@
+const store: Record<string, string> = {};
+
+export async function getSetting(key: string): Promise<string | null> {
+  return store[key] ?? null;
+}
+
+export async function setSetting(key: string, value: string): Promise<void> {
+  store[key] = value;
+}
+
+export async function getAdmins(): Promise<string[]> {
+  return store['admins'] ? JSON.parse(store['admins']) : [];
+}
+
+export async function setAdmins(admins: string[]): Promise<void> {
+  store['admins'] = JSON.stringify(admins);
+}
+
+export async function fetchSettings() {
+  return {
+    tenantId: store['tenantId'] ?? 'blue-ocean',
+    appName: store['appName'] ?? 'Blue Ocean',
+    theme: { primary: store['theme.primary'] ?? '#B99C5A' },
+    brand: { logoCid: store['brand.logoCid'] ?? '' },
+    fiatKey: store['fiatKey'],
+    feeAddress: store['feeAddress'] ?? '',
+    feeBps: store['feeBps'] ? Number(store['feeBps']) : 0,
+    admins: store['admins'] ? JSON.parse(store['admins']) : [],
+    rpcUrl: store['rpcUrl'] ?? '',
+    rpcFallbackUrls: store['rpcFallbackUrls']
+      ? JSON.parse(store['rpcFallbackUrls'])
+      : [],
+    wakuBootstrap: store['wakuBootstrap']
+      ? JSON.parse(store['wakuBootstrap'])
+      : [],
+    paymentFactoryAddress: store['paymentFactoryAddress'],
+  };
+}
+
+export const subscribeToSettingsWrites = jest
+  .fn()
+  .mockResolvedValue(() => {});
+
+export const __store = store;

--- a/services/chatConfig.ts
+++ b/services/chatConfig.ts
@@ -2,8 +2,8 @@ import chain from './chain';
 
 let getAdmins: (() => Promise<string[]>) | undefined;
 
-if (chain === 'ton') {
-  ({ getAdmins } = require('./tonSettings'));
+if (chain === 'near') {
+  ({ getAdmins } = require('./nearSettings'));
 }
 
 export async function isChatConfigured(): Promise<boolean> {

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -1,10 +1,10 @@
 import { errorLog } from '@/utils/logger';
 import nearAuth from '@/features/auth/services/nearAuth';
-import { fetchSettings } from './tonSettings';
+import { fetchSettings } from './nearSettings';
 import { requireEnv } from '../utils/appConfig';
-import { assertTonChain } from './chain';
+import { assertNearChain } from './chain';
 
-assertTonChain();
+assertNearChain();
 
 export let ORDER_PAYMENT_FACTORY_ADDRESS = '';
 
@@ -13,7 +13,7 @@ export async function getOrderPaymentFactoryAddress(): Promise<string> {
     const settings = await fetchSettings();
     ORDER_PAYMENT_FACTORY_ADDRESS =
       settings.paymentFactoryAddress ||
-      requireEnv('TON_PAYMENT_FACTORY_ADDRESS');
+      requireEnv('NEAR_PAYMENT_FACTORY_CONTRACT');
   }
   return ORDER_PAYMENT_FACTORY_ADDRESS;
 }

--- a/services/nearNotifications.ts
+++ b/services/nearNotifications.ts
@@ -1,12 +1,12 @@
 import { getValue, setValue, listValues, removeValue } from './nearKvStore';
 import { Notification } from '../types';
 import { requireEnv } from '../utils/appConfig';
-import { assertTonChain } from './chain';
+import { assertNearChain } from './chain';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_NOTIFICATIONS_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_NOTIFICATIONS_CONTRACT') : 'near:disabled';
 
 export async function getNotification(id: string): Promise<Notification | null> {
   const res = await getValue(ADDRESS, id);

--- a/services/nearOrders.ts
+++ b/services/nearOrders.ts
@@ -1,13 +1,13 @@
 import { getValue, setValue, listValues, removeValue } from './nearKvStore';
 import { Order } from '../types';
 import { requireEnv } from '../utils/appConfig';
-import { assertTonChain } from './chain';
+import { assertNearChain } from './chain';
 import { requireStoreId } from '@blue-ocean/utils';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_ORDERS_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_ORDERS_CONTRACT') : 'near:disabled';
 
 export async function getOrder(storeId: string, id: string): Promise<Order | null> {
   const sid = requireStoreId(storeId);

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -1,8 +1,8 @@
 import { debugLog, errorLog } from '@/utils/logger';
-import { assertTonChain } from './chain';
+import { assertNearChain } from './chain';
 import { getValue, setValue, listValues } from './nearKvStore';
 
-assertTonChain();
+assertNearChain();
 import config, { getWakuBootstrapNodes, requireEnv } from '../utils/appConfig';
 import {
   LightNode,
@@ -22,11 +22,11 @@ import { sign } from '@noble/ed25519';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_SETTINGS_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_SETTINGS_CONTRACT') : 'near:disabled';
 
 const TEST_ADMIN = 'EQtestadmin';
 const NETWORK =
-  (config.TON_NETWORK || process.env.TON_NETWORK || 'mainnet').toLowerCase();
+  (config.NEAR_NETWORK || process.env.NEAR_NETWORK || 'mainnet').toLowerCase();
 const legacyAdmin =
   config.ADMIN_WALLET_ADDRESS || process.env.ADMIN_WALLET_ADDRESS || '';
 const ADMIN_MAIN =

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -11,10 +11,10 @@ import {
   OrderTrackingStep,
 } from '../types';
 import { sha256 } from '@noble/hashes/sha256';
-import { getStore } from '@/features/stores/services/tonStores';
-import { getProduct, setProduct } from '@/features/products/services/tonProducts';
+import { getStore } from '@/features/stores/services/nearStores';
+import { getProduct, setProduct } from '@/features/products/services/nearProducts';
 import nearAuth from '@/features/auth/services/nearAuth';
-import { adminResolve, deployOrderPayment } from './tonContract';
+import { adminResolve, deployOrderPayment } from './nearContract';
 import config from '../utils/appConfig';
 import { calculateCardFees } from '@/payments/card';
 
@@ -294,7 +294,7 @@ class OrderService {
     if (!order || !order.escrowAddr) return;
     const actor = nearAuth.getAccountId();
     const network =
-      (config.TON_NETWORK || process.env.TON_NETWORK || 'mainnet').toLowerCase();
+      (config.NEAR_NETWORK || process.env.NEAR_NETWORK || 'mainnet').toLowerCase();
     const legacy =
       config.ADMIN_WALLET_ADDRESS || process.env.ADMIN_WALLET_ADDRESS || '';
     const admin =

--- a/src/features/auth/services/nearUsers.ts
+++ b/src/features/auth/services/nearUsers.ts
@@ -6,12 +6,12 @@ import {
 } from '@/services/nearKvStore';
 import { User } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_USERS_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_USERS_CONTRACT') : 'near:disabled';
 
 export async function getUser(id: string): Promise<User | null> {
   const res = await getValue(ADDRESS, id);

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -29,8 +29,8 @@ import { CartItem, ShippingAddress, Store } from '@/types';
 let getStore:
   | ((storeId: string, id: string) => Promise<Store | null>)
   | undefined;
-if (chain === 'ton') {
-  ({ getStore } = require('@/features/stores/services/tonStores'));
+if (chain === 'near') {
+  ({ getStore } = require('@/features/stores/services/nearStores'));
 }
 
 import OrderService from '@/services/orders';

--- a/src/features/cart/hooks/useCartStores.ts
+++ b/src/features/cart/hooks/useCartStores.ts
@@ -3,8 +3,8 @@ import chain from '@/services/chain';
 import { CartItem, Store } from '@/types';
 
 let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
-if (chain === 'ton') {
-  ({ getStore } = require('@/services/tonStores'));
+if (chain === 'near') {
+  ({ getStore } = require('@/services/nearStores'));
 }
 
 export default function useCartStores(cartItems: CartItem[]) {

--- a/src/features/cart/services/nearCart.ts
+++ b/src/features/cart/services/nearCart.ts
@@ -1,12 +1,12 @@
 import { getValue, setValue, listValues, removeValue } from '@/services/nearKvStore';
 import { CartItem } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_CART_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_CART_CONTRACT') : 'near:disabled';
 
 export async function getCartItem(id: string): Promise<CartItem | null> {
   const res = await getValue(ADDRESS, id);

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -4,8 +4,8 @@ import chain from '@/services/chain';
 import { Product, Category, HeroBanner } from '@/types';
 
 let listCategories: (() => Promise<Category[]>) | undefined;
-if (chain === 'ton') {
-  ({ listCategories } = require('@/features/products/services/tonCategories'));
+if (chain === 'near') {
+  ({ listCategories } = require('@/features/products/services/nearCategories'));
 }
 
 export function useHome() {

--- a/src/features/products/components/BulkProductUploader.tsx
+++ b/src/features/products/components/BulkProductUploader.tsx
@@ -9,8 +9,8 @@ import chain from '@/services/chain';
 
 let setProductBatch: ((storeId: string, items: Product[]) => Promise<void>) | undefined;
 let estimateSetProductBatch: ((items: Product[]) => number) | undefined;
-if (chain === 'ton') {
-  ({ setProductBatch, estimateSetProductBatch } = require('@/features/products/services/tonProducts'));
+if (chain === 'near') {
+  ({ setProductBatch, estimateSetProductBatch } = require('@/features/products/services/nearProducts'));
 }
 
 interface Summary {

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -26,8 +26,8 @@ import chain from '@/services/chain';
 let setProductBatch:
   | ((items: ProductIndexItem[]) => Promise<void>)
   | undefined;
-if (chain === 'ton') {
-  ({ setProductBatch } = require('../services/tonProductIndex'));
+if (chain === 'near') {
+  ({ setProductBatch } = require('../services/nearProductIndex'));
 }
 // Note: Avoid importing expo-video on web — it can break bundling if APIs differ.
 // We'll lazily require react-native-video on native platforms for preview.

--- a/src/features/products/services/nearCategories.ts
+++ b/src/features/products/services/nearCategories.ts
@@ -6,12 +6,12 @@ import {
 } from '@/services/nearKvStore';
 import { Category } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_CATEGORIES_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_CATEGORIES_CONTRACT') : 'near:disabled';
 
 export async function getCategory(id: string): Promise<Category | null> {
   const res = await getValue(ADDRESS, id);

--- a/src/features/products/services/nearProductIndex.ts
+++ b/src/features/products/services/nearProductIndex.ts
@@ -1,9 +1,9 @@
 import { Buffer } from 'buffer';
 import { ProductIndexItem } from '@/types';
 import nearAuth from '../../auth/services/nearAuth';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 
-assertTonChain();
+assertNearChain();
 
 export function encodeProductIndexItem(item: ProductIndexItem): string {
   return JSON.stringify(item);

--- a/src/features/products/services/nearProducts.ts
+++ b/src/features/products/services/nearProducts.ts
@@ -1,16 +1,16 @@
 import { getValue, setValue, listValues, removeValue } from '@/services/nearKvStore';
 import { Product } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import { requireStoreId } from '@blue-ocean/utils';
 import { errorLog } from '@/utils/logger';
 import { productSchema } from '@/schemas/waku';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_PRODUCTS_ADDRESS') : 'ton:disabled';
-const DISABLED = ADDRESS === 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_PRODUCTS_CONTRACT') : 'near:disabled';
+const DISABLED = ADDRESS === 'near:disabled';
 let SEEDED = false;
 
 function ensureSeed() {

--- a/src/features/reviews/services/nearReports.ts
+++ b/src/features/reviews/services/nearReports.ts
@@ -1,12 +1,12 @@
 import { setValue, listValues, removeValue } from '@/services/nearKvStore';
 import { Report } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_REPORTS_ADDRESS') : 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_REPORTS_CONTRACT') : 'near:disabled';
 
 export async function addReport(report: Report) {
   await setValue(ADDRESS, report.id, JSON.stringify(report));

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -6,14 +6,14 @@ import {
 } from '@/services/nearKvStore';
 import { Store } from '@/types';
 import { requireEnv } from '@/utils/appConfig';
-import { assertTonChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import { requireStoreId } from '@blue-ocean/utils';
 
-assertTonChain();
+assertNearChain();
 
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const ADDRESS = CHAIN === 'ton' ? requireEnv('TON_STORES_ADDRESS') : 'ton:disabled';
-const DISABLED = ADDRESS === 'ton:disabled';
+const ADDRESS = CHAIN === 'near' ? requireEnv('NEAR_STORES_CONTRACT') : 'near:disabled';
+const DISABLED = ADDRESS === 'near:disabled';
 let SEEDED = false;
 
 function ensureSeed() {

--- a/tests/admin-disputes.test.tsx
+++ b/tests/admin-disputes.test.tsx
@@ -1,6 +1,6 @@
 import OrderService from '../services/orders';
 import ordersAgent from '../agents/orders-agent';
-import { adminResolve } from '../services/tonContract';
+import { adminResolve } from '../services/nearContract';
 
 jest.mock('../agents/orders-agent', () => ({
   get: jest.fn(),
@@ -8,7 +8,7 @@ jest.mock('../agents/orders-agent', () => ({
   subscribe: jest.fn(),
 }));
 
-jest.mock('../services/tonContract', () => ({
+jest.mock('../services/nearContract', () => ({
   adminResolve: jest.fn().mockResolvedValue('tx'),
 }));
 

--- a/tests/admin-store-detail.test.tsx
+++ b/tests/admin-store-detail.test.tsx
@@ -17,13 +17,13 @@ jest.mock('../contexts/ThemeContext', () => ({
   }),
 }));
 
-jest.mock('@/features/stores/services/tonStores', () => ({ getStore: jest.fn() }));
+jest.mock('@/features/stores/services/nearStores', () => ({ getStore: jest.fn() }));
 
 jest.mock('@/features/auth/AuthContext', () => ({ useAuth: jest.fn() }));
 
 describe('Admin store detail access control', () => {
   const { useLocalSearchParams, router } = require('expo-router');
-  const { getStore } = require('@/features/stores/services/tonStores');
+  const { getStore } = require('@/features/stores/services/nearStores');
   const { useAuth } = require('@/features/auth/AuthContext');
 
   beforeEach(() => {

--- a/tests/bulkProductUploader.test.ts
+++ b/tests/bulkProductUploader.test.ts
@@ -18,7 +18,7 @@ jest.mock('../services/media', () => ({
 const setProductBatchMock = jest.fn(async (_storeId: string, _products: Product[]) => {});
 const estimateSetProductBatchMock = jest.fn(async (_products: Product[]) => 1);
 
-jest.mock('@/features/products/services/tonProducts', () => ({
+jest.mock('@/features/products/services/nearProducts', () => ({
   setProductBatch: (storeId: string, products: Product[]) => setProductBatchMock(storeId, products),
   estimateSetProductBatch: (products: Product[]) => estimateSetProductBatchMock(products),
 }));
@@ -29,7 +29,7 @@ describe('BulkProductUploader processRecords', () => {
     setProductBatchMock.mockClear();
     estimateSetProductBatchMock.mockClear();
     insertConfig({
-      TON_RPC_URL: 'http://localhost',
+      NEAR_RPC_URL: 'http://localhost',
       ADMIN_WALLET_ADDRESS_MAINNET: undefined,
       ADMIN_WALLET_ADDRESS_TESTNET: undefined,
 

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -4,7 +4,7 @@ import { CartItem, ShippingAddress } from '../types';
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
 
-jest.mock('../services/tonOrders', () => ({
+jest.mock('../services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
   getOrder: jest.fn(async (id: string) => mockStore[id] || null),
   listOrders: jest.fn().mockResolvedValue([]),
@@ -14,17 +14,17 @@ jest.mock('../services/tonOrders', () => ({
 
 jest.mock('../services/eventBus', () => ({ publish: jest.fn() }));
 
-jest.mock('../services/tonContract', () => ({
+jest.mock('../services/nearContract', () => ({
   deployOrderPayment: jest.fn(),
   releasePayment: jest.fn(),
   refundPayment: jest.fn(),
 }));
 
-jest.mock('@/features/stores/services/tonStores', () => ({
+jest.mock('@/features/stores/services/nearStores', () => ({
   getStore: jest.fn(async (id: string) => ({ id, name: id, owner: `seller_${id}`, nftId: id })),
 }));
 
-jest.mock('@/features/products/services/tonProducts', () => ({
+jest.mock('@/features/products/services/nearProducts', () => ({
   getProduct: jest.fn(async (id: string) => mockProducts[id] || null),
   setProduct: jest.fn(async (p: any) => {
     mockProducts[p.id] = p;

--- a/tests/chatConfig.test.ts
+++ b/tests/chatConfig.test.ts
@@ -1,7 +1,7 @@
 import { isChatConfigured } from '../services/chatConfig';
-import { getAdmins } from '../services/tonSettings';
+import { getAdmins } from '../services/nearSettings';
 
-jest.mock('../services/tonSettings', () => ({
+jest.mock('../services/nearSettings', () => ({
   getAdmins: jest.fn(),
 }));
 

--- a/tests/initGlobals.ts
+++ b/tests/initGlobals.ts
@@ -1,14 +1,14 @@
 // Setup global variables required by React Native modules
 // eslint-disable-next-line
 (globalThis as any).__DEV__ = true;
-process.env.TON_SETTINGS_ADDRESS = 'EQtestsettings';
-process.env.TON_ORDERS_ADDRESS = 'EQtestorders';
-process.env.TON_PRODUCT_INDEX_ADDRESS = 'EQtestproductindex';
-process.env.TON_NOTIFICATIONS_ADDRESS = 'EQtestnotifications';
-process.env.TON_STORES_ADDRESS = 'EQteststores';
-process.env.TON_REPORTS_ADDRESS = 'EQtestreports';
-process.env.TON_REVIEWS_ADDRESS = 'EQtestreviews';
-process.env.TON_CATEGORIES_ADDRESS = 'EQtestcategories';
-process.env.TON_CART_ADDRESS = 'EQtestcart';
-process.env.TON_PRODUCTS_ADDRESS = 'EQtestproducts';
-process.env.TON_USERS_ADDRESS = 'EQtestusers';
+process.env.NEAR_SETTINGS_CONTRACT = 'EQtestsettings';
+process.env.NEAR_ORDERS_CONTRACT = 'EQtestorders';
+process.env.NEAR_PRODUCT_INDEX_CONTRACT = 'EQtestproductindex';
+process.env.NEAR_NOTIFICATIONS_CONTRACT = 'EQtestnotifications';
+process.env.NEAR_STORES_CONTRACT = 'EQteststores';
+process.env.NEAR_REPORTS_CONTRACT = 'EQtestreports';
+process.env.NEAR_REVIEWS_CONTRACT = 'EQtestreviews';
+process.env.NEAR_CATEGORIES_CONTRACT = 'EQtestcategories';
+process.env.NEAR_CART_CONTRACT = 'EQtestcart';
+process.env.NEAR_PRODUCTS_CONTRACT = 'EQtestproducts';
+process.env.NEAR_USERS_CONTRACT = 'EQtestusers';

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -1,11 +1,11 @@
 import OrderService from '../services/orders';
-import { deployOrderPayment } from '../services/tonContract';
+import { deployOrderPayment } from '../services/nearContract';
 import { CartItem, ShippingAddress } from '../types';
 
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
 
-jest.mock('../services/tonOrders', () => ({
+jest.mock('../services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
   getOrder: jest.fn(async (id: string) => mockStore[id] || null),
   listOrders: jest.fn().mockResolvedValue([]),
@@ -15,7 +15,7 @@ jest.mock('../services/tonOrders', () => ({
 
 jest.mock('../services/eventBus', () => ({ publish: jest.fn() }));
 
-jest.mock('../services/tonContract', () => ({
+jest.mock('../services/nearContract', () => ({
   deployOrderPayment: jest
     .fn()
     .mockImplementation(async (amount: number) => ({
@@ -26,15 +26,15 @@ jest.mock('../services/tonContract', () => ({
   refundPayment: jest.fn(),
 }));
 
-jest.mock('@/features/auth/services/tonUsers', () => ({
+jest.mock('@/features/auth/services/nearUsers', () => ({
   getUser: jest.fn().mockResolvedValue({ publicKey: 'a'.repeat(64) }),
 }));
 
-jest.mock('@/features/stores/services/tonStores', () => ({
+jest.mock('@/features/stores/services/nearStores', () => ({
   getStore: jest.fn(async (id: string) => ({ id, name: id, owner: `seller_${id}`, nftId: id })),
 }));
 
-jest.mock('@/features/products/services/tonProducts', () => ({
+jest.mock('@/features/products/services/nearProducts', () => ({
   getProduct: jest.fn(async (id: string) => mockProducts[id] || null),
   setProduct: jest.fn(async (p: any) => {
     mockProducts[p.id] = p;

--- a/tests/nearSettings.test.ts
+++ b/tests/nearSettings.test.ts
@@ -1,4 +1,4 @@
-import { fetchSettings } from '../services/tonSettings';
+import { fetchSettings } from '../services/nearSettings';
 
 jest.mock('../services/nearKvStore', () => require('./tonKvMock'));
 

--- a/tests/notificationsAgent.test.ts
+++ b/tests/notificationsAgent.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../utils/ensureTonWallet', () => jest.fn().mockResolvedValue(undefined));
 
 const setNotificationMock = jest.fn();
-jest.mock('../services/tonNotifications', () => ({
+jest.mock('../services/nearNotifications', () => ({
   setNotification: (...args: any[]) => setNotificationMock(...args),
   getNotification: jest.fn(),
   listNotifications: jest.fn(),

--- a/tests/orderRevenueMetrics.test.tsx
+++ b/tests/orderRevenueMetrics.test.tsx
@@ -6,7 +6,7 @@ jest.mock('../contexts/ThemeContext', () => ({
   useTheme: () => ({ colors: { text: { primary: '#000' } } }),
 }));
 
-jest.mock('../services/tonOrders', () => ({
+jest.mock('../services/nearOrders', () => ({
   listOrdersBySeller: jest.fn(async () => [
     { id: '1', total: 10 } as any,
     { id: '2', total: 5 } as any,

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -7,7 +7,7 @@ import { getEd25519KeyPair } from '../services/localIdentity';
 
 const mockStore: Record<string, any> = {};
 
-jest.mock('../services/tonOrders', () => ({
+jest.mock('../services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => {
     mockStore[o.id] = o;
   }),
@@ -26,7 +26,7 @@ jest.mock('../agents/settings-agent', () => ({
   default: { getInstance: () => ({ getAdmins: getAdminsMock }) },
 }));
 
-jest.mock('../services/tonContract', () => ({
+jest.mock('../services/nearContract', () => ({
   deployOrderPayment: jest.fn().mockResolvedValue({ contractAddress: 'escrow1', txHash: 'tx1' }),
   releasePayment: jest.fn().mockResolvedValue('hash-release'),
   refundPayment: jest.fn().mockResolvedValue('hash-refund'),

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 describe('PinataService', () => {
   beforeEach(async () => {
     insertConfig({
-      TON_RPC_URL: 'https://ton.example',
+      NEAR_RPC_URL: 'https://near.example',
       ADMIN_WALLET_ADDRESS_MAINNET: undefined,
       ADMIN_WALLET_ADDRESS_TESTNET: undefined,
       EXPO_PUBLIC_PINATA_API_KEY: undefined,

--- a/tests/reputation.test.tsx
+++ b/tests/reputation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 
-jest.mock('@/features/stores/services/tonStores', () => ({
+jest.mock('@/features/stores/services/nearStores', () => ({
   getStore: jest.fn(async (id: string) => ({ id, name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 })),
   setStore: jest.fn(async () => {}),
   listStores: jest.fn(async () => [{ id: 's1', name: 'Store', owner: 'owner1', nftId: 'n1', reputation: 0 }]),

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -3,13 +3,13 @@ jest.mock('@/features/auth/services/nearAuth', () => ({
   signIn: jest.fn(),
 }));
 jest.mock('../services/nearKvStore', () => require('./tonKvMock'));
-jest.mock('../services/tonSettings');
+jest.mock('../services/nearSettings');
 
 import SettingsAgent from '../agents/settings-agent';
 import { __clear } from './tonKvMock';
-import * as tonSettings from '../services/tonSettings';
-const directSetAdmins = tonSettings.setAdmins;
-const __store = (tonSettings as any).__store;
+import * as nearSettings from '../services/nearSettings';
+const directSetAdmins = nearSettings.setAdmins;
+const __store = (nearSettings as any).__store;
 let subscribed: (evt: any) => void;
 
 describe('SettingsAgent TON integration', () => {
@@ -19,7 +19,7 @@ describe('SettingsAgent TON integration', () => {
     (SettingsAgent as any).ADMIN_CACHE_TTL = 10; // short TTL for tests
     for (const k of Object.keys(__store)) delete __store[k];
     subscribed = () => {};
-    (tonSettings.subscribeToSettingsWrites as jest.Mock).mockImplementation(
+    (nearSettings.subscribeToSettingsWrites as jest.Mock).mockImplementation(
       async (cb) => {
         subscribed = cb;
         return () => {};
@@ -48,7 +48,7 @@ describe('SettingsAgent TON integration', () => {
   });
 
   it('refreshes admin list on settings write event', async () => {
-    const getSpy = jest.spyOn(tonSettings, 'getAdmins');
+    const getSpy = jest.spyOn(nearSettings, 'getAdmins');
     const agent = SettingsAgent.getInstance();
     await agent.setAdmins(['addr_admin']);
 
@@ -87,7 +87,7 @@ describe('SettingsAgent TON integration', () => {
   });
 
   it('resets admin cache TTL after setAdmins', async () => {
-    const getSpy = jest.spyOn(tonSettings, 'getAdmins');
+    const getSpy = jest.spyOn(nearSettings, 'getAdmins');
     const agent = SettingsAgent.getInstance();
     await agent.setAdmins(['addr_admin']);
     await new Promise((r) => setTimeout(r, 20));

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -2,37 +2,37 @@ import 'dotenv/config';
 import { insertConfig } from './testUtils';
 
 insertConfig({
-  TON_RPC_URL: 'https://ton.test',
+  NEAR_RPC_URL: 'https://near.test',
   ADMIN_WALLET_ADDRESS_MAINNET: 'EQtestadmin',
   ADMIN_WALLET_ADDRESS_TESTNET: 'EQtestadmin',
   EXPO_PUBLIC_WAKU_BOOTSTRAP: '/dns4/test.waku/tcp/443/wss/p2p/TEST',
-  TON_SETTINGS_ADDRESS: 'EQtestsettings',
-  TON_ORDERS_ADDRESS: 'EQtestorders',
-  TON_PRODUCT_INDEX_ADDRESS: 'EQtestproductindex',
-  TON_NOTIFICATIONS_ADDRESS: 'EQtestnotifications',
-  TON_STORES_ADDRESS: 'EQteststores',
-  TON_REPORTS_ADDRESS: 'EQtestreports',
-  TON_REVIEWS_ADDRESS: 'EQtestreviews',
-  TON_CATEGORIES_ADDRESS: 'EQtestcategories',
-  TON_CART_ADDRESS: 'EQtestcart',
-  TON_PRODUCTS_ADDRESS: 'EQtestproducts',
-  TON_USERS_ADDRESS: 'EQtestusers',
-  TON_PAYMENT_FACTORY_ADDRESS: 'EQtestfactory',
-  EXPO_PUBLIC_CHAIN: 'ton',
+  NEAR_SETTINGS_CONTRACT: 'EQtestsettings',
+  NEAR_ORDERS_CONTRACT: 'EQtestorders',
+  NEAR_PRODUCT_INDEX_CONTRACT: 'EQtestproductindex',
+  NEAR_NOTIFICATIONS_CONTRACT: 'EQtestnotifications',
+  NEAR_STORES_CONTRACT: 'EQteststores',
+  NEAR_REPORTS_CONTRACT: 'EQtestreports',
+  NEAR_REVIEWS_CONTRACT: 'EQtestreviews',
+  NEAR_CATEGORIES_CONTRACT: 'EQtestcategories',
+  NEAR_CART_CONTRACT: 'EQtestcart',
+  NEAR_PRODUCTS_CONTRACT: 'EQtestproducts',
+  NEAR_USERS_CONTRACT: 'EQtestusers',
+  NEAR_PAYMENT_FACTORY_CONTRACT: 'EQtestfactory',
+  EXPO_PUBLIC_CHAIN: 'near',
 });
 
 jest.mock('../services/nearKvStore', () => require('./tonKvMock'));
-jest.mock('../services/tonSettings');
+jest.mock('../services/nearSettings');
 const { loadTenantSettings } = require('../constants/tenant');
 
 var __DEV__ = false;
 
 beforeEach(async () => {
   insertConfig({
-    TON_RPC_URL: 'https://ton.test',
+    NEAR_RPC_URL: 'https://near.test',
     ADMIN_WALLET_ADDRESS_MAINNET: 'EQtestadmin',
     ADMIN_WALLET_ADDRESS_TESTNET: 'EQtestadmin',
-    EXPO_PUBLIC_CHAIN: 'ton',
+    EXPO_PUBLIC_CHAIN: 'near',
   });
   await loadTenantSettings();
 });

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -17,8 +17,8 @@ jest.mock('../contexts/ThemeContext', () => ({
   }),
 }));
 
-jest.mock('@/features/stores/services/tonStores', () => ({ getStore: jest.fn() }));
-jest.mock('@/features/products/services/tonProducts', () => ({ listProducts: jest.fn() }));
+jest.mock('@/features/stores/services/nearStores', () => ({ getStore: jest.fn() }));
+jest.mock('@/features/products/services/nearProducts', () => ({ listProducts: jest.fn() }));
 
 jest.mock('@/features/auth/AuthContext', () => ({ useAuth: jest.fn() }));
 
@@ -29,8 +29,8 @@ jest.mock('../components/OrderRevenueMetrics', () => ({
 
 describe('StoreDashboardScreen', () => {
   const { useLocalSearchParams, router } = require('expo-router');
-  const { getStore } = require('@/features/stores/services/tonStores');
-  const { listProducts } = require('@/features/products/services/tonProducts');
+  const { getStore } = require('@/features/stores/services/nearStores');
+  const { listProducts } = require('@/features/products/services/nearProducts');
   const { useAuth } = require('@/features/auth/AuthContext');
 
   beforeEach(() => {

--- a/tests/storeIsolation.test.ts
+++ b/tests/storeIsolation.test.ts
@@ -1,6 +1,6 @@
-import { setProduct, listProducts } from '@/features/products/services/tonProducts';
-import { setOrder, listOrders } from '../services/tonOrders';
-import { setStore, listStores } from '@/features/stores/services/tonStores';
+import { setProduct, listProducts } from '@/features/products/services/nearProducts';
+import { setOrder, listOrders } from '../services/nearOrders';
+import { setStore, listStores } from '@/features/stores/services/nearStores';
 import { Product, Order, Store, ShippingAddress } from '../types';
 
 jest.mock('../services/nearKvStore', () => {

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -17,7 +17,7 @@ jest.mock('../services/localIdentity', () => ({
 
 jest.mock('../services/nearKvStore', () => require('./tonKvMock'));
 import { __clear } from './tonKvMock';
-import { setAdmins } from '../services/tonSettings';
+import { setAdmins } from '../services/nearSettings';
 
 describe('UsersAgent TON integration', () => {
   beforeEach(() => {

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -1,23 +1,22 @@
 // Configuration values are loaded from environment variables.
 // Only a minimal set of keys is supported at runtime.
 
-// Only enforce TON addresses when running in TON mode. When using NEAR,
-// these are not required and should not crash the app if missing.
+// Only enforce NEAR contracts when running in NEAR mode.
 const CHAIN = (process.env.EXPO_PUBLIC_CHAIN || '').toLowerCase();
-const TON_REQUIRED_ENV_KEYS: string[] = [
-  'TON_SETTINGS_ADDRESS',
-  'TON_ORDERS_ADDRESS',
-  'TON_PRODUCT_INDEX_ADDRESS',
-  'TON_NOTIFICATIONS_ADDRESS',
-  'TON_STORES_ADDRESS',
-  'TON_REPORTS_ADDRESS',
-  'TON_REVIEWS_ADDRESS',
-  'TON_CATEGORIES_ADDRESS',
-  'TON_CART_ADDRESS',
-  'TON_PRODUCTS_ADDRESS',
-  'TON_USERS_ADDRESS',
+const NEAR_REQUIRED_ENV_KEYS: string[] = [
+  'NEAR_SETTINGS_CONTRACT',
+  'NEAR_ORDERS_CONTRACT',
+  'NEAR_PRODUCT_INDEX_CONTRACT',
+  'NEAR_NOTIFICATIONS_CONTRACT',
+  'NEAR_STORES_CONTRACT',
+  'NEAR_REPORTS_CONTRACT',
+  'NEAR_REVIEWS_CONTRACT',
+  'NEAR_CATEGORIES_CONTRACT',
+  'NEAR_CART_CONTRACT',
+  'NEAR_PRODUCTS_CONTRACT',
+  'NEAR_USERS_CONTRACT',
 ];
-const REQUIRED_ENV_KEYS: string[] = CHAIN === 'ton' ? TON_REQUIRED_ENV_KEYS : [];
+const REQUIRED_ENV_KEYS: string[] = CHAIN === 'near' ? NEAR_REQUIRED_ENV_KEYS : [];
 
 const ENV_KEYS = [
   'EXPO_PUBLIC_DEBUG_LOGS',
@@ -25,13 +24,13 @@ const ENV_KEYS = [
   'EXPO_PUBLIC_CHAIN',
   'ADMIN_WALLET_ADDRESS_MAINNET',
   'ADMIN_WALLET_ADDRESS_TESTNET',
-  'TON_NETWORK',
-  'TON_PAYMENT_FACTORY_ADDRESS',
+  'NEAR_NETWORK',
+  'NEAR_PAYMENT_FACTORY_CONTRACT',
 
   ...REQUIRED_ENV_KEYS,
-  'TON_RPC_URL',
-  'TON_RPC_FALLBACK_URLS',
-  'ENABLE_UNSAFE_TON_PRIVATE_KEY',
+  'NEAR_RPC_URL',
+  'NEAR_RPC_FALLBACK_URLS',
+  'ENABLE_UNSAFE_NEAR_PRIVATE_KEY',
   'EXPO_PUBLIC_PINATA_API_KEY',
   'EXPO_PUBLIC_PINATA_SECRET_API_KEY',
   'EXPO_PUBLIC_PINATA_JWT',
@@ -43,7 +42,7 @@ function loadConfig(): Record<string, string> {
     const value = process.env[key];
     if (value !== undefined) {
       if (
-        key === 'ENABLE_UNSAFE_TON_PRIVATE_KEY' &&
+        key === 'ENABLE_UNSAFE_NEAR_PRIVATE_KEY' &&
         process.env.NODE_ENV === 'production'
       ) {
         continue;
@@ -94,7 +93,7 @@ export function requireEnv(key: string): string {
   return value;
 }
 
-export function getTonRpcUrls(): string[] {
+export function getNearRpcUrls(): string[] {
   let tenantRpc = '';
   let tenantFallbacks: string[] = [];
   try {
@@ -102,9 +101,9 @@ export function getTonRpcUrls(): string[] {
     tenantRpc = tenant.AppConfig?.rpcUrl || '';
     tenantFallbacks = tenant.AppConfig?.rpcFallbackUrls || [];
   } catch {}
-  const envPrimary = config.TON_RPC_URL || process.env.TON_RPC_URL || '';
+  const envPrimary = config.NEAR_RPC_URL || process.env.NEAR_RPC_URL || '';
   const envFallbackRaw =
-    config.TON_RPC_FALLBACK_URLS || process.env.TON_RPC_FALLBACK_URLS || '';
+    config.NEAR_RPC_FALLBACK_URLS || process.env.NEAR_RPC_FALLBACK_URLS || '';
   const envFallbacks = envFallbackRaw
     .split(',')
     .map((u) => u.trim())
@@ -112,10 +111,10 @@ export function getTonRpcUrls(): string[] {
   let primary = envPrimary || tenantRpc;
   const fallbacks = envFallbacks.length > 0 ? envFallbacks : tenantFallbacks;
   if (!primary) {
-    primary = 'https://testnet.toncenter.com/api/v2/jsonRPC';
+    primary = 'https://rpc.testnet.near.org';
     // eslint-disable-next-line no-console
     console.warn(
-      'TON_RPC_URL not set, defaulting to https://testnet.toncenter.com/api/v2/jsonRPC',
+      'NEAR_RPC_URL not set, defaulting to https://rpc.testnet.near.org',
     );
   }
   return [primary, ...fallbacks];


### PR DESCRIPTION
## Summary
- migrate service modules from TON to NEAR implementations
- update environment and agent logic for NEAR usage
- drop legacy TON-specific service files

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b65ffc3483268f8620c4d04a3cfc