### PR TITLE
chore: guard against duplicate query providers

### DIFF
--- a/docs/provider-invariants.md
+++ b/docs/provider-invariants.md
@@ -1,0 +1,3 @@
+# Provider Invariants
+
+- Only a single `QueryClientProvider` should be mounted at any time. Multiple providers create separate React Query caches and can lead to inconsistent data. The `CheckedQueryClientProvider` component in [`providers/CheckedQueryClientProvider.tsx`](../providers/CheckedQueryClientProvider.tsx) enforces this during development and will throw if another provider mounts.

--- a/providers/AppProviders.tsx
+++ b/providers/AppProviders.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { WalletProvider } from './WalletProvider';
 import { WakuProvider } from '@/contexts/WakuContext';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 import GlobalErrorBoundary from '@/components/GlobalErrorBoundary';
 
 interface Props {
@@ -16,9 +17,9 @@ export default function AppProviders({ children }: Props) {
     <GlobalErrorBoundary>
       <ThemeProvider>
         <WalletProvider>
-          <QueryClientProvider client={queryClient}>
+          <CheckedQueryClientProvider client={queryClient}>
             <WakuProvider>{children}</WakuProvider>
-          </QueryClientProvider>
+          </CheckedQueryClientProvider>
         </WalletProvider>
       </ThemeProvider>
     </GlobalErrorBoundary>

--- a/providers/CheckedQueryClientProvider.tsx
+++ b/providers/CheckedQueryClientProvider.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  QueryClientProvider as BaseQueryClientProvider,
+  type QueryClientProviderProps,
+} from '@tanstack/react-query';
+
+let mountedInstances = 0;
+
+export function CheckedQueryClientProvider(props: QueryClientProviderProps) {
+  if (__DEV__) {
+    mountedInstances += 1;
+    if (mountedInstances > 1) {
+      throw new Error('Multiple QueryClientProvider instances detected. Only one should be mounted.');
+    }
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (__DEV__) {
+        mountedInstances -= 1;
+      }
+    };
+  }, []);
+
+  return <BaseQueryClientProvider {...props} />;
+}


### PR DESCRIPTION
## Summary
- add development guard that throws if more than one QueryClientProvider mounts
- document the single-query-provider invariant for contributors

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b77166ecac8326a9b2a14b7678bcce