### PR TITLE
refactor: use Redirect on admin index

### DIFF
--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,20 +1,7 @@
-import { useEffect } from 'react';
-import { useRouter } from 'expo-router';
+import { Redirect } from 'expo-router';
 import useRequirePlatformAdmin from '../../hooks/useRequirePlatformAdmin';
-import ErrorBoundary from '@/components/ui/ErrorBoundary';
-import RequireWallet from '../../components/RequireWallet';
 
 export default function AdminIndex() {
   useRequirePlatformAdmin();
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace('/admin/overview'); // eslint-disable-line no-restricted-syntax
-  }, [router]);
-
-  return (
-    <RequireWallet>
-      <ErrorBoundary>{null}</ErrorBoundary>
-    </RequireWallet>
-  );
+  return <Redirect href="/admin/overview" />;
 }


### PR DESCRIPTION
## Summary
- redirect admin index directly to overview via Expo Router Redirect

## Testing
- ⚠️ `yarn test` (fails: SyntaxError unexpected token in tests)
- ⚠️ `yarn web:router` (Metro bundler started but redirect behavior not observable in headless env)


------
https://chatgpt.com/codex/tasks/task_e_68b84af543a483268a98e42583007fce