### PR TITLE
fix: forward refs in Button

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import {
   Pressable,
   Text,
@@ -15,16 +15,20 @@ interface ButtonProps extends PressableProps {
   loading?: boolean;
 }
 
-export default function Button({
-  title,
-  variant = 'primary',
-  loading = false,
-  style,
-  disabled,
-  children,
-  accessibilityRole = 'button',
-  ...rest
-}: ButtonProps) {
+const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
+  (
+    {
+      title,
+      variant = 'primary',
+      loading = false,
+      style,
+      disabled,
+      children,
+      accessibilityRole = 'button',
+      ...rest
+    },
+    ref,
+  ) => {
   const { getColor } = useTheme();
 
   const isDisabled = disabled || loading;
@@ -59,6 +63,7 @@ export default function Button({
 
   return (
     <Pressable
+      ref={ref}
       accessibilityRole={accessibilityRole}
       style={[buttonStyle, { backgroundColor }, borderStyle, style]}
       disabled={isDisabled}
@@ -73,7 +78,10 @@ export default function Button({
       )}
     </Pressable>
   );
-}
+},
+);
+
+export default Button;
 
 const styles = StyleSheet.create({
   text: {


### PR DESCRIPTION
## Summary
- forward React refs through Button component to work with expo-router Link

## Testing
- `yarn lint`
- `yarn test` *(fails: Unexpected token '<' in tests/*.tsx; TypeScript errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b774ed024c832683d1d180bd988f40