### PR TITLE
Add web smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,4 @@ jobs:
       - run: yarn typecheck
       - run: yarn test
       - run: yarn build:web
+      - run: node tests/web-smoke.js

--- a/README.md
+++ b/README.md
@@ -352,6 +352,17 @@ yarn test
 
 Run `yarn install` before executing `yarn test` so Jest and other dependencies are present.
 
+### Web Smoke Test
+
+Verify the exported web build serves the root page correctly:
+
+```sh
+yarn build:web
+node tests/web-smoke.js
+```
+
+The script starts a temporary server for `dist/` and asserts the home page includes the `#root` marker.
+
 ## Runbooks & Checklists
 
 - [Incident Runbook](docs/incident-runbook.md)

--- a/tests/web-smoke.js
+++ b/tests/web-smoke.js
@@ -1,0 +1,46 @@
+const { spawn } = require('child_process');
+
+const PORT = 4173;
+const URL = `http://localhost:${PORT}/`;
+const MARKER = '<div id="root">';
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(retries = 20) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(URL);
+      if (res.status === 200) {
+        return res;
+      }
+    } catch (err) {
+      // ignore and retry
+    }
+    await wait(500);
+  }
+  throw new Error('Unable to fetch index');
+}
+
+async function main() {
+  const server = spawn('npx', ['--yes', 'serve@14.2.0', 'dist', '-l', String(PORT)], {
+    stdio: 'inherit',
+  });
+
+  try {
+    const res = await fetchWithRetry();
+    const html = await res.text();
+    if (!html.includes(MARKER)) {
+      throw new Error('DOM marker not found');
+    }
+    console.log('Web smoke test passed');
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    server.kill();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to serve web build and check for root DOM marker
- run web smoke test in CI
- document running the smoke test locally

## Testing
- `npx eslint tests/web-smoke.js`
- `yarn build:web` *(fails: No dist/**/index.js files found)*
- `node tests/web-smoke.js`
- `yarn test tests/homeErrorBoundary.test.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b701dd8a788326ad78b97068638055