### PR TITLE
chore: add TON reference check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,6 @@ jobs:
         with:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
+      - run: node scripts/check-no-ton.js
       - run: yarn typecheck && yarn lint && yarn doctor && yarn build:web
       - run: yarn test

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## TON reference check
+
+To keep the codebase free of TON integrations, a pre-commit and CI check scans tracked files for the string `TON` and common TON RPC endpoints like `toncenter.com`, `tonapi.io`, and `ton.org`.
+
+Run the check manually with:
+
+```bash
+node scripts/check-no-ton.js
+```
+
+Any matches will cause commits or CI runs to fail.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:web": "cross-env EXPO_PUBLIC_USE_ROUTER=0 expo start --web",
     "web:router": "cross-env EXPO_PUBLIC_USE_ROUTER=1 expo start --web",
     "build": "node scripts/app.js build",
-        "build:web": "cross-env EXPO_WEB_BUNDLER=metro EXPO_PUBLIC_USE_ROUTER=1 expo export --platform web --output-dir dist",
+    "build:web": "cross-env EXPO_WEB_BUNDLER=metro EXPO_PUBLIC_USE_ROUTER=1 expo export --platform web --output-dir dist",
     "preview": "node scripts/app.js preview",
     "docker:dev": "node scripts/app.js docker dev",
     "docker:build:web": "node scripts/app.js docker build",
@@ -166,6 +166,9 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "yarn lint"
+    ],
+    "**/*": [
+      "node scripts/check-no-ton.js"
     ]
   }
 }

--- a/scripts/check-no-ton.js
+++ b/scripts/check-no-ton.js
@@ -1,0 +1,49 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const PATTERNS = [
+  { regex: /\bTON\b/, label: 'TON' },
+  { regex: /toncenter\.com/i, label: 'toncenter.com' },
+  { regex: /tonapi\.io/i, label: 'tonapi.io' },
+  { regex: /ton\.org/i, label: 'ton.org' },
+];
+
+const IGNORE_PREFIXES = ['docs/', 'scripts/check-no-ton.js'];
+
+function isIgnored(file) {
+  return IGNORE_PREFIXES.some((p) => file === p || file.startsWith(p));
+}
+
+const files = execSync('git ls-files', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean)
+  .filter((file) => !isIgnored(file));
+
+const violations = [];
+
+for (const file of files) {
+  let content;
+  try {
+    content = fs.readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const { regex, label } of PATTERNS) {
+      if (regex.test(line)) {
+        violations.push(`${file}:${i + 1}: found ${label}`);
+        break;
+      }
+    }
+  }
+}
+
+if (violations.length) {
+  console.error('Forbidden TON references found:');
+  for (const v of violations) console.error('  ' + v);
+  process.exit(1);
+}
+
+console.log('No TON references found');


### PR DESCRIPTION
## Summary
- add script to scan tracked files for TON references and common RPC endpoints
- run TON scan in CI and pre-commit
- document TON reference check in contributing guide

## Testing
- `node scripts/check-no-ton.js`
- `yarn lint`
- `yarn test` *(fails: SyntaxError: Unexpected token '<' / Type errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dcfe7cb88326954e77e8ef570bd8