### PR TITLE
feat: apply theme canvas backgrounds and safe areas

### DIFF
--- a/app/(tabs)/cart.tsx
+++ b/app/(tabs)/cart.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import AppShell from '../../components/layout/AppShell';
 
 export default function CartScreen() {
   return (
-    <View>
-      <Text>Cart Screen</Text>
-    </View>
+    <AppShell showSearch={false}>
+      <View>
+        <Text>Cart Screen</Text>
+      </View>
+    </AppShell>
   );
 }
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ const CartModal = lazy(() => import('@/features/cart/components/CartModal'));
 const ProductFormModal = lazy(() => import('@/features/products/components/ProductFormModal'));
 const InfoModal = lazy(() => import('@/components/InfoModal'));
 import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters';
+import { spacing } from '@/shared/ui/tokens';
 
 
 function HomeScreenContent() {
@@ -238,7 +239,7 @@ function HomeScreenContent() {
   return (
     <SafeAreaView
       testID="home-root"
-      style={[styles.container, { backgroundColor: colors.background }]}
+      style={[styles.container, { backgroundColor: colors.canvas }]}
     >
     <HomeHeader />
     <SearchBar
@@ -247,6 +248,7 @@ function HomeScreenContent() {
     />
 
     <ScrollView
+      style={{ backgroundColor: colors.canvas }}
       showsVerticalScrollIndicator={false}
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={refresh} />
@@ -495,14 +497,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   section: {
-    paddingHorizontal: 16,
-    marginBottom: 24,
+    paddingHorizontal: spacing.spacer16,
+    marginBottom: spacing.spacer24,
   },
   sectionHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 16,
+    marginBottom: spacing.spacer16,
   },
   sectionTitle: {
     fontSize: 18,
@@ -511,7 +513,7 @@ const styles = StyleSheet.create({
   sectionActions: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: spacing.spacer8,
   },
   seeAll: {
     fontSize: 14,
@@ -520,7 +522,7 @@ const styles = StyleSheet.create({
   sortButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.spacer12,
     paddingVertical: 6,
     borderRadius: 16,
     borderWidth: 1,
@@ -528,7 +530,7 @@ const styles = StyleSheet.create({
   sortText: {
     fontSize: 12,
     fontWeight: '500',
-    marginLeft: 4,
+    marginLeft: spacing.spacer4,
   },
   addProductButton: {
     width: 28,
@@ -539,10 +541,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   categoriesList: {
-    paddingLeft: 16,
+    paddingLeft: spacing.spacer16,
   },
   categoryWrapper: {
-    marginLeft: 20,
+    marginLeft: spacing.spacer20,
   },
   categoryCard: {
     alignItems: 'center',
@@ -555,7 +557,7 @@ const styles = StyleSheet.create({
     borderRadius: 30,
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: spacing.spacer8,
     borderWidth: 1,
   },
   categoryEmoji: {
@@ -623,16 +625,16 @@ const styles = StyleSheet.create({
   },
   helperText: {
     fontSize: 12,
-    marginTop: 4,
+    marginTop: spacing.spacer4,
     textAlign: 'end',
   },
   adminActionsContainer: {
-    padding: 16,
-    marginBottom: 24,
+    padding: spacing.spacer16,
+    marginBottom: spacing.spacer24,
   },
   clearDataButton: {
     borderRadius: 12,
-    paddingVertical: 12,
+    paddingVertical: spacing.spacer12,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -640,13 +642,13 @@ const styles = StyleSheet.create({
   clearDataText: {
     fontSize: 16,
     fontWeight: '600',
-    marginLeft: 8,
+    marginLeft: spacing.spacer8,
   },
   categorySelector: {
     borderWidth: 1,
     borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingHorizontal: spacing.spacer16,
+    paddingVertical: spacing.spacer12,
   },
   categorySelectorText: {
     fontSize: 16,
@@ -679,8 +681,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer16,
     borderBottomWidth: 1,
   },
   categorySelectorItemContent: {
@@ -689,7 +691,7 @@ const styles = StyleSheet.create({
   },
   categorySelectorItemIcon: {
     fontSize: 24,
-    marginRight: 12,
+    marginRight: spacing.spacer12,
   },
   categorySelectorItemText: {
     fontSize: 16,
@@ -699,6 +701,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   buttonSpinner: {
-    marginRight: 8,
+    marginRight: spacing.spacer8,
   },
 });

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -30,7 +30,7 @@ export default function Document({ children }: { children: React.ReactNode }) {
             __html: `
               html, body { height: 100% !important; margin: 0 !important; padding: 0 !important; }
               #root, #app-root { height: 100% !important; min-height: 100vh !important; min-width: 100vw !important; }
-              body { background: #fff; }
+              body { background: transparent; }
             `,
           }}
         />

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -33,7 +33,7 @@ export default function Categories() {
     <ErrorBoundary>
       <AppShell>
         {categories.length > 0 ? (
-          <ScrollView contentContainerStyle={styles.list}>
+          <ScrollView style={{ backgroundColor: colors.canvas }} contentContainerStyle={styles.list}>
             {categories.map((c) => (
               <TouchableOpacity
                 key={c.id}

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import SmartImage from '../components/SmartImage';
 import Button from '../components/ui/Button';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import { spacing } from '@/shared/ui/tokens';
 
 export default function Landing() {
   const { push } = useAppRouter();
@@ -42,19 +43,19 @@ export default function Landing() {
   return (
     <ErrorBoundary>
       <AppShell>
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView style={{ backgroundColor: colors.canvas }} showsVerticalScrollIndicator={false}>
           {/* Hero */}
-        <View style={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 12, alignItems: 'center' }}>
+        <View style={{ paddingHorizontal: spacing.spacer16, paddingTop: spacing.spacer24, paddingBottom: spacing.spacer12, alignItems: 'center' }}>
           <Text style={{ color: colors.text.primary, fontSize: 28, fontWeight: '800', textAlign: 'center' }}>
             Blue Ocean Marketplace
           </Text>
-          <Text style={{ color: colors.text.secondary, marginTop: 8, textAlign: 'center' }}>
+          <Text style={{ color: colors.text.secondary, marginTop: spacing.spacer8, textAlign: 'center' }}>
             Decentralized commerce on NEAR — own your store, your data, your future.
           </Text>
-          <View style={{ marginTop: 12 }}>
+          <View style={{ marginTop: spacing.spacer12 }}>
             <GoldDivider width={200} />
           </View>
-          <View style={{ flexDirection: 'row', gap: 12, marginTop: 16 }}>
+          <View style={{ flexDirection: 'row', gap: spacing.spacer12, marginTop: spacing.spacer16 }}>
             <Link href="/store/alpha" asChild>
               <Button title="Open Alpha Store" style={{ borderRadius: 10 }} />
             </Link>
@@ -71,7 +72,7 @@ export default function Landing() {
         {/* Banners */}
         <Section title="Highlights" center>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <View style={{ flexDirection: 'row', gap: 12, paddingHorizontal: 16 }}>
+            <View style={{ flexDirection: 'row', gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }}>
               {(banners.length ? banners : [
                 { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
                 { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
@@ -96,7 +97,7 @@ export default function Landing() {
         {/* Categories */}
         <Section title="Categories">
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <View style={{ flexDirection: 'row', gap: 8 }}>
+            <View style={{ flexDirection: 'row', gap: spacing.spacer8 }}>
               {(categories.length ? categories : [
                 { id: 'electronics', name: 'Electronics' },
                 { id: 'fashion', name: 'Fashion' },
@@ -109,8 +110,8 @@ export default function Landing() {
                   key={c.id}
                   onPress={() => push(`/category/${c.id}`)}
                   style={{
-                    paddingHorizontal: 12,
-                    paddingVertical: 8,
+                    paddingHorizontal: spacing.spacer12,
+                    paddingVertical: spacing.spacer8,
                     borderRadius: 16,
                     borderWidth: 1,
                     borderColor: colors.border.primary,
@@ -126,7 +127,7 @@ export default function Landing() {
 
         {/* Featured */}
         <Section title="Featured">
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12, paddingHorizontal: 0 }}>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.spacer12, paddingHorizontal: 0 }}>
             {featured.map((p) => (
               <View key={p.id} style={{ width: '48%' }}>
                 <ProductCard product={p} />

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { useTheme } from '@/contexts/ThemeContext';
 import GlobalHeader from '../GlobalHeader';
 
 interface AppShellProps {
@@ -9,10 +11,12 @@ interface AppShellProps {
 }
 
 export default function AppShell({ children, showSearch = true }: AppShellProps) {
+  const { theme, colors } = useTheme();
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+      <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
       <GlobalHeader showSearch={showSearch} />
-      <View style={{ flex: 1 }}>{children}</View>
+      <View style={{ flex: 1, backgroundColor: colors.canvas }}>{children}</View>
     </SafeAreaView>
   );
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,6 +1,7 @@
 export const Colors = {
   // Primary Colors
   background: '#0E0D0A', // Darkest background
+  canvas: '#0E0D0A',
   gold: '#B99C5A', // Gold accent
   
   // Text Colors

--- a/constants/LightColors.ts
+++ b/constants/LightColors.ts
@@ -1,6 +1,7 @@
 export const LightColors = {
   // Primary Colors
   background: '#FFFFFF',
+  canvas: '#FFFFFF',
   gold: '#B99C5A', // Keep gold accent the same
   
   // Text Colors

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 try {
   if (typeof document !== 'undefined') {
     const style = document.createElement('style');
-    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: #fff; }`;
+    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: transparent; }`;
     document.head.appendChild(style);
     let root = document.getElementById('root') || document.getElementById('app-root');
     if (!root) {

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https:; connect-src 'self' http: https: ws: wss: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; worker-src 'self' blob:; child-src 'self' blob:;"
     />
     <style>
-      html, body, #root { height:100%; background:#fff; }
+      html, body, #root { height:100%; background:transparent; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add `canvas` color token and use it for screen backgrounds
- apply SafeArea + themed StatusBar in AppShell and wrap Cart screen
- replace magic spacing on landing and home screens with shared tokens and remove hard-coded white web backgrounds

## Testing
- `yarn test` *(fails: Test Suites: 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b776c2df08832683961187d3ea760e