### PR TITLE
refactor: restore default not-found screen

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,5 +1,5 @@
-import { Stack, router } from 'expo-router';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function NotFoundScreen() {
   return (
@@ -7,12 +7,6 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: 'Oops!' }} />
       <View style={styles.container}>
         <Text style={styles.text}>This screen doesn't exist.</Text>
-        <View style={styles.link}>
-          <Button
-            title="Go to home screen!"
-            onPress={() => router.replace('/')}
-          />
-        </View>
       </View>
     </>
   );
@@ -28,9 +22,5 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 20,
     fontWeight: '600',
-  },
-  link: {
-    marginTop: 15,
-    paddingVertical: 15,
   },
 });


### PR DESCRIPTION
## Summary
- remove dev-only redirect and Go Home button, returning to default 404 screen

## Testing
- `npx expo export --platform web`
- `npx expo start --web` *(fails: ENOSPC: System limit for number of file watchers reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b728d6cf108326b0d9b800a1c4a598