### PR TITLE
chore: enforce no tabs route group

### DIFF
--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,1 +1,1 @@
-export { default } from './(tabs)/categories';
+export { default } from './categories';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,8 +24,12 @@ module.exports = [
       'no-restricted-syntax': [
         'error',
         {
-          selector: "JSXAttribute[name.name='href'][value.value=/\\(tabs\\)/]",
-          message: "Use '/' or named routes instead of '/(tabs)/' in hrefs.",
+          selector: "Literal[value=/\\(tabs\\)/]",
+          message: "Avoid using the tabs route group; use root-relative '/' paths instead.",
+        },
+        {
+          selector: "TemplateElement[value.raw=/\\(tabs\\)/]",
+          message: "Avoid using the tabs route group; use root-relative '/' paths instead.",
         },
       ],
     },
@@ -96,6 +100,17 @@ module.exports = [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "Literal[value=/\\(tabs\\)/]",
+          message: "Avoid using the tabs route group; use root-relative '/' paths instead.",
+        },
+        {
+          selector: "TemplateElement[value.raw=/\\(tabs\\)/]",
+          message: "Avoid using the tabs route group; use root-relative '/' paths instead.",
+        },
+      ],
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fix:near": "node scripts/fix-near.js",
     "seed": "node scripts/app.js seed",
     "lint": "node scripts/app.js lint",
+    "pretest": "yarn lint",
     "typecheck": "node scripts/app.js typecheck",
     "test": "node scripts/app.js test",
     "depcheck": "node scripts/app.js depcheck",

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Text } from 'react-native';
-import HomeScreen from '../app/(tabs)/index';
+import HomeScreen from '../app/index';
 
 jest.mock('../hooks/useAppRouter', () => () => ({ push: jest.fn() }));
 jest.mock('expo-router', () => ({


### PR DESCRIPTION
## Summary
- add ESLint rule to forbid string literals containing the tabs route group
- run lint before tests
- use root relative routes in categories export and Home error boundary test

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b75ac846a48326b67c6e650047ea4b