### PR TITLE
Use expo-router for seller CTA navigation

### DIFF
--- a/src/features/home/components/CTABecomeSeller.tsx
+++ b/src/features/home/components/CTABecomeSeller.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
-import useAppRouter from 'hooks/useAppRouter';
+import { router } from 'expo-router';
 
 export default function CTABecomeSeller() {
   const { colors } = useTheme();
-  const { push } = useAppRouter();
 
   return (
     <TouchableOpacity
       style={[styles.button, { backgroundColor: colors.gold }]}
-      onPress={() => push('/stores/create')}
+      onPress={() => router.push('/stores/create')}
       accessibilityRole="link"
     >
       <Text style={[styles.text, { color: colors.text.inverse }]}>Become a Seller</Text>


### PR DESCRIPTION
## Summary
- navigate to the store creation screen with `expo-router`

## Testing
- `npx tsc --noEmit` (fails: Type '"end"' is not assignable to type '"center" | "auto" | "left" | "right" | "justify" | undefined')
- `npx expo start --web`


------
https://chatgpt.com/codex/tasks/task_e_68b7519d439083269ffa19a79be5f14c