### PR TITLE
fix: correct card fee import path

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -16,7 +16,7 @@ import { getProduct, setProduct } from '@/features/products/services/nearProduct
 import nearAuth from '@/features/auth/services/nearAuth';
 import { adminResolve, deployOrderPayment } from './nearContract';
 import config from '../utils/appConfig';
-import { calculateCardFees } from '@/payments/card';
+import { calculateCardFees } from '@/features/payments/services/card';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';


### PR DESCRIPTION
## Summary
- import card fee calculator from `features/payments/services`

## Testing
- `yarn test`
- `yarn lint`
- `yarn build:web` *(fails: Cannot resolve '../constants/styles' in src/features/cart/constants/styles)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d832ff2c8326b17f6b87e1fffd71