### PR TITLE
enforce tab service boundaries and use hooks

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,3 @@
-import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect, useRef, Suspense, lazy } from 'react';
 import {
   View,
@@ -15,14 +14,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import useAppRouter from 'hooks/useAppRouter';
 import { Plus, Pencil, X, ArrowUpDown } from 'lucide-react-native';
-import DatabaseService from '@/services/database';
 import { Product, Category, HeroBanner } from '@/types';
-import chain from '@/services/chain';
-
-let listCategories: (() => Promise<Category[]>) | undefined;
-if (chain === 'near') {
-  ({ listCategories } = require('@/features/products/services/nearCategories'));
-}
+import { useHome } from '@/features/home/hooks/useHome';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -47,14 +40,21 @@ function HomeScreenContent() {
   const { push } = useAppRouter();
   const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
-  const [products, setProducts] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>([]);
+  const {
+    products,
+    categories,
+    heroBanners,
+    refreshing,
+    refresh,
+    upsertBanner,
+    removeBanner,
+    upsertProduct,
+    removeProduct,
+    error,
+  } = useHome();
   const [currentBannerIndex, setCurrentBannerIndex] = useState(0);
   const [bannerFormVisible, setBannerFormVisible] = useState(false);
   const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
   const [productFormVisible, setProductFormVisible] = useState(false);
   const [productToEdit, setProductToEdit] = useState<Product | null>(null);
   const [showCartModal, setShowCartModal] = useState(false);
@@ -101,10 +101,6 @@ function HomeScreenContent() {
   ];
 
   useEffect(() => {
-    loadData();
-  }, []);
-
-  useEffect(() => {
     // Check if we should show the cart modal from URL params
     if (params.showCart === 'true') {
       setShowCartModal(true);
@@ -129,20 +125,8 @@ function HomeScreenContent() {
     }
   }, [heroBanners.length]);
 
-  const loadData = async () => {
-    try {
-      setLoading(true);
-      const db = DatabaseService.getInstance();
-      const [productsData, categoriesData, bannersData] = await Promise.all([
-        db.getProducts(),
-        listCategories ? listCategories() : Promise.resolve([]),
-        db.getHeroBanners(),
-      ]);
-      setProducts(productsData);
-      setCategories(categoriesData);
-      setHeroBanners(bannersData);
-    } catch (error) {
-      errorLog('HomeScreen loadData error:', error);
+  useEffect(() => {
+    if (error) {
       setInfoModal({
         visible: true,
         title: t('common.error'),
@@ -150,16 +134,9 @@ function HomeScreenContent() {
         type: 'error',
         buttonText: t('common.reload'),
       });
-    } finally {
-      setLoading(false);
     }
-  };
+  }, [error, t]);
 
-  const onRefresh = async () => {
-    setRefreshing(true);
-    await loadData();
-    setRefreshing(false);
-  };
 
   const addBanner = () => {
     setEditingBanner(null);
@@ -172,15 +149,11 @@ function HomeScreenContent() {
   };
 
   const handleBannerSaved = (b: HeroBanner, isNew: boolean) => {
-    if (isNew) {
-      setHeroBanners((prev) => [...prev, b]);
-    } else {
-      setHeroBanners((prev) => prev.map((h) => (h.id === b.id ? b : h)));
-    }
+    upsertBanner(b, isNew);
   };
 
   const handleBannerDeleted = (id: string) => {
-    setHeroBanners((prev) => prev.filter((b) => b.id !== id));
+    removeBanner(id);
   };
 
   const addProduct = () => {
@@ -194,15 +167,11 @@ function HomeScreenContent() {
   };
 
   const handleProductSaved = (p: Product, isNew: boolean) => {
-    if (isNew) {
-      setProducts((prev) => [...prev, p]);
-    } else {
-      setProducts((prev) => prev.map((prod) => (prod.id === p.id ? p : prod)));
-    }
+    upsertProduct(p, isNew);
   };
 
   const handleProductDeleted = (id: string) => {
-    setProducts((prev) => prev.filter((p) => p.id !== id));
+    removeProduct(id);
   };
 
   const renderCategory = ({ item }: { item: Category }) => (
@@ -326,22 +295,8 @@ function HomeScreenContent() {
 
   const handleReload = () => {
     setInfoModal((prev) => ({ ...prev, visible: false }));
-    loadData();
+    refresh();
   };
-
-  if (loading) {
-    return (
-      <SafeAreaView
-        style={[styles.container, { backgroundColor: colors.background }]}
-      >
-        <HomeHeader
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-        />
-        <Spinner label="Loading home" />
-      </SafeAreaView>
-    );
-  }
 
   return (
     <SafeAreaView
@@ -355,7 +310,7 @@ function HomeScreenContent() {
     <ScrollView
       showsVerticalScrollIndicator={false}
       refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        <RefreshControl refreshing={refreshing} onRefresh={refresh} />
       }
     >
       <CategoryTabs
@@ -656,7 +611,9 @@ function HomeScreenContent() {
 export default function HomeScreen() {
   return (
     <ErrorBoundary>
-      <HomeScreenContent />
+      <Suspense fallback={<Spinner />}>
+        <HomeScreenContent />
+      </Suspense>
     </ErrorBoundary>
   );
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -33,15 +33,7 @@ import { useAppInfo } from '@/contexts/AppInfoContext';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
-import OrderService from '@/services/orders';
-import CartService from '@/features/cart/services/cart';
-import DatabaseService from '@/services/database';
-import chain from '@/services/chain';
-
-let listStores: (() => Promise<any[]>) | undefined;
-if (chain === 'near') {
-  ({ listStores } = require('@/features/stores/services/nearStores'));
-}
+import { useProfileData } from 'hooks/useProfileData';
 
 
 
@@ -56,14 +48,11 @@ export default function ProfileScreen() {
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [showOrderTracking, setShowOrderTracking] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState(null);
-  const [userOrders, setUserOrders] = useState([]);
-  const [wishlistCount, setWishlistCount] = useState(0);
-  const [reviewCount, setReviewCount] = useState(0);
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const scrollViewRef = useRef<ScrollView>(null);
   const { openAuthModal } = useAuthModal();
-  const [storeId, setStoreId] = useState<string | null>(null);
   const { push, replace } = useAppRouter();
+  const { ordersCount, wishlistCount, reviewCount, storeId } = useProfileData(user);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -79,42 +68,6 @@ export default function ProfileScreen() {
     loadSettings();
   }, []);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!isLoggedIn || !user) return;
-      const orderService = OrderService.getInstance();
-      const cartService = CartService.getInstance();
-      const db = DatabaseService.getInstance();
-
-      try {
-        const [ordersCount, reviews, wishlist] = await Promise.all([
-          orderService.getUserOrderCount(user.id),
-          db.getReviews(),
-          Promise.resolve(cartService.getWishlistItemsCount()),
-        ]);
-        setUserOrders(new Array(ordersCount).fill(null));
-        setWishlistCount(wishlist);
-        setReviewCount(reviews.filter((r) => r.userId === user.id).length);
-      } catch (err) {
-        errorLog('Error loading profile data', err);
-      }
-    };
-    fetchData();
-  }, [isLoggedIn, user]);
-
-  useEffect(() => {
-    const loadStore = async () => {
-      if (!user?.address || !listStores) return;
-      try {
-        const stores = await listStores();
-        const store = stores.find((s) => s.owner === user.address);
-        if (store) setStoreId(store.id);
-      } catch (err) {
-        errorLog('Failed to load store for user', err);
-      }
-    };
-    loadStore();
-  }, [user?.address]);
 
   const loadSettings = async () => {
     try {
@@ -261,7 +214,7 @@ export default function ProfileScreen() {
           >
             <View style={styles.statItem}>
               <Text style={[styles.statNumber, { color: colors.gold }]}>
-                {userOrders.length}
+                {ordersCount}
               </Text>
               <Text
                 style={[styles.statLabel, { color: colors.text.secondary }]}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,29 @@ module.exports = [
       ],
     },
   },
+  // Prevent tabs from importing services directly
+  {
+    files: ['app/\\(tabs\\)/**/*.ts', 'app/\\(tabs\\)/**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: ['@/services/**'],
+        },
+      ],
+    },
+  },
   // Non type-aware rules for tests
   {
     files: ['tests/**/*.ts', 'tests/**/*.tsx'],

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { errorLog } from '@/utils/logger';
+import OrderService from '@/services/orders';
+import CartService from '@/features/cart/services/cart';
+import DatabaseService from '@/services/database';
+import chain from '@/services/chain';
+import { User } from '@/types';
+
+let listStores: (() => Promise<any[]>) | undefined;
+if (chain === 'near') {
+  ({ listStores } = require('@/features/stores/services/nearStores'));
+}
+
+export function useProfileData(user?: User | null) {
+  const [ordersCount, setOrdersCount] = useState(0);
+  const [wishlistCount, setWishlistCount] = useState(0);
+  const [reviewCount, setReviewCount] = useState(0);
+  const [storeId, setStoreId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!user) return;
+      try {
+        const orderService = OrderService.getInstance();
+        const cartService = CartService.getInstance();
+        const db = DatabaseService.getInstance();
+        const [count, reviews, wishlist] = await Promise.all([
+          orderService.getUserOrderCount(user.id),
+          db.getReviews(),
+          Promise.resolve(cartService.getWishlistItemsCount()),
+        ]);
+        setOrdersCount(count);
+        setWishlistCount(wishlist);
+        setReviewCount(reviews.filter((r: any) => r.userId === user.id).length);
+      } catch (err) {
+        errorLog('Error loading profile data', err);
+      }
+    };
+    fetchData();
+  }, [user]);
+
+  useEffect(() => {
+    const loadStore = async () => {
+      if (!user?.address || !listStores) return;
+      try {
+        const stores = await listStores();
+        const store = stores.find((s: any) => s.owner === user.address);
+        if (store) setStoreId(store.id);
+      } catch (err) {
+        errorLog('Failed to load store for user', err);
+      }
+    };
+    loadStore();
+  }, [user?.address]);
+
+  return { ordersCount, wishlistCount, reviewCount, storeId };
+}
+
+export default useProfileData;


### PR DESCRIPTION
## Summary
- add ESLint rule preventing `app/(tabs)` components from importing from `@/services`
- refactor home tab to fetch data via `useHome` hook and wrap in Suspense
- extract profile data fetching into `useProfileData` hook and update profile screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70456852c83269b533dfcb7c9f237