### PR TITLE
feat: add AgentError and improve error handling

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -22,6 +22,7 @@ import { getWakuBootstrapNodes } from '../utils/appConfig';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { errorLog } from '../utils/logger';
 import { buildTopic } from '../utils/wakuTopics';
+import AgentError from '@/types/AgentError';
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
@@ -102,7 +103,7 @@ class NotificationsAgent {
     try {
       const bootstrap = getWakuBootstrapNodes();
       if (bootstrap.length === 0) {
-        throw new Error('No Waku bootstrap nodes configured');
+        throw new AgentError('WAKU_BOOTSTRAP_UNCONFIGURED', 'No Waku bootstrap nodes configured', 'notifications-agent');
       }
       this.node = await createLightNode({ libp2p: { bootstrap } } as any);
       await this.node.start();

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -40,6 +40,7 @@ import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { orderStatusMessageSchema } from '../schemas/waku/order.status';
 import { buildTopic } from '../utils/wakuTopics';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import AgentError from '@/types/AgentError';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found'],
@@ -198,7 +199,7 @@ class OrdersAgent {
       const admins = await SettingsAgent.getInstance().getAdmins();
       allowed = allowed.concat(admins);
       if (!address || !allowed.includes(address)) {
-        throw new Error('Unauthorized order update');
+        throw new AgentError('UNAUTHORIZED', 'Unauthorized order update', 'orders-agent');
       }
     }
   }
@@ -269,15 +270,17 @@ class OrdersAgent {
     const normalized = normalizeMessage<Order>('Order', order);
     const current = await this.get(normalized.id);
     if (!current) {
-      throw new Error('Order not found');
+      throw new AgentError('ORDER_NOT_FOUND', 'Order not found', 'orders-agent');
     }
     await this.ensureAuthorized(current);
     let statusChanged = false;
     if (normalized.status !== current.status) {
       const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
       if (!allowed.includes(normalized.status)) {
-        throw new Error(
+        throw new AgentError(
+          'INVALID_STATUS_TRANSITION',
           `Invalid status transition from ${current.status} to ${normalized.status}`,
+          'orders-agent',
         );
       }
       statusChanged = true;
@@ -328,7 +331,7 @@ class OrdersAgent {
   async remove(id: string): Promise<void> {
     const order = await this.get(id);
     if (!order) {
-      throw new Error('Order not found');
+      throw new AgentError('ORDER_NOT_FOUND', 'Order not found', 'orders-agent');
     }
     await this.ensureAuthorized(order);
     const sid = order.items?.[0]?.product?.storeId || '';
@@ -375,15 +378,19 @@ class OrdersAgent {
   async releasePayment(orderId: string): Promise<string> {
     const order = await this.get(orderId);
     if (!order) {
-      throw new Error('Order not found');
+      throw new AgentError('ORDER_NOT_FOUND', 'Order not found', 'orders-agent');
     }
     await this.ensureAuthorized(order);
     if (!order.escrowAddr) {
-      throw new Error('Order escrow address not found');
+      throw new AgentError('ESCROW_NOT_FOUND', 'Order escrow address not found', 'orders-agent');
     }
     const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
     if (!allowed.includes('released')) {
-      throw new Error(`Invalid status transition from ${order.status} to released`);
+      throw new AgentError(
+        'INVALID_STATUS_TRANSITION',
+        `Invalid status transition from ${order.status} to released`,
+        'orders-agent',
+      );
     }
     const hash = await releasePayment(order.escrowAddr);
     const updated: Order = {
@@ -437,15 +444,19 @@ class OrdersAgent {
   async refundPayment(orderId: string): Promise<string> {
     const order = await this.get(orderId);
     if (!order) {
-      throw new Error('Order not found');
+      throw new AgentError('ORDER_NOT_FOUND', 'Order not found', 'orders-agent');
     }
     await this.ensureAuthorized(order);
     if (!order.escrowAddr) {
-      throw new Error('Order escrow address not found');
+      throw new AgentError('ESCROW_NOT_FOUND', 'Order escrow address not found', 'orders-agent');
     }
     const allowed = ALLOWED_STATUS_TRANSITIONS[order.status] || [];
     if (!allowed.includes('refunded')) {
-      throw new Error(`Invalid status transition from ${order.status} to refunded`);
+      throw new AgentError(
+        'INVALID_STATUS_TRANSITION',
+        `Invalid status transition from ${order.status} to refunded`,
+        'orders-agent',
+      );
     }
     const hash = await refundPayment(order.escrowAddr);
     const updated: Order = {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -29,6 +29,7 @@ import type { WakuMessage } from '@/types/waku';
 import { errorLog } from '@/utils/logger';
 import { buildTopic } from '@/utils/wakuTopics';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import AgentError from '@/types/AgentError';
 
 import {
   getProductCache,
@@ -172,7 +173,7 @@ class ProductsAgent {
     const { address } = await this.ensureWallet();
     const store = await getStore(storeId, storeId);
     if (!store || store.owner !== address) {
-      throw new Error('Only the store owner can manage products');
+      throw new AgentError('UNAUTHORIZED', 'Only the store owner can manage products', 'products-agent');
     }
   }
 

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -6,6 +6,7 @@ import { selectProduct } from './products-agent';
 import storesAgent from './stores-agent';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import AgentError from '@/types/AgentError';
 
 assertNearChain();
 
@@ -23,7 +24,7 @@ class ReviewAgent {
     const normalized = normalizeMessage<Review>('Review', review);
 
     if (!normalized.orderId) {
-      throw new Error('Order reference required');
+      throw new AgentError('ORDER_REFERENCE_REQUIRED', 'Order reference required', 'review-agent');
     }
 
     const order = await ordersAgent.get(normalized.orderId);
@@ -33,12 +34,12 @@ class ReviewAgent {
       order.status === 'delivered' &&
       order.items.some((i) => i.productId === normalized.productId);
     if (!validOrder) {
-      throw new Error('Only completed orders can be reviewed');
+      throw new AgentError('INVALID_ORDER_STATE', 'Only completed orders can be reviewed', 'review-agent');
     }
 
     const existing = await getReviews(normalized.productId);
     if (existing.some((r) => r.userId === normalized.userId)) {
-      throw new Error('Duplicate review');
+      throw new AgentError('DUPLICATE_REVIEW', 'Duplicate review', 'review-agent');
     }
 
     await addReview(review);

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -8,6 +8,7 @@ import validateNearAddress from '@/utils/validateNearAddress';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 import type { WakuMessage } from '@/types/waku';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import AgentError from '@/types/AgentError';
 
 assertNearChain();
 
@@ -31,7 +32,7 @@ class UsersAgent {
     const { address, publicKey } = await this.ensureWallet();
     const admins = await SettingsAgent.getInstance().getAdmins();
     if (address !== normalized.address && !admins.includes(address)) {
-      throw new Error('Only the user or an admin can add this user');
+      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can add this user', 'users-agent');
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = {
@@ -41,7 +42,7 @@ class UsersAgent {
       chatPublicKey,
     };
     if (!validateNearAddress(address)) {
-      throw new Error('Invalid NEAR address');
+      throw new AgentError('INVALID_NEAR_ADDRESS', 'Invalid NEAR address', 'users-agent');
     }
     await setUser(enriched);
   }
@@ -51,7 +52,7 @@ class UsersAgent {
     const { address, publicKey } = await this.ensureWallet();
     const admins = await SettingsAgent.getInstance().getAdmins();
     if (address !== normalized.address && !admins.includes(address)) {
-      throw new Error('Only the user or an admin can update this user');
+      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can update this user', 'users-agent');
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = {
@@ -61,7 +62,7 @@ class UsersAgent {
       chatPublicKey,
     };
     if (!validateNearAddress(address)) {
-      throw new Error('Invalid NEAR address');
+      throw new AgentError('INVALID_NEAR_ADDRESS', 'Invalid NEAR address', 'users-agent');
     }
     await setUser(enriched);
   }
@@ -69,10 +70,10 @@ class UsersAgent {
   async remove(id: string): Promise<void> {
     const { address } = await this.ensureWallet();
     const user = await getUser(id);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
     const admins = await SettingsAgent.getInstance().getAdmins();
     if (address !== user.address && !admins.includes(address)) {
-      throw new Error('Only the user or an admin can remove this user');
+      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can remove this user', 'users-agent');
     }
     await removeUser(id);
   }
@@ -81,10 +82,10 @@ class UsersAgent {
   async requestKyc(userId: string, documentUri: string): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
     const user = await getUser(userId);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
     const admins = await SettingsAgent.getInstance().getAdmins();
     if (address !== user.address && !admins.includes(address)) {
-      throw new Error('Only the user or an admin can request KYC');
+      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can request KYC', 'users-agent');
     }
     const enriched: User = normalizeMessage<User>('User', {
       ...user,
@@ -106,10 +107,10 @@ class UsersAgent {
     const { address, publicKey } = await this.ensureWallet();
     const admins = await SettingsAgent.getInstance().getAdmins();
     if (!admins.includes(address)) {
-      throw new Error('Only admins can update KYC');
+      throw new AgentError('UNAUTHORIZED', 'Only admins can update KYC', 'users-agent');
     }
     const user = await getUser(userId);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
     const enriched: User = normalizeMessage<User>('User', {
       ...user,
       publicKey,

--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -14,6 +14,7 @@ import NotificationPopup from './NotificationPopup';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useWaku } from '@/contexts/WakuContext';
 import { parseNotificationWakuPayload } from '../schemas/waku';
+import AgentError from '@/types/AgentError';
 
 interface NotificationState {
   unreadCount: number;
@@ -26,6 +27,7 @@ interface NotificationActions {
     message: string,
     type?: 'success' | 'info' | 'warning' | 'error',
   ) => void;
+  showAgentError: (error: AgentError) => void;
 }
 
 const NotificationStateContext = createContext<NotificationState>({
@@ -35,6 +37,7 @@ const NotificationStateContext = createContext<NotificationState>({
 
 const NotificationActionsContext = createContext<NotificationActions>({
   showNotification: () => {},
+  showAgentError: () => {},
 });
 
 export const useNotificationState = () => useContext(NotificationStateContext);
@@ -74,10 +77,21 @@ function NotificationPopupProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const showAgentError = useCallback(
+    (error: AgentError) => {
+      setActiveNotification({
+        title: error.source,
+        message: `[${error.code}] ${error.message}`,
+        type: 'error',
+      });
+    },
+    [],
+  );
+
   const handleClose = () => setActiveNotification(null);
 
   return (
-    <NotificationActionsContext.Provider value={{ showNotification }}>
+    <NotificationActionsContext.Provider value={{ showNotification, showAgentError }}>
       {children}
       {activeNotification && (
         <NotificationPopup

--- a/types/AgentError.ts
+++ b/types/AgentError.ts
@@ -1,0 +1,11 @@
+export default class AgentError extends Error {
+  code: string;
+  source: string;
+
+  constructor(code: string, message: string, source: string) {
+    super(message);
+    this.code = code;
+    this.source = source;
+    this.name = 'AgentError';
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable AgentError type with code, message, source
- use AgentError in agents instead of generic Error strings
- display formatted AgentError notifications

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b612df9db0832687a7b98d0179fae7