### PR TITLE
refactor: handle not-found in dev with Redirect

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,16 +1,9 @@
-import { Stack, router } from 'expo-router';
+import { Redirect, Stack, router } from 'expo-router';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useEffect } from 'react';
 
 export default function NotFoundScreen() {
-  useEffect(() => {
-    if (__DEV__) {
-      router.replace('/');
-    }
-  }, []);
-
   if (__DEV__) {
-    return null;
+    return <Redirect href="/" />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- redirect to home in development instead of useEffect logic

## Testing
- `yarn lint app/+not-found.tsx`
- `yarn test app/+not-found.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b84cff0710832695a619bfcab3a212