### PR TITLE
Fix cart modal imports for chain and hooks

### DIFF
--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -25,6 +25,9 @@ import {
   ChevronRight,
 } from 'lucide-react-native';
 import { CartItem, ShippingAddress, Store } from '@/types';
+import chain from '@/services/chain';
+import useCart from '../hooks/useCart';
+import useCartStores from '../hooks/useCartStores';
 
 let getStore:
   | ((storeId: string, id: string) => Promise<Store | null>)


### PR DESCRIPTION
## Summary
- add missing chain import to CartModal so chain guard works
- import cart hooks to access cart state and stores

## Testing
- `npx jest --config jest.config.js --runTestsByPath tests/cartService.test.ts --runInBand` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b604153ee88326b63fc3b7c46b5651