### PR TITLE
chore: improve waku error logging

### DIFF
--- a/services/waku.ts
+++ b/services/waku.ts
@@ -80,7 +80,10 @@ export async function ensureNode(): Promise<LightNode | null> {
     await waitForRemotePeer(cachedNode, [Protocols.Relay]);
     return cachedNode;
   } catch (err) {
-    errorLog('Failed to start Waku node', err);
+    errorLog(
+      'Failed to start Waku node',
+      err instanceof Error ? err.stack : String(err),
+    );
     cachedNode = null;
     return null;
   }


### PR DESCRIPTION
## Summary
- log complete error stack when Waku node startup fails for easier debugging

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b83febf778832690cc5d0f7d3717d3