### PR TITLE
refactor: wrap MoonPay loader in modal

### DIFF
--- a/src/features/payments/components/MoonPayModal.tsx
+++ b/src/features/payments/components/MoonPayModal.tsx
@@ -79,9 +79,11 @@ export default function MoonPayModal({
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>
         {loading && (
-          <View style={[styles.loading, { pointerEvents: 'none' }]}>
-            <Spinner />
-          </View>
+          <Modal transparent visible>
+            <View style={styles.loadingOverlay} pointerEvents="none">
+              <Spinner />
+            </View>
+          </Modal>
         )}
         <WebView
           source={{ uri: url }}
@@ -99,16 +101,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  loading: {
-    position: 'absolute',
-    top: 0,
-    start: 0,
-    end: 0,
-    bottom: 0,
+  loadingOverlay: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.3)',
-    zIndex: 1,
     ...Platform.select({
       web: { backdropFilter: 'blur(2px)' },
     }),


### PR DESCRIPTION
## Summary
- replace absolute MoonPay loader overlay with modal to manage z-index

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Type '"end"' is not assignable to type '"center" | "left" | "right" | undefined')*
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fdc026e08326a8104a920a3f8a44