### PR TITLE
refactor: centralize ui token exports

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Platform, ViewStyle, StyleProp } from 'react-native';
-import { radius, shadows } from '@/constants/tokens';
+import { radius, shadows } from 'src/shared/ui/tokens';
 
 interface CardProps {
   children?: React.ReactNode;

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -16,7 +16,7 @@ import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from '@/features/cart/components/WishlistModal';
 import CartService from '@/features/cart/services/cart';
-import { spacing, radius } from '@/constants/tokens';
+import { spacing, radius } from 'src/shared/ui/tokens';
 
 interface GlobalHeaderProps {
   searchQuery?: string;

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
-import { spacing, radius, zIndex, shadows } from '@/constants/tokens';
+import { spacing, radius, zIndex, shadows } from 'src/shared/ui/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 import Button from '@/components/ui/Button';
 

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -4,7 +4,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import NotificationService from '../services/notification';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '@/features/auth/AuthContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from 'src/shared/ui/tokens';
 
 interface NotificationBadgeProps {
   size?: number;

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native
 import { Package, Tag, MessageCircle, Info, CircleCheck as CheckCircle, CircleAlert as AlertCircle } from 'lucide-react-native';
 import { Notification } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, radius, shadows } from '@/constants/tokens';
+import { spacing, radius, shadows } from 'src/shared/ui/tokens';
 import { typography } from '@/constants/styles';
 
 interface NotificationItemProps {

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { X } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, zIndex } from '@/constants/tokens';
+import { spacing, zIndex } from 'src/shared/ui/tokens';
 
 interface NotificationPopupProps {
   title: string;

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,7 +7,7 @@ import {
   PressableProps,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing, radius } from '@/constants/tokens';
+import { spacing, radius } from 'src/shared/ui/tokens';
 
 interface ButtonProps extends PressableProps {
   title?: string;

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from 'src/shared/ui/tokens';
 import Button from './Button';
 import { usePathname, router } from 'expo-router';
 import { errorLog } from '@/utils/logger';

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import GoldDivider from './GoldDivider';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from 'src/shared/ui/tokens';
 
 export default function Section({
   title,

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -8,7 +8,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from 'src/shared/ui/tokens';
 
 interface SpinnerProps {
   size?: 'small' | 'large';

--- a/src/shared/ui/tokens.ts
+++ b/src/shared/ui/tokens.ts
@@ -1,0 +1,2 @@
+export { spacing, radius, colors, zIndex, shadows, tokens, lightTokens } from '@/constants/tokens';
+export type { Tokens } from '@/constants/tokens';


### PR DESCRIPTION
## Summary
- centralize token exports under src/shared/ui
- update primitive components to consume tokens from shared module

## Testing
- `yarn lint`
- `yarn test`
- `yarn typecheck` *(fails: Type '"end"' is not assignable to type '"center" | "left" | "right" | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5d5203083268f6e4d7d40d4c1e0