### PR TITLE
fix: correct context imports in CartModal

### DIFF
--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -39,12 +39,12 @@ const MoonPayButton = require('@/features/payments/components/MoonPayButton').de
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import commonStyles from '@/constants/styles';
-import { useCurrency } from '../contexts/CurrencyContext';
-import { useNotifications } from './NotificationContext';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import { useNotifications } from '@/components/NotificationContext';
+import { useLanguage } from '@/contexts/LanguageContext';
 import { router } from 'expo-router';
-import InfoModal from './InfoModal';
-import ConfirmationModal from './ConfirmationModal';
+import InfoModal from '@/components/InfoModal';
+import ConfirmationModal from '@/components/ConfirmationModal';
 
 interface CartModalProps {
   visible: boolean;


### PR DESCRIPTION
## Summary
- fix CartModal's context and component imports to use project aliases

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e333ad488326a03519bf9011e5ea