### PR TITLE
feat: wrap Home screen with error boundary

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -43,7 +43,7 @@ const { width } = Dimensions.get('window');
 const BANNER_WIDTH = width - 32;
 const BANNER_HEIGHT = (BANNER_WIDTH * 9) / 16;
 
-export default function HomeScreen() {
+function HomeScreenContent() {
   const { push } = useAppRouter();
   const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
@@ -342,22 +342,21 @@ export default function HomeScreen() {
   }
 
   return (
-    <ErrorBoundary>
-      <SafeAreaView
-        style={[styles.container, { backgroundColor: colors.background }]}
-      >
-      <HomeHeader
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-      />
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
+    <HomeHeader
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+    />
 
-      <ScrollView
-        showsVerticalScrollIndicator={false}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-        }
-      >
-        <CategoryTabs
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    >
+      <CategoryTabs
           categories={categories}
           selectedCategory={selectedCategory}
           setSelectedCategory={setSelectedCategory}
@@ -638,7 +637,14 @@ export default function HomeScreen() {
         visible={showCartModal}
         onClose={() => setShowCartModal(false)}
       />
-      </SafeAreaView>
+    </SafeAreaView>
+  );
+}
+
+export default function HomeScreen() {
+  return (
+    <ErrorBoundary>
+      <HomeScreenContent />
     </ErrorBoundary>
   );
 }

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -27,6 +27,12 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     errorLog('ErrorBoundary caught error:', error, info);
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.error(error.stack);
+      // eslint-disable-next-line no-console
+      console.error(info.componentStack);
+    }
     this.setState({ error });
   }
 

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
+import HomeScreen from '../app/(tabs)/index';
+
+jest.mock('../hooks/useAppRouter', () => () => ({ push: jest.fn() }));
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/index',
+  router: { replace: jest.fn() },
+}));
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return {
+    SafeAreaView: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
+jest.mock('../features/auth/AuthContext', () => ({
+  useAuth: () => ({ isStoreOwner: false }),
+}));
+jest.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (s: string) => s }),
+}));
+jest.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: { background: '#fff', text: { primary: '#000', secondary: '#333' } } }),
+}));
+jest.mock('../features/home/components/HomeHeader', () => {
+  const React = require('react');
+  return () => {
+    throw new Error('boom');
+  };
+});
+jest.mock('../features/home/components/CategoryTabs', () => () => null);
+jest.mock('../features/home/components/ProductGrid', () => () => null);
+jest.mock('../shared/ui/Spinner', () => () => null);
+jest.mock('../shared/ui/EmptyState', () => () => null);
+jest.mock('../components/BannerFormModal', () => () => null);
+jest.mock('../features/cart/components/CartModal', () => () => null);
+jest.mock('../features/products/components/ProductFormModal', () => () => null);
+jest.mock('../components/SmartImage', () => () => null);
+jest.mock('../components/InfoModal', () => () => null);
+jest.mock('../services/database', () => ({}));
+jest.mock('../services/chain', () => 'near');
+jest.mock('../features/products/services/nearCategories', () => ({
+  listCategories: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../features/home/hooks/useHomeScreen', () => ({
+  useHomeScreen: () => ({
+    filteredProducts: [],
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    selectedCategory: null,
+    setSelectedCategory: jest.fn(),
+    minPrice: null,
+    setMinPrice: jest.fn(),
+    maxPrice: null,
+    setMaxPrice: jest.fn(),
+    sortBy: 'name',
+    setSortBy: jest.fn(),
+    showSortModal: false,
+    setShowSortModal: jest.fn(),
+  }),
+}));
+
+describe('HomeScreen error handling', () => {
+  it('shows fallback and keeps app shell when child throws', () => {
+    const App = () => (
+      <>
+        <HomeScreen />
+        <Text>App shell</Text>
+      </>
+    );
+    const root = renderer.create(<App />);
+    const tree = root.toJSON();
+    const str = JSON.stringify(tree);
+    expect(str).toContain('Something went wrong');
+    expect(str).toContain('App shell');
+    expect(str).toContain('Retry');
+  });
+});


### PR DESCRIPTION
## Summary
- wrap HomeScreen in a dedicated ErrorBoundary so failures don't blank the app
- log stack traces in development for easier debugging
- add regression test ensuring Home errors are isolated

## Testing
- `yarn lint "app/(tabs)/index.tsx" components/ui/ErrorBoundary.tsx tests/homeErrorBoundary.test.tsx`
- `yarn test tests/homeErrorBoundary.test.tsx` *(fails: Jest failed to parse many test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ff9f804c8326b37002348bb3ae01