### PR TITLE
refactor: extract home filters and banner hooks

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -15,6 +15,7 @@ import useAppRouter from 'hooks/useAppRouter';
 import { Plus, X, ArrowUpDown } from 'lucide-react-native';
 import { Product, Category, HeroBanner } from '@/types';
 import { useHome } from '@/features/home/hooks/useHome';
+import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -32,7 +33,7 @@ const BannerFormModal = lazy(() => import('@/components/BannerFormModal'));
 const CartModal = lazy(() => import('@/features/cart/components/CartModal'));
 const ProductFormModal = lazy(() => import('@/features/products/components/ProductFormModal'));
 const InfoModal = lazy(() => import('@/components/InfoModal'));
-import { useHomeScreen, SortOption } from '@/features/home/hooks/useHomeScreen';
+import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters';
 
 
 function HomeScreenContent() {
@@ -42,15 +43,25 @@ function HomeScreenContent() {
   const {
     products,
     categories,
-    heroBanners,
-    refreshing,
-    refresh,
-    upsertBanner,
-    removeBanner,
+    refreshing: dataRefreshing,
+    refresh: refreshData,
     upsertProduct,
     removeProduct,
-    error,
+    error: dataError,
   } = useHome();
+  const {
+    heroBanners,
+    refreshing: bannersRefreshing,
+    refresh: refreshBanners,
+    upsertBanner,
+    removeBanner,
+    error: bannersError,
+  } = useHomeBanners();
+  const refreshing = dataRefreshing || bannersRefreshing;
+  const refresh = async () => {
+    await Promise.all([refreshData(), refreshBanners()]);
+  };
+  const error = dataError || bannersError;
   const [bannerFormVisible, setBannerFormVisible] = useState(false);
   const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
   const [productFormVisible, setProductFormVisible] = useState(false);
@@ -81,7 +92,7 @@ function HomeScreenContent() {
     setSortBy,
     showSortModal,
     setShowSortModal,
-  } = useHomeScreen(products);
+  } = useHomeFilters(products);
 
   // Fallback content to guarantee a rich homepage even with empty services
   const fallbackCategories: Category[] = [

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import chain from '@/services/chain';
-import { Product, Category, HeroBanner } from '@/types';
+import { Product, Category } from '@/types';
 
 let listCategories: (() => Promise<Category[]>) | undefined;
 if (chain === 'near') {
@@ -14,19 +14,17 @@ export function useHome() {
     queryKey: ['home'],
     queryFn: async () => {
       const db = DatabaseService.getInstance();
-      const [productsData, categoriesData, bannersData] = await Promise.all([
+      const [productsData, categoriesData] = await Promise.all([
         db.getProducts(),
         listCategories ? listCategories() : Promise.resolve([]),
-        db.getHeroBanners(),
       ]);
-      return { productsData, categoriesData, bannersData };
+      return { productsData, categoriesData };
     },
     suspense: true,
   });
 
   const [products, setProducts] = useState<Product[]>(data.productsData);
   const [categories, setCategories] = useState<Category[]>(data.categoriesData);
-  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>(data.bannersData);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -37,7 +35,6 @@ export function useHome() {
       if (res.data) {
         setProducts(res.data.productsData);
         setCategories(res.data.categoriesData);
-        setHeroBanners(res.data.bannersData);
       }
       setError(null);
     } catch (err) {
@@ -46,16 +43,6 @@ export function useHome() {
       setRefreshing(false);
     }
   }, [refetch]);
-
-  const upsertBanner = useCallback((b: HeroBanner, isNew: boolean) => {
-    setHeroBanners((prev) =>
-      isNew ? [...prev, b] : prev.map((h) => (h.id === b.id ? b : h)),
-    );
-  }, []);
-
-  const removeBanner = useCallback((id: string) => {
-    setHeroBanners((prev) => prev.filter((b) => b.id !== id));
-  }, []);
 
   const upsertProduct = useCallback((p: Product, isNew: boolean) => {
     setProducts((prev) =>
@@ -70,14 +57,11 @@ export function useHome() {
   return {
     products,
     categories,
-    heroBanners,
     loading: false,
     refreshing,
     error,
     reload: refresh,
     refresh,
-    upsertBanner,
-    removeBanner,
     upsertProduct,
     removeProduct,
   };

--- a/src/features/home/hooks/useHomeBanners.ts
+++ b/src/features/home/hooks/useHomeBanners.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import DatabaseService from '@/services/database';
+import { HeroBanner } from '@/types';
+
+export function useHomeBanners() {
+  const { data, refetch } = useQuery({
+    queryKey: ['homeBanners'],
+    queryFn: async () => {
+      const db = DatabaseService.getInstance();
+      return db.getHeroBanners();
+    },
+    suspense: true,
+  });
+
+  const [heroBanners, setHeroBanners] = useState<HeroBanner[]>(data ?? []);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const res = await refetch();
+      if (res.data) {
+        setHeroBanners(res.data);
+      }
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refetch]);
+
+  const upsertBanner = useCallback((b: HeroBanner, isNew: boolean) => {
+    setHeroBanners((prev) =>
+      isNew ? [...prev, b] : prev.map((h) => (h.id === b.id ? b : h)),
+    );
+  }, []);
+
+  const removeBanner = useCallback((id: string) => {
+    setHeroBanners((prev) => prev.filter((b) => b.id !== id));
+  }, []);
+
+  return {
+    heroBanners,
+    refreshing,
+    error,
+    refresh,
+    upsertBanner,
+    removeBanner,
+  } as const;
+}
+
+export type UseHomeBannersReturn = ReturnType<typeof useHomeBanners>;

--- a/src/features/home/hooks/useHomeFilters.ts
+++ b/src/features/home/hooks/useHomeFilters.ts
@@ -3,7 +3,7 @@ import { Product } from '@/types';
 
 export type SortOption = 'newest' | 'price-low' | 'price-high' | 'rating';
 
-export function useHomeScreen(products: Product[]) {
+export function useHomeFilters(products: Product[]) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [minPrice, setMinPrice] = useState('');
@@ -73,4 +73,4 @@ export function useHomeScreen(products: Product[]) {
   } as const;
 }
 
-export type UseHomeScreenReturn = ReturnType<typeof useHomeScreen>;
+export type UseHomeFiltersReturn = ReturnType<typeof useHomeFilters>;

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -44,16 +44,37 @@ jest.mock('../services/chain', () => 'near');
 jest.mock('../features/products/services/nearCategories', () => ({
   listCategories: jest.fn().mockResolvedValue([]),
 }));
-jest.mock('../features/home/hooks/useHomeScreen', () => ({
-  useHomeScreen: () => ({
+jest.mock('../features/home/hooks/useHome', () => ({
+  useHome: () => ({
+    products: [],
+    categories: [],
+    refreshing: false,
+    refresh: jest.fn(),
+    upsertProduct: jest.fn(),
+    removeProduct: jest.fn(),
+    error: null,
+  }),
+}));
+jest.mock('../features/home/hooks/useHomeBanners', () => ({
+  useHomeBanners: () => ({
+    heroBanners: [],
+    refreshing: false,
+    refresh: jest.fn(),
+    upsertBanner: jest.fn(),
+    removeBanner: jest.fn(),
+    error: null,
+  }),
+}));
+jest.mock('../features/home/hooks/useHomeFilters', () => ({
+  useHomeFilters: () => ({
     filteredProducts: [],
     searchQuery: '',
     setSearchQuery: jest.fn(),
     selectedCategory: null,
     setSelectedCategory: jest.fn(),
-    minPrice: null,
+    minPrice: '',
     setMinPrice: jest.fn(),
-    maxPrice: null,
+    maxPrice: '',
     setMaxPrice: jest.fn(),
     sortBy: 'name',
     setSortBy: jest.fn(),


### PR DESCRIPTION
## Summary
- split banner management into `useHomeBanners`
- extract product filtering into `useHomeFilters`
- update home screen and tests to use new hooks

## Testing
- `npx tsc --noEmit` *(fails: Type '"end"' is not assignable to type '"center" | "left" | "right" | undefined')*
- `npx expo start --web`


------
https://chatgpt.com/codex/tasks/task_e_68b7519c3f788326935893c0a59c1e0d