### PR TITLE
fix: avoid infinite redirect

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,8 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return <Redirect href="/" />;
+  // Redirect to the landing page to avoid navigating to the current
+  // route repeatedly which caused an infinite loop and the
+  // "Maximum update depth exceeded" warning.
+  return <Redirect href="/landing" />;
 }


### PR DESCRIPTION
## Summary
- avoid redirect loop on root route by sending users to landing page

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b77399fcd88326b227877f8c35f48e