### PR TITLE
feat: add immutable agent selectors

### DIFF
--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -25,13 +25,27 @@ class CartAgent {
     await removeCartItem(id);
   }
 
-  async get(id: string): Promise<CartItem | null> {
-    return await getCartItem(id);
+  /**
+   * Returns a defensive copy of a cart item by id.
+   */
+  async selectCartItem(id: string): Promise<CartItem | null> {
+    const item = await getCartItem(id);
+    return item ? JSON.parse(JSON.stringify(item)) : null;
   }
 
-  async getAll(): Promise<CartItem[]> {
-    return await listCartItems();
+  /**
+   * Returns defensive copies of all cart items.
+   */
+  async getCartItems(): Promise<CartItem[]> {
+    const list = await listCartItems();
+    return list.map((c) => JSON.parse(JSON.stringify(c)));
   }
 }
 
-export default new CartAgent();
+const cartAgent = new CartAgent();
+
+export const getCartItems = (): Promise<CartItem[]> => cartAgent.getCartItems();
+export const selectCartItem = (id: string): Promise<CartItem | null> =>
+  cartAgent.selectCartItem(id);
+
+export default cartAgent;

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -30,13 +30,28 @@ class CategoriesAgent {
     await removeCategory(id);
   }
 
-  async get(id: string): Promise<Category | null> {
-    return await getCategory(id);
+  /**
+   * Returns a defensive copy of a category by id.
+   */
+  async selectCategory(id: string): Promise<Category | null> {
+    const cat = await getCategory(id);
+    return cat ? JSON.parse(JSON.stringify(cat)) : null;
   }
 
-  async getAll(): Promise<Category[]> {
-    return await listCategories();
+  /**
+   * Returns defensive copies of all categories.
+   */
+  async getCategories(): Promise<Category[]> {
+    const list = await listCategories();
+    return list.map((c) => JSON.parse(JSON.stringify(c)));
   }
 }
 
-export default new CategoriesAgent();
+const categoriesAgent = new CategoriesAgent();
+
+export const getCategories = (): Promise<Category[]> =>
+  categoriesAgent.getCategories();
+export const selectCategory = (id: string): Promise<Category | null> =>
+  categoriesAgent.selectCategory(id);
+
+export default categoriesAgent;

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -5,7 +5,7 @@ import {
   getProduct,
   listProducts,
   removeProduct,
-  getProducts,
+  getProducts as fetchProducts,
   getVersion,
 } from '@/features/products/services/nearProducts';
 import { getStore } from '@/features/stores/services/nearStores';
@@ -101,7 +101,7 @@ class ProductsAgent {
   private async loadFromIndex(index: string[]): Promise<void> {
     for (let i = 0; i < index.length; i += PAGE_SIZE) {
       const slice = index.slice(i, i + PAGE_SIZE);
-      const batch = await getProducts('default', slice);
+      const batch = await fetchProducts('default', slice);
       batch.forEach((p) => {
         this.cache.set(p.id, p);
         this.summaries.set(p.id, { rating: p.rating, reviews: p.reviews });
@@ -202,27 +202,40 @@ class ProductsAgent {
     this.summaries.delete(id);
   }
 
-  async get(id: string): Promise<Product | null> {
+  /**
+   * Returns a defensive copy of the requested product.
+   * Mutating the result will not affect the internal cache.
+   */
+  async selectProduct(id: string): Promise<Product | null> {
     await this.ensureCache();
     const cached = this.cache.get(id);
-    if (cached) return cached;
+    if (cached) return JSON.parse(JSON.stringify(cached));
     const prod = await getProduct('default', id);
     if (prod) {
       this.cache.set(id, prod);
       this.summaries.set(id, { rating: prod.rating, reviews: prod.reviews });
+      return JSON.parse(JSON.stringify(prod));
     }
-    return prod;
+    return null;
   }
 
-  async getAll(): Promise<Product[]> {
+  /**
+   * Returns a new array containing defensive copies of all cached products.
+   */
+  async getProducts(): Promise<Product[]> {
     await this.ensureCache();
-    return Array.from(this.cache.values());
+    return Array.from(this.cache.values()).map((p) =>
+      JSON.parse(JSON.stringify(p)),
+    );
   }
 
+  /**
+   * Returns an immutable summary object for the given product id.
+   */
   async getSummary(id: string): Promise<ProductSummary> {
     const cached = this.summaries.get(id);
-    if (cached) return cached;
-    const prod = await this.get(id);
+    if (cached) return { ...cached };
+    const prod = await this.selectProduct(id);
     return prod ? { rating: prod.rating, reviews: prod.reviews } : { rating: 0, reviews: 0 };
   }
 
@@ -235,4 +248,17 @@ class ProductsAgent {
   }
 }
 
-export default new ProductsAgent();
+const productsAgent = new ProductsAgent();
+
+/**
+ * Selector returning a defensive copy of all products.
+ */
+export const getProducts = (): Promise<Product[]> => productsAgent.getProducts();
+
+/**
+ * Selector returning a defensive copy of a product by id.
+ */
+export const selectProduct = (id: string): Promise<Product | null> =>
+  productsAgent.selectProduct(id);
+
+export default productsAgent;

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -2,7 +2,7 @@ import { Review } from '../types';
 import { assertNearChain } from '../services/chain';
 import { addReview, getReviews } from '@/features/reviews/services/nearReviews';
 import ordersAgent from './orders-agent';
-import productsAgent from './products-agent';
+import { selectProduct } from './products-agent';
 import storesAgent from './stores-agent';
 import ensureNearWallet from '../utils/ensureNearWallet';
 
@@ -41,7 +41,7 @@ class ReviewAgent {
 
     await addReview(review);
     this.subscribers.forEach((cb) => cb(review));
-    const product = await productsAgent.get(review.productId);
+    const product = await selectProduct(review.productId);
     if (product) {
       await storesAgent.recordReview(product.storeId, review.rating);
     }

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -92,13 +92,27 @@ class StoresAgent {
     await removeStore(id, id);
   }
 
-  async get(id: string): Promise<Store | null> {
-    return await getStore(id, id);
+  /**
+   * Returns a defensive copy of a store by id.
+   */
+  async selectStore(id: string): Promise<Store | null> {
+    const store = await getStore(id, id);
+    return store ? JSON.parse(JSON.stringify(store)) : null;
   }
 
-  async getAll(): Promise<Store[]> {
-    return await listStores('default');
+  /**
+   * Returns defensive copies of all stores.
+   */
+  async getStores(): Promise<Store[]> {
+    const list = await listStores('default');
+    return list.map((s) => JSON.parse(JSON.stringify(s)));
   }
 }
 
-export default new StoresAgent();
+const storesAgent = new StoresAgent();
+
+export const getStores = (): Promise<Store[]> => storesAgent.getStores();
+export const selectStore = (id: string): Promise<Store | null> =>
+  storesAgent.selectStore(id);
+
+export default storesAgent;

--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, I18nManager } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import storesAgent from '../../../agents/stores-agent';
-import productsAgent from '../../../agents/products-agent';
+import storesAgent, { selectStore } from '../../../agents/stores-agent';
+import { getProducts } from '../../../agents/products-agent';
 import reviewAgent from '../../../agents/review-agent';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { Store, Product } from '../../../types';
@@ -27,10 +27,10 @@ export default function StorefrontStoreScreen() {
     let callback: ((sid: string, s: number) => void) | undefined;
     const load = async () => {
       if (!storeId) return;
-      const s = await storesAgent.get(storeId);
+      const s = await selectStore(storeId);
       setStore(s);
       setScore(storesAgent.getReputationScore(storeId));
-      const all = await productsAgent.getAll();
+      const all = await getProducts();
       const filtered = all.filter((p) => p.storeId === storeId);
       setProducts(filtered);
       const entries = await Promise.all(

--- a/app/storefront/_StorefrontScreen.tsx
+++ b/app/storefront/_StorefrontScreen.tsx
@@ -9,7 +9,7 @@ import {
   I18nManager,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import productsAgent from '../../agents/products-agent';
+import { getProducts } from '../../agents/products-agent';
 import reviewAgent from '../../agents/review-agent';
 import ProductCard from '@/features/products/components/ProductCard';
 import { Product } from '../../types';
@@ -43,7 +43,7 @@ export default function StorefrontScreen({ initialCategory }: Props) {
 
   useEffect(() => {
     const load = async () => {
-      const all = await productsAgent.getAll();
+      const all = await getProducts();
       setProducts(all);
       const entries = await Promise.all(
         all.map(async (p) => {

--- a/services/database.ts
+++ b/services/database.ts
@@ -2,8 +2,14 @@
 import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import usersAgent from '../agents/users-agent';
-import categoriesAgent from '../agents/categories-agent';
-import productsAgent from '../agents/products-agent';
+import categoriesAgent, {
+  getCategories as fetchCategories,
+  selectCategory as fetchCategory,
+} from '../agents/categories-agent';
+import productsAgent, {
+  getProducts as fetchProducts,
+  selectProduct as fetchProduct,
+} from '../agents/products-agent';
 import ordersAgent from '../agents/orders-agent';
 import SettingsAgent from '../agents/settings-agent';
 import reviewAgent from '../agents/review-agent';
@@ -96,7 +102,7 @@ class DatabaseService {
   }
 
   async getCategories(): Promise<Category[]> {
-    return categoriesAgent.getAll();
+    return fetchCategories();
   }
 
   async addCategory(
@@ -111,7 +117,7 @@ class DatabaseService {
   }
 
   async updateCategory(id: string, data: Partial<Category>): Promise<void> {
-    const existing = categoriesAgent.get(id);
+    const existing = await fetchCategory(id);
     if (!existing) return;
     await categoriesAgent.update({ ...existing, ...data });
   }
@@ -131,11 +137,11 @@ class DatabaseService {
 
   // Products
   async getProducts(): Promise<Product[]> {
-    return productsAgent.getAll();
+    return fetchProducts();
   }
 
   async getProduct(id: string): Promise<Product | null> {
-    return productsAgent.get(id) || null;
+    return fetchProduct(id);
   }
 
   async addProduct(product: Omit<Product, 'id'>): Promise<string> {
@@ -146,7 +152,7 @@ class DatabaseService {
   }
 
   async updateProduct(id: string, data: Partial<Product>): Promise<void> {
-    const existing = productsAgent.get(id);
+    const existing = await fetchProduct(id);
     if (!existing) return;
     await productsAgent.update({ ...existing, ...data });
   }
@@ -157,7 +163,7 @@ class DatabaseService {
 
   // Subcategories
   async addSubcategory(sub: Subcategory): Promise<void> {
-    const cat = categoriesAgent.get(sub.categoryId);
+    const cat = await fetchCategory(sub.categoryId);
     if (!cat) return;
     cat.subcategories = cat.subcategories || [];
     cat.subcategories.push(sub);
@@ -168,7 +174,8 @@ class DatabaseService {
     id: string,
     data: Partial<Subcategory>,
   ): Promise<void> {
-    for (const cat of categoriesAgent.getAll()) {
+    const cats = await fetchCategories();
+    for (const cat of cats) {
       const idx = cat.subcategories?.findIndex((s) => s.id === id) ?? -1;
       if (idx >= 0 && cat.subcategories) {
         cat.subcategories[idx] = { ...cat.subcategories[idx], ...data };
@@ -179,7 +186,8 @@ class DatabaseService {
   }
 
   async deleteSubcategory(id: string): Promise<void> {
-    for (const cat of categoriesAgent.getAll()) {
+    const cats = await fetchCategories();
+    for (const cat of cats) {
       const before = cat.subcategories?.length || 0;
       cat.subcategories = cat.subcategories?.filter((s) => s.id !== id);
       if ((cat.subcategories?.length || 0) !== before) {
@@ -416,7 +424,7 @@ class DatabaseService {
   async addWishlistItem(userId: string, productId: string): Promise<void> {
     const list = this.wishlist[userId] || [];
     if (list.some((w) => w.productId === productId)) return;
-    const product = productsAgent.get(productId);
+    const product = await fetchProduct(productId);
     if (!product) return;
     list.push({
       id: `${productId}_${Date.now()}`,

--- a/src/features/cart/services/cart.ts
+++ b/src/features/cart/services/cart.ts
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '@/types';
 import DatabaseService from '@/services/database';
-import cartAgent from '@/agents/cart-agent';
+import cartAgent, { getCartItems } from '@/agents/cart-agent';
 import eventBus from '@/services/eventBus';
 import nearAuth from '../../auth/services/nearAuth';
  
@@ -45,7 +45,7 @@ class CartService {
 
       if (uid) {
         try {
-          const all = await cartAgent.getAll();
+          const all = await getCartItems();
           this.cartItems = all.filter((it) => it.id.startsWith(`${uid}_`));
         } catch (err) {
           errorLog('Error fetching cart from storage:', err);
@@ -227,7 +227,7 @@ class CartService {
   public async clearCart(): Promise<void> {
     const uid = await this.getCurrentUserId();
     this.cartItems = [];
-    const allItems = await cartAgent.getAll();
+    const allItems = await getCartItems();
     for (const item of allItems) {
       if (!uid || item.id.startsWith(`${uid}_`)) {
         await cartAgent.remove(item.id);

--- a/tests/cartService.test.ts
+++ b/tests/cartService.test.ts
@@ -5,15 +5,18 @@ import nearAuth from '@/features/auth/services/nearAuth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CartItem, WishlistItem, Product } from '../types';
 
+const mockGetCartItems = jest.fn();
 jest.mock('../agents/cart-agent', () => ({
   __esModule: true,
   default: {
-    getAll: jest.fn(),
+    getCartItems: mockGetCartItems,
     add: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
-    get: jest.fn(),
+    selectCartItem: jest.fn(),
   },
+  getCartItems: mockGetCartItems,
+  selectCartItem: jest.fn(),
 }));
 
 jest.mock('../services/database', () => ({
@@ -72,14 +75,14 @@ describe('CartService storage', () => {
     (CartService as any).instance = undefined;
     (AsyncStorage.getItem as jest.Mock).mockReset();
     (AsyncStorage.setItem as jest.Mock).mockReset();
-    (cartAgent.getAll as jest.Mock).mockReset();
+    (cartAgent.getCartItems as jest.Mock).mockReset();
     (DatabaseService.getInstance as jest.Mock).mockReset();
     (nearAuth.getAccountId as jest.Mock).mockReset();
   });
 
   it('loads user cart and wishlist when logged in', async () => {
     (nearAuth.getAccountId as jest.Mock).mockReturnValue('user1');
-    (cartAgent.getAll as jest.Mock).mockResolvedValue([userCartItem]);
+    (cartAgent.getCartItems as jest.Mock).mockResolvedValue([userCartItem]);
     (DatabaseService.getInstance as jest.Mock).mockReturnValue({
       getWishlistItems: jest.fn().mockResolvedValue([wishItem]),
     });
@@ -105,7 +108,7 @@ describe('CartService storage', () => {
 
     expect(svc.getCartItems()).toEqual([anonCartItem]);
     expect(svc.getWishlistItems()).toEqual([wishItem]);
-    expect(cartAgent.getAll).not.toHaveBeenCalled();
+    expect(cartAgent.getCartItems).not.toHaveBeenCalled();
     expect(DatabaseService.getInstance).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- return copies from product, category, cart, and store selectors
- switch UI and services to use exported selectors
- document immutability guarantees with JSDoc

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b60b7012648326909874efe2017940