### PR TITLE
docs: clarify home path and NEAR_STRICT behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ yarn start      # web
 yarn test
 ```
 
+Then open `/` to see the Home screen.
+
 ## Design Tokens
 
 Shared design tokens live in `constants/tokens.ts`. Import `spacing`, `radius`, `colors`, `zIndex`, and `shadows` to keep styles consistent across components.
@@ -114,6 +116,8 @@ the desired values:
 
 The OrderPayment factory contract address is configured by admins through the
 **Admin → Settings** dashboard and does not require an environment variable.
+
+`NEAR_STRICT` remains permissive in development, so local runs skip strict NEAR validation.
 
 - `ADMIN_WALLET_ADDRESS` – NEAR account granted admin rights if no on-chain list exists (required)
 - `NEAR_RPC_URL` – primary NEAR RPC endpoint used for blockchain calls (optional; overrides tenant setting)


### PR DESCRIPTION
## Summary
- note to open `/` for Home screen
- document that `NEAR_STRICT` stays permissive during development

## Testing
- `yarn test` *(fails: Jest encountered unexpected tokens and TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6506590e48326930b97fb29eb3146