### PR TITLE
Wrap routes with Suspense and enable React Query suspense

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,7 +29,9 @@ export default function App() {
                       <NotificationProvider>
                         <ErrorBoundary>
                           <QueryClientProvider client={queryClient}>
-                            <Router />
+                            <React.Suspense fallback={null}>
+                              <Router />
+                            </React.Suspense>
                           </QueryClientProvider>
                         </ErrorBoundary>
                       </NotificationProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,13 @@
+import React from 'react';
 import { Slot } from 'expo-router';
 import { TenantProvider } from '../contexts/TenantContext';
 
 export default function RootLayout() {
   return (
     <TenantProvider>
-      <Slot />
+      <React.Suspense fallback={null}>
+        <Slot />
+      </React.Suspense>
     </TenantProvider>
   );
 }

--- a/src/features/cart/hooks/useCartStores.ts
+++ b/src/features/cart/hooks/useCartStores.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { CartItem, Store } from '@/types';
 
@@ -8,25 +9,28 @@ if (chain === 'near') {
 }
 
 export default function useCartStores(cartItems: CartItem[]) {
-  const [stores, setStores] = useState<Record<string, Store>>({});
+  const ids = React.useMemo(
+    () => Array.from(new Set(cartItems.map((i) => i.product.storeId))),
+    [cartItems],
+  );
 
-  useEffect(() => {
-    const fetchStores = async () => {
-      const ids = Array.from(new Set(cartItems.map((i) => i.product.storeId)));
+  const { data: stores = {} } = useQuery({
+    queryKey: ['cart-stores', ids],
+    queryFn: async () => {
       const entries = await Promise.all(
         ids.map(async (id) => {
           const store = getStore ? await getStore(id, id) : null;
           return store ? ([id, store] as const) : null;
-        })
+        }),
       );
       const map: Record<string, Store> = {};
       entries.forEach((entry) => {
         if (entry) map[entry[0]] = entry[1];
       });
-      setStores(map);
-    };
-    fetchStores();
-  }, [cartItems]);
+      return map;
+    },
+    suspense: true,
+  });
 
   return stores;
 }

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import chain from '@/services/chain';
 import { Product, Category, HeroBanner } from '@/types';
@@ -9,38 +10,42 @@ if (chain === 'near') {
 }
 
 export function useHome() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
-  const loadData = useCallback(async () => {
-    try {
-      setLoading(true);
+  const { data, refetch } = useQuery({
+    queryKey: ['home'],
+    queryFn: async () => {
       const db = DatabaseService.getInstance();
       const [productsData, categoriesData, bannersData] = await Promise.all([
         db.getProducts(),
         listCategories ? listCategories() : Promise.resolve([]),
         db.getHeroBanners(),
       ]);
-      setProducts(productsData);
-      setCategories(categoriesData);
-      setHeroBanners(bannersData);
+      return { productsData, categoriesData, bannersData };
+    },
+    suspense: true,
+  });
+
+  const [products, setProducts] = useState<Product[]>(data.productsData);
+  const [categories, setCategories] = useState<Category[]>(data.categoriesData);
+  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>(data.bannersData);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const res = await refetch();
+      if (res.data) {
+        setProducts(res.data.productsData);
+        setCategories(res.data.categoriesData);
+        setHeroBanners(res.data.bannersData);
+      }
       setError(null);
     } catch (err) {
       setError(err as Error);
     } finally {
-      setLoading(false);
+      setRefreshing(false);
     }
-  }, []);
-
-  const refresh = useCallback(async () => {
-    setRefreshing(true);
-    await loadData();
-    setRefreshing(false);
-  }, [loadData]);
+  }, [refetch]);
 
   const upsertBanner = useCallback((b: HeroBanner, isNew: boolean) => {
     setHeroBanners((prev) =>
@@ -62,18 +67,14 @@ export function useHome() {
     setProducts((prev) => prev.filter((p) => p.id !== id));
   }, []);
 
-  useEffect(() => {
-    void loadData();
-  }, [loadData]);
-
   return {
     products,
     categories,
     heroBanners,
-    loading,
+    loading: false,
     refreshing,
     error,
-    reload: loadData,
+    reload: refresh,
     refresh,
     upsertBanner,
     removeBanner,

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,88 +1,88 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import NotificationService from '@/services/notification';
 import { Notification } from '@/types';
 import { useAuth } from '@/features/auth/AuthContext';
 
 export function useNotifications() {
   const { isLoggedIn, user } = useAuth();
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<Error | null>(null);
 
-  const loadNotifications = useCallback(async () => {
-    if (!user) return;
-    setLoading(true);
-    try {
+  const { data: notifications = [], isFetching, refetch } = useQuery({
+    queryKey: ['notifications', user?.id],
+    queryFn: async () => {
       const notificationService = NotificationService.getInstance();
-      const data = await notificationService.getNotifications(user.id);
-      setNotifications(data);
-      setError(null);
-    } catch (err) {
-      setError(err as Error);
-    } finally {
-      setLoading(false);
-    }
-  }, [user]);
+      return user ? notificationService.getNotifications(user.id) : [];
+    },
+    enabled: isLoggedIn && !!user,
+    suspense: true,
+    initialData: [],
+  });
 
-  const markAsRead = useCallback(async (id: string): Promise<boolean> => {
-    try {
-      const service = NotificationService.getInstance();
-      const success = await service.markAsRead(id);
-      if (success) {
-        setNotifications((prev) =>
-          prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
-        );
+  const markAsRead = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        const service = NotificationService.getInstance();
+        const success = await service.markAsRead(id);
+        if (success) {
+          queryClient.setQueryData<Notification[]>(['notifications', user?.id], (prev = []) =>
+            prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+          );
+        }
+        return success;
+      } catch (err) {
+        setError(err as Error);
+        return false;
       }
-      return success;
-    } catch (err) {
-      setError(err as Error);
-      return false;
-    }
-  }, []);
+    },
+    [queryClient, user?.id],
+  );
 
-  const markAllAsRead = useCallback(async (): Promise<boolean> => {
-    if (!user) return false;
-    try {
-      const service = NotificationService.getInstance();
-      const success = await service.markAllAsRead(user.id);
-      if (success) {
-        setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  const markAllAsRead = useCallback(
+    async (): Promise<boolean> => {
+      if (!user) return false;
+      try {
+        const service = NotificationService.getInstance();
+        const success = await service.markAllAsRead(user.id);
+        if (success) {
+          queryClient.setQueryData<Notification[]>(['notifications', user.id], (prev = []) =>
+            prev.map((n) => ({ ...n, read: true })),
+          );
+        }
+        return success;
+      } catch (err) {
+        setError(err as Error);
+        return false;
       }
-      return success;
-    } catch (err) {
-      setError(err as Error);
-      return false;
-    }
-  }, [user]);
+    },
+    [queryClient, user],
+  );
 
-  const deleteNotification = useCallback(async (id: string): Promise<boolean> => {
-    try {
-      const service = NotificationService.getInstance();
-      const success = await service.deleteNotification(id);
-      if (success) {
-        setNotifications((prev) => prev.filter((n) => n.id !== id));
+  const deleteNotification = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        const service = NotificationService.getInstance();
+        const success = await service.deleteNotification(id);
+        if (success) {
+          queryClient.setQueryData<Notification[]>(['notifications', user?.id], (prev = []) =>
+            prev.filter((n) => n.id !== id),
+          );
+        }
+        return success;
+      } catch (err) {
+        setError(err as Error);
+        return false;
       }
-      return success;
-    } catch (err) {
-      setError(err as Error);
-      return false;
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isLoggedIn && user) {
-      void loadNotifications();
-    } else {
-      setLoading(false);
-      setNotifications([]);
-    }
-  }, [isLoggedIn, user, loadNotifications]);
+    },
+    [queryClient, user?.id],
+  );
 
   return {
     notifications,
-    loading,
+    loading: isFetching,
     error,
-    reload: loadNotifications,
+    reload: refetch,
     markAsRead,
     markAllAsRead,
     deleteNotification,


### PR DESCRIPTION
## Summary
- wrap Router and Slot in React.Suspense with null fallbacks
- switch feature hooks to React Query with suspense enabled

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token and TypeScript errors)*
- `yarn typecheck` *(fails: TextInput type errors in ProductFormModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e57fd468832699118ddbcbddafe8