### PR TITLE
refactor: remove tabs group routes

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -585,7 +585,7 @@ export default function HomeScreen() {
             <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
               {t('home.categories')}
             </Text>
-            <TouchableOpacity onPress={() => push('/(tabs)/categories')}>
+            <TouchableOpacity onPress={() => push('/categories')}>
               <Text style={[styles.seeAll, { color: colors.gold }]}>
                 {t('common.viewAll')}
               </Text>

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -189,7 +189,7 @@ export default function OrdersScreen() {
         title={t('orders.emptyTitle') as string}
         message={t('orders.emptyMessage') as string}
         actionText={t('orders.shopNow') as string}
-        onAction={() => push('/(tabs)')}
+        onAction={() => push('/')}
       />
     ) : (
       <EmptyState

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -398,7 +398,7 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() => push('/(tabs)/orders')}
+              onPress={() => push('/orders')}
             >
               <View style={styles.menuItemContent}>
                 <Text style={[styles.menuText, { color: colors.text.primary }]}>

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -5,7 +5,7 @@ export default function CategoriesAlias() {
   // Web-safe alias so navigating to '/categories' mounts the Tabs group child
   return (
     <ErrorBoundary>
-      <Redirect href="/(tabs)/categories" />
+      <Redirect href="/categories" />
     </ErrorBoundary>
   );
 }

--- a/app/driver-dashboard.tsx
+++ b/app/driver-dashboard.tsx
@@ -45,7 +45,7 @@ export default function DriverDashboardScreen() {
     if (canGoBack) {
       back();
     } else {
-      replace('/(tabs)');
+      replace('/');
     }
   };
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,7 +4,7 @@ import ErrorBoundary from '@/components/ui/ErrorBoundary';
 export default function Index() {
   return (
     <ErrorBoundary>
-      <Redirect href="/(tabs)" />
+      <Redirect href="/" />
     </ErrorBoundary>
   );
 }

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -58,7 +58,7 @@ export default function Landing() {
             <Link href="/store/alpha" asChild>
               <Button title="Open Alpha Store" style={{ borderRadius: 10 }} />
             </Link>
-            <Link href="/(tabs)" asChild>
+            <Link href="/" asChild>
               <Button
                 title="Browse App"
                 variant="secondary"

--- a/app/probe.tsx
+++ b/app/probe.tsx
@@ -23,7 +23,7 @@ export default function Probe() {
           PROBE OK
         </Text>
         <Link
-          href="/(tabs)/categories"
+          href="/categories"
           style={{ color: colors.gold, fontWeight: '700' }}
         >
           Open Tabs → Categories

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -296,7 +296,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
     await addToCart();
     // Navigate to cart or checkout
     push({
-      pathname: '/(tabs)',
+      pathname: '/',
       params: { showCart: 'true' },
     });
   };

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -58,7 +58,7 @@ export default function ReviewsScreen() {
     if (canGoBack) {
       back();
     } else {
-      replace('/(tabs)');
+      replace('/');
     }
   };
 

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -1030,7 +1030,7 @@ export default function SubcategoryScreen() {
                 }]}
                 onPress={() => {
                   setShowCategorySelector(false);
-                  push('/(tabs)/categories');
+                  push('/categories');
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -59,7 +59,7 @@ export default function GlobalHeader({
         <View style={styles.headerTop}>
           <TouchableOpacity
             style={styles.logo}
-            onPress={() => router.push('/(tabs)')}
+            onPress={() => router.push('/')}
           >
             {logoCid ? (
               <SmartImage uri={logoCid} width={50} height={50} style={styles.logoImage} contentFit="contain" />

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -124,12 +124,12 @@ export default function UserAvatar() {
 
   const handleProfile = () => {
     hideDropdown();
-    router.push('/(tabs)/profile');
+    router.push('/profile');
   };
 
   const handleSettings = () => {
     hideDropdown();
-    router.push('/(tabs)/profile');
+    router.push('/profile');
   };
 
   const handleLanguageSwitch = async () => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,13 @@ module.exports = [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXAttribute[name.name='href'][value.value=/\\(tabs\\)/]",
+          message: "Use '/' or named routes instead of '/(tabs)/' in hrefs.",
+        },
+      ],
     },
   },
   // Feature boundaries

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -60,7 +60,7 @@ export default function FloatingCartWidget() {
 
     const goToCheckout = () => {
       setIsExpanded(false);
-      router.push({ pathname: '/(tabs)', params: { showCart: 'true' } });
+      router.push({ pathname: '/', params: { showCart: 'true' } });
     };
 
   if (cartItems.length === 0) {

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -693,7 +693,7 @@ export default function ProductFormModal({
                 style={[styles.categorySelectorItem, { borderBottomColor: colors.border.secondary, backgroundColor: colors.interactive.secondary }]}
                 onPress={() => {
                   setShowCategorySelector(false);
-                  router.push('/(tabs)/categories');
+                  router.push('/categories');
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>


### PR DESCRIPTION
## Summary
- remove `(tabs)` path segments from router navigation
- forbid `/(tabs)/` in hrefs via ESLint

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6da7aa4148326ad2ef46d075542c6