### PR TITLE
feat: add global error boundary

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -72,6 +72,23 @@ class NotificationsAgent {
     this.subscribers.delete(cb);
   }
 
+  async trackAnalytics(
+    event: string,
+    payload: Record<string, unknown> = {},
+  ): Promise<void> {
+    const node = await this.ensureNode();
+    if (!node) return;
+    try {
+      const topic = buildTopic('analytics', '1');
+      const encoder = createEncoder({ contentTopic: topic });
+      await node.lightPush.send(encoder, {
+        payload: utf8ToBytes(JSON.stringify({ type: event, ...payload })),
+      });
+    } catch (err) {
+      errorLog('Failed to broadcast analytics event', err);
+    }
+  }
+
   private async ensureNode(): Promise<LightNode | null> {
     if (this.node) return this.node;
     try {

--- a/components/GlobalErrorBoundary.tsx
+++ b/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import notificationsAgent from '@/agents/notifications-agent';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class GlobalErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    notificationsAgent
+      .trackAnalytics('app.error', {
+        message: error.message,
+        stack: error.stack,
+        componentStack: info.componentStack,
+      })
+      .catch(() => {});
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>Something went wrong</Text>
+          <Text style={styles.message}>Please restart the app and try again.</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  message: {
+    textAlign: 'center',
+  },
+});

--- a/providers/AppProviders.tsx
+++ b/providers/AppProviders.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { WalletProvider } from './WalletProvider';
 import { WakuProvider } from '@/contexts/WakuContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import GlobalErrorBoundary from '@/components/GlobalErrorBoundary';
 
 interface Props {
   children: React.ReactNode;
@@ -12,12 +13,14 @@ export default function AppProviders({ children }: Props) {
   const [queryClient] = React.useState(() => new QueryClient());
 
   return (
-    <ThemeProvider>
-      <WalletProvider>
-        <QueryClientProvider client={queryClient}>
-          <WakuProvider>{children}</WakuProvider>
-        </QueryClientProvider>
-      </WalletProvider>
-    </ThemeProvider>
+    <GlobalErrorBoundary>
+      <ThemeProvider>
+        <WalletProvider>
+          <QueryClientProvider client={queryClient}>
+            <WakuProvider>{children}</WakuProvider>
+          </QueryClientProvider>
+        </WalletProvider>
+      </ThemeProvider>
+    </GlobalErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- add `GlobalErrorBoundary` component that reports errors to analytics via `notifications-agent`
- mount `GlobalErrorBoundary` in `AppProviders`
- extend `notifications-agent` with analytics tracking utility

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b60b71d838832693d0d6c97e498ad2