### PR TITLE
refactor: use root alias for constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn test
 Shared design tokens live in `constants/tokens.ts`. Import `spacing`, `radius`, `colors`, `zIndex`, and `shadows` to keep styles consistent across components.
 
 ```ts
-import { spacing, radius, zIndex, shadows } from '../constants/tokens';
+import { spacing, radius, zIndex, shadows } from '@/constants/tokens';
 
 const styles = StyleSheet.create({
   button: {

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -18,7 +18,7 @@ import EmptyState from '../../components/ui/EmptyState';
 import OrderTrackingModal from '../../components/OrderTrackingModal';
 import InfoModal from '../../components/InfoModal';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCurrency } from '../../contexts/CurrencyContext';
 

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -11,7 +11,7 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import Spinner from '../../components/ui/Spinner';
 import InfoModal from '../../components/InfoModal';
 import { useAppInfo } from '../../contexts/AppInfoContext';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 import SettingsAgent from '../../agents/settings-agent';
 import BrandingSettings from '../../components/settings/BrandingSettings';
 import CurrencySettings from '../../components/settings/CurrencySettings';

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -18,7 +18,7 @@ import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import InfoModal from '../../components/InfoModal';
 import Spinner from '../../components/ui/Spinner';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 
 
 

--- a/app/control/LiveFocusView.tsx
+++ b/app/control/LiveFocusView.tsx
@@ -3,7 +3,7 @@ import { View, Text, Button, FlatList } from 'react-native';
 import { RoadmapProvider, useRoadmap } from '../../contexts/RoadmapContext';
 import RoadmapService from '../../services/roadmap';
 import type { RoadmapTask } from '../../types';
-import { spacing, typography } from '../../constants/styles';
+import { spacing, typography } from '@/constants/styles';
 
 function LiveFocusInner() {
   const { activeRoadmap, tasks, completeTask, progress } = useRoadmap();

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -25,7 +25,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import DatabaseService from '../services/database';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import { DeliveryJob } from '../types';
-import commonStyles from '../constants/styles';
+import commonStyles from '@/constants/styles';
 
 
 

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -43,7 +43,7 @@ import { useAccountId } from '@/features/auth/services/nearAuth';
 import chatAgent from '../../agents/chat-agent';
 import moderationAgent from '../../agents/moderation-agent';
 import reviewAgent from '../../agents/review-agent';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '@/features/cart/components/FloatingCartWidget';
 import SmartImage from '../../components/SmartImage';

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -21,7 +21,7 @@ import Spinner from '../../components/ui/Spinner';
 import InfoModal from '../../components/InfoModal';
 import ConfirmationModal from '../../components/ConfirmationModal';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 import Card from '../../components/Card';
 import SmartImage from '../../components/SmartImage';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';

--- a/app/store/[storeId]/admin/_DeliveriesScreen.tsx
+++ b/app/store/[storeId]/admin/_DeliveriesScreen.tsx
@@ -19,7 +19,7 @@ import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { DeliveryJob, User } from '../../../../types';
-import commonStyles from '../../../../constants/styles';
+import commonStyles from '@/constants/styles';
 import SmartImage from '../../../../components/SmartImage';
 
 export default function AdminDeliveriesScreen() {

--- a/app/store/[storeId]/admin/_DisputesScreen.tsx
+++ b/app/store/[storeId]/admin/_DisputesScreen.tsx
@@ -9,7 +9,7 @@ import ordersAgent from '../../../../agents/orders-agent';
 import { Order } from '../../../../types';
 import DisputeEvidence from '../../../../components/DisputeEvidence';
 import DisputeResolver from '../../../../components/DisputeResolver';
-import commonStyles from '../../../../constants/styles';
+import commonStyles from '@/constants/styles';
 
 export default function AdminDisputesScreen() {
   const { colors } = useTheme();

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { User as UserType } from '../../../../types';
 import Spinner from '../../../../components/ui/Spinner';
-import commonStyles from '../../../../constants/styles';
+import commonStyles from '@/constants/styles';
 import SmartImage from '../../../../components/SmartImage';
 
 

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -11,7 +11,7 @@ import { useLanguage } from '../../../../contexts/LanguageContext';
 import Spinner from '../../../../components/ui/Spinner';
 import InfoModal from '../../../../components/InfoModal';
 import { useAppInfo } from '../../../../contexts/AppInfoContext';
-import commonStyles from '../../../../constants/styles';
+import commonStyles from '@/constants/styles';
 import SettingsAgent from '../../../../agents/settings-agent';
 import BrandingSettings from '../../../../components/settings/BrandingSettings';
 import CurrencySettings from '../../../../components/settings/CurrencySettings';

--- a/app/store/[storeId]/admin/_UserManagementScreen.tsx
+++ b/app/store/[storeId]/admin/_UserManagementScreen.tsx
@@ -19,7 +19,7 @@ import { useTheme } from '../../../../contexts/ThemeContext';
 import DatabaseService from '../../../../services/database';
 import { User as UserType, CustomerTier, UserRole } from '../../../../types';
 import { useNotifications } from '../../../../components/NotificationContext';
-import commonStyles from '../../../../constants/styles';
+import commonStyles from '@/constants/styles';
 import Spinner from '../../../../components/ui/Spinner';
 
 export default function UserManagementScreen() {

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -15,7 +15,7 @@ import DatabaseService from '../../services/database';
 import { User } from '../../types';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
-import commonStyles from '../../constants/styles';
+import commonStyles from '@/constants/styles';
 import SmartImage from '../../components/SmartImage';
 
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Platform, ViewStyle, StyleProp } from 'react-native';
-import { radius, shadows } from '../constants/tokens';
+import { radius, shadows } from '@/constants/tokens';
 
 interface CardProps {
   children?: React.ReactNode;

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -16,7 +16,7 @@ import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from '@/features/cart/components/WishlistModal';
 import CartService from '@/features/cart/services/cart';
-import { spacing, radius } from '../constants/tokens';
+import { spacing, radius } from '@/constants/tokens';
 
 interface GlobalHeaderProps {
   searchQuery?: string;

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
-import { spacing, radius, zIndex, shadows } from '../constants/tokens';
+import { spacing, radius, zIndex, shadows } from '@/constants/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 import Button from '@/components/ui/Button';
 

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -4,7 +4,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import NotificationService from '../services/notification';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '@/features/auth/AuthContext';
-import { spacing } from '../constants/tokens';
+import { spacing } from '@/constants/tokens';
 
 interface NotificationBadgeProps {
   size?: number;

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -3,8 +3,8 @@ import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native
 import { Package, Tag, MessageCircle, Info, CircleCheck as CheckCircle, CircleAlert as AlertCircle } from 'lucide-react-native';
 import { Notification } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, radius, shadows } from '../constants/tokens';
-import { typography } from '../constants/styles';
+import { spacing, radius, shadows } from '@/constants/tokens';
+import { typography } from '@/constants/styles';
 
 interface NotificationItemProps {
   notification: Notification;

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { X } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, zIndex } from '../constants/tokens';
+import { spacing, zIndex } from '@/constants/tokens';
 
 interface NotificationPopupProps {
   title: string;

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import GoldDivider from './GoldDivider';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing } from '../../constants/tokens';
+import { spacing } from '@/constants/tokens';
 
 export default function Section({
   title,

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -8,7 +8,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing } from '../../constants/tokens';
+import { spacing } from '@/constants/tokens';
 
 interface SpinnerProps {
   size?: 'small' | 'large';

--- a/contexts/TenantContext.tsx
+++ b/contexts/TenantContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { usePathname } from 'expo-router';
-import { loadTenantSettings } from '../constants/tenant';
+import { loadTenantSettings } from '@/constants/tenant';
 
 interface TenantContextType {
   storeId: string | null;

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,7 +1,7 @@
 import { errorLog } from '@/utils/logger';
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { tokens as darkTokens, lightTokens, Tokens } from '../constants/tokens';
+import { tokens as darkTokens, lightTokens, Tokens } from '@/constants/tokens';
 import { useAppInfo } from './AppInfoContext';
 
 const THEME_STORAGE_KEY = 'app_theme';

--- a/tests/bulkProductUploader.test.ts
+++ b/tests/bulkProductUploader.test.ts
@@ -1,6 +1,6 @@
 import { Product } from '../types';
 import { insertConfig } from './testUtils';
-import { loadTenantSettings, getAdmins } from '../constants/tenant';
+import { loadTenantSettings, getAdmins } from '@/constants/tenant';
 
 jest.mock('expo-document-picker', () => ({}));
 

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -46,7 +46,7 @@ jest.mock('@/features/auth/services/nearAuth', () => ({
   signIn: jest.fn(),
 }));
 
-jest.mock('../constants/tenant', () => ({
+jest.mock('@/constants/tenant', () => ({
   getFeeSettings: jest.fn().mockResolvedValue({ feeAddress: 'fee_addr', feeBps: 250 }),
 }));
 

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,5 +1,5 @@
 import { insertConfig } from './testUtils';
-import { loadTenantSettings, getAdmins } from '../constants/tenant';
+import { loadTenantSettings, getAdmins } from '@/constants/tenant';
 import PinataService from '../services/pinata';
 import fs from 'fs';
 import path from 'path';

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -23,7 +23,7 @@ insertConfig({
 
 jest.mock('../services/nearKvStore', () => require('./nearKvMock'));
 jest.mock('../services/nearSettings');
-const { loadTenantSettings } = require('../constants/tenant');
+const { loadTenantSettings } = require('@/constants/tenant');
 
 var __DEV__ = false;
 

--- a/utils/appConfig.ts
+++ b/utils/appConfig.ts
@@ -76,7 +76,7 @@ export function getWakuBootstrapNodes(): string[] {
       .filter(Boolean);
   }
   try {
-    const tenant = require('../constants/tenant');
+    const tenant = require('@/constants/tenant');
     const list = tenant.AppConfig?.wakuBootstrap || [];
     if (Array.isArray(list) && list.length > 0) {
       return list;
@@ -97,7 +97,7 @@ export function getNearRpcUrls(): string[] {
   let tenantRpc = '';
   let tenantFallbacks: string[] = [];
   try {
-    const tenant = require('../constants/tenant');
+    const tenant = require('@/constants/tenant');
     tenantRpc = tenant.AppConfig?.rpcUrl || '';
     tenantFallbacks = tenant.AppConfig?.rpcFallbackUrls || [];
   } catch {}


### PR DESCRIPTION
## Summary
- replace relative constants imports with root alias `@/constants/*`
- update dynamic `require` calls to use the alias

## Testing
- `yarn lint README.md app/(tabs)/orders.tsx app/admin/settings.tsx app/category/[id].tsx app/control/LiveFocusView.tsx app/driver-dashboard.tsx app/product/_ProductScreen.tsx app/reviews/index.tsx app/store/[storeId]/admin/_DeliveriesScreen.tsx app/store/[storeId]/admin/_DisputesScreen.tsx app/store/[storeId]/admin/_KycApprovalsScreen.tsx app/store/[storeId]/admin/_SettingsScreen.tsx app/store/[storeId]/admin/_UserManagementScreen.tsx app/user/[id].tsx components/Card.tsx components/GlobalHeader.tsx components/InfoModal.tsx components/NotificationBadge.tsx components/NotificationItem.tsx components/NotificationPopup.tsx components/ui/Section.tsx components/ui/Spinner.tsx contexts/TenantContext.tsx contexts/ThemeContext.tsx tests/bulkProductUploader.test.ts tests/cardCheckoutFee.test.ts tests/pinataService.test.ts tests/setupEnv.ts utils/appConfig.ts`
- `yarn test` *(fails: SyntaxError: Unexpected token '<' in multiple test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5df535ef08326a4386ea856a9e628