### PR TITLE
Require wallet authentication for admin screens

### DIFF
--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,19 +1,22 @@
 import { Stack } from 'expo-router';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import RequireWallet from '../../components/RequireWallet';
 
 export default function AdminLayout() {
   return (
-    <ErrorBoundary>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="index" />
-        <Stack.Screen name="overview" />
-        <Stack.Screen name="stores" />
-        <Stack.Screen name="stores/[storeId]" />
-        <Stack.Screen name="user-directory" />
-        <Stack.Screen name="fees" />
-        <Stack.Screen name="compliance" />
-        <Stack.Screen name="settings" />
-      </Stack>
-    </ErrorBoundary>
+    <RequireWallet>
+      <ErrorBoundary>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="index" />
+          <Stack.Screen name="overview" />
+          <Stack.Screen name="stores" />
+          <Stack.Screen name="stores/[storeId]" />
+          <Stack.Screen name="user-directory" />
+          <Stack.Screen name="fees" />
+          <Stack.Screen name="compliance" />
+          <Stack.Screen name="settings" />
+        </Stack>
+      </ErrorBoundary>
+    </RequireWallet>
   );
 }

--- a/app/admin/compliance.tsx
+++ b/app/admin/compliance.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
+import RequireWallet from '../../components/RequireWallet';
 
 export default function Compliance() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
-      <Text style={{ color: colors.text.primary }}>Compliance tools coming soon.</Text>
-    </View>
+    <RequireWallet>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>Compliance tools coming soon.</Text>
+      </View>
+    </RequireWallet>
   );
 }
 

--- a/app/admin/fees.tsx
+++ b/app/admin/fees.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
+import RequireWallet from '../../components/RequireWallet';
 
 export default function Fees() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
-      <Text style={{ color: colors.text.primary }}>Fees management coming soon.</Text>
-    </View>
+    <RequireWallet>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>Fees management coming soon.</Text>
+      </View>
+    </RequireWallet>
   );
 }
 

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,12 +1,15 @@
 import { Redirect } from 'expo-router';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import RequireWallet from '../../components/RequireWallet';
 
 export default function AdminIndex() {
   useRequirePlatformAdmin();
   return (
-    <ErrorBoundary>
-      <Redirect href="/admin/overview" />
-    </ErrorBoundary>
+    <RequireWallet>
+      <ErrorBoundary>
+        <Redirect href="/admin/overview" />
+      </ErrorBoundary>
+    </RequireWallet>
   );
 }

--- a/app/admin/overview.tsx
+++ b/app/admin/overview.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
+import RequireWallet from '../../components/RequireWallet';
 
 export default function AdminOverview() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Text style={[styles.title, { color: colors.text.primary }]}>Platform Overview</Text>
-    </View>
+    <RequireWallet>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Text style={[styles.title, { color: colors.text.primary }]}>Platform Overview</Text>
+      </View>
+    </RequireWallet>
   );
 }
 

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -13,6 +13,7 @@ import InfoModal from '../../components/InfoModal';
 import { useAppInfo } from '../../contexts/AppInfoContext';
 import commonStyles from '@/constants/styles';
 import SettingsAgent from '../../agents/settings-agent';
+import RequireWallet from '../../components/RequireWallet';
 import BrandingSettings from '../../components/settings/BrandingSettings';
 import CurrencySettings from '../../components/settings/CurrencySettings';
 import EnvironmentSettings from '../../components/settings/EnvironmentSettings';
@@ -130,33 +131,36 @@ export default function SettingsScreen() {
 
   if (loading) {
     return (
-      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
-        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
-          <TouchableOpacity onPress={() => router.back()}> 
-            <ArrowLeft size={24} color={colors.text.primary} /> 
-          </TouchableOpacity> 
-          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text> 
-          <View style={commonStyles.spacer24} /> 
-        </View> 
-        <Spinner label="Loading settings" />
-      </SafeAreaView>
+      <RequireWallet>
+        <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+          <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
+            <TouchableOpacity onPress={() => router.back()}>
+              <ArrowLeft size={24} color={colors.text.primary} />
+            </TouchableOpacity>
+            <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text>
+            <View style={commonStyles.spacer24} />
+          </View>
+          <Spinner label="Loading settings" />
+        </SafeAreaView>
+      </RequireWallet>
     );
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
-      <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
-        <TouchableOpacity onPress={() => router.back()}> 
-          <ArrowLeft size={24} color={colors.text.primary} /> 
-        </TouchableOpacity> 
-        <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text> 
-        <View style={commonStyles.spacer24} /> 
-      </View> 
-      <ScrollView
-        style={styles.content}
-        contentContainerStyle={styles.contentContainer}
-        showsVerticalScrollIndicator={false}
-      >
+    <RequireWallet>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
+          <TouchableOpacity onPress={() => router.back()}>
+            <ArrowLeft size={24} color={colors.text.primary} />
+          </TouchableOpacity>
+          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text>
+          <View style={commonStyles.spacer24} />
+        </View>
+        <ScrollView
+          style={styles.content}
+          contentContainerStyle={styles.contentContainer}
+          showsVerticalScrollIndicator={false}
+        >
         <View style={styles.sectionHeader}>
           <SettingsIcon size={24} color={colors.gold} />
           <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>הגדרות כלליות</Text>
@@ -216,6 +220,7 @@ export default function SettingsScreen() {
         onClose={() => setInfoModal({ ...infoModal, visible: false })}
       />
     </SafeAreaView>
+  </RequireWallet>
   );
 }
 

--- a/app/admin/stores/[storeId]/impersonate.tsx
+++ b/app/admin/stores/[storeId]/impersonate.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import useRequirePlatformAdmin from '@/hooks/useRequirePlatformAdmin';
+import RequireWallet from '../../../../components/RequireWallet';
 
 export default function ImpersonateStore() {
   useRequirePlatformAdmin();
@@ -12,5 +13,5 @@ export default function ImpersonateStore() {
     }
   }, [storeId]);
 
-  return null;
+  return <RequireWallet>{null}</RequireWallet>;
 }

--- a/app/admin/stores/[storeId]/index.tsx
+++ b/app/admin/stores/[storeId]/index.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const StoreDetailScreen = React.lazy(() => import('./_StoreDetailScreen'));
 
 export default function AdminStoreDetailRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Store Detail" />}>
-      <StoreDetailScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Store Detail" />}>
+        <StoreDetailScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/admin/stores/index.tsx
+++ b/app/admin/stores/index.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../components/ui/Spinner';
+import RequireWallet from '../../../components/RequireWallet';
 
 const StoresScreen = React.lazy(() => import('./_StoresScreen'));
 
 export default function AdminStoresRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Stores" />}>
-      <StoresScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Stores" />}>
+        <StoresScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import useRequirePlatformAdmin from 'hooks/useRequirePlatformAdmin';
+import RequireWallet from '@/components/RequireWallet';
 import chain from '@/services/chain';
 import { User } from '@/types';
 
@@ -22,16 +23,18 @@ export default function UserDirectory() {
   }, []);
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
-      {users.map((u) => (
-        <Text key={u.id} style={{ color: colors.text.primary }}>
-          {u.displayName || u.id}
-        </Text>
-      ))}
-      {users.length === 0 && (
-        <Text style={{ color: colors.text.secondary }}>No users found.</Text>
-      )}
-    </View>
+    <RequireWallet>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        {users.map((u) => (
+          <Text key={u.id} style={{ color: colors.text.primary }}>
+            {u.displayName || u.id}
+          </Text>
+        ))}
+        {users.length === 0 && (
+          <Text style={{ color: colors.text.secondary }}>No users found.</Text>
+        )}
+      </View>
+    </RequireWallet>
   );
 }
 

--- a/app/store/[storeId]/admin/_layout.tsx
+++ b/app/store/[storeId]/admin/_layout.tsx
@@ -1,21 +1,24 @@
 import { Stack } from 'expo-router';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import RequireWallet from '../../../../components/RequireWallet';
 
 export default function StoreAdminLayout() {
   return (
-    <ErrorBoundary>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="dashboard" />
-        <Stack.Screen name="products" />
-        <Stack.Screen name="orders" />
-        <Stack.Screen name="kyc-approvals" />
-        <Stack.Screen name="user-management" />
-        <Stack.Screen name="pricing-tiers" />
-        <Stack.Screen name="deliveries" />
-        <Stack.Screen name="bulk-upload" />
-        <Stack.Screen name="disputes" />
-        <Stack.Screen name="settings" />
-      </Stack>
-    </ErrorBoundary>
+    <RequireWallet>
+      <ErrorBoundary>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="dashboard" />
+          <Stack.Screen name="products" />
+          <Stack.Screen name="orders" />
+          <Stack.Screen name="kyc-approvals" />
+          <Stack.Screen name="user-management" />
+          <Stack.Screen name="pricing-tiers" />
+          <Stack.Screen name="deliveries" />
+          <Stack.Screen name="bulk-upload" />
+          <Stack.Screen name="disputes" />
+          <Stack.Screen name="settings" />
+        </Stack>
+      </ErrorBoundary>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/bulk-upload.tsx
+++ b/app/store/[storeId]/admin/bulk-upload.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const BulkUploadScreen = React.lazy(() => import('./_BulkUploadScreen'));
 
 export default function BulkUploadRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Bulk Upload" />}>
-      <BulkUploadScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Bulk Upload" />}>
+        <BulkUploadScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const DashboardScreen = React.lazy(() => import('./_DashboardScreen'));
 
 export default function DashboardRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Dashboard" />}>
-      <DashboardScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Dashboard" />}>
+        <DashboardScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/deliveries.tsx
+++ b/app/store/[storeId]/admin/deliveries.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const DeliveriesScreen = React.lazy(() => import('./_DeliveriesScreen'));
 
 export default function DeliveriesRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Deliveries" />}>
-      <DeliveriesScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Deliveries" />}>
+        <DeliveriesScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/disputes.tsx
+++ b/app/store/[storeId]/admin/disputes.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const DisputesScreen = React.lazy(() => import('./_DisputesScreen'));
 
 export default function DisputesRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Disputes" />}>
-      <DisputesScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Disputes" />}>
+        <DisputesScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/kyc-approvals.tsx
+++ b/app/store/[storeId]/admin/kyc-approvals.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const KycApprovalsScreen = React.lazy(() => import('./_KycApprovalsScreen'));
 
 export default function KycApprovalsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="KYC Approvals" />}>
-      <KycApprovalsScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="KYC Approvals" />}>
+        <KycApprovalsScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/orders.tsx
+++ b/app/store/[storeId]/admin/orders.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const OrdersScreen = React.lazy(() => import('./_OrdersScreen'));
 
 export default function OrdersRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Orders" />}>
-      <OrdersScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Orders" />}>
+        <OrdersScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/pricing-tiers.tsx
+++ b/app/store/[storeId]/admin/pricing-tiers.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const PricingTiersScreen = React.lazy(() => import('./_PricingTiersScreen'));
 
 export default function PricingTiersRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Pricing Tiers" />}>
-      <PricingTiersScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Pricing Tiers" />}>
+        <PricingTiersScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/products.tsx
+++ b/app/store/[storeId]/admin/products.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const ProductsScreen = React.lazy(() => import('./_ProductsScreen'));
 
 export default function ProductsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Products" />}>
-      <ProductsScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Products" />}>
+        <ProductsScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/settings.tsx
+++ b/app/store/[storeId]/admin/settings.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const SettingsScreen = React.lazy(() => import('./_SettingsScreen'));
 
 export default function SettingsRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="Settings" />}>
-      <SettingsScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="Settings" />}>
+        <SettingsScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/app/store/[storeId]/admin/user-management.tsx
+++ b/app/store/[storeId]/admin/user-management.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import Spinner from '../../../../components/ui/Spinner';
+import RequireWallet from '../../../../components/RequireWallet';
 
 const UserManagementScreen = React.lazy(() => import('./_UserManagementScreen'));
 
 export default function UserManagementRoute(props: any) {
   return (
-    <Suspense fallback={<Spinner label="User Management" />}>
-      <UserManagementScreen {...props} />
-    </Suspense>
+    <RequireWallet>
+      <Suspense fallback={<Spinner label="User Management" />}>
+        <UserManagementScreen {...props} />
+      </Suspense>
+    </RequireWallet>
   );
 }

--- a/components/RequireWallet.tsx
+++ b/components/RequireWallet.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Redirect, usePathname, useSearchParams } from 'expo-router';
+import { useAccountId } from '@/features/auth/services/nearAuth';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function RequireWallet({ children }: Props) {
+  const accountId = useAccountId();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  if (!accountId) {
+    let dest = pathname;
+    const query = params.toString();
+    if (query) dest += `?${query}`;
+    return <Redirect href={`/login?redirect=${encodeURIComponent(dest)}`} />;
+  }
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add `RequireWallet` to gate routes based on NEAR wallet presence and redirect to login with return path
- protect admin layouts and screen exports with `RequireWallet`

## Testing
- `yarn lint`
- `yarn test` *(fails: Unexpected token '<' in tests; TS errors in eventBus and waku message schema)*


------
https://chatgpt.com/codex/tasks/task_e_68b6029c1c008326861e851bb3fb4c07