### PR TITLE
refactor: enforce dimensions on SmartImage

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -302,9 +302,9 @@ export default function HomeScreen() {
       >
         <SmartImage
           uri={item.image}
-          style={styles.heroImage}
+          width={BANNER_WIDTH}
+          height={BANNER_HEIGHT}
           contentFit="cover"
-          cachePolicy="disk"
         />
         <View style={styles.heroOverlay}>
           <View style={styles.heroContent}>
@@ -856,10 +856,6 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   bannerTouchable: {
-    width: '100%',
-    height: '100%',
-  },
-  heroImage: {
     width: '100%',
     height: '100%',
   },

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -76,7 +76,7 @@ export default function Landing() {
               ] as any[]).map((b) => (
                 <View key={b.id} style={{ width: 280, height: 140, borderRadius: 12, overflow: 'hidden', borderWidth: 1, borderColor: colors.border.primary, backgroundColor: colors.surface.primary }}>
                   {b.image ? (
-                    <SmartImage uri={b.image} style={{ width: '100%', height: '100%' }} contentFit="cover" cachePolicy="disk" />
+                    <SmartImage uri={b.image} width={280} height={140} contentFit="cover" />
                   ) : (
                     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
                       <Text style={{ color: colors.gold, fontWeight: '800' }}>{b.title}</Text>

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -60,6 +60,7 @@ interface MediaItem {
 }
 
 const { width } = Dimensions.get('window');
+const COVER_SIZE = Math.min(width, 540);
 
 export default function ProductDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -484,9 +485,9 @@ export default function ProductDetailScreen() {
           {mainImageUri ? (
             <SmartImage
               uri={mainImageUri}
-              style={styles.coverImage}
+              width={COVER_SIZE}
+              height={COVER_SIZE}
               contentFit="cover"
-              cachePolicy="disk"
             />
           ) : (
             <View style={styles.noImageContainer}>
@@ -517,9 +518,9 @@ export default function ProductDetailScreen() {
                 >
                   <SmartImage
                     uri={media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri}
-                    style={styles.galleryImage}
+                    width={80}
+                    height={80}
                     contentFit="cover"
-                    cachePolicy="disk"
                   />
                   {media.type === 'video' && (
                     <View style={styles.videoIndicator}>
@@ -692,9 +693,9 @@ export default function ProductDetailScreen() {
                   >
                     <SmartImage
                       uri={media.type === 'video' ? videoThumbnails[media.id] || media.uri : media.uri}
-                      style={styles.galleryImage}
+                      width={80}
+                      height={80}
                       contentFit="cover"
-                      cachePolicy="disk"
                     />
                     {media.type === 'video' && (
                       <View style={styles.videoIndicator}>
@@ -965,10 +966,6 @@ const styles = StyleSheet.create({
     aspectRatio: 1,
     marginBottom: 16,
   },
-  coverImage: {
-    width: '100%',
-    height: '100%',
-  },
   noImageContainer: {
     width: '100%',
     height: '100%',
@@ -999,10 +996,6 @@ const styles = StyleSheet.create({
     position: 'relative',
     borderWidth: 1,
     overflow: 'hidden',
-  },
-  galleryImage: {
-    width: '100%',
-    height: '100%',
   },
   videoIndicator: {
     position: 'absolute',

--- a/app/reviews/[orderId].tsx
+++ b/app/reviews/[orderId].tsx
@@ -106,8 +106,9 @@ export default function SubmitReviewScreen() {
         <View style={styles.productRow}>
           <SmartImage
             uri={item.product.images[0]}
+            width={60}
+            height={60}
             style={styles.productImage}
-            cachePolicy="disk"
           />
           <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={1}>
             {item.product.name}
@@ -163,7 +164,7 @@ const styles = StyleSheet.create({
   headerTitle: { fontSize: 18, fontWeight: 'bold' },
   content: { padding: 16 },
   productRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 24 },
-  productImage: { width: 60, height: 60, borderRadius: 8, marginLeft: 12 },
+  productImage: { borderRadius: 8, marginLeft: 12 },
   productName: { flex: 1, fontSize: 16, fontWeight: '600', textAlign: 'end' },
   ratingSection: { alignItems: 'center', marginBottom: 24 },
   input: { borderWidth: 1, borderRadius: 8, padding: 12, marginBottom: 16 },

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -302,8 +302,9 @@ export default function ReviewsScreen() {
         >
           <SmartImage
             uri={item.productImage}
+            width={40}
+            height={40}
             style={styles.productThumbnail}
-            cachePolicy="disk"
           />
           <View style={styles.productDetails}>
             <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={1}>
@@ -321,8 +322,9 @@ export default function ReviewsScreen() {
         <View style={styles.userInfo}>
           <SmartImage
             uri={item.userAvatar}
+            width={32}
+            height={32}
             style={styles.userAvatar}
-            cachePolicy="disk"
           />
           <View>
             <Text style={[styles.userName, { color: colors.text.primary }]}>{item.userName}</Text>
@@ -408,8 +410,9 @@ export default function ReviewsScreen() {
               <View key={index} style={styles.orderSelectorItemRow}>
                 <SmartImage
                   uri={orderItem.product.images[0]}
+                  width={40}
+                  height={40}
                   style={styles.orderSelectorItemImage}
-                  cachePolicy="disk"
                 />
                 <Text style={[styles.orderSelectorItemName, { color: colors.text.primary }]} numberOfLines={1}>
                   {orderItem.product.name} x{orderItem.quantity}
@@ -710,8 +713,9 @@ export default function ReviewsScreen() {
                     <View key={index} style={styles.selectedOrderItem}>
                       <SmartImage
                         uri={item.product.images[0]}
+                        width={50}
+                        height={50}
                         style={styles.selectedOrderItemImage}
-                        cachePolicy="disk"
                       />
                       <View style={styles.selectedOrderItemDetails}>
                         <Text style={[styles.selectedOrderItemName, { color: colors.text.primary }]}>
@@ -1000,8 +1004,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   productThumbnail: {
-    width: 40,
-    height: 40,
     borderRadius: 8,
     marginRight: 12,
   },
@@ -1029,8 +1031,6 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   userAvatar: {
-    width: 32,
-    height: 32,
     borderRadius: 16,
     marginRight: 12,
   },
@@ -1168,8 +1168,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   orderSelectorItemImage: {
-    width: 40,
-    height: 40,
     borderRadius: 8,
     marginLeft: 12,
   },
@@ -1226,8 +1224,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   selectedOrderItemImage: {
-    width: 50,
-    height: 50,
     borderRadius: 8,
     marginLeft: 12,
   },

--- a/app/store/[storeId]/admin/_DeliveriesScreen.tsx
+++ b/app/store/[storeId]/admin/_DeliveriesScreen.tsx
@@ -252,8 +252,9 @@ export default function AdminDeliveriesScreen() {
               <TouchableOpacity onPress={() => openProof(job.proofUri!)}>
                 <SmartImage
                   uri={job.proofUri}
+                  width={80}
+                  height={80}
                   style={styles.proofImage}
-                  cachePolicy="disk"
                 />
               </TouchableOpacity>
             )}
@@ -404,8 +405,6 @@ const styles = StyleSheet.create({
     marginLeft: 8,
   },
   proofImage: {
-    width: 80,
-    height: 80,
     borderRadius: 8,
     marginTop: 8,
   },

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -146,8 +146,9 @@ export default function KycApprovalsScreen() {
                     {request.avatar ? (
                       <SmartImage
                         uri={request.avatar}
+                        width={60}
+                        height={60}
                         style={[styles.avatar, { borderColor: colors.gold }]}
-                        cachePolicy="disk"
                       />
                     ) : (
                       <View style={[styles.avatarPlaceholder, { 
@@ -269,8 +270,6 @@ const styles = StyleSheet.create({
     marginRight: 16,
   },
   avatar: {
-    width: 60,
-    height: 60,
     borderRadius: 30,
     borderWidth: 2,
   },

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   Platform,
   ActivityIndicator,
+  Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -33,6 +34,9 @@ import commonStyles from '@/constants/styles';
 import Card from '@/components/Card';
 import SmartImage from '@/components/SmartImage';
 
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_WIDTH = (SCREEN_WIDTH - 32 - 8) / 2;
+const IMAGE_HEIGHT = 140;
 
 
 interface MediaItem {
@@ -459,9 +463,9 @@ export default function SubcategoryScreen() {
         {item.images && item.images.length > 0 ? (
           <SmartImage
             uri={item.images[0]}
-            style={styles.productImage}
+            width={CARD_WIDTH}
+            height={IMAGE_HEIGHT}
             contentFit="cover"
-            cachePolicy="disk"
           />
         ) : (
           <View style={styles.noImageContainer}>
@@ -1171,21 +1175,18 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   productCard: {
-    width: '48%',
+    width: CARD_WIDTH,
     borderRadius: 12,
     marginBottom: 16,
     borderWidth: 1,
   },
   productImageContainer: {
     position: 'relative',
-    height: 140,
+    height: IMAGE_HEIGHT,
+    width: CARD_WIDTH,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
     overflow: 'hidden',
-  },
-  productImage: {
-    width: '100%',
-    height: '100%',
   },
   noImageContainer: {
     width: '100%',

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -158,8 +158,9 @@ export default function UserProfileScreen() {
             {user.avatar ? (
               <SmartImage
                 uri={user.avatar}
+                width={100}
+                height={100}
                 style={[styles.avatar, { borderColor: colors.gold }]}
-                cachePolicy="disk"
               />
             ) : (
               <View style={[styles.avatarPlaceholder, { backgroundColor: colors.surface.primary, borderColor: colors.border.primary }]}>
@@ -286,8 +287,6 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   avatar: {
-    width: 100,
-    height: 100,
     borderRadius: 50,
     borderWidth: 3,
   },

--- a/components/FullScreenMediaViewer.tsx
+++ b/components/FullScreenMediaViewer.tsx
@@ -318,9 +318,9 @@ export default function FullScreenMediaViewer({
                     <Animated.View style={[styles.imageWrapper, animatedStyle]}>
                       <SmartImage
                         uri={currentMedia.uri}
-                        style={styles.media}
+                        width={width}
+                        height={height}
                         contentFit="contain"
-                        cachePolicy="disk"
                       />
                     </Animated.View>
                   </PanGestureHandler>
@@ -448,10 +448,6 @@ const styles = StyleSheet.create({
     height: height,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  media: {
-    width: '100%',
-    height: '100%',
   },
   overlay: {
     flex: 1,

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -62,7 +62,7 @@ export default function GlobalHeader({
             onPress={() => router.push('/(tabs)')}
           >
             {logoCid ? (
-              <SmartImage uri={logoCid} style={styles.logoImage} contentFit="contain" cachePolicy="disk" />
+              <SmartImage uri={logoCid} width={50} height={50} style={styles.logoImage} contentFit="contain" />
             ) : (
               <View
                 style={[styles.logoIcon, { backgroundColor: colors.gold }]}
@@ -171,8 +171,6 @@ const styles = StyleSheet.create({
     marginLeft: spacing.spacer8,
   },
   logoImage: {
-    width: 50,
-    height: 50,
     borderRadius: radius.lg,
     marginLeft: spacing.spacer8,
   },

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -223,7 +223,7 @@ export default function MediaUploader({
       }]}>
         {item.type === 'video' ? (
           <View style={styles.videoContainer}>
-            <SmartImage uri={thumbnailMap[item.id] || item.uri} style={styles.mediaThumbnail} contentFit="cover" cachePolicy="disk" />
+            <SmartImage uri={thumbnailMap[item.id] || item.uri} width={100} height={100} contentFit="cover" />
             <View pointerEvents="none" style={styles.playOverlay}>
               <Play size={24} color={colors.text.inverse} fill={colors.text.inverse} />
             </View>
@@ -232,7 +232,7 @@ export default function MediaUploader({
             </View>
           </View>
         ) : (
-          <SmartImage uri={item.uri} style={styles.mediaThumbnail} contentFit="cover" cachePolicy="disk" />
+          <SmartImage uri={item.uri} width={100} height={100} contentFit="cover" />
         )}
         
         <TouchableOpacity
@@ -349,10 +349,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: 'hidden',
     borderWidth: 1,
-  },
-  mediaThumbnail: {
-    width: '100%',
-    height: '100%',
   },
   videoContainer: {
     position: 'relative',

--- a/components/MediaViewer.tsx
+++ b/components/MediaViewer.tsx
@@ -3,6 +3,7 @@ import {
   View,
   StyleSheet,
   TouchableOpacity,
+  Dimensions,
 } from 'react-native';
 import SmartImage from './SmartImage';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -15,6 +16,9 @@ import Animated, {
   withSpring,
   runOnJS,
 } from 'react-native-reanimated';
+
+const { width, height } = Dimensions.get('window');
+const VIEWER_HEIGHT = height * 0.7;
 
 interface MediaItem {
   type: 'image' | 'video';
@@ -94,11 +98,11 @@ export default function MediaViewer({ media, initialIndex, onClose }: Props) {
             <PanGestureHandler onGestureEvent={panHandler}>
               <Animated.View style={[styles.mediaWrapper, animatedStyle]}>
                 {currentMedia?.type === 'image' ? (
-                  <SmartImage uri={currentMedia.url} style={styles.media} contentFit="contain" cachePolicy="disk" />
+                  <SmartImage uri={currentMedia.url} width={width} height={VIEWER_HEIGHT} contentFit="contain" />
                 ) : (
                   <View style={styles.videoPlaceholder}>
                     {/* In a real app, you'd use react-native-video here */}
-                    <SmartImage uri={currentMedia?.url || ''} style={styles.media} contentFit="contain" cachePolicy="disk" />
+                    <SmartImage uri={currentMedia?.url || ''} width={width} height={VIEWER_HEIGHT} contentFit="contain" />
                   </View>
                 )}
               </Animated.View>
@@ -156,10 +160,6 @@ const styles = StyleSheet.create({
     height: '70%',
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  media: {
-    width: '100%',
-    height: '100%',
   },
   videoPlaceholder: {
     width: '100%',

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -446,9 +446,10 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
               <View key={index} style={[styles.orderItem, { borderBottomColor: colors.border.secondary }]}>
                 <SmartImage
                   uri={item.product.images[0]}
+                  width={50}
+                  height={50}
                   style={styles.itemImage}
                   contentFit="cover"
-                  cachePolicy="disk"
                 />
                 <View style={styles.itemInfo}>
                   <Text style={[styles.itemName, { color: colors.text.primary }]}>{item.product.name}</Text>
@@ -722,8 +723,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   itemImage: {
-    width: 50,
-    height: 50,
     borderRadius: 8,
     marginRight: 12,
   },

--- a/components/ProofUploader.tsx
+++ b/components/ProofUploader.tsx
@@ -106,7 +106,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
     <View style={styles.container}>
       {uri ? (
         uri.match(/\.(jpg|jpeg|png|gif|webp)$/i) ? (
-          <SmartImage uri={uri} style={styles.preview} contentFit="cover" cachePolicy="disk" />
+          <SmartImage uri={uri} width={100} height={100} style={styles.preview} contentFit="cover" />
         ) : (
           <View style={[styles.filePreview, { borderColor: colors.border.primary }]}>
             <FileIcon size={24} color={colors.text.primary} />
@@ -176,9 +176,7 @@ const styles = StyleSheet.create({
     fontWeight: '600'
   },
   preview: {
-    width: 100,
-    height: 100,
-    borderRadius: 8
+    borderRadius: 8,
   },
   filePreview: {
     width: 100,

--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -4,15 +4,19 @@ import { Image as ExpoImage, ImageProps } from 'expo-image';
 const fallback = require('../assets/images/icon.png');
 const shimmer = { blurhash: 'L5H2EC=PM+yV0g-mq.wG9c010J]' };
 
-interface SmartImageProps extends Omit<ImageProps, 'source'> {
+interface SmartImageProps extends Omit<ImageProps, 'source' | 'width' | 'height'> {
   uri: string;
+  width: number;
+  height: number;
 }
 
 export default function SmartImage({
   uri,
+  width,
+  height,
   style,
   contentFit = 'cover',
-  cachePolicy = 'disk',
+  cachePolicy = 'memory-disk',
   placeholder = shimmer,
   ...props
 }: SmartImageProps) {
@@ -22,6 +26,8 @@ export default function SmartImage({
     <ExpoImage
       {...props}
       source={source}
+      width={width}
+      height={height}
       style={style}
       contentFit={contentFit}
       cachePolicy={cachePolicy}

--- a/src/features/auth/components/AgeVerificationModal.tsx
+++ b/src/features/auth/components/AgeVerificationModal.tsx
@@ -88,7 +88,7 @@ export default function AgeVerificationModal() {
                 ]}
               >
                 {logoCid ? (
-                  <SmartImage uri={logoCid} style={styles.logoImage} contentFit="contain" cachePolicy="disk" />
+                  <SmartImage uri={logoCid} width={60} height={60} style={styles.logoImage} contentFit="contain" />
                 ) : (
                   <Shield size={60} color={colors.gold} />
                 )}
@@ -220,8 +220,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
   },
   logoImage: {
-    width: 60,
-    height: 60,
     borderRadius: Platform.OS === 'web' ? 8 : 30,
   },
   platformName: {

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -311,9 +311,10 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     >
       <SmartImage
         uri={item.product.images?.[0] || ''}
+        width={60}
+        height={60}
         style={styles.productImage}
         contentFit="cover"
-        cachePolicy="disk"
       />
 
       <View style={styles.productInfo}>
@@ -1298,7 +1299,7 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     borderWidth: 1,
   },
-  productImage: { width: 60, height: 60, borderRadius: 8, marginRight: 12 },
+  productImage: { borderRadius: 8, marginRight: 12 },
   productInfo: { flex: 1, marginRight: 12 },
   productName: { fontSize: 14, fontWeight: '600', marginBottom: 4, textAlign: 'end' },
   productPrice: { fontSize: 16, fontWeight: 'bold', textAlign: 'end' },

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -114,6 +114,8 @@ export default function FloatingCartWidget() {
               <SmartImage
                 key={item.id}
                 uri={item.product.images[0]}
+                width={32}
+                height={32}
                 style={[
                   styles.previewImage,
                   {
@@ -123,7 +125,6 @@ export default function FloatingCartWidget() {
                   }
                 ]}
                 contentFit="cover"
-                cachePolicy="disk"
               />
             ))}
             {cartItems.length > 3 && (
@@ -157,9 +158,10 @@ export default function FloatingCartWidget() {
               }]}>
                 <SmartImage
                   uri={item.product.images[0]}
+                  width={40}
+                  height={40}
                   style={styles.itemImage}
                   contentFit="cover"
-                  cachePolicy="disk"
                 />
                 
                 <View style={styles.itemInfo}>
@@ -296,8 +298,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   previewImage: {
-    width: 32,
-    height: 32,
     borderRadius: 16,
     borderWidth: 2,
   },
@@ -328,8 +328,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   itemImage: {
-    width: 40,
-    height: 40,
     borderRadius: 8,
     marginEnd: 12,
   },

--- a/src/features/cart/components/WishlistModal.tsx
+++ b/src/features/cart/components/WishlistModal.tsx
@@ -49,7 +49,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
       ]}
       onPress={() => viewProduct(item.productId)}
     >
-      <SmartImage uri={item.product.images[0]} style={styles.productImage} contentFit="cover" cachePolicy="disk" />
+      <SmartImage uri={item.product.images[0]} width={80} height={80} style={styles.productImage} contentFit="cover" />
 
       <View style={styles.productInfo}>
         <Text style={[styles.productName, { color: colors.text.primary }]} numberOfLines={2}>
@@ -167,8 +167,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   productImage: {
-    width: 80,
-    height: 80,
     borderRadius: 8,
     marginRight: 12,
   },

--- a/src/features/products/components/ProductCard.tsx
+++ b/src/features/products/components/ProductCard.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Alert,
+  Dimensions,
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import { Heart, Pencil, ShoppingCart, Tag } from 'lucide-react-native';
@@ -20,6 +21,9 @@ import { useAccountId } from '../../auth/services/nearAuth';
 import productsAgent from '@/agents/products-agent';
 import Card from '@/components/Card';
 
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_WIDTH = (SCREEN_WIDTH - 32 - 12) / 2;
+const IMAGE_HEIGHT = 140;
 interface ProductCardProps {
   product: Product;
   isOwner?: boolean;
@@ -161,10 +165,10 @@ export default function ProductCard({
     ]} onPress={handlePress}>
       <View style={styles.imageContainer}>
         {product.images && product.images.length > 0 ? (
-          <SmartImage uri={product.images[0]} style={styles.image} contentFit="cover" cachePolicy="disk" />
+          <SmartImage uri={product.images[0]} width={CARD_WIDTH} height={IMAGE_HEIGHT} contentFit="cover" />
         ) : product.videos && product.videos.length > 0 ? (
           videoThumbnail ? (
-            <SmartImage uri={videoThumbnail} style={styles.image} contentFit="cover" cachePolicy="disk" />
+            <SmartImage uri={videoThumbnail} width={CARD_WIDTH} height={IMAGE_HEIGHT} contentFit="cover" />
           ) : (
             <View style={styles.noImageContainer}>
               <Text style={styles.noImageText}>אין תמונה</Text>
@@ -312,11 +316,8 @@ const styles = StyleSheet.create({
   },
   imageContainer: {
     position: 'relative',
-    height: 140,
-  },
-  image: {
-    width: '100%',
-    height: '100%',
+    height: IMAGE_HEIGHT,
+    width: CARD_WIDTH,
   },
   noImageContainer: {
     width: '100%',


### PR DESCRIPTION
## Summary
- require width/height for SmartImage and default to memory-disk cache
- pass explicit image dimensions on product and store screens
- drop unused inline styling that triggered layout recalculations

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Type '"end"' is not assignable to type '"center" | "left" | "right"')*
- `yarn test` *(fails: Jest encountered an unexpected token, TS errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eed8e2ac83269ea102358e66171b