### PR TITLE
feat: validate agent messages

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -1,7 +1,13 @@
 import { CartItem } from '../types';
 import { assertNearChain } from '../services/chain';
-import { setCartItem, getCartItem, listCartItems, removeCartItem } from '@/features/cart/services/nearCart';
+import {
+  setCartItem,
+  getCartItem,
+  listCartItems,
+  removeCartItem,
+} from '@/features/cart/services/nearCart';
 import ensureNearWallet from '../utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -12,12 +18,14 @@ class CartAgent {
 
   async add(item: CartItem): Promise<void> {
     await this.ensureWallet();
-    await setCartItem(item);
+    const normalized = normalizeMessage<CartItem>('CartItem', item);
+    await setCartItem(normalized);
   }
 
   async update(item: CartItem): Promise<void> {
     await this.ensureWallet();
-    await setCartItem(item);
+    const normalized = normalizeMessage<CartItem>('CartItem', item);
+    await setCartItem(normalized);
   }
 
   async remove(id: string): Promise<void> {

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -7,6 +7,7 @@ import {
   removeCategory,
 } from '@/features/products/services/nearCategories';
 import ensureNearWallet from '@/utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -17,12 +18,14 @@ class CategoriesAgent {
 
   async add(item: Category): Promise<void> {
     await this.ensureWallet();
-    await setCategory(item);
+    const normalized = normalizeMessage<Category>('Category', item);
+    await setCategory(normalized);
   }
 
   async update(item: Category): Promise<void> {
     await this.ensureWallet();
-    await setCategory(item);
+    const normalized = normalizeMessage<Category>('Category', item);
+    await setCategory(normalized);
   }
 
   async remove(id: string): Promise<void> {

--- a/agents/chat-agent.ts
+++ b/agents/chat-agent.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import DatabaseService from '../services/database';
 import { ChatRoom } from '../types';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 class ChatAgent {
   private emitter = new EventEmitter();
@@ -23,7 +24,7 @@ class ChatAgent {
       sellerPublicKey,
       roomId,
     );
-    const room: ChatRoom = {
+    const room = normalizeMessage<ChatRoom>('ChatRoom', {
       id: roomId,
       userId: sellerAddress,
       userName: sellerName,
@@ -31,7 +32,7 @@ class ChatAgent {
       lastMessage: '',
       lastMessageTime: Date.now(),
       unreadCount: 0,
-    };
+    });
     this.emitter.emit('open', room);
   }
 

--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -1,12 +1,9 @@
 import { uuid } from '@/utils/uuid';
 import { Report } from '@/types';
 import { assertNearChain } from '@/services/chain';
-import {
-  addReport,
-  listReports,
-  removeReport,
-} from '@/features/reviews/services/nearReports';
+import { addReport, listReports, removeReport } from '@/features/reviews/services/nearReports';
 import ensureNearWallet from '@/utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -20,27 +17,27 @@ class ModerationAgent {
 
   async reportProduct(productId: string, reason: string): Promise<void> {
     const { address } = await this.ensureWallet();
-    const report: Report = {
+    const report = normalizeMessage<Report>('Report', {
       id: uuid(),
       type: 'product',
       targetId: productId,
       reason,
       reporter: address,
       timestamp: Date.now(),
-    };
+    });
     await addReport(report);
   }
 
   async reportStore(storeId: string, reason: string): Promise<void> {
     const { address } = await this.ensureWallet();
-    const report: Report = {
+    const report = normalizeMessage<Report>('Report', {
       id: uuid(),
       type: 'store',
       targetId: storeId,
       reason,
       reporter: address,
       timestamp: Date.now(),
-    };
+    });
     await addReport(report);
   }
 

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -7,6 +7,7 @@ import {
   listNotifications,
   removeNotification,
 } from '../services/nearNotifications';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 import {
@@ -32,16 +33,18 @@ class NotificationsAgent {
 
   async add(item: Notification, storeId = 'default'): Promise<void> {
     await this.ensureWallet();
-    await setNotification(item);
-    this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item, undefined, storeId);
+    const normalized = normalizeMessage<Notification>('Notification', item);
+    await setNotification(normalized);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.broadcastWaku(normalized, undefined, storeId);
   }
 
   async update(item: Notification, storeId = 'default'): Promise<void> {
     await this.ensureWallet();
-    await setNotification(item);
-    this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item, undefined, storeId);
+    const normalized = normalizeMessage<Notification>('Notification', item);
+    await setNotification(normalized);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.broadcastWaku(normalized, undefined, storeId);
   }
 
   async remove(id: string): Promise<void> {
@@ -57,11 +60,16 @@ class NotificationsAgent {
     return await listNotifications();
   }
 
-  async broadcast(event: NotificationEvent, item: Notification, storeId: string): Promise<void> {
+  async broadcast(
+    event: NotificationEvent,
+    item: Notification,
+    storeId: string,
+  ): Promise<void> {
     await this.ensureWallet();
-    await setNotification(item);
-    this.subscribers.forEach((cb) => cb(item));
-    await this.broadcastWaku(item, event, storeId);
+    const normalized = normalizeMessage<Notification>('Notification', item);
+    await setNotification(normalized);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.broadcastWaku(normalized, event, storeId);
   }
 
   subscribe(cb: (n: Notification) => void) {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -39,6 +39,7 @@ import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { orderStatusMessageSchema } from '../schemas/waku/order.status';
 import { buildTopic } from '../utils/wakuTopics';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -172,12 +173,13 @@ class OrdersAgent {
       trackingSteps: this.getTrackingSteps(status),
       updatedAt: new Date().toISOString(),
     };
-    const sid = updated.items?.[0]?.product?.storeId || '';
-    this.storeMap.set(updated.id, sid);
+    const normalized = normalizeMessage<Order>('Order', updated);
+    const sid = normalized.items?.[0]?.product?.storeId || '';
+    this.storeMap.set(normalized.id, sid);
     this.knownStores.add(sid);
-    await setOrder(sid, updated);
-    this.subscribers.forEach((cb) => cb(updated));
-    await this.notifyStatusChange(updated);
+    await setOrder(sid, normalized);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.notifyStatusChange(normalized);
   }
 
   private async ensureWallet() {
@@ -202,18 +204,19 @@ class OrdersAgent {
   }
 
   async add(order: Order): Promise<void> {
-    await this.ensureAuthorized(order);
-    let enriched = order;
-    if (!order.paymentContractAddress || !order.paymentTxHash) {
-      const { contractAddress, txHash } = await deployOrderPayment(order.total);
+    const normalized = normalizeMessage<Order>('Order', order);
+    await this.ensureAuthorized(normalized);
+    let enriched = normalized;
+    if (!normalized.paymentContractAddress || !normalized.paymentTxHash) {
+      const { contractAddress, txHash } = await deployOrderPayment(normalized.total);
       enriched = {
-        ...order,
+        ...normalized,
         paymentContractAddress: contractAddress,
         escrowAddr: contractAddress,
         paymentTxHash: txHash,
       };
-    } else if (!order.escrowAddr && order.paymentContractAddress) {
-      enriched = { ...order, escrowAddr: order.paymentContractAddress };
+    } else if (!normalized.escrowAddr && normalized.paymentContractAddress) {
+      enriched = { ...normalized, escrowAddr: normalized.paymentContractAddress };
     }
     let toStore: any = { ...enriched };
     // ensure integrity of items by hashing their serialized form
@@ -243,7 +246,8 @@ class OrdersAgent {
       const sid = toStore.items?.[0]?.product?.storeId || '';
       this.storeMap.set(toStore.id, sid);
       this.knownStores.add(sid);
-      await setOrder(sid, toStore);
+      const normalizedStore = normalizeMessage<Order>('Order', toStore);
+      await setOrder(sid, normalizedStore);
       await this.subscribeStore(sid);
     }
     await logOrderEvent({
@@ -262,58 +266,61 @@ class OrdersAgent {
   }
 
   async update(order: Order): Promise<void> {
-    const current = await this.get(order.id);
+    const normalized = normalizeMessage<Order>('Order', order);
+    const current = await this.get(normalized.id);
     if (!current) {
       throw new Error('Order not found');
     }
     await this.ensureAuthorized(current);
     let statusChanged = false;
-    if (order.status !== current.status) {
+    if (normalized.status !== current.status) {
       const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
-      if (!allowed.includes(order.status)) {
-        throw new Error(`Invalid status transition from ${current.status} to ${order.status}`);
+      if (!allowed.includes(normalized.status)) {
+        throw new Error(
+          `Invalid status transition from ${current.status} to ${normalized.status}`,
+        );
       }
       statusChanged = true;
     }
     {
-      const sid = order.items?.[0]?.product?.storeId || '';
-      this.storeMap.set(order.id, sid);
+      const sid = normalized.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(normalized.id, sid);
       this.knownStores.add(sid);
-      await setOrder(sid, order);
+      await setOrder(sid, normalized);
       await this.subscribeStore(sid);
     }
     await logOrderEvent({
-      tenant: order.items?.[0]?.product?.storeId || '',
+      tenant: normalized.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
       payload: {
-        orderId: order.id,
+        orderId: normalized.id,
         prevStatus: current.status,
-        newStatus: order.status,
+        newStatus: normalized.status,
       },
       actor: nearAuth.getAccountId() || '',
       timestamp: Date.now(),
     });
-    const sid = order.items?.[0]?.product?.storeId || '';
+    const sid = normalized.items?.[0]?.product?.storeId || '';
     await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
-      ...this.buildBaseEvent(order),
+      ...this.buildBaseEvent(normalized),
       prevStatus: current.status,
-      newStatus: order.status,
+      newStatus: normalized.status,
     });
-    this.subscribers.forEach((cb) => cb(order));
+    this.subscribers.forEach((cb) => cb(normalized));
     if (statusChanged) {
-      await this.notifyStatusChange(order);
-      if (order.status === 'released') {
-        await this.recordSellerMetric(order.sellerAddress, 'completed');
-      } else if (order.status === 'refunded') {
-        await this.recordSellerMetric(order.sellerAddress, 'refunded');
+      await this.notifyStatusChange(normalized);
+      if (normalized.status === 'released') {
+        await this.recordSellerMetric(normalized.sellerAddress, 'completed');
+      } else if (normalized.status === 'refunded') {
+        await this.recordSellerMetric(normalized.sellerAddress, 'refunded');
       }
-      if (order.status === 'disputed' || current.status === 'disputed') {
+      if (normalized.status === 'disputed' || current.status === 'disputed') {
         await eventBus.publish(buildTopic('orders', sid), 'dispute.updated', {
-          ...this.buildBaseEvent(order),
+          ...this.buildBaseEvent(normalized),
           prevStatus: current.status,
-          newStatus: order.status,
+          newStatus: normalized.status,
         });
-        await this.notifyDisputeUpdate(order);
+        await this.notifyDisputeUpdate(normalized);
       }
     }
   }
@@ -384,32 +391,33 @@ class OrdersAgent {
       status: 'released',
       updatedAt: new Date().toISOString(),
     };
+    const normalized = normalizeMessage<Order>('Order', updated);
     {
-      const sid = updated.items?.[0]?.product?.storeId || '';
-      this.storeMap.set(updated.id, sid);
+      const sid = normalized.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(normalized.id, sid);
       this.knownStores.add(sid);
-      await setOrder(sid, updated);
+      await setOrder(sid, normalized);
       await this.subscribeStore(sid);
     }
     await logOrderEvent({
-      tenant: updated.items?.[0]?.product?.storeId || '',
+      tenant: normalized.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
       payload: {
-        orderId: updated.id,
+        orderId: normalized.id,
         prevStatus: order.status,
-        newStatus: updated.status,
+        newStatus: normalized.status,
       },
       actor: nearAuth.getAccountId() || '',
       timestamp: Date.now(),
     });
-    const sid = updated.items?.[0]?.product?.storeId || '';
+    const sid = normalized.items?.[0]?.product?.storeId || '';
     await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
-      ...this.buildBaseEvent(updated),
+      ...this.buildBaseEvent(normalized),
       prevStatus: order.status,
-      newStatus: updated.status,
+      newStatus: normalized.status,
     });
     await eventBus.publish(buildTopic('orders', sid), 'payment.received', {
-      ...this.buildBaseEvent(updated),
+      ...this.buildBaseEvent(normalized),
     });
     await Promise.all(
       order.items.map((item) =>
@@ -419,9 +427,9 @@ class OrdersAgent {
         )
       )
     );
-    this.subscribers.forEach((cb) => cb(updated));
-    await this.notifyStatusChange(updated);
-    await this.notifyPaymentReceived(updated);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.notifyStatusChange(normalized);
+    await this.notifyPaymentReceived(normalized);
     await this.recordSellerMetric(order.sellerAddress, 'completed');
     return hash;
   }
@@ -445,32 +453,33 @@ class OrdersAgent {
       status: 'refunded',
       updatedAt: new Date().toISOString(),
     };
+    const normalized = normalizeMessage<Order>('Order', updated);
     {
-      const sid = updated.items?.[0]?.product?.storeId || '';
-      this.storeMap.set(updated.id, sid);
+      const sid = normalized.items?.[0]?.product?.storeId || '';
+      this.storeMap.set(normalized.id, sid);
       this.knownStores.add(sid);
-      await setOrder(sid, updated);
+      await setOrder(sid, normalized);
       await this.subscribeStore(sid);
     }
     await logOrderEvent({
-      tenant: updated.items?.[0]?.product?.storeId || '',
+      tenant: normalized.items?.[0]?.product?.storeId || '',
       type: 'order.updated',
       payload: {
-        orderId: updated.id,
+        orderId: normalized.id,
         prevStatus: order.status,
-        newStatus: updated.status,
+        newStatus: normalized.status,
       },
       actor: nearAuth.getAccountId() || '',
       timestamp: Date.now(),
     });
-    const sid = updated.items?.[0]?.product?.storeId || '';
+    const sid = normalized.items?.[0]?.product?.storeId || '';
     await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
-      ...this.buildBaseEvent(updated),
+      ...this.buildBaseEvent(normalized),
       prevStatus: order.status,
-      newStatus: updated.status,
+      newStatus: normalized.status,
     });
-    this.subscribers.forEach((cb) => cb(updated));
-    await this.notifyStatusChange(updated);
+    this.subscribers.forEach((cb) => cb(normalized));
+    await this.notifyStatusChange(normalized);
     await this.recordSellerMetric(order.sellerAddress, 'refunded');
     return hash;
   }

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -28,6 +28,7 @@ import { sign } from '@noble/ed25519';
 import type { WakuMessage } from '@/types/waku';
 import { errorLog } from '@/utils/logger';
 import { buildTopic } from '@/utils/wakuTopics';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 import {
   getProductCache,
@@ -176,21 +177,29 @@ class ProductsAgent {
   }
 
   async add(item: Product): Promise<void> {
-    await this.assertStoreOwner(item.storeId);
-    await setProduct(item.storeId, item);
-    this.cache.set(item.id, item);
-    this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
-    await this.subscribeStore(item.storeId);
-    await this.broadcast(item);
+    const normalized = normalizeMessage<Product>('Product', item);
+    await this.assertStoreOwner(normalized.storeId);
+    await setProduct(normalized.storeId, normalized);
+    this.cache.set(normalized.id, normalized);
+    this.summaries.set(normalized.id, {
+      rating: normalized.rating,
+      reviews: normalized.reviews,
+    });
+    await this.subscribeStore(normalized.storeId);
+    await this.broadcast(normalized);
   }
 
   async update(item: Product): Promise<void> {
-    await this.assertStoreOwner(item.storeId);
-    await setProduct(item.storeId, item);
-    this.cache.set(item.id, item);
-    this.summaries.set(item.id, { rating: item.rating, reviews: item.reviews });
-    await this.subscribeStore(item.storeId);
-    await this.broadcast(item);
+    const normalized = normalizeMessage<Product>('Product', item);
+    await this.assertStoreOwner(normalized.storeId);
+    await setProduct(normalized.storeId, normalized);
+    this.cache.set(normalized.id, normalized);
+    this.summaries.set(normalized.id, {
+      rating: normalized.rating,
+      reviews: normalized.reviews,
+    });
+    await this.subscribeStore(normalized.storeId);
+    await this.broadcast(normalized);
   }
 
   async remove(id: string): Promise<void> {

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -5,6 +5,7 @@ import ordersAgent from './orders-agent';
 import productsAgent from './products-agent';
 import storesAgent from './stores-agent';
 import ensureNearWallet from '../utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -19,31 +20,32 @@ class ReviewAgent {
 
   async add(review: Review): Promise<void> {
     await this.ensureWallet();
+    const normalized = normalizeMessage<Review>('Review', review);
 
-    if (!review.orderId) {
+    if (!normalized.orderId) {
       throw new Error('Order reference required');
     }
 
-    const order = await ordersAgent.get(review.orderId);
+    const order = await ordersAgent.get(normalized.orderId);
     const validOrder =
       order &&
-      order.userId === review.userId &&
+      order.userId === normalized.userId &&
       order.status === 'delivered' &&
-      order.items.some((i) => i.productId === review.productId);
+      order.items.some((i) => i.productId === normalized.productId);
     if (!validOrder) {
       throw new Error('Only completed orders can be reviewed');
     }
 
-    const existing = await getReviews(review.productId);
-    if (existing.some((r) => r.userId === review.userId)) {
+    const existing = await getReviews(normalized.productId);
+    if (existing.some((r) => r.userId === normalized.userId)) {
       throw new Error('Duplicate review');
     }
 
-    await addReview(review);
-    this.subscribers.forEach((cb) => cb(review));
-    const product = await productsAgent.get(review.productId);
+    await addReview(normalized);
+    this.subscribers.forEach((cb) => cb(normalized));
+    const product = await productsAgent.get(normalized.productId);
     if (product) {
-      await storesAgent.recordReview(product.storeId, review.rating);
+      await storesAgent.recordReview(product.storeId, normalized.rating);
     }
   }
 

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -8,6 +8,7 @@ import {
   subscribeToSettingsWrites,
 } from '../services/nearSettings';
 import ensureNearWallet from '../utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -76,8 +77,9 @@ class SettingsAgent {
   async setAdmins(admins: string[]): Promise<void> {
     await this.ensureWallet();
     const actor = nearAuth.getAccountId()!;
-    await storeAdmins(admins, actor);
-    this.admins = admins;
+    const normalized = normalizeMessage<string[]>('Admins', admins as any);
+    await storeAdmins(normalized, actor);
+    this.admins = normalized;
     this.adminsFetchedAt = Date.now();
   }
 

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -7,6 +7,7 @@ import {
   removeStore,
 } from '@/features/stores/services/nearStores';
 import ensureNearWallet from '@/utils/ensureNearWallet';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -79,12 +80,14 @@ class StoresAgent {
 
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore(item.id, this.toRecord(item));
+    const normalized = normalizeMessage<Store>('Store', item);
+    await setStore(normalized.id, this.toRecord(normalized));
   }
 
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
-    await setStore(item.id, this.toRecord(item));
+    const normalized = normalizeMessage<Store>('Store', item);
+    await setStore(normalized.id, this.toRecord(normalized));
   }
 
   async remove(id: string): Promise<void> {

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,17 +1,13 @@
 import { User } from '@/types';
 import { assertNearChain } from '@/services/chain';
-import {
-  getUser,
-  setUser,
-  listUsers,
-  removeUser,
-} from '@/features/auth/services/nearUsers';
+import { getUser, setUser, listUsers, removeUser } from '@/features/auth/services/nearUsers';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import SettingsAgent from './settings-agent';
 import ensureNearWallet from '@/utils/ensureNearWallet';
 import validateNearAddress from '@/utils/validateNearAddress';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 import type { WakuMessage } from '@/types/waku';
+import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
@@ -31,13 +27,19 @@ class UsersAgent {
   }
 
   async add(user: User): Promise<void> {
+    const normalized = normalizeMessage<User>('User', user);
     const { address, publicKey } = await this.ensureWallet();
     const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== user.address && !admins.includes(address)) {
+    if (address !== normalized.address && !admins.includes(address)) {
       throw new Error('Only the user or an admin can add this user');
     }
     const chatPublicKey = await getPublicKeyHex();
-    const enriched: User = { ...user, publicKey, address, chatPublicKey };
+    const enriched: User = {
+      ...normalized,
+      publicKey,
+      address,
+      chatPublicKey,
+    };
     if (!validateNearAddress(address)) {
       throw new Error('Invalid NEAR address');
     }
@@ -45,13 +47,19 @@ class UsersAgent {
   }
 
   async update(user: User): Promise<void> {
+    const normalized = normalizeMessage<User>('User', user);
     const { address, publicKey } = await this.ensureWallet();
     const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== user.address && !admins.includes(address)) {
+    if (address !== normalized.address && !admins.includes(address)) {
       throw new Error('Only the user or an admin can update this user');
     }
     const chatPublicKey = await getPublicKeyHex();
-    const enriched: User = { ...user, publicKey, address, chatPublicKey };
+    const enriched: User = {
+      ...normalized,
+      publicKey,
+      address,
+      chatPublicKey,
+    };
     if (!validateNearAddress(address)) {
       throw new Error('Invalid NEAR address');
     }
@@ -78,14 +86,14 @@ class UsersAgent {
     if (address !== user.address && !admins.includes(address)) {
       throw new Error('Only the user or an admin can request KYC');
     }
-    const enriched: User = {
+    const enriched: User = normalizeMessage<User>('User', {
       ...user,
       publicKey,
       address,
       kycStatus: 'pending',
       kycRequestedAt: new Date().toISOString(),
       kycDocumentUri: documentUri,
-    };
+    });
     await setUser(enriched);
   }
 
@@ -102,14 +110,14 @@ class UsersAgent {
     }
     const user = await getUser(userId);
     if (!user) throw new Error('User not found');
-    const enriched: User = {
+    const enriched: User = normalizeMessage<User>('User', {
       ...user,
       publicKey,
       address,
       kycStatus: status,
       kycApprovedBy: adminId ?? address,
       kycApprovedAt: new Date().toISOString(),
-    };
+    });
     await setUser(enriched);
   }
 
@@ -126,10 +134,10 @@ class UsersAgent {
     const msg = signed.payload;
     switch (msg.type) {
       case 'user.add':
-        await this.add(msg.payload);
+        await this.add(normalizeMessage<User>('User', msg.payload));
         break;
       case 'user.update':
-        await this.update(msg.payload);
+        await this.update(normalizeMessage<User>('User', msg.payload));
         break;
       case 'user.remove':
         await this.remove(msg.payload.id);

--- a/lib/normalizeMessage.ts
+++ b/lib/normalizeMessage.ts
@@ -1,0 +1,75 @@
+import {
+  Product,
+  Order,
+  Category,
+  Store,
+  Notification,
+  User,
+  CartItem,
+  ChatRoom,
+  Report,
+  Review,
+} from '../types';
+
+export type PayloadTypes =
+  | 'Product'
+  | 'Order'
+  | 'Category'
+  | 'Store'
+  | 'Notification'
+  | 'User'
+  | 'CartItem'
+  | 'ChatRoom'
+  | 'Report'
+  | 'Review'
+  | 'Admins';
+
+const requiredFields: Record<PayloadTypes, string[]> = {
+  Product: [
+    'id',
+    'name',
+    'price',
+    'description',
+    'category',
+    'images',
+    'rating',
+    'reviews',
+    'storeId',
+    'stock',
+  ],
+  Order: [
+    'id',
+    'userId',
+    'items',
+    'total',
+    'status',
+    'shippingAddress',
+    'paymentMethod',
+    'itemsHash',
+    'createdAt',
+    'updatedAt',
+    'trackingSteps',
+  ],
+  Category: ['id', 'name', 'icon'],
+  Store: ['id', 'name', 'owner', 'nftId'],
+  Notification: ['id', 'userId', 'title', 'message', 'type', 'read', 'timestamp'],
+  User: ['address'],
+  CartItem: ['id', 'productId', 'product', 'quantity', 'addedAt'],
+  ChatRoom: ['id', 'userId', 'userName', 'lastMessage', 'lastMessageTime', 'unreadCount'],
+  Report: ['id', 'type', 'targetId', 'reason', 'reporter', 'timestamp'],
+  Review: ['id', 'orderId', 'productId', 'rating', 'userId'],
+  Admins: ['length'],
+};
+
+export function normalizeMessage<T>(type: PayloadTypes, payload: unknown): T {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid message payload');
+  }
+  const keys = requiredFields[type];
+  for (const k of keys) {
+    if (!(k in (payload as Record<string, unknown>))) {
+      throw new Error('Invalid message payload');
+    }
+  }
+  return payload as T;
+}

--- a/tests/normalizeMessage.test.ts
+++ b/tests/normalizeMessage.test.ts
@@ -1,0 +1,51 @@
+import { normalizeMessage } from '../lib/normalizeMessage';
+import { Product, Order } from '../types';
+
+describe('normalizeMessage', () => {
+  it('accepts valid product and rejects malformed', () => {
+    const good: Product = {
+      id: 'p1',
+      name: 'prod',
+      price: 1,
+      description: 'd',
+      category: 'c',
+      images: [],
+      rating: 0,
+      reviews: 0,
+      storeId: 's',
+      stock: 0,
+    } as any; // optional fields ignored
+    expect(normalizeMessage<Product>('Product', good)).toEqual(good);
+    const bad = { id: 'p1', name: 'prod' } as any;
+    expect(() => normalizeMessage<Product>('Product', bad)).toThrow(
+      'Invalid message payload',
+    );
+  });
+
+  it('accepts valid order and rejects malformed', () => {
+    const good: Order = {
+      id: 'o1',
+      userId: 'u1',
+      items: [],
+      total: 0,
+      status: 'order_received',
+      shippingAddress: {
+        name: 'n',
+        phone: 'p',
+        street: 's',
+        city: 'c',
+        postalCode: 'pc',
+      },
+      paymentMethod: 'cash_on_delivery',
+      itemsHash: 'h',
+      createdAt: 'now',
+      updatedAt: 'now',
+      trackingSteps: [],
+    } as any;
+    expect(normalizeMessage<Order>('Order', good)).toEqual(good);
+    const bad = { id: 'o1' } as any;
+    expect(() => normalizeMessage<Order>('Order', bad)).toThrow(
+      'Invalid message payload',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add normalizeMessage utility to validate payload structures
- call normalizeMessage across agents before mutating state
- cover normalizeMessage with unit tests

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npx jest --runTestsByPath tests/normalizeMessage.test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60b6f46848326b901096828d0571e