### PR TITLE
fix: correct nearStores import path

### DIFF
--- a/src/features/cart/hooks/useCartStores.ts
+++ b/src/features/cart/hooks/useCartStores.ts
@@ -5,7 +5,7 @@ import { CartItem, Store } from '@/types';
 
 let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
 if (chain === 'near') {
-  ({ getStore } = require('@/services/nearStores'));
+  ({ getStore } = require('@/features/stores/services/nearStores'));
 }
 
 export default function useCartStores(cartItems: CartItem[]) {


### PR DESCRIPTION
## Summary
- fix cart stores hook import for nearStores service

## Testing
- `yarn lint`
- `yarn test` *(fails: SyntaxError: Unexpected token '<')*

------
https://chatgpt.com/codex/tasks/task_e_68b60b613e9483269391f4a4181658fc