### PR TITLE
Simplify root layout and fix tabs redirect

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { Slot } from 'expo-router';
 import AppProviders from '../providers/AppProviders';
 
 export default function RootLayout() {
   return (
     <AppProviders>
-      <React.Suspense fallback={null}>
-        <Slot />
-      </React.Suspense>
+      <Slot />
     </AppProviders>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,11 @@
 import { Redirect } from 'expo-router';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 export default function Index() {
-  return <Redirect href='/' />;
+  return (
+    <ErrorBoundary>
+      <Redirect href="/(tabs)" />
+    </ErrorBoundary>
+  );
 }
 


### PR DESCRIPTION
## Summary
- remove React.Suspense wrapper so root layout only provides top-level providers and a `<Slot />`
- redirect root index to the tabs group via error boundary to avoid duplicate tab layouts

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0a3ea2883268fe65671cbf32e2e