### PR TITLE
feat: add product and store query hooks

### DIFF
--- a/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
+++ b/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
@@ -1,34 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Button from '@/components/ui/Button';
 import { useLocalSearchParams, router } from 'expo-router';
 import { useTheme } from '@/contexts/ThemeContext';
 import useRequirePlatformAdmin from 'hooks/useRequirePlatformAdmin';
-import chain from '@/services/chain';
-import { Store } from '@/types';
-
-let getStore:
-  | ((tenantId: string, id: string) => Promise<Store | null>)
-  | undefined;
-if (chain === 'near') {
-  ({ getStore } = require('@/features/stores/services/nearStores'));
-}
+import { useStore } from '@/features/products/hooks';
 
 export default function StoreDetail() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
-  const [store, setStore] = useState<Store | null>(null);
-
-  useEffect(() => {
-    if (storeId && getStore) {
-      getStore(storeId, storeId).then(setStore).catch(() => {});
-    }
-  }, [storeId]);
-
-  if (!store) {
-    return null;
-  }
+  const { data: store } = useStore(storeId);
+  if (!store) return null;
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}> 

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -48,6 +48,7 @@ import GlobalHeader from '../../components/GlobalHeader';
 import FloatingCartWidget from '@/features/cart/components/FloatingCartWidget';
 import SmartImage from '../../components/SmartImage';
 import eventBus from '../../services/eventBus';
+import { useProduct } from '@/features/products/hooks';
 
 
 
@@ -71,13 +72,13 @@ export default function ProductDetailScreen({ id }: { id: string }) {
   const [selectedMediaIndex, setSelectedMediaIndex] = useState(0);
   const [isFavorite, setIsFavorite] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
-  const [loading, setLoading] = useState(false);
   const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const [videoThumbnails, setVideoThumbnails] = useState<Record<string, string>>({});
   const address = useAccountId();
   const [reviews, setReviews] = useState<Review[]>([]);
+  const { data: fetchedProduct, isLoading: productLoading } = useProduct(id);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -93,11 +94,28 @@ export default function ProductDetailScreen({ id }: { id: string }) {
       : 0;
 
   useEffect(() => {
-    loadProduct();
+    if (productLoading) return;
+    if (address && fetchedProduct && fetchedProduct.storeId !== address) {
+      setInfoModal({
+        visible: true,
+        title: 'שגיאה',
+        message: 'מוצר לא נמצא',
+        type: 'error',
+      });
+      setProduct(null);
+      return;
+    }
+    if (fetchedProduct) {
+      setProduct(fetchedProduct);
+      eventBus.track('catalog.product_view', { productId: fetchedProduct.id });
+    }
+  }, [fetchedProduct, productLoading, address]);
+
+  useEffect(() => {
     loadCategories();
     loadPricingTiers();
     loadReviews();
-  }, [id, address]);
+  }, [id]);
 
   useEffect(() => {
     const sub = (rev: Review) => {
@@ -145,33 +163,6 @@ export default function ProductDetailScreen({ id }: { id: string }) {
     loadThumbs();
   }, [product]);
 
-  const loadProduct = async () => {
-    try {
-      const db = DatabaseService.getInstance();
-      const fetched = await db.getProduct(id);
-      if (address && fetched && fetched.storeId !== address) {
-        setInfoModal({
-          visible: true,
-          title: 'שגיאה',
-          message: 'מוצר לא נמצא',
-          type: 'error',
-        });
-        return;
-      }
-      if (fetched) {
-        setProduct(fetched);
-        eventBus.track('catalog.product_view', { productId: fetched.id });
-      }
-    } catch (error) {
-      errorLog('Error loading product:', error);
-      setInfoModal({
-        visible: true,
-        title: 'שגיאה',
-        message: 'טעינת המוצר נכשלה',
-        type: 'error',
-      });
-    }
-  };
 
   const loadCategories = async () => {
     try {

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -5,12 +5,11 @@ import { useTheme } from '@/contexts/ThemeContext';
 import chain from '@/services/chain';
 import OrderRevenueMetrics from '@/components/OrderRevenueMetrics';
 import { useAuth } from '@/features/auth/AuthContext';
+import { useStore } from '@/features/products/hooks';
 
 let listProducts: (() => Promise<any[]>) | undefined;
-let getStore: ((tenant: string, id: string) => Promise<any>) | undefined;
 if (chain === 'near') {
   ({ listProducts } = require('@/features/products/services/nearProducts'));
-  ({ getStore } = require('@/features/stores/services/nearStores'));
 }
 
 export default function StoreDashboardScreen() {
@@ -19,13 +18,13 @@ export default function StoreDashboardScreen() {
   const { user } = useAuth();
   const [productCount, setProductCount] = useState(0);
   const [authorized, setAuthorized] = useState(false);
+  const { data: store } = useStore(storeId);
 
   useEffect(() => {
     const loadStats = async () => {
-      if (!storeId || !getStore || !listProducts) return;
-      const store = await getStore(storeId, storeId);
+      if (!storeId || !store || !listProducts) return;
       const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
-      if (!store || (store.owner !== user?.address && !isAdmin)) {
+      if (store.owner !== user?.address && !isAdmin) {
         router.replace(`/store/${storeId}`);
         return;
       }
@@ -35,7 +34,7 @@ export default function StoreDashboardScreen() {
     };
 
     loadStats();
-  }, [storeId, user?.address]);
+  }, [storeId, store, user?.address]);
   
 
   if (!authorized) {

--- a/src/features/products/hooks/index.ts
+++ b/src/features/products/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useProduct } from './useProduct';
+export { useStore } from './useStore';

--- a/src/features/products/hooks/useProduct.ts
+++ b/src/features/products/hooks/useProduct.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import chain from '@/services/chain';
+import { Product } from '@/types';
+
+let getProduct: ((storeId: string, id: string) => Promise<Product | null>) | undefined;
+if (chain === 'near') {
+  ({ getProduct } = require('../services/nearProducts'));
+}
+
+export function useProduct(id?: string, storeId: string = 'default') {
+  return useQuery({
+    queryKey: ['product', storeId, id],
+    queryFn: () =>
+      getProduct && id ? getProduct(storeId, id) : Promise.resolve(null),
+    enabled: !!id && !!getProduct,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/products/hooks/useStore.ts
+++ b/src/features/products/hooks/useStore.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import chain from '@/services/chain';
+import { Store } from '@/types';
+
+let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
+if (chain === 'near') {
+  ({ getStore } = require('@/features/stores/services/nearStores'));
+}
+
+export function useStore(id?: string, storeId: string = 'default') {
+  return useQuery({
+    queryKey: ['store', storeId, id],
+    queryFn: () => (getStore && id ? getStore(storeId, id) : Promise.resolve(null)),
+    enabled: !!id && !!getStore,
+    staleTime: 5 * 60 * 1000,
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `useProduct` and `useStore` hooks with react-query
- export product hooks for easy discovery
- refactor product and store admin screens to consume new hooks

## Testing
- `yarn lint src/features/products/hooks app/admin/stores/[storeId]/_StoreDetailScreen.tsx app/store/[storeId]/admin/_DashboardScreen.tsx app/product/_ProductScreen.tsx`
- `CI=1 yarn test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b6048770548326a5b81829bee53999