### PR TITLE
refactor: extract home screen filters into hook

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -45,6 +45,7 @@ import CartModal from '@/features/cart/components/CartModal';
 import ProductFormModal from '@/features/products/components/ProductFormModal';
 import SmartImage from '@/components/SmartImage';
 import InfoModal from '@/components/InfoModal';
+import { useHomeScreen, SortOption } from '@/features/home/hooks/useHomeScreen';
 
 const { width } = Dimensions.get('window');
 const BANNER_WIDTH = width - 32;
@@ -55,22 +56,13 @@ export default function HomeScreen() {
   const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
   const [products, setProducts] = useState<Product[]>([]);
-  const [filteredProducts, setFilteredProducts] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [minPrice, setMinPrice] = useState('');
-  const [maxPrice, setMaxPrice] = useState('');
   const [currentBannerIndex, setCurrentBannerIndex] = useState(0);
   const [bannerFormVisible, setBannerFormVisible] = useState(false);
   const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [sortBy, setSortBy] = useState<
-    'newest' | 'price-low' | 'price-high' | 'rating'
-  >('newest');
-  const [showSortModal, setShowSortModal] = useState(false);
   const [productFormVisible, setProductFormVisible] = useState(false);
   const [productToEdit, setProductToEdit] = useState<Product | null>(null);
   const [showCartModal, setShowCartModal] = useState(false);
@@ -85,6 +77,22 @@ export default function HomeScreen() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const bannerScrollRef = useRef<ScrollView>(null);
+
+  const {
+    filteredProducts,
+    searchQuery,
+    setSearchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    sortBy,
+    setSortBy,
+    showSortModal,
+    setShowSortModal,
+  } = useHomeScreen(products);
 
   // Fallback content to guarantee a rich homepage even with empty services
   const fallbackCategories: Category[] = [
@@ -129,10 +137,6 @@ export default function HomeScreen() {
     }
   }, [heroBanners.length]);
 
-  useEffect(() => {
-    filterAndSortProducts();
-  }, [products, searchQuery, sortBy, selectedCategory, minPrice, maxPrice]);
-
   const loadData = async () => {
     try {
       setLoading(true);
@@ -163,55 +167,6 @@ export default function HomeScreen() {
     setRefreshing(true);
     await loadData();
     setRefreshing(false);
-  };
-
-  const filterAndSortProducts = () => {
-    let filtered = products;
-
-    // Filter by search query
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (product) =>
-          product.name.toLowerCase().includes(q) ||
-          product.category.toLowerCase().includes(q)
-      );
-    }
-
-    // Filter by category
-    if (selectedCategory) {
-      filtered = filtered.filter((p) => p.category === selectedCategory);
-    }
-
-    // Filter by price range
-    const min = parseFloat(minPrice);
-    const max = parseFloat(maxPrice);
-    if (!isNaN(min)) {
-      filtered = filtered.filter((p) => p.price >= min);
-    }
-    if (!isNaN(max)) {
-      filtered = filtered.filter((p) => p.price <= max);
-    }
-
-    // Sort products
-    filtered = [...filtered].sort((a, b) => {
-      switch (sortBy) {
-        case 'price-low':
-          return a.price - b.price;
-        case 'price-high':
-          return b.price - a.price;
-        case 'rating':
-          return b.rating - a.rating;
-        case 'newest':
-        default:
-          return (
-            new Date(b.createdAt || 0).getTime() -
-            new Date(a.createdAt || 0).getTime()
-          );
-      }
-    });
-
-    setFilteredProducts(filtered);
   };
 
   const addBanner = () => {
@@ -761,7 +716,7 @@ export default function HomeScreen() {
                   ],
                 ]}
                 onPress={() => {
-                  setSortBy(option.key as any);
+                  setSortBy(option.key as SortOption);
                   setShowSortModal(false);
                 }}
               >

--- a/src/features/home/hooks/useHomeScreen.ts
+++ b/src/features/home/hooks/useHomeScreen.ts
@@ -1,0 +1,76 @@
+import { useState, useMemo } from 'react';
+import { Product } from '@/types';
+
+export type SortOption = 'newest' | 'price-low' | 'price-high' | 'rating';
+
+export function useHomeScreen(products: Product[]) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [sortBy, setSortBy] = useState<SortOption>('newest');
+  const [showSortModal, setShowSortModal] = useState(false);
+
+  const filteredProducts = useMemo(() => {
+    let filtered = products;
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (product) =>
+          product.name.toLowerCase().includes(q) ||
+          product.category.toLowerCase().includes(q),
+      );
+    }
+
+    if (selectedCategory) {
+      filtered = filtered.filter((p) => p.category === selectedCategory);
+    }
+
+    const min = parseFloat(minPrice);
+    const max = parseFloat(maxPrice);
+    if (!isNaN(min)) {
+      filtered = filtered.filter((p) => p.price >= min);
+    }
+    if (!isNaN(max)) {
+      filtered = filtered.filter((p) => p.price <= max);
+    }
+
+    filtered = [...filtered].sort((a, b) => {
+      switch (sortBy) {
+        case 'price-low':
+          return a.price - b.price;
+        case 'price-high':
+          return b.price - a.price;
+        case 'rating':
+          return b.rating - a.rating;
+        case 'newest':
+        default:
+          return (
+            new Date(b.createdAt || 0).getTime() -
+            new Date(a.createdAt || 0).getTime()
+          );
+      }
+    });
+
+    return filtered;
+  }, [products, searchQuery, selectedCategory, minPrice, maxPrice, sortBy]);
+
+  return {
+    filteredProducts,
+    searchQuery,
+    setSearchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    sortBy,
+    setSortBy,
+    showSortModal,
+    setShowSortModal,
+  } as const;
+}
+
+export type UseHomeScreenReturn = ReturnType<typeof useHomeScreen>;


### PR DESCRIPTION
## Summary
- add `useHomeScreen` hook to manage search, category, price, and sort state
- use `useHomeScreen` in home screen index to clean up rendering

## Testing
- `yarn lint`
- `yarn test` *(fails: hangs at RUNS and no suites executed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e53c448883268f8ca19c79bb2418