### PR TITLE
Avoid self-redirect loops

### DIFF
--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,12 +1,1 @@
-import { Redirect } from 'expo-router';
-import ErrorBoundary from '@/components/ui/ErrorBoundary';
-
-export default function CategoriesAlias() {
-  // Web-safe alias so navigating to '/categories' mounts the Tabs group child
-  return (
-    <ErrorBoundary>
-      <Redirect href="/categories" />
-    </ErrorBoundary>
-  );
-}
-
+export { default } from './(tabs)/categories';

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,1 @@
-import { Redirect } from 'expo-router';
-import ErrorBoundary from '@/components/ui/ErrorBoundary';
-
-export default function Index() {
-  return (
-    <ErrorBoundary>
-      <Redirect href="/" />
-    </ErrorBoundary>
-  );
-}
-
+export { default } from './(tabs)/index';


### PR DESCRIPTION
## Summary
- re-export home and categories routes to avoid self-referential redirects that caused navigation loops

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token / TS errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b6f4165c808326a0ec21047666c1d9