### PR TITLE
feat: allow start and end text alignment

### DIFF
--- a/types/react-native-text-align.d.ts
+++ b/types/react-native-text-align.d.ts
@@ -1,0 +1,13 @@
+import 'react-native';
+
+declare module 'react-native' {
+  interface TextStyle {
+    textAlign?: 'auto' | 'left' | 'right' | 'center' | 'justify' | 'start' | 'end';
+  }
+
+  interface TextInputProps {
+    textAlign?: 'left' | 'right' | 'center' | 'start' | 'end';
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- widen React Native text alignment types to include `start` and `end`

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b80f602d1c8326a4c6ab441ce4a230