### PR TITLE
warn if tabs segment appears in path during development

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,16 @@
-import { Slot } from 'expo-router';
+import { Slot, usePathname } from 'expo-router';
+import { useEffect } from 'react';
 import AppProviders from '../providers/AppProviders';
 
 export default function RootLayout() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (__DEV__ && pathname?.includes('(tabs)')) {
+      console.warn("`(tabs)` should not appear in the pathname in development.");
+    }
+  }, [pathname]);
+
   return (
     <AppProviders>
       <Slot />


### PR DESCRIPTION
## Summary
- warn in development when `(tabs)` is present in the pathname

## Testing
- `yarn test` *(fails: unexpected token in test files and TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fdd4eb8883269d3a0157f1a41f0b