### PR TITLE
chore: extend fix-near script for TON cleanup

### DIFF
--- a/scripts/fix-near.js
+++ b/scripts/fix-near.js
@@ -3,6 +3,7 @@
   - Sets near-api-js to 6.2.6 if present
   - Sets @near-wallet-selector/* to 9.3.0 if present
   - Ensures root package.json resolutions include these pins
+  - Rewrites leftover TON constants or URLs to their NEAR equivalents
   - Prints a summary and next steps
 */
 
@@ -16,11 +17,19 @@ const TARGETS = [
   path.join(ROOT, 'relayer', 'package.json'),
 ].filter((p) => fs.existsSync(p));
 
+const SEARCH_PATHS = ['src', 'packages', 'config', 'docs']
+  .map((p) => path.join(ROOT, p))
+  .filter((p) => fs.existsSync(p));
+const EXTRA_FILES = ['.env', '.env.example']
+  .map((p) => path.join(ROOT, p))
+  .filter((p) => fs.existsSync(p));
+
 const NEAR_JS_VERSION = '2.1.4';
 const SELECTOR_VERSION = '8.9.3';
 const LATEST_CB_VERSION = '0.2.4';
 
 let changed = 0;
+let rewritten = 0;
 
 function setDep(obj, name, ver) {
   let hit = false;
@@ -75,9 +84,54 @@ for (const pkgPath of TARGETS) {
   }
 }
 
+function isTextFile(file) {
+  const ext = path.extname(file).toLowerCase();
+  return [
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+    '.json',
+    '.md',
+    '.env',
+    '.yml',
+    '.yaml',
+    '.sh',
+  ].includes(ext);
+}
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(fullPath);
+    else if (entry.isFile() && isTextFile(fullPath)) rewriteFile(fullPath);
+  }
+}
+
+function rewriteFile(file) {
+  const original = fs.readFileSync(file, 'utf8');
+  let output = original
+    .replace(/\bTON\b/g, 'NEAR')
+    .replace(/\bTon\b/g, 'Near')
+    .replace(/TON_/g, 'NEAR_')
+    .replace(/Ton_/g, 'Near_')
+    .replace(/https?:\/\/[^"'\s]*ton[^"'\s]*/gi, (m) => m.replace(/ton/gi, 'near'));
+  if (output !== original) {
+    fs.writeFileSync(file, output);
+    rewritten++;
+    console.log(`✔ Rewrote ${path.relative(ROOT, file)}`);
+  }
+}
+
+for (const dir of SEARCH_PATHS) walk(dir);
+for (const file of EXTRA_FILES) rewriteFile(file);
+
 console.log('\nSummary:');
-if (changed === 0) console.log('• No changes needed.');
+if (changed === 0) console.log('• No package.json changes needed.');
 else console.log(`• Wrote ${changed} package.json file(s).`);
+if (rewritten === 0) console.log('• No TON references found.');
+else console.log(`• Rewrote ${rewritten} file(s) replacing TON → NEAR.`);
 
 console.log('\nNext steps:');
 console.log('1) yarn install');


### PR DESCRIPTION
## Summary
- expand fix-near script to scan repo and rewrite any leftover TON identifiers or URLs to NEAR

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token '<')*

------
https://chatgpt.com/codex/tasks/task_e_68b5dcf871c48326bfb4f4afbb79361f