### PR TITLE
chore: log route transitions in dev

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,26 @@
-import { Slot, usePathname } from 'expo-router';
-import { useEffect } from 'react';
+import { Slot, usePathname, useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { getPathFromState } from '@react-navigation/native';
 import AppProviders from '../providers/AppProviders';
 
 export default function RootLayout() {
+  const router = useRouter();
   const pathname = usePathname();
+  const prevPathRef = useRef(pathname);
+
+  useEffect(() => {
+    if (!__DEV__) return;
+    const unsubscribe = router.addListener('state', (e: any) => {
+      const nextPath = getPathFromState(e.data.state);
+      const prevPath = prevPathRef.current;
+      if (prevPath !== nextPath) {
+        // eslint-disable-next-line no-console
+        console.debug(`[Route] ${prevPath} -> ${nextPath}`);
+        prevPathRef.current = nextPath;
+      }
+    });
+    return unsubscribe;
+  }, [router]);
 
   useEffect(() => {
     if (__DEV__ && pathname?.includes('(tabs)')) {


### PR DESCRIPTION
## Summary
- hook into router state changes to log pathname transitions during development

## Testing
- `yarn lint app/_layout.tsx`
- `yarn test app/_layout.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b701d477308326a62a37f1ffce14b4