### PR TITLE
docs: record sprint verification attempt

### DIFF
--- a/docs/qa/sprint-verification.md
+++ b/docs/qa/sprint-verification.md
@@ -1,0 +1,19 @@
+# Sprint Verification - Tabs, Search, Filters
+
+## Environment Setup
+- `yarn web:router` used to boot the Expo web app.
+- Installed Playwright and system dependencies to enable headless browser testing.
+- Encountered repeated `ENOSPC` errors indicating the system limit for file watchers was reached while Metro Bundler initialized.
+- Attempts to increase `fs.inotify` limits and run with `CHOKIDAR_USEPOLLING=1` still resulted in `ENOSPC`.
+
+## Verification Steps
+1. Navigate to `/` and ensure tab bar is visible with no `/tabs/` path segment.
+2. Switch between tabs and confirm navigation without `/tabs/` appearing in the URL.
+3. Use search and filter controls on product listings.
+
+## Results
+- App failed to launch due to file watcher limits; navigation and search/filter functionality could not be verified.
+- No regressions were confirmed or rejected in this session.
+
+## Notes
+- The environment requires higher `fs.inotify` limits or a pre-built static bundle to complete verification.


### PR DESCRIPTION
## Summary
- note that expo web app could not launch due to fs.inotify watcher limits preventing verification

## Testing
- `yarn lint docs/qa/sprint-verification.md`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b7046a8e00832698a7543cf4174249