### PR TITLE
feat: add production 404 screen

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,12 +1,26 @@
-import { Stack } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { Stack, router } from 'expo-router';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useEffect } from 'react';
 
 export default function NotFoundScreen() {
+  useEffect(() => {
+    if (__DEV__) {
+      router.replace('/');
+    }
+  }, []);
+
+  if (__DEV__) {
+    return null;
+  }
+
   return (
     <>
-      <Stack.Screen options={{ title: 'Oops!' }} />
+      <Stack.Screen options={{ title: '404' }} />
       <View style={styles.container}>
-        <Text style={styles.text}>This screen doesn't exist.</Text>
+        <Text style={styles.text}>404 - Page Not Found</Text>
+        <TouchableOpacity onPress={() => router.replace('/')}>
+          <Text style={styles.link}>Go Home</Text>
+        </TouchableOpacity>
       </View>
     </>
   );
@@ -22,5 +36,10 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 20,
     fontWeight: '600',
+  },
+  link: {
+    marginTop: 20,
+    fontSize: 16,
+    color: '#007aff',
   },
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
     '<rootDir>/tests/storeDashboard.test.tsx',
     '<rootDir>/tests/admin-impersonate.test.tsx',
     '<rootDir>/tests/admin-store-detail.test.tsx',
+    '<rootDir>/tests/not-found.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/tests/not-found.test.tsx
+++ b/tests/not-found.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import NotFoundScreen from '../app/+not-found';
+
+jest.mock('expo-router', () => ({
+  router: { replace: jest.fn() },
+  Stack: { Screen: () => null },
+}));
+
+describe('NotFoundScreen', () => {
+  const { router } = require('expo-router');
+  const { TouchableOpacity } = require('react-native');
+  const originalDev = (globalThis as any).__DEV__;
+
+  beforeEach(() => {
+    router.replace.mockReset();
+  });
+
+  afterEach(() => {
+    (globalThis as any).__DEV__ = originalDev;
+  });
+
+  it('redirects home in dev', () => {
+    (globalThis as any).__DEV__ = true;
+    act(() => {
+      renderer.create(<NotFoundScreen />);
+    });
+    expect(router.replace).toHaveBeenCalledWith('/');
+  });
+
+  it('renders Go Home button in production', () => {
+    (globalThis as any).__DEV__ = false;
+    let tree: renderer.ReactTestRenderer | undefined;
+    act(() => {
+      tree = renderer.create(<NotFoundScreen />);
+    });
+    const button = tree!.root.findByType(TouchableOpacity);
+    expect(router.replace).not.toHaveBeenCalled();
+    act(() => {
+      button.props.onPress();
+    });
+    expect(router.replace).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## Summary
- show 404 page with Go Home button and dev redirect
- cover not-found page logic in tests

## Testing
- `npm test` *(fails: Jest failed to parse a file)*

------
https://chatgpt.com/codex/tasks/task_e_68b76abd0f4483268f110d86defccb3d