### PR TITLE
Add Playwright smoke test for home screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-yarn-
       - run: yarn install --frozen-lockfile
+      - run: npx playwright install --with-deps chromium
       - run: yarn lint
       - run: yarn typecheck
       - run: yarn test

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -237,6 +237,7 @@ function HomeScreenContent() {
 
   return (
     <SafeAreaView
+      testID="home-root"
       style={[styles.container, { backgroundColor: colors.background }]}
     >
     <HomeHeader />

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "react-test-renderer": "18.2.0",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
+    "playwright": "^1.48.2",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "ts-prune": "^0.10.3",

--- a/tests/web-smoke.js
+++ b/tests/web-smoke.js
@@ -1,8 +1,9 @@
 const { spawn } = require('child_process');
+const { chromium } = require('playwright');
 
 const PORT = 4173;
 const URL = `http://localhost:${PORT}/`;
-const MARKER = '<div id="root">';
+const MARKER = '[data-testid="home-root"]';
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,14 +14,14 @@ async function fetchWithRetry(retries = 20) {
     try {
       const res = await fetch(URL);
       if (res.status === 200) {
-        return res;
+        return;
       }
     } catch (err) {
       // ignore and retry
     }
     await wait(500);
   }
-  throw new Error('Unable to fetch index');
+  throw new Error('Unable to reach server');
 }
 
 async function main() {
@@ -29,12 +30,13 @@ async function main() {
   });
 
   try {
-    const res = await fetchWithRetry();
-    const html = await res.text();
-    if (!html.includes(MARKER)) {
-      throw new Error('DOM marker not found');
-    }
+    await fetchWithRetry();
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    await page.goto(URL);
+    await page.waitForSelector(MARKER, { timeout: 5000 });
     console.log('Web smoke test passed');
+    await browser.close();
   } catch (err) {
     console.error(err);
     process.exitCode = 1;


### PR DESCRIPTION
## Summary
- mark HomeScreen root with `data-testid="home-root"`
- add Playwright-based `web-smoke` test
- install Playwright in CI and dev dependencies

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Type '"end"' is not assignable...)*
- `yarn test` *(fails: Cannot read properties of undefined (reading 'sourceFile'))*
- `yarn build:web` *(fails: No dist/**/index.js files found. Did you run yarn build:web?)*
- `node tests/web-smoke.js` *(fails: Timeout 5000ms exceeded waiting for [data-testid="home-root"])*


------
https://chatgpt.com/codex/tasks/task_e_68b7716335d083269d83aa4e0f5a3126