### PR TITLE
feat: centralize navigation logging

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2 } from 'lucide-react-native';
 import DatabaseService from '../../services/database';
 import { Category } from '../../types';
@@ -34,6 +34,7 @@ export default function CategoriesScreen() {
   const [loading, setLoading] = useState(true);
   const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
+  const { push, back } = useAppRouter();
   const NUM_COLUMNS = 2;
   const ITEM_HEIGHT = 176;
   const getItemLayout = (_: Category[] | null | undefined, index: number) => ({
@@ -180,7 +181,7 @@ export default function CategoriesScreen() {
   const renderCategory = ({ item }: { item: Category }) => (
     <TouchableOpacity
       style={[styles.categoryCard]}
-      onPress={() => router.push(`/category/${item.id}`)}
+      onPress={() => push(`/category/${item.id}`)}
     >
       <View style={[styles.categoryIcon]}>
         <Text style={styles.categoryEmoji}>{item.icon}</Text>
@@ -211,7 +212,7 @@ export default function CategoriesScreen() {
         <View
           style={[styles.header, { borderBottomColor: colors.border.primary }]}
         >
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>קטגוריות</Text>
@@ -248,7 +249,7 @@ export default function CategoriesScreen() {
       <View
         style={[styles.header, { borderBottomColor: colors.border.primary }]}
       >
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,7 +14,8 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import {
   Heart,
   Plus,
@@ -50,6 +51,7 @@ const BANNER_WIDTH = width - 32;
 const BANNER_HEIGHT = (BANNER_WIDTH * 9) / 16;
 
 export default function HomeScreen() {
+  const { push } = useAppRouter();
   const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
   const [products, setProducts] = useState<Product[]>([]);
@@ -259,7 +261,7 @@ export default function HomeScreen() {
   const renderCategory = ({ item }: { item: Category }) => (
     <TouchableOpacity
       style={[styles.categoryCard]}
-      onPress={() => router.push(`/category/${item.id}`)}
+      onPress={() => push(`/category/${item.id}`)}
     >
       <View
         style={[
@@ -285,7 +287,7 @@ export default function HomeScreen() {
                 borderColor: colors.gold,
               },
             ]}
-            onPress={() => router.push(`/category/${item.id}`)}
+            onPress={() => push(`/category/${item.id}`)}
           >
             <Pencil size={10} color={colors.gold} />
           </TouchableOpacity>
@@ -298,7 +300,7 @@ export default function HomeScreen() {
     <View key={item.id} style={styles.heroBanner}>
       <TouchableOpacity
         style={styles.bannerTouchable}
-        onPress={() => router.push(`/category/${item.category}`)}
+        onPress={() => push(`/category/${item.category}`)}
       >
         <SmartImage
           uri={item.image}
@@ -502,7 +504,7 @@ export default function HomeScreen() {
         </View>
         <TouchableOpacity
           style={[styles.becomeSellerButton, { backgroundColor: colors.gold }]}
-          onPress={() => router.push('/stores/create')}
+          onPress={() => push('/stores/create')}
           accessibilityRole="link"
         >
           <Text style={[styles.becomeSellerText, { color: colors.text.inverse }]}>Become a Seller</Text>
@@ -583,7 +585,7 @@ export default function HomeScreen() {
             <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
               {t('home.categories')}
             </Text>
-            <TouchableOpacity onPress={() => router.push('/(tabs)/categories')}>
+            <TouchableOpacity onPress={() => push('/(tabs)/categories')}>
               <Text style={[styles.seeAll, { color: colors.gold }]}>
                 {t('common.viewAll')}
               </Text>

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -7,7 +7,7 @@ import {
   FlatList,
   TouchableOpacity,
 } from 'react-native';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { Package, ArrowLeft, ChevronLeft, ShoppingBag, Clock, Calendar, Truck } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import OrderService from '../../services/orders';
@@ -33,6 +33,7 @@ export default function OrdersScreen() {
   const { colors } = useTheme();
   const { t, currentLanguage } = useLanguage();
   const { currencySymbol } = useCurrency();
+  const { push, back } = useAppRouter();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -188,7 +189,7 @@ export default function OrdersScreen() {
         title={t('orders.emptyTitle') as string}
         message={t('orders.emptyMessage') as string}
         actionText={t('orders.shopNow') as string}
-        onAction={() => router.push('/(tabs)')}
+        onAction={() => push('/(tabs)')}
       />
     ) : (
       <EmptyState
@@ -205,7 +206,7 @@ export default function OrdersScreen() {
     <AppShell showSearch={false}>
       
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}> 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -9,7 +9,7 @@ import {
   Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import {
   Settings,
   User,
@@ -63,6 +63,7 @@ export default function ProfileScreen() {
   const scrollViewRef = useRef<ScrollView>(null);
   const { openAuthModal } = useAuthModal();
   const [storeId, setStoreId] = useState<string | null>(null);
+  const { push, replace } = useAppRouter();
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -150,7 +151,7 @@ export default function ProfileScreen() {
     try {
       await logout();
       // Navigate to home page after logout
-      router.replace('/');
+      replace('/');
       setInfoModal({
         visible: true,
         title: 'התנתקות',
@@ -306,7 +307,7 @@ export default function ProfileScreen() {
                 },
               ]}
               onPress={() =>
-                storeId && router.push(`/store/${storeId}/admin/dashboard`)
+                storeId && push(`/store/${storeId}/admin/dashboard`)
               }
             >
               <View style={styles.menuItemContent}>
@@ -325,7 +326,7 @@ export default function ProfileScreen() {
                 },
               ]}
               onPress={() =>
-                storeId && router.push(`/store/${storeId}/admin/deliveries`)
+                storeId && push(`/store/${storeId}/admin/deliveries`)
               }
             >
               <View style={styles.menuItemContent}>
@@ -344,7 +345,7 @@ export default function ProfileScreen() {
                     borderColor: colors.border.primary,
                   },
                 ]}
-                onPress={() => router.push('/kyc')}
+                onPress={() => push('/kyc')}
               >
                 <View style={styles.menuItemContent}>
                   <Shield size={24} color={colors.gold} />
@@ -371,7 +372,7 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() => router.push('/driver-dashboard')}
+              onPress={() => push('/driver-dashboard')}
             >
               <View style={styles.menuItemContent}>
                 <Truck size={24} color={colors.gold} />
@@ -397,7 +398,7 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() => router.push('/(tabs)/orders')}
+              onPress={() => push('/(tabs)/orders')}
             >
               <View style={styles.menuItemContent}>
                 <Text style={[styles.menuText, { color: colors.text.primary }]}>

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -33,6 +33,7 @@ export default function SettingsScreen() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   useRequirePlatformAdmin();
+  const { back } = useAppRouter();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { currentLanguage, t } = useLanguage();
@@ -134,7 +135,7 @@ export default function SettingsScreen() {
       <RequireWallet>
         <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
           <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-            <TouchableOpacity onPress={() => router.back()}>
+            <TouchableOpacity onPress={() => back()}>
               <ArrowLeft size={24} color={colors.text.primary} />
             </TouchableOpacity>
             <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text>
@@ -150,7 +151,7 @@ export default function SettingsScreen() {
     <RequireWallet>
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text>

--- a/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
+++ b/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Button from '@/components/ui/Button';
-import { useLocalSearchParams, router } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { useTheme } from '@/contexts/ThemeContext';
 import useRequirePlatformAdmin from 'hooks/useRequirePlatformAdmin';
 import chain from '@/services/chain';
@@ -16,6 +17,7 @@ if (chain === 'near') {
 
 export default function StoreDetail() {
   useRequirePlatformAdmin();
+  const { push } = useAppRouter();
   const { colors } = useTheme();
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const [store, setStore] = useState<Store | null>(null);
@@ -38,7 +40,7 @@ export default function StoreDetail() {
       <Text style={[styles.value, { color: colors.text.primary }]}>{store.owner}</Text>
       <Button
         title="Impersonate"
-        onPress={() => router.push(`/store/${store.id}/admin/dashboard?impersonate=true`)}
+        onPress={() => push(`/store/${store.id}/admin/dashboard?impersonate=true`)}
         style={{ marginTop: 24 }}
       />
     </View>

--- a/app/admin/stores/[storeId]/impersonate.tsx
+++ b/app/admin/stores/[storeId]/impersonate.tsx
@@ -1,17 +1,19 @@
 import { useEffect } from 'react';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import useRequirePlatformAdmin from '@/hooks/useRequirePlatformAdmin';
 import RequireWallet from '../../../../components/RequireWallet';
 
 export default function ImpersonateStore() {
   useRequirePlatformAdmin();
+  const { replace } = useAppRouter();
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
 
   useEffect(() => {
     if (storeId) {
-      router.replace(`/store/${storeId}/admin/dashboard?impersonate=true`);
+      replace(`/store/${storeId}/admin/dashboard?impersonate=true`);
     }
-  }, [storeId]);
+  }, [storeId, replace]);
 
   return <RequireWallet>{null}</RequireWallet>;
 }

--- a/app/admin/stores/_StoresScreen.tsx
+++ b/app/admin/stores/_StoresScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Text } from 'react-native';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { useTheme } from '@/contexts/ThemeContext';
 import useRequirePlatformAdmin from 'hooks/useRequirePlatformAdmin';
 import chain from '@/services/chain';
@@ -15,6 +15,7 @@ if (chain === 'near') {
 
 export default function AdminStores() {
   useRequirePlatformAdmin();
+  const { push } = useAppRouter();
   const { colors } = useTheme();
   const [stores, setStores] = useState<Store[]>([]);
 
@@ -27,7 +28,7 @@ export default function AdminStores() {
   const items: AdminListItem[] = stores.map((s) => ({
     id: s.id,
     title: s.name || s.id,
-    onPress: () => router.push(`/admin/stores/${s.id}`),
+    onPress: () => push(`/admin/stores/${s.id}`),
   }));
 
   return (

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -10,7 +10,8 @@ import {
   TextInput,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { z } from 'zod';
 import { createValidateParams } from '@/lib/validateParams';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2 } from 'lucide-react-native';
@@ -27,6 +28,7 @@ const validateParams = createValidateParams(z.object({ id: z.string() }));
 
 
 export default function CategoryScreen() {
+  const { push, back } = useAppRouter();
   const params = validateParams(useLocalSearchParams());
   const id = params.success ? params.data.id : undefined;
   const [category, setCategory] = useState<Category | null>(null);
@@ -199,7 +201,7 @@ export default function CategoryScreen() {
         backgroundColor: colors.surface.primary,
         borderColor: colors.border.primary 
       }]}
-      onPress={() => router.push(`/subcategory/${item.id}`)}
+      onPress={() => push(`/subcategory/${item.id}`)}
     >
       <View style={[styles.subcategoryIcon, { 
         backgroundColor: colors.interactive.secondary,
@@ -229,7 +231,7 @@ export default function CategoryScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>טוען...</Text>
@@ -244,7 +246,7 @@ export default function CategoryScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>קטגוריה לא נמצאה</Text>
@@ -257,7 +259,7 @@ export default function CategoryScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{category.name}</Text>

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import {
   ArrowLeft,
   Truck,
@@ -30,6 +31,7 @@ import commonStyles from '@/constants/styles';
 
 
 export default function DriverDashboardScreen() {
+  const { back, replace } = useAppRouter();
   const { user, isDriver, isAdmin } = useAuth();
   const { colors } = useTheme();
   const [jobs, setJobs] = useState<DeliveryJob[]>([]);
@@ -41,15 +43,15 @@ export default function DriverDashboardScreen() {
       typeof (router as any).canGoBack === 'function' &&
       (router as any).canGoBack();
     if (canGoBack) {
-      router.back();
+      back();
     } else {
-      router.replace('/(tabs)');
+      replace('/(tabs)');
     }
   };
 
   useEffect(() => {
     if (!isDriver && !isAdmin) {
-      router.replace('/');
+      replace('/');
       return;
     }
     loadJobs();

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Button from '@/components/ui/Button';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import ProofUploader from '../../components/ProofUploader';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -13,6 +13,7 @@ export default function KycScreen() {
   const { user } = useAuth();
   const { colors } = useTheme();
   const [docUri, setDocUri] = useState('');
+  const { back } = useAppRouter();
 
   const submit = async () => {
     if (!user || !docUri) return;
@@ -20,7 +21,7 @@ export default function KycScreen() {
       type: 'kyc.request',
       payload: { userId: user.id, documentUri: docUri },
     });
-    router.back();
+    back();
   };
 
   return (

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, Pressable, ScrollView } from 'react-native';
-import { Link, router } from 'expo-router';
+import { Link } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import AppShell from '../components/layout/AppShell';
 import Section from '../components/ui/Section';
 import GoldDivider from '../components/ui/GoldDivider';
@@ -13,6 +14,7 @@ import Button from '../components/ui/Button';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function Landing() {
+  const { push } = useAppRouter();
   const { colors } = useTheme();
   const [featured, setFeatured] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -105,7 +107,7 @@ export default function Landing() {
               ] as any[]).map((c) => (
                 <Pressable
                   key={c.id}
-                  onPress={() => router.push(`/category/${c.id}`)}
+                  onPress={() => push(`/category/${c.id}`)}
                   style={{
                     paddingHorizontal: 12,
                     paddingVertical: 8,

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -13,7 +13,7 @@ import {
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import {
   ArrowLeft,
   Heart,
@@ -63,6 +63,7 @@ const { width } = Dimensions.get('window');
 const COVER_SIZE = Math.min(width, 540);
 
 export default function ProductDetailScreen({ id }: { id: string }) {
+  const { push, back } = useAppRouter();
   const [product, setProduct] = useState<Product | null>(null);
   const [categories, setCategories] = useState<Category[]>([]);
   const [pricingTiers, setPricingTiers] = useState<PricingTier[]>([]);
@@ -303,7 +304,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
   const buyNow = async () => {
     await addToCart();
     // Navigate to cart or checkout
-    router.push({
+    push({
       pathname: '/(tabs)',
       params: { showCart: 'true' },
     });
@@ -345,7 +346,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
   };
 
   const handleProductDeleted = (id: string) => {
-    router.back();
+    back();
   };
 
   // Calculate effective price based on pricing tier and quantity
@@ -395,7 +396,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
         <View
           style={[styles.header, { borderBottomColor: colors.border.primary }]}
         >
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>
@@ -426,7 +427,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
       <ScrollView showsVerticalScrollIndicator={false}>
         {/* Header */}
         <View style={styles.header}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <View style={styles.headerActions}>

--- a/app/reviews/[orderId].tsx
+++ b/app/reviews/[orderId].tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useLocalSearchParams, router } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { Star, ArrowLeft } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -12,6 +13,7 @@ import { Order, Review } from '../../types';
 import SmartImage from '../../components/SmartImage';
 
 export default function SubmitReviewScreen() {
+  const { replace, back } = useAppRouter();
   const { orderId } = useLocalSearchParams<{ orderId: string }>();
   const { isLoggedIn, user } = useAuth();
   const { colors } = useTheme();
@@ -56,7 +58,7 @@ export default function SubmitReviewScreen() {
       verified: true,
     };
     await reviewAgent.add(review);
-    router.replace('/reviews');
+    replace('/reviews');
   };
 
   const renderStars = () => (
@@ -96,7 +98,7 @@ export default function SubmitReviewScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
-        <TouchableOpacity onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
+        <TouchableOpacity onPress={() => back()} style={[styles.backButton, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>כתיבת ביקורת</Text>

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -13,6 +13,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Star, Plus, X, Send, Filter, Search, ThumbsUp, ArrowLeft } from 'lucide-react-native';
 import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import DatabaseService from '../../services/database';
 import { Product, Review, Order } from '../../types';
 import { useAuth } from '@/features/auth/AuthContext';
@@ -47,6 +48,7 @@ export default function ReviewsScreen() {
   const [sortBy, setSortBy] = useState<'newest' | 'highest' | 'lowest'>('newest');
   const { isLoggedIn, isAdmin, user } = useAuth();
   const { colors } = useTheme();
+  const { push, back, replace } = useAppRouter();
 
   const goBack = () => {
     // If there's no history, navigate home
@@ -54,9 +56,9 @@ export default function ReviewsScreen() {
       typeof (router as any).canGoBack === 'function' &&
       (router as any).canGoBack();
     if (canGoBack) {
-      router.back();
+      back();
     } else {
-      router.replace('/(tabs)');
+      replace('/(tabs)');
     }
   };
 
@@ -298,7 +300,7 @@ export default function ReviewsScreen() {
       <View style={styles.reviewHeader}>
         <TouchableOpacity 
           style={styles.productInfo}
-          onPress={() => router.push(`/product/${item.productId}`)}
+          onPress={() => push(`/product/${item.productId}`)}
         >
           <SmartImage
             uri={item.productImage}

--- a/app/store/[storeId]/admin/_BulkUploadScreen.tsx
+++ b/app/store/[storeId]/admin/_BulkUploadScreen.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect } from 'react';
 import { Alert } from 'react-native';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import AdminBulkUploader from '@/features/products/components/AdminBulkUploader';
 import { useAuth } from '@/features/auth/AuthContext';
 
 export default function BulkUploadScreen() {
   const { isAdmin } = useAuth();
+  const { replace } = useAppRouter();
 
   useEffect(() => {
     if (!isAdmin) {
       Alert.alert('Access denied', 'Admins only', [
-        { text: 'OK', onPress: () => router.replace('/') },
+        { text: 'OK', onPress: () => replace('/') },
       ]);
     }
   }, [isAdmin]);

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { useTheme } from '@/contexts/ThemeContext';
 import chain from '@/services/chain';
 import OrderRevenueMetrics from '@/components/OrderRevenueMetrics';
@@ -14,6 +15,7 @@ if (chain === 'near') {
 }
 
 export default function StoreDashboardScreen() {
+  const { replace, push } = useAppRouter();
   const { storeId, impersonate } = useLocalSearchParams<{ storeId: string; impersonate?: string }>();
   const { colors } = useTheme();
   const { user } = useAuth();
@@ -26,7 +28,7 @@ export default function StoreDashboardScreen() {
       const store = await getStore(storeId, storeId);
       const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
       if (!store || (store.owner !== user?.address && !isAdmin)) {
-        router.replace(`/store/${storeId}`);
+        replace(`/store/${storeId}`);
         return;
       }
       setAuthorized(true);
@@ -52,13 +54,13 @@ export default function StoreDashboardScreen() {
       <View style={styles.nav}>
         <TouchableOpacity
           style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => router.push(`/store/${storeId}/admin/products`)}
+          onPress={() => push(`/store/${storeId}/admin/products`)}
         >
           <Text style={{ color: colors.text.primary }}>ניהול מוצרים</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => router.push(`/store/${storeId}/admin/orders`)}
+          onPress={() => push(`/store/${storeId}/admin/orders`)}
         >
           <Text style={{ color: colors.text.primary }}>צפייה בהזמנות</Text>
         </TouchableOpacity>

--- a/app/store/[storeId]/admin/_DeliveriesScreen.tsx
+++ b/app/store/[storeId]/admin/_DeliveriesScreen.tsx
@@ -12,7 +12,7 @@ import {
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, Plus, Truck, ChevronDown } from 'lucide-react-native';
 import FullScreenMediaViewer from '../../../../components/FullScreenMediaViewer';
 import { useAuth } from '@/features/auth/AuthContext';
@@ -35,12 +35,13 @@ export default function AdminDeliveriesScreen() {
     { id: string; uri: string; type: 'image' | 'video' }[]
   >([]);
   const [viewerVisible, setViewerVisible] = useState(false);
+  const { replace, back } = useAppRouter();
   // Matrix integration is currently disabled and tracked separately.
   // const matrixService = MatrixService.getInstance(); // TODO: re-enable Matrix later
 
   useEffect(() => {
     if (!isStoreOwner) {
-      router.replace('/');
+      replace('/');
       return;
     }
     loadData();
@@ -125,7 +126,7 @@ export default function AdminDeliveriesScreen() {
       <View
         style={[styles.header, { borderBottomColor: colors.border.primary }]}
       >
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>

--- a/app/store/[storeId]/admin/_DisputesScreen.tsx
+++ b/app/store/[storeId]/admin/_DisputesScreen.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowLeft } from 'lucide-react-native';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useAuth } from '@/features/auth/AuthContext';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import ordersAgent from '../../../../agents/orders-agent';
 import { Order } from '../../../../types';
 import DisputeEvidence from '../../../../components/DisputeEvidence';
@@ -15,10 +15,11 @@ export default function AdminDisputesScreen() {
   const { colors } = useTheme();
   const { isAdmin } = useAuth();
   const [orders, setOrders] = useState<Order[]>([]);
+  const { replace, back } = useAppRouter();
 
   useEffect(() => {
     if (!isAdmin) {
-      router.replace('/');
+      replace('/');
       return;
     }
     const load = async () => {
@@ -48,7 +49,7 @@ export default function AdminDisputesScreen() {
           borderBottomColor: colors.border.primary,
         }}
       >
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={{ flex: 1, textAlign: 'center', fontSize: 18, color: colors.text.primary }}>

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, CircleCheck as CheckCircle, Circle as XCircle, Clock, User, Mail, FileText, Calendar } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
@@ -26,11 +26,12 @@ export default function KycApprovalsScreen() {
   const [loading, setLoading] = useState(true);
   const { isAdmin, isDriver, user } = useAuth();
   const { colors } = useTheme();
+  const { replace, back } = useAppRouter();
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
       Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => router.replace('/') }
+        { text: 'אישור', onPress: () => replace('/') }
       ]);
       return;
     }
@@ -107,7 +108,7 @@ export default function KycApprovalsScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>
@@ -121,7 +122,7 @@ export default function KycApprovalsScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>

--- a/app/store/[storeId]/admin/_PricingTiersScreen.tsx
+++ b/app/store/[storeId]/admin/_PricingTiersScreen.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import {
   ArrowLeft,
   Plus,
@@ -29,6 +29,7 @@ import PricingTierFormModal from '@/features/products/components/PricingTierForm
 import Card from '../../../../components/Card';
 
 export default function PricingTiersScreen() {
+  const { replace, back } = useAppRouter();
   const { isAdmin, isDriver } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
@@ -46,7 +47,7 @@ export default function PricingTiersScreen() {
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
-      router.replace('/');
+      replace('/');
       return;
     }
     loadPricingTiers();
@@ -164,7 +165,7 @@ export default function PricingTiersScreen() {
         <View
           style={[styles.header, { borderBottomColor: colors.border.primary }]}
         >
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>
@@ -192,7 +193,7 @@ export default function PricingTiersScreen() {
       <View
         style={[styles.header, { borderBottomColor: colors.border.primary }]}
       >
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
@@ -23,6 +23,7 @@ import MoonPaySettings from '../../../../components/settings/MoonPaySettings';
 import PaymentFactorySettings from '../../../../components/settings/PaymentFactorySettings';
 
 export default function SettingsScreen() {
+  const { replace, back } = useAppRouter();
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
   const [name, setName] = useState('');
   const [logoCidInput, setLogoCidInput] = useState('');
@@ -56,7 +57,7 @@ export default function SettingsScreen() {
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
-      router.replace('/');
+      replace('/');
       return;
     }
     loadSettings();
@@ -136,7 +137,7 @@ export default function SettingsScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
-          <TouchableOpacity onPress={() => router.back()}> 
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} /> 
           </TouchableOpacity> 
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text> 
@@ -150,7 +151,7 @@ export default function SettingsScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
-        <TouchableOpacity onPress={() => router.back()}> 
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} /> 
         </TouchableOpacity> 
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>הגדרות מערכת</Text> 

--- a/app/store/[storeId]/admin/_UserManagementScreen.tsx
+++ b/app/store/[storeId]/admin/_UserManagementScreen.tsx
@@ -12,7 +12,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { ArrowLeft, Search, User, Mail, Calendar, Shield, UserCheck, UserX, Filter, X, Save, ChevronDown } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '../../../../contexts/ThemeContext';
@@ -38,6 +38,7 @@ export default function UserManagementScreen() {
   const [filterKyc, setFilterKyc] = useState<string | null>(null);
   const [showFilterModal, setShowFilterModal] = useState(false);
   
+  const { replace, back } = useAppRouter();
   const { isAdmin, isDriver, user } = useAuth();
   const { colors } = useTheme();
   const { showNotification } = useNotifications();
@@ -45,7 +46,7 @@ export default function UserManagementScreen() {
   useEffect(() => {
     if (!isAdmin && !isDriver) {
       Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => router.replace('/') }
+        { text: 'אישור', onPress: () => replace('/') }
       ]);
       return;
     }
@@ -297,7 +298,7 @@ export default function UserManagementScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>ניהול משתמשים</Text>
@@ -311,7 +312,7 @@ export default function UserManagementScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>ניהול משתמשים</Text>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -13,7 +13,8 @@ import {
   Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { z } from 'zod';
 import { createValidateParams } from '@/lib/validateParams';
 import { ArrowLeft, Plus, Pencil, X, Save, Trash2, Heart } from 'lucide-react-native';
@@ -51,6 +52,7 @@ interface MediaItem {
 }
 
 export default function SubcategoryScreen() {
+  const { push, back } = useAppRouter();
   const params = validateParams(useLocalSearchParams());
   const id = params.success ? params.data.id : undefined;
   const [subcategory, setSubcategory] = useState<Subcategory | null>(null);
@@ -247,7 +249,7 @@ export default function SubcategoryScreen() {
       await db.deleteSubcategory(subcategory.id);
       setShowSubcategoryEditModal(false);
       setInfoModal({ visible: true, title: "הצלחה", message: "תת-הקטגוריה נמחקה בהצלחה", type: "success" });
-      router.back();
+      back();
     } catch (error) {
       errorLog("Error deleting subcategory:", error);
       setInfoModal({ visible: true, title: "שגיאה", message: "מחיקת תת-הקטגוריה נכשלה", type: "error" });
@@ -472,7 +474,7 @@ export default function SubcategoryScreen() {
         backgroundColor: colors.surface.primary,
         borderColor: colors.border.primary,
       }]}
-      onPress={() => router.push(`/product/${item.id}`)}
+      onPress={() => push(`/product/${item.id}`)}
     >
       <View style={styles.productImageContainer}>
         {item.images && item.images.length > 0 ? (
@@ -544,7 +546,7 @@ export default function SubcategoryScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>טוען...</Text>
@@ -559,7 +561,7 @@ export default function SubcategoryScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>לא נמצא</Text>
@@ -575,7 +577,7 @@ export default function SubcategoryScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>{subcategory.name}</Text>
@@ -974,7 +976,7 @@ export default function SubcategoryScreen() {
                 }]}
                 onPress={() => {
                   setShowCategorySelector(false);
-                  router.push('/(tabs)/categories');
+                  push('/(tabs)/categories');
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>
@@ -1034,7 +1036,7 @@ export default function SubcategoryScreen() {
                 }]}
                 onPress={() => {
                   setShowSubcategorySelector(false);
-                  router.push(`/category/${newProduct.category}`);
+                  push(`/category/${newProduct.category}`);
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>
@@ -1095,7 +1097,7 @@ export default function SubcategoryScreen() {
                 onPress={() => {
                   setShowPricingTierSelector(false);
                   if (storeId) {
-                    router.push(`/store/${storeId}/admin/pricing-tiers`);
+                    push(`/store/${storeId}/admin/pricing-tiers`);
                   }
                 }}
               >

--- a/app/user/[id].tsx
+++ b/app/user/[id].tsx
@@ -9,7 +9,8 @@ import {
   Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { z } from 'zod';
 import { createValidateParams } from '@/lib/validateParams';
 import { ArrowLeft, User as UserIcon, Mail, Calendar, Shield, MessageCircle } from 'lucide-react-native';
@@ -25,6 +26,7 @@ const validateParams = createValidateParams(z.object({ id: z.string() }));
 
 
 export default function UserProfileScreen() {
+  const { back } = useAppRouter();
   const params = validateParams(useLocalSearchParams());
   const id = params.success ? params.data.id : undefined;
   const [user, setUser] = useState<User | null>(null);
@@ -34,7 +36,7 @@ export default function UserProfileScreen() {
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
-      router.back();
+      back();
       return;
     }
     if (!id) return;
@@ -105,7 +107,7 @@ export default function UserProfileScreen() {
     
     try {
       // Close this screen
-      router.back();
+      back();
 
       // Messaging via Matrix is currently disabled and tracked separately.
       // TODO: re-enable Matrix later
@@ -123,7 +125,7 @@ export default function UserProfileScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>טוען...</Text>
@@ -137,7 +139,7 @@ export default function UserProfileScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => router.back()}>
+          <TouchableOpacity onPress={() => back()}>
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
           <Text style={[styles.headerTitle, { color: colors.text.primary }]}>משתמש לא נמצא</Text>
@@ -157,7 +159,7 @@ export default function UserProfileScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={() => back()}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.text.primary }]}>פרופיל משתמש</Text>

--- a/hooks/useAppRouter.ts
+++ b/hooks/useAppRouter.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { useRouter } from 'expo-router';
+import { debugLog } from '@/utils/logger';
+
+export function useAppRouter() {
+  const router = useRouter();
+
+  const push = useCallback(
+    (...args: Parameters<typeof router.push>) => {
+      debugLog('[router] push', ...args);
+      router.push(...args);
+    },
+    [router],
+  );
+
+  const replace = useCallback(
+    (...args: Parameters<typeof router.replace>) => {
+      debugLog('[router] replace', ...args);
+      router.replace(...args);
+    },
+    [router],
+  );
+
+  const back = useCallback(() => {
+    debugLog('[router] back');
+    router.back();
+  }, [router]);
+
+  return { push, replace, back };
+}
+
+export default useAppRouter;

--- a/hooks/useRequirePlatformAdmin.ts
+++ b/hooks/useRequirePlatformAdmin.ts
@@ -1,14 +1,15 @@
 import { useEffect } from 'react';
-import { router } from 'expo-router';
+import useAppRouter from 'hooks/useAppRouter';
 import { useAuth } from '@/features/auth/AuthContext';
 
 export default function useRequirePlatformAdmin() {
   const { user } = useAuth();
+  const { replace } = useAppRouter();
 
   useEffect(() => {
     if (user?.role !== 'platform-admin') {
-      router.replace('/');
+      replace('/');
     }
-  }, [user]);
+  }, [user, replace]);
 }
 


### PR DESCRIPTION
## Summary
- add `useAppRouter` hook wrapping `expo-router` push/replace/back with logging
- refactor screens to use hook for navigation
- centralize route transition logging

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b60484487483268c562a7964a7703c