### PR TITLE
Simplify root layout and update index redirect

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,33 +1,7 @@
-import { Slot, usePathname, useRouter } from 'expo-router';
-import { useEffect, useRef } from 'react';
-import { getPathFromState } from '@react-navigation/native';
+import { Slot } from 'expo-router';
 import AppProviders from '../providers/AppProviders';
 
 export default function RootLayout() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const prevPathRef = useRef(pathname);
-
-  useEffect(() => {
-    if (!__DEV__) return;
-    const unsubscribe = router.addListener('state', (e: any) => {
-      const nextPath = getPathFromState(e.data.state);
-      const prevPath = prevPathRef.current;
-      if (prevPath !== nextPath) {
-        // eslint-disable-next-line no-console
-        console.debug(`[Route] ${prevPath} -> ${nextPath}`);
-        prevPathRef.current = nextPath;
-      }
-    });
-    return unsubscribe;
-  }, [router]);
-
-  useEffect(() => {
-    if (__DEV__ && pathname?.includes('(tabs)')) {
-      console.warn("`(tabs)` should not appear in the pathname in development.");
-    }
-  }, [pathname]);
-
   return (
     <AppProviders>
       <Slot />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,1 +1,5 @@
-export { default } from './(tabs)/index';
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/" />;
+}


### PR DESCRIPTION
## Summary
- Remove tab routing logic from root layout and render only Slot inside providers
- Redirect root index route to `/`

## Testing
- `npx expo export --platform web`
- `npx expo start --web` *(fails: ENOSPC: System limit for number of file watchers reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b7266553f4832696a478f727ab50a2