### PR TITLE
chore: log router path on route changes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AppInfoProvider } from '@/contexts/AppInfoContext';
@@ -13,9 +13,22 @@ import { WakuProvider } from '@/contexts/WakuContext';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AppProviders from './providers/AppProviders';
-import { Router } from 'expo-router';
+import { Router, usePathname, useRouter, useSegments } from 'expo-router';
 
 export default function App() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const segments = useSegments();
+
+  useEffect(() => {
+    if (!__DEV__) return;
+
+    const path = (router as any).getPath?.() ?? pathname;
+    const currentTab = segments[0] ?? '';
+    // eslint-disable-next-line no-console
+    console.log('[breadcrumb]', path, currentTab);
+  }, [router, pathname, segments]);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>


### PR DESCRIPTION
## Summary
- log path and current tab on route changes in dev mode

## Testing
- `npx tsc --noEmit` *(fails: ProductFormModal type errors)*
- `npx expo start --web` *(fails: ENOSPC: System limit for number of file watchers reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b75ac379f4832682f261d250a55e25