### PR TITLE
refactor: centralize theme colors

### DIFF
--- a/components/AdminNotificationBanner.tsx
+++ b/components/AdminNotificationBanner.tsx
@@ -1,22 +1,24 @@
 import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
-import { 
-  View, 
-  Text, 
-  StyleSheet, 
-  TouchableOpacity, 
-  Animated, 
-  Easing 
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Animated,
+  Easing
 } from 'react-native';
 import { Bell, X } from 'lucide-react-native';
 import NotificationService from '../services/notification';
 import { useAuth } from '@/features/auth/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function AdminNotificationBanner() {
   const [visible, setVisible] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
   const translateY = new Animated.Value(-60);
   const { user } = useAuth();
+  const { getColor } = useTheme();
 
   useEffect(() => {
     if (!user) {
@@ -80,23 +82,26 @@ export default function AdminNotificationBanner() {
   }
 
   return (
-    <Animated.View 
+    <Animated.View
       style={[
         styles.container,
-        { transform: [{ translateY }] }
+        { backgroundColor: getColor('adminBanner.background'), transform: [{ translateY }] }
       ]}
     >
       <View style={styles.content}>
-        <Bell size={20} color="#FFFFFF" />
-        <Text style={styles.message}>
+        <Bell size={20} color={getColor('adminBanner.text')} />
+        <Text style={[styles.message, { color: getColor('adminBanner.text') }] }>
           You have {unreadCount} unread {unreadCount === 1 ? 'notification' : 'notifications'}
         </Text>
-        <TouchableOpacity style={styles.viewButton} onPress={handleViewAll}>
-          <Text style={styles.viewButtonText}>View</Text>
+        <TouchableOpacity
+          style={[styles.viewButton, { backgroundColor: getColor('adminBanner.buttonBackground') }]}
+          onPress={handleViewAll}
+        >
+          <Text style={[styles.viewButtonText, { color: getColor('adminBanner.text') }]}>View</Text>
         </TouchableOpacity>
       </View>
       <TouchableOpacity style={styles.closeButton} onPress={hideBanner}>
-        <X size={16} color="#FFFFFF" />
+        <X size={16} color={getColor('adminBanner.text')} />
       </TouchableOpacity>
     </Animated.View>
   );
@@ -108,7 +113,6 @@ const styles = StyleSheet.create({
     top: 0,
     start: 0,
     end: 0,
-    backgroundColor: '#20B2AA',
     padding: 12,
     flexDirection: 'row',
     alignItems: 'center',
@@ -121,21 +125,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   message: {
-    color: '#FFFFFF',
     fontSize: 14,
     fontWeight: '500',
     marginLeft: 8,
     flex: 1,
   },
   viewButton: {
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 16,
     marginLeft: 8,
   },
   viewButtonText: {
-    color: '#FFFFFF',
     fontSize: 12,
     fontWeight: '600',
   },

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -13,7 +13,7 @@ interface NotificationBadgeProps {
 
 export default function NotificationBadge({ size = spacing.spacer20, style }: NotificationBadgeProps) {
   const [unreadCount, setUnreadCount] = useState(0);
-  const { colors } = useTheme();
+  const { getColor } = useTheme();
   const { isLoggedIn, user } = useAuth();
 
   useEffect(() => {
@@ -51,13 +51,13 @@ export default function NotificationBadge({ size = spacing.spacer20, style }: No
         width: size, 
         height: size, 
         borderRadius: size / 2,
-        backgroundColor: colors.status.error
+        backgroundColor: getColor('status.error')
       },
       style
     ]}>
       <Text style={[styles.badgeText, { 
         fontSize: size * 0.5,
-        color: colors.text.primary
+        color: getColor('text.primary')
       }]}>
         {unreadCount > 99 ? '99+' : unreadCount}
       </Text>

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -32,7 +32,7 @@ export default function UserAvatar() {
   const { isLoggedIn, isAdmin, user, logout } = useAuth();
   const { openAuthModal } = useAuthModal();
   const { currentLanguage, setLanguage, t } = useLanguage();
-  const { theme, toggleTheme, colors } = useTheme();
+  const { theme, toggleTheme, getColor } = useTheme();
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const [storeId, setStoreId] = useState<string | null>(null);
 
@@ -43,10 +43,10 @@ export default function UserAvatar() {
   };
 
   const getRandomColor = () => {
-    const colors = ['#B99C5A', '#20B2AA', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD'];
+    const palette = getColor('avatarPalette') as string[];
     const initials = getInitials();
-    const index = initials.charCodeAt(0) % colors.length;
-    return colors[index];
+    const index = initials.charCodeAt(0) % palette.length;
+    return palette[index];
   };
 
   const showDropdown = () => {
@@ -146,10 +146,22 @@ export default function UserAvatar() {
   return (
     <>
       <TouchableOpacity style={styles.avatarContainer} onPress={showDropdown}>
-        <View style={[styles.avatar, { backgroundColor: getRandomColor() }]}>
-          <Text style={styles.avatarText}>{getInitials()}</Text>
+        <View
+          style={[
+            styles.avatar,
+            { backgroundColor: getRandomColor(), borderColor: getColor('adminBanner.buttonBackground') },
+          ]}
+        >
+          <Text style={[styles.avatarText, { color: getColor('text.inverse') }]}>{getInitials()}</Text>
         </View>
-        {isAdmin && <View style={[styles.adminIndicator, { backgroundColor: colors.gold, borderColor: colors.background }]} />}
+        {isAdmin && (
+          <View
+            style={[
+              styles.adminIndicator,
+              { backgroundColor: getColor('gold'), borderColor: getColor('background') },
+            ]}
+          />
+        )}
       </TouchableOpacity>
 
       <Modal
@@ -170,63 +182,65 @@ export default function UserAvatar() {
             style={[
               styles.dropdown,
               {
-                backgroundColor: colors.surface.elevated,
-                borderColor: colors.border.primary,
+                backgroundColor: getColor('surface.elevated'),
+                borderColor: getColor('border.primary'),
                 opacity: fadeAnim,
-                transform: [{
-                  translateY: fadeAnim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [-10, 0],
-                  }),
-                }],
+                transform: [
+                  {
+                    translateY: fadeAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [-10, 0],
+                    }),
+                  },
+                ],
               }
             ]}
           >
             {/* User Info - Now Clickable */}
             <TouchableOpacity style={styles.userInfo} onPress={handleProfile}>
               <View style={[styles.dropdownAvatar, { backgroundColor: getRandomColor() }]}>
-                <Text style={[styles.dropdownAvatarText, { color: colors.text.inverse }]}>
+                <Text style={[styles.dropdownAvatarText, { color: getColor('text.inverse') }]}>
                   {getInitials()}
                 </Text>
               </View>
               <View style={styles.userDetails}>
-                <Text style={[styles.userName, { color: colors.text.primary }]}>
+                <Text style={[styles.userName, { color: getColor('text.primary') }]}> 
                   {isLoggedIn ? user?.displayName || user?.username : t('profile.guest')}
                 </Text>
-                <Text style={[styles.userRole, { color: colors.gold }]}>
+                <Text style={[styles.userRole, { color: getColor('gold') }]}> 
                   {isLoggedIn ? (isAdmin ? t('profile.admin') : t('profile.customer')) : t('profile.guestBrowsing')}
                 </Text>
               </View>
             </TouchableOpacity>
 
             {/* Divider */}
-            <View style={[styles.divider, { backgroundColor: colors.border.primary }]} />
+            <View style={[styles.divider, { backgroundColor: getColor('border.primary') }]} />
 
             {/* Menu Items */}
             <View style={styles.menuItems}>
               {!isLoggedIn ? (
                 <TouchableOpacity style={styles.menuItem} onPress={handleLogin}>
-                  <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('auth.login')}</Text>
+                  <Text style={[styles.menuText, { color: getColor('text.primary') }]}>{t('auth.login')}</Text>
                 </TouchableOpacity>
               ) : (
                 <>
                   {isAdmin && (
                     <>
                       <TouchableOpacity style={styles.menuItem} onPress={handleAdminDashboard}>
-                        <Shield size={20} color={colors.gold} />
-                        <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.dashboard')}</Text>
+                        <Shield size={20} color={getColor('gold')} />
+                        <Text style={[styles.menuText, { color: getColor('text.primary') }]}>{t('profile.dashboard')}</Text>
                       </TouchableOpacity>
                       
                       <TouchableOpacity style={styles.menuItem} onPress={handleUserManagement}>
-                        <User size={20} color={colors.gold} />
-                        <Text style={[styles.menuText, { color: colors.text.primary }]}>ניהול משתמשים</Text>
+                        <User size={20} color={getColor('gold')} />
+                        <Text style={[styles.menuText, { color: getColor('text.primary') }]}>ניהול משתמשים</Text>
                       </TouchableOpacity>
                     </>
                   )}
                   
                   <TouchableOpacity style={styles.menuItem} onPress={handleSettings}>
-                    <Settings size={20} color={colors.gold} />
-                    <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.settings')}</Text>
+                    <Settings size={20} color={getColor('gold')} />
+                    <Text style={[styles.menuText, { color: getColor('text.primary') }]}>{t('profile.settings')}</Text>
                   </TouchableOpacity>
                 </>
               )}
@@ -235,29 +249,29 @@ export default function UserAvatar() {
               <TouchableOpacity style={styles.menuItem} onPress={handleThemeToggle}>
                 {theme === 'dark' ? (
                   <>
-                    <Sun size={20} color={colors.gold} />
-                    <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.lightMode')}</Text>
+                    <Sun size={20} color={getColor('gold')} />
+                    <Text style={[styles.menuText, { color: getColor('text.primary') }]}>{t('profile.lightMode')}</Text>
                   </>
                 ) : (
                   <>
-                    <Moon size={20} color={colors.gold} />
-                    <Text style={[styles.menuText, { color: colors.text.primary }]}>{t('profile.darkMode')}</Text>
+                    <Moon size={20} color={getColor('gold')} />
+                    <Text style={[styles.menuText, { color: getColor('text.primary') }]}>{t('profile.darkMode')}</Text>
                   </>
                 )}
               </TouchableOpacity>
 
               {/* Language Switcher */}
               <TouchableOpacity style={styles.menuItem} onPress={handleLanguageSwitch}>
-                <Globe size={20} color={colors.gold} />
-                <Text style={[styles.menuText, { color: colors.text.primary }]}>
+                <Globe size={20} color={getColor('gold')} />
+                <Text style={[styles.menuText, { color: getColor('text.primary') }]}>
                   {currentLanguage === 'en' ? t('profile.hebrew') : t('profile.english')}
                 </Text>
               </TouchableOpacity>
 
               {isLoggedIn && (
                 <TouchableOpacity style={styles.menuItem} onPress={handleLogout}>
-                  <LogOut size={20} color={colors.status.error} />
-                  <Text style={[styles.menuText, { color: colors.status.error }]}>{t('auth.logout')}</Text>
+                  <LogOut size={20} color={getColor('status.error')} />
+                  <Text style={[styles.menuText, { color: getColor('status.error') }]}>{t('auth.logout')}</Text>
                 </TouchableOpacity>
               )}
             </View>
@@ -291,10 +305,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 2,
-    borderColor: 'rgba(255, 255, 255, 0.2)',
   },
   avatarText: {
-    color: '#FFFFFF',
     fontSize: 14,
     fontWeight: 'bold',
   },

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,6 +7,7 @@ import {
   PressableProps,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
+import { spacing, radius } from '@/constants/tokens';
 
 interface ButtonProps extends PressableProps {
   title?: string;
@@ -24,28 +25,27 @@ export default function Button({
   accessibilityRole = 'button',
   ...rest
 }: ButtonProps) {
-  const { tokens } = useTheme();
-  const { colors, spacing, radius } = tokens;
+  const { getColor } = useTheme();
 
   const isDisabled = disabled || loading;
 
   const backgroundColor = isDisabled
-    ? colors.interactive.disabled
+    ? getColor('interactive.disabled')
     : variant === 'primary'
-      ? colors.interactive.primary
-      : colors.interactive.secondary;
+      ? getColor('interactive.primary')
+      : getColor('interactive.secondary');
 
   const textColor = isDisabled
-    ? colors.text.secondary
+    ? getColor('text.secondary')
     : variant === 'primary'
-      ? colors.text.inverse
-      : colors.text.primary;
+      ? getColor('text.inverse')
+      : getColor('text.primary');
 
   const borderStyle =
     variant === 'secondary'
       ? {
           borderWidth: 1,
-          borderColor: isDisabled ? colors.interactive.disabled : colors.border.primary,
+          borderColor: isDisabled ? getColor('interactive.disabled') : getColor('border.primary'),
         }
       : null;
 

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -21,13 +21,13 @@ export default function EmptyState({
   actionText,
   onAction,
 }: EmptyStateProps) {
-  const { colors } = useTheme();
+  const { getColor } = useTheme();
 
   return (
     <View style={styles.container}>
-      <Icon size={80} color={colors.interactive.disabled} />
-      <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
-      <Text style={[styles.message, { color: colors.text.secondary }]}>{message}</Text>
+      <Icon size={80} color={getColor('interactive.disabled')} />
+      <Text style={[styles.title, { color: getColor('text.primary') }]}>{title}</Text>
+      <Text style={[styles.message, { color: getColor('text.secondary') }]}>{message}</Text>
       {actionText && onAction && (
         <Button title={actionText} onPress={onAction} style={styles.actionButton} />
       )}

--- a/components/ui/GoldDivider.tsx
+++ b/components/ui/GoldDivider.tsx
@@ -3,13 +3,13 @@ import { View } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 
 export default function GoldDivider({ width = 120 }: { width?: number }) {
-  const { colors } = useTheme();
+  const { getColor } = useTheme();
   return (
     <View
       style={{
         height: 2,
         width,
-        backgroundColor: colors.gold,
+        backgroundColor: getColor('gold'),
         borderRadius: 1,
       }}
     />

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -13,12 +13,12 @@ export default function Section({
   children: React.ReactNode;
   center?: boolean;
 }) {
-  const { colors } = useTheme();
+  const { getColor } = useTheme();
   return (
     <View style={{ paddingHorizontal: spacing.spacer16, paddingVertical: spacing.spacer16 }}>
       <Text
         style={{
-          color: colors.text.primary,
+          color: getColor('text.primary'),
           fontSize: 18,
           fontWeight: '700',
           textAlign: center ? 'center' : 'left',

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -23,14 +23,14 @@ export default function Spinner({
   label,
   style,
 }: SpinnerProps) {
-  const { colors } = useTheme();
-  const spinnerColor = color || colors.gold;
+  const { getColor } = useTheme();
+  const spinnerColor = color || getColor('gold');
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }, style]}>
+    <View style={[styles.container, { backgroundColor: getColor('background') }, style]}>
       <ActivityIndicator size={size} color={spinnerColor} />
       {label ? (
-        <Text style={[styles.label, { color: colors.text.primary }]}>{label}</Text>
+        <Text style={[styles.label, { color: getColor('text.primary') }]}>{label}</Text>
       ) : null}
     </View>
   );

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -48,4 +48,14 @@ export const Colors = {
     inactive: 'rgba(255, 255, 255, 0.6)',
     border: 'rgba(185, 156, 90, 0.3)',
   },
+
+  // Admin Notification Banner Colors
+  adminBanner: {
+    background: '#20B2AA',
+    text: '#FFFFFF',
+    buttonBackground: 'rgba(255, 255, 255, 0.2)',
+  },
+
+  // Avatar Color Palette
+  avatarPalette: ['#B99C5A', '#20B2AA', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD'],
 };

--- a/constants/LightColors.ts
+++ b/constants/LightColors.ts
@@ -48,4 +48,14 @@ export const LightColors = {
     inactive: 'rgba(26, 26, 26, 0.6)',
     border: 'rgba(185, 156, 90, 0.3)',
   },
+
+  // Admin Notification Banner Colors
+  adminBanner: {
+    background: '#20B2AA',
+    text: '#FFFFFF',
+    buttonBackground: 'rgba(255, 255, 255, 0.2)',
+  },
+
+  // Avatar Color Palette
+  avatarPalette: ['#B99C5A', '#20B2AA', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD'],
 };

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -32,7 +32,23 @@ const ThemeContext = createContext<ThemeContextType>({
   toggleTheme: async () => {},
 });
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => {
+  const { theme, tokens, colors, setTheme, toggleTheme } = useContext(ThemeContext);
+
+  const getColor = useCallback(
+    (path: string): any => {
+      return path.split('.').reduce((acc: any, key) => (acc ? acc[key] : undefined), colors);
+    },
+    [colors],
+  );
+
+  const getTokens = useCallback(() => tokens, [tokens]);
+
+  return useMemo(
+    () => ({ theme, colors, getTokens, getColor, setTheme, toggleTheme }),
+    [theme, colors, getTokens, getColor, setTheme, toggleTheme],
+  );
+};
 
 interface ThemeProviderProps {
   children: ReactNode;


### PR DESCRIPTION
## Summary
- centralize avatar and banner color constants in theme tokens
- expose memoized `getColor` via `useTheme`
- replace direct color references with `getColor` in common components

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb5221f483268ea5e2f33c35b3b1