### PR TITLE
feat: add redirect button on not found screen

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,5 +1,5 @@
-import { Link, Stack } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { Stack, router } from 'expo-router';
+import { Button, StyleSheet, Text, View } from 'react-native';
 
 export default function NotFoundScreen() {
   return (
@@ -7,9 +7,12 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: 'Oops!' }} />
       <View style={styles.container}>
         <Text style={styles.text}>This screen doesn't exist.</Text>
-        <Link href="/" style={styles.link}>
-          <Text>Go to home screen!</Text>
-        </Link>
+        <View style={styles.link}>
+          <Button
+            title="Go to home screen!"
+            onPress={() => router.replace('/')}
+          />
+        </View>
       </View>
     </>
   );


### PR DESCRIPTION
## Summary
- replace link on not-found page with a button that calls `router.replace('/')`

## Testing
- `yarn lint app/+not-found.tsx`
- `yarn test app/+not-found.tsx` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e534cc18832690e0aea7a5c0c0f5