### PR TITLE
refactor: centralize token imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Then open `/` to see the Home screen.
 
 ## Design Tokens
 
-Shared design tokens live in `constants/tokens.ts`. Import `spacing`, `radius`, `colors`, `zIndex`, and `shadows` to keep styles consistent across components.
+Shared design tokens are re-exported from `src/shared/ui/tokens.ts`. Import `spacing`, `radius`, `colors`, `zIndex`, and `shadows` to keep styles consistent across components.
 
 ```ts
-import { spacing, radius, zIndex, shadows } from '@/constants/tokens';
+import { spacing, radius, zIndex, shadows } from '@/shared/ui/tokens';
 
 const styles = StyleSheet.create({
   button: {

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Platform, ViewStyle, StyleProp } from 'react-native';
-import { radius, shadows } from '@/constants/tokens';
+import { radius, shadows } from '@/shared/ui/tokens';
 
 interface CardProps {
   children?: React.ReactNode;

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -16,7 +16,7 @@ import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
 import WishlistModal from '@/features/cart/components/WishlistModal';
 import CartService from '@/features/cart/services/cart';
-import { spacing, radius } from '@/constants/tokens';
+import { spacing, radius } from '@/shared/ui/tokens';
 
 interface GlobalHeaderProps {
   searchQuery?: string;

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
-import { spacing, radius, zIndex, shadows } from '@/constants/tokens';
+import { spacing, radius, zIndex, shadows } from '@/shared/ui/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 import Button from '@/components/ui/Button';
 

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -4,7 +4,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import NotificationService from '../services/notification';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '@/features/auth/AuthContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from '@/shared/ui/tokens';
 
 interface NotificationBadgeProps {
   size?: number;

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native
 import { Package, Tag, MessageCircle, Info, CircleCheck as CheckCircle, CircleAlert as AlertCircle } from 'lucide-react-native';
 import { Notification } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, radius, shadows } from '@/constants/tokens';
+import { spacing, radius, shadows } from '@/shared/ui/tokens';
 import { typography } from '@/constants/styles';
 
 interface NotificationItemProps {

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { X } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { spacing, zIndex } from '@/constants/tokens';
+import { spacing, zIndex } from '@/shared/ui/tokens';
 
 interface NotificationPopupProps {
   title: string;

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,7 +7,7 @@ import {
   PressableProps,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing, radius } from '@/constants/tokens';
+import { spacing, radius } from '@/shared/ui/tokens';
 
 interface ButtonProps extends PressableProps {
   title?: string;

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from '@/shared/ui/tokens';
 import Button from './Button';
 import { usePathname, router } from 'expo-router';
 import { errorLog } from '@/utils/logger';

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import GoldDivider from './GoldDivider';
 import { useTheme } from '../../contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from '@/shared/ui/tokens';
 
 export default function Section({
   title,

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -9,7 +9,7 @@ import React, {
   useMemo,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { tokens as darkTokens, lightTokens, Tokens } from '@/constants/tokens';
+import { tokens as darkTokens, lightTokens, Tokens } from '@/shared/ui/tokens';
 import { useAppInfo } from './AppInfoContext';
 
 const THEME_STORAGE_KEY = 'app_theme';

--- a/src/shared/ui/Spinner.tsx
+++ b/src/shared/ui/Spinner.tsx
@@ -8,7 +8,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
-import { spacing } from '@/constants/tokens';
+import { spacing } from '@/shared/ui/tokens';
 
 interface SpinnerProps {
   size?: 'small' | 'large';

--- a/src/shared/ui/tokens.ts
+++ b/src/shared/ui/tokens.ts
@@ -1,0 +1,2 @@
+export { spacing, radius, zIndex, shadows, colors, tokens, lightTokens } from '@/constants/tokens';
+export type { Tokens } from '@/constants/tokens';


### PR DESCRIPTION
## Summary
- re-export design tokens via shared UI entrypoint
- update primitives and header components to use shared token import
- document new token path

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token and type errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b6fc3e95448326b8ddbba81fa6e353