### PR TITLE
feat: add typography and core tokens

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -88,10 +88,13 @@ function mapTitle(t: (key: string) => string, raw: string) {
   // Try i18n keys for known items, fall back to raw
   const map: Record<string, string> = {
     Home: t('navigation.home'),
-    Categories: t('navigation.categories'),
-    Orders: 'הזמנות',
-    Notifications: t('navigation.notifications'),
+    Stores: t('navigation.stores'),
+    Cart: t('navigation.cart'),
+    Orders: t('navigation.orders'),
     Profile: t('navigation.profile'),
+    Categories: t('navigation.categories'),
+    Notifications: t('navigation.notifications'),
+    Reviews: t('navigation.reviews'),
     Dashboard: 'Dashboard',
     Catalog: 'Catalog',
   };

--- a/app/(tabs)/cart.tsx
+++ b/app/(tabs)/cart.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import AppShell from '../../components/layout/AppShell';
 
 export default function CartScreen() {
   return (
-    <View>
-      <Text>Cart Screen</Text>
-    </View>
+    <AppShell showSearch={false}>
+      <View>
+        <Text>Cart Screen</Text>
+      </View>
+    </AppShell>
   );
 }
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -22,7 +22,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import HomeHeader from '@/features/home/components/HomeHeader';
 import SearchBar from '@/features/home/components/SearchBar';
 import PriceRange from '@/features/home/components/PriceRange';
-import CategoryTabs from '@/features/home/components/CategoryTabs';
+import CategoryChips from '@/features/home/components/CategoryChips';
 import CTABecomeSeller from '@/features/home/components/CTABecomeSeller';
 import BannerArea from '@/features/home/components/BannerArea';
 const ProductGrid = lazy(() => import('@/features/home/components/ProductGrid'));
@@ -34,6 +34,7 @@ const CartModal = lazy(() => import('@/features/cart/components/CartModal'));
 const ProductFormModal = lazy(() => import('@/features/products/components/ProductFormModal'));
 const InfoModal = lazy(() => import('@/components/InfoModal'));
 import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters';
+import { spacing } from '@/shared/ui/tokens';
 
 
 function HomeScreenContent() {
@@ -238,7 +239,7 @@ function HomeScreenContent() {
   return (
     <SafeAreaView
       testID="home-root"
-      style={[styles.container, { backgroundColor: colors.background }]}
+      style={[styles.container, { backgroundColor: colors.canvas }]}
     >
     <HomeHeader />
     <SearchBar
@@ -247,16 +248,17 @@ function HomeScreenContent() {
     />
 
     <ScrollView
+      style={{ backgroundColor: colors.canvas }}
       showsVerticalScrollIndicator={false}
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={refresh} />
       }
     >
-      <CategoryTabs
-          categories={categories}
-          selectedCategory={selectedCategory}
-          setSelectedCategory={setSelectedCategory}
-        />
+      <CategoryChips
+        categories={categories}
+        selectedCategory={selectedCategory}
+        setSelectedCategory={setSelectedCategory}
+      />
       <PriceRange
           minPrice={minPrice}
           setMinPrice={setMinPrice}
@@ -495,14 +497,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   section: {
-    paddingHorizontal: 16,
-    marginBottom: 24,
+    paddingHorizontal: spacing.spacer16,
+    marginBottom: spacing.spacer24,
   },
   sectionHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 16,
+    marginBottom: spacing.spacer16,
   },
   sectionTitle: {
     fontSize: 18,
@@ -511,7 +513,7 @@ const styles = StyleSheet.create({
   sectionActions: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: spacing.spacer8,
   },
   seeAll: {
     fontSize: 14,
@@ -520,7 +522,7 @@ const styles = StyleSheet.create({
   sortButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.spacer12,
     paddingVertical: 6,
     borderRadius: 16,
     borderWidth: 1,
@@ -528,7 +530,7 @@ const styles = StyleSheet.create({
   sortText: {
     fontSize: 12,
     fontWeight: '500',
-    marginLeft: 4,
+    marginLeft: spacing.spacer4,
   },
   addProductButton: {
     width: 28,
@@ -539,10 +541,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   categoriesList: {
-    paddingLeft: 16,
+    paddingLeft: spacing.spacer16,
   },
   categoryWrapper: {
-    marginLeft: 20,
+    marginLeft: spacing.spacer20,
   },
   categoryCard: {
     alignItems: 'center',
@@ -555,7 +557,7 @@ const styles = StyleSheet.create({
     borderRadius: 30,
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: spacing.spacer8,
     borderWidth: 1,
   },
   categoryEmoji: {
@@ -623,16 +625,16 @@ const styles = StyleSheet.create({
   },
   helperText: {
     fontSize: 12,
-    marginTop: 4,
+    marginTop: spacing.spacer4,
     textAlign: 'end',
   },
   adminActionsContainer: {
-    padding: 16,
-    marginBottom: 24,
+    padding: spacing.spacer16,
+    marginBottom: spacing.spacer24,
   },
   clearDataButton: {
     borderRadius: 12,
-    paddingVertical: 12,
+    paddingVertical: spacing.spacer12,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -640,13 +642,13 @@ const styles = StyleSheet.create({
   clearDataText: {
     fontSize: 16,
     fontWeight: '600',
-    marginLeft: 8,
+    marginLeft: spacing.spacer8,
   },
   categorySelector: {
     borderWidth: 1,
     borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingHorizontal: spacing.spacer16,
+    paddingVertical: spacing.spacer12,
   },
   categorySelectorText: {
     fontSize: 16,
@@ -679,8 +681,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer16,
     borderBottomWidth: 1,
   },
   categorySelectorItemContent: {
@@ -689,7 +691,7 @@ const styles = StyleSheet.create({
   },
   categorySelectorItemIcon: {
     fontSize: 24,
-    marginRight: 12,
+    marginRight: spacing.spacer12,
   },
   categorySelectorItemText: {
     fontSize: 16,
@@ -699,6 +701,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   buttonSpinner: {
-    marginRight: 8,
+    marginRight: spacing.spacer8,
   },
 });

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -30,7 +30,7 @@ export default function Document({ children }: { children: React.ReactNode }) {
             __html: `
               html, body { height: 100% !important; margin: 0 !important; padding: 0 !important; }
               #root, #app-root { height: 100% !important; min-height: 100vh !important; min-width: 100vw !important; }
-              body { background: #fff; }
+              body { background: transparent; }
             `,
           }}
         />

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -33,7 +33,7 @@ export default function Categories() {
     <ErrorBoundary>
       <AppShell>
         {categories.length > 0 ? (
-          <ScrollView contentContainerStyle={styles.list}>
+          <ScrollView style={{ backgroundColor: colors.canvas }} contentContainerStyle={styles.list}>
             {categories.map((c) => (
               <TouchableOpacity
                 key={c.id}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,8 +1,8 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  // Redirect to the landing page to avoid navigating to the current
-  // route repeatedly which caused an infinite loop and the
-  // "Maximum update depth exceeded" warning.
-  return <Redirect href="/landing" />;
+  // Redirect to the root route and let Expo Router handle the tab layout.
+  // Using "/" avoids repeating the current route which previously caused
+  // an infinite loop and a "Maximum update depth exceeded" warning.
+  return <Redirect href="/" />;
 }

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import SmartImage from '../components/SmartImage';
 import Button from '../components/ui/Button';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import { spacing } from '@/shared/ui/tokens';
 
 export default function Landing() {
   const { push } = useAppRouter();
@@ -42,19 +43,19 @@ export default function Landing() {
   return (
     <ErrorBoundary>
       <AppShell>
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView style={{ backgroundColor: colors.canvas }} showsVerticalScrollIndicator={false}>
           {/* Hero */}
-        <View style={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 12, alignItems: 'center' }}>
+        <View style={{ paddingHorizontal: spacing.spacer16, paddingTop: spacing.spacer24, paddingBottom: spacing.spacer12, alignItems: 'center' }}>
           <Text style={{ color: colors.text.primary, fontSize: 28, fontWeight: '800', textAlign: 'center' }}>
             Blue Ocean Marketplace
           </Text>
-          <Text style={{ color: colors.text.secondary, marginTop: 8, textAlign: 'center' }}>
+          <Text style={{ color: colors.text.secondary, marginTop: spacing.spacer8, textAlign: 'center' }}>
             Decentralized commerce on NEAR — own your store, your data, your future.
           </Text>
-          <View style={{ marginTop: 12 }}>
+          <View style={{ marginTop: spacing.spacer12 }}>
             <GoldDivider width={200} />
           </View>
-          <View style={{ flexDirection: 'row', gap: 12, marginTop: 16 }}>
+          <View style={{ flexDirection: 'row', gap: spacing.spacer12, marginTop: spacing.spacer16 }}>
             <Link href="/store/alpha" asChild>
               <Button title="Open Alpha Store" style={{ borderRadius: 10 }} />
             </Link>
@@ -71,7 +72,7 @@ export default function Landing() {
         {/* Banners */}
         <Section title="Highlights" center>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <View style={{ flexDirection: 'row', gap: 12, paddingHorizontal: 16 }}>
+            <View style={{ flexDirection: 'row', gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }}>
               {(banners.length ? banners : [
                 { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
                 { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
@@ -96,7 +97,7 @@ export default function Landing() {
         {/* Categories */}
         <Section title="Categories">
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <View style={{ flexDirection: 'row', gap: 8 }}>
+            <View style={{ flexDirection: 'row', gap: spacing.spacer8 }}>
               {(categories.length ? categories : [
                 { id: 'electronics', name: 'Electronics' },
                 { id: 'fashion', name: 'Fashion' },
@@ -109,8 +110,8 @@ export default function Landing() {
                   key={c.id}
                   onPress={() => push(`/category/${c.id}`)}
                   style={{
-                    paddingHorizontal: 12,
-                    paddingVertical: 8,
+                    paddingHorizontal: spacing.spacer12,
+                    paddingVertical: spacing.spacer8,
                     borderRadius: 16,
                     borderWidth: 1,
                     borderColor: colors.border.primary,
@@ -126,7 +127,7 @@ export default function Landing() {
 
         {/* Featured */}
         <Section title="Featured">
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12, paddingHorizontal: 0 }}>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.spacer12, paddingHorizontal: 0 }}>
             {featured.map((p) => (
               <View key={p.id} style={{ width: '48%' }}>
                 <ProductCard product={p} />

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { useTheme } from '@/contexts/ThemeContext';
 import GlobalHeader from '../GlobalHeader';
 
 interface AppShellProps {
@@ -9,10 +11,12 @@ interface AppShellProps {
 }
 
 export default function AppShell({ children, showSearch = true }: AppShellProps) {
+  const { theme, colors } = useTheme();
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+      <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
       <GlobalHeader showSearch={showSearch} />
-      <View style={{ flex: 1 }}>{children}</View>
+      <View style={{ flex: 1, backgroundColor: colors.canvas }}>{children}</View>
     </SafeAreaView>
   );
 }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,13 +1,8 @@
 import React, { forwardRef } from 'react';
-import {
-  Pressable,
-  Text,
-  StyleSheet,
-  ActivityIndicator,
-  PressableProps,
-} from 'react-native';
+import { Pressable, ActivityIndicator, PressableProps } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import { spacing, radius } from '@/shared/ui/tokens';
+import Text from '@/shared/ui/Text';
 
 interface ButtonProps extends PressableProps {
   title?: string;
@@ -74,7 +69,9 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
       ) : children ? (
         children
       ) : (
-        <Text style={[styles.text, { color: textColor }]}>{title}</Text>
+        <Text variant="md" weight="600" style={{ color: textColor }}>
+          {title}
+        </Text>
       )}
     </Pressable>
   );
@@ -82,12 +79,3 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
 );
 
 export default Button;
-
-const styles = StyleSheet.create({
-  text: {
-    fontSize: 16,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-});
-

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,6 +1,7 @@
 export const Colors = {
   // Primary Colors
   background: '#0E0D0A', // Darkest background
+  canvas: '#0E0D0A',
   gold: '#B99C5A', // Gold accent
   
   // Text Colors

--- a/constants/LightColors.ts
+++ b/constants/LightColors.ts
@@ -1,6 +1,7 @@
 export const LightColors = {
   // Primary Colors
   background: '#FFFFFF',
+  canvas: '#FFFFFF',
   gold: '#B99C5A', // Keep gold accent the same
   
   // Text Colors

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -40,9 +40,27 @@ export const shadows = {
   },
 };
 
-export const colors = darkColors;
+const dark = {
+  canvas: darkColors.canvas,
+  surface: darkColors.surface.primary,
+  primary: darkColors.interactive.primary,
+  muted: darkColors.text.secondary,
+  border: darkColors.border.secondary,
+  ...darkColors,
+};
+
+const light = {
+  canvas: LightColors.canvas,
+  surface: LightColors.surface.primary,
+  primary: LightColors.interactive.primary,
+  muted: LightColors.text.secondary,
+  border: LightColors.border.secondary,
+  ...LightColors,
+};
+
+export const colors = dark;
 
 export const tokens = { spacing, radius, colors, zIndex, shadows };
-export const lightTokens = { ...tokens, colors: LightColors };
+export const lightTokens = { ...tokens, colors: light };
 
 export type Tokens = typeof tokens;

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -53,14 +53,14 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       }
     } catch (error) {
       errorLog('Error loading stored language:', error);
+      await setLanguage('en');
     }
   };
 
   const setLanguage = async (language: Language) => {
     try {
       setCurrentLanguage(language);
-      
-      // Update translations
+
       if (language === 'en') {
         setTranslations(enTranslations);
         setIsRTL(false);
@@ -70,11 +70,27 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       }
       configureRTL(language === 'he');
 
-      // Store language preference
       await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, language);
     } catch (error) {
       errorLog('Error setting language:', error);
+      setTranslations(enTranslations);
+      setIsRTL(false);
+      setCurrentLanguage('en');
+      configureRTL(false);
+      await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
     }
+  };
+
+  const getValue = (obj: any, keys: string[]) => {
+    let val = obj;
+    for (const k of keys) {
+      if (val && typeof val === 'object' && k in val) {
+        val = val[k];
+      } else {
+        return undefined;
+      }
+    }
+    return val;
   };
 
   const t = (
@@ -82,7 +98,6 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     options?: Record<string, string | number> | string
   ): string => {
     const keys = key.split('.');
-    let value: any = translations;
     let params: Record<string, string | number> | undefined;
     let fallback: string | undefined;
 
@@ -92,18 +107,15 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       params = options;
     }
 
-    for (const k of keys) {
-      if (value && typeof value === 'object' && k in value) {
-        value = value[k];
-      } else {
-        return fallback || key;
-      }
+    let value = getValue(translations, keys);
+    if (value === undefined) {
+      value = getValue(enTranslations, keys);
     }
 
-      if (typeof value === 'string') {
-        if (params) {
-          return value.replace(/\{(.*?)\}/g, (_, p) => String(params?.[p] ?? ''));
-        }
+    if (typeof value === 'string') {
+      if (params) {
+        return value.replace(/\{(.*?)\}/g, (_, p) => String(params?.[p] ?? ''));
+      }
       return value;
     }
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -13,10 +13,10 @@ flowchart LR
     BecomeSeller --> MintStore[Mint Store]
     MintStore --> Home
 
-    click Home "../app/(tabs)/index.tsx" "Home screen"
+    click Home "../app/index.tsx" "Home screen"
     click Store "../app/store/[storeId]/index.tsx" "Storefront"
     click Product "../app/product/[id].tsx" "Product page"
-    click Cart "../app/(tabs)/cart.tsx" "Cart screen"
+    click Cart "../app/cart.tsx" "Cart screen"
     click Checkout "../src/features/cart/components/CartModal.tsx" "Checkout steps"
     click BecomeSeller "../src/features/home/components/CTABecomeSeller.tsx" "Become Seller CTA"
     click MintStore "../src/features/stores/components/StoreCreation.tsx" "Mint Store component"

--- a/hooks/useAppRouter.ts
+++ b/hooks/useAppRouter.ts
@@ -2,12 +2,19 @@ import { useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { debugLog } from '@/utils/logger';
 
+function warnGroupPath(path: unknown) {
+  if (__DEV__ && typeof path === 'string' && /(\([^/]+\))/g.test(path)) {
+    console.warn('[router] group segment in path', path);
+  }
+}
+
 export function useAppRouter() {
   const router = useRouter();
 
   const push = useCallback(
     (...args: Parameters<typeof router.push>) => {
       debugLog('[router] push', ...args);
+      warnGroupPath(args[0]);
       router.push(...args);
     },
     [router],
@@ -16,6 +23,7 @@ export function useAppRouter() {
   const replace = useCallback(
     (...args: Parameters<typeof router.replace>) => {
       debugLog('[router] replace', ...args);
+      warnGroupPath(args[0]);
       router.replace(...args);
     },
     [router],

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 try {
   if (typeof document !== 'undefined') {
     const style = document.createElement('style');
-    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: #fff; }`;
+    style.innerHTML = `html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; } body { background: transparent; }`;
     document.head.appendChild(style);
     let root = document.getElementById('root') || document.getElementById('app-root');
     if (!root) {

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https:; connect-src 'self' http: https: ws: wss: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; worker-src 'self' blob:; child-src 'self' blob:;"
     />
     <style>
-      html, body, #root { height:100%; background:#fff; }
+      html, body, #root { height:100%; background:transparent; }
     </style>
   </head>
   <body>

--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, Suspense, lazy } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
+import { View, ScrollView, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
 import { Plus, Pencil } from 'lucide-react-native';
 import { HeroBanner } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -7,6 +7,8 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import useAppRouter from 'hooks/useAppRouter';
 import EmptyState from '@/shared/ui/EmptyState';
 import Spinner from '@/shared/ui/Spinner';
+import Text from '@/shared/ui/Text';
+import Heading from '@/shared/ui/Heading';
 
 const SmartImage = lazy(() => import('@/components/SmartImage'));
 
@@ -65,22 +67,26 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
           <View style={styles.heroContent}>
             {item.discount ? (
               <Text
-                style={[
-                  styles.heroDiscount,
-                  {
-                    color: colors.text.inverse,
-                    backgroundColor: colors.gold,
-                  },
-                ]}
+                variant="xs"
+                weight="600"
+                style={{
+                  paddingHorizontal: 8,
+                  paddingVertical: 4,
+                  borderRadius: 8,
+                  alignSelf: 'flex-start',
+                  marginBottom: 8,
+                  color: colors.text.inverse,
+                  backgroundColor: colors.gold,
+                }}
               >
                 {item.discount} הנחה
               </Text>
             ) : null}
-            <Text style={[styles.heroTitle, { color: colors.gold }]}>
+            <Heading size="lg" style={{ color: colors.gold }}>
               {item.title}
-            </Text>
+            </Heading>
 
-            <Text style={[styles.heroSubtitle, { color: colors.gold }]}>
+            <Text variant="sm" style={{ marginTop: 4, color: colors.gold }}>
               {item.subtitle}
             </Text>
           </View>
@@ -112,7 +118,11 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
             onPress={onAddBanner}
           >
             <Plus size={20} color={colors.text.inverse} />
-            <Text style={[styles.addBannerText, { color: colors.text.inverse }]}>
+            <Text
+              variant="sm"
+              weight="600"
+              style={{ marginStart: 8, color: colors.text.inverse }}
+            >
               {t('banner.addBanner')}
             </Text>
           </TouchableOpacity>
@@ -184,10 +194,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     borderRadius: 12,
   },
-  addBannerText: {
-    marginStart: 8,
-    fontWeight: '600',
-  },
   bannerScrollContent: { paddingHorizontal: 16 },
   heroBanner: { marginRight: 16, position: 'relative' },
   bannerTouchable: { borderRadius: 12, overflow: 'hidden' },
@@ -199,23 +205,17 @@ const styles = StyleSheet.create({
     bottom: 0,
     justifyContent: 'flex-end',
     borderRadius: 12,
+    zIndex: 1,
   },
   heroContent: { padding: 16 },
-  heroDiscount: {
-    fontSize: 12,
-    fontWeight: '600',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 8,
-    alignSelf: 'flex-start',
-    marginBottom: 8,
-  },
-  heroTitle: { fontSize: 18, fontWeight: '700' },
-  heroSubtitle: { fontSize: 14, marginTop: 4 },
+  heroDiscount: {},
+  heroTitle: {},
+  heroSubtitle: {},
   bannerIndicators: {
     flexDirection: 'row',
     justifyContent: 'center',
     marginTop: 8,
+    zIndex: 1,
   },
   indicator: {
     width: 8,

--- a/src/features/home/components/CTABecomeSeller.tsx
+++ b/src/features/home/components/CTABecomeSeller.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { router } from 'expo-router';
+import Text from '@/shared/ui/Text';
 
 export default function CTABecomeSeller() {
   const { colors } = useTheme();
@@ -12,7 +13,9 @@ export default function CTABecomeSeller() {
       onPress={() => router.push('/stores/create')}
       accessibilityRole="link"
     >
-      <Text style={[styles.text, { color: colors.text.inverse }]}>Become a Seller</Text>
+      <Text variant="md" weight="600" style={{ color: colors.text.inverse }}>
+        Become a Seller
+      </Text>
     </TouchableOpacity>
   );
 }
@@ -24,10 +27,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     alignItems: 'center',
     marginBottom: 16,
-  },
-  text: {
-    fontSize: 16,
-    fontWeight: '600',
   },
 });
 

--- a/src/features/home/components/CategoryChips.tsx
+++ b/src/features/home/components/CategoryChips.tsx
@@ -3,17 +3,17 @@ import { View, ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-nati
 import { Category } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 
-interface CategoryTabsProps {
+interface CategoryChipsProps {
   categories: Category[];
   selectedCategory: string | null;
   setSelectedCategory: (id: string | null) => void;
 }
 
-export default function CategoryTabs({
+export default function CategoryChips({
   categories,
   selectedCategory,
   setSelectedCategory,
-}: CategoryTabsProps) {
+}: CategoryChipsProps) {
   const { colors } = useTheme();
 
   return (

--- a/src/shared/ui/Heading.tsx
+++ b/src/shared/ui/Heading.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { TextProps, TextStyle } from 'react-native';
+import Text from './Text';
+import { typography } from './tokens';
+
+type Size = keyof typeof typography;
+
+interface HeadingProps extends TextProps {
+  size?: Size;
+  weight?: TextStyle['fontWeight'];
+}
+
+export default function Heading({
+  size = 'lg',
+  weight = '700',
+  ...rest
+}: HeadingProps) {
+  return <Text variant={size} weight={weight} {...rest} />;
+}
+

--- a/src/shared/ui/Text.tsx
+++ b/src/shared/ui/Text.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Text as RNText, TextProps, TextStyle } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { typography } from './tokens';
+
+type Variant = keyof typeof typography;
+
+interface Props extends TextProps {
+  variant?: Variant;
+  weight?: TextStyle['fontWeight'];
+}
+
+export default function Text({
+  variant = 'md',
+  weight = '400',
+  style,
+  ...rest
+}: Props) {
+  const { getColor } = useTheme();
+  const { fontSize, lineHeight, letterSpacing } = typography[variant];
+
+  return (
+    <RNText
+      style={[
+        {
+          fontSize,
+          lineHeight,
+          letterSpacing,
+          fontWeight: weight,
+          color: getColor('text.primary'),
+        },
+        style,
+      ]}
+      {...rest}
+    />
+  );
+}
+

--- a/src/shared/ui/tokens.ts
+++ b/src/shared/ui/tokens.ts
@@ -1,2 +1,26 @@
-export { spacing, radius, zIndex, shadows, colors, tokens, lightTokens } from '@/constants/tokens';
-export type { Tokens } from '@/constants/tokens';
+import {
+  spacing,
+  radius,
+  zIndex,
+  shadows,
+  colors,
+  tokens as baseTokens,
+  lightTokens as baseLightTokens,
+} from '@/constants/tokens';
+
+export const typography = {
+  xs: { fontSize: 12, lineHeight: 16, letterSpacing: 0.01 },
+  sm: { fontSize: 14, lineHeight: 20, letterSpacing: 0.01 },
+  md: { fontSize: 16, lineHeight: 24, letterSpacing: 0.01 },
+  lg: { fontSize: 20, lineHeight: 28, letterSpacing: 0 },
+  xl: { fontSize: 24, lineHeight: 32, letterSpacing: 0 },
+  '2xl': { fontSize: 32, lineHeight: 40, letterSpacing: 0 },
+};
+
+export const tokens = { ...baseTokens, typography };
+export const lightTokens = { ...baseLightTokens, typography };
+
+export { spacing, radius, zIndex, shadows, colors };
+
+export type Tokens = typeof tokens;
+

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../features/home/components/HomeHeader', () => {
     throw new Error('boom');
   };
 });
-jest.mock('../features/home/components/CategoryTabs', () => () => null);
+jest.mock('../features/home/components/CategoryChips', () => () => null);
 jest.mock('../features/home/components/ProductGrid', () => () => null);
 jest.mock('../shared/ui/Spinner', () => () => null);
 jest.mock('../shared/ui/EmptyState', () => () => null);

--- a/translations/en.json
+++ b/translations/en.json
@@ -27,6 +27,9 @@
   },
   "navigation": {
     "home": "Home",
+    "stores": "Stores",
+    "cart": "Cart",
+    "orders": "Orders",
     "categories": "Categories",
     "notifications": "Notifications",
     "reviews": "Reviews",

--- a/translations/he.json
+++ b/translations/he.json
@@ -27,6 +27,9 @@
   },
   "navigation": {
     "home": "בית",
+    "stores": "חנויות",
+    "cart": "עגלה",
+    "orders": "הזמנות",
     "categories": "קטגוריות",
     "notifications": "התראות",
     "reviews": "ביקורות",


### PR DESCRIPTION
## Summary
- consolidate palette into theme tokens and expose shared radius and shadows
- add typography scale and Text/Heading primitives
- refactor Button and home banner/CTA to use design tokens
- add i18n fallback to English and localize tab titles
- redirect root index to "/" with dev-time guard for group paths and rename home category chips

## Testing
- `yarn test` *(fails: Test Suites: 6 failed, 6 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b776c2df08832683961187d3ea760e