### PR TITLE
Improve Waku node error logging

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
     '<rootDir>/tests/admin-impersonate.test.tsx',
     '<rootDir>/tests/admin-store-detail.test.tsx',
     '<rootDir>/tests/not-found.test.tsx',
+    '<rootDir>/tests/wakuErrorLogging.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -80,10 +80,10 @@ export async function ensureNode(): Promise<LightNode | null> {
     await waitForRemotePeer(cachedNode, [Protocols.Relay]);
     return cachedNode;
   } catch (err) {
-    errorLog(
-      'Failed to start Waku node',
-      err instanceof Error ? err.stack : String(err),
-    );
+    errorLog('Failed to start Waku node', err instanceof Error ? err.message : err);
+    if (err instanceof Error && err.stack) {
+      errorLog(err.stack);
+    }
     cachedNode = null;
     return null;
   }

--- a/tests/wakuErrorLogging.test.ts
+++ b/tests/wakuErrorLogging.test.ts
@@ -1,0 +1,24 @@
+jest.mock(
+  '@waku/sdk',
+  () => ({
+    createLightNode: jest.fn(async () => {
+      throw new Error('boom');
+    }),
+    waitForRemotePeer: jest.fn(),
+    Protocols: { Relay: 'relay' },
+  }),
+  { virtual: true },
+);
+
+jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
+
+import { ensureNode } from '../services/waku';
+import { errorLog } from '@/utils/logger';
+
+describe('ensureNode error logging', () => {
+  it('logs a descriptive error when startup fails', async () => {
+    await expect(ensureNode()).resolves.toBeNull();
+    expect(errorLog).toHaveBeenNthCalledWith(1, 'Failed to start Waku node', 'boom');
+    expect(errorLog).toHaveBeenNthCalledWith(2, expect.stringContaining('Error: boom'));
+  });
+});


### PR DESCRIPTION
## Summary
- log Waku node startup failures with the error message and optional stack trace
- cover Waku node startup failures with a new Jest test

## Testing
- `npx eslint services/waku.ts tests/wakuErrorLogging.test.ts jest.config.js`
- `npx jest tests/wakuErrorLogging.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b84d1f6bf8832686870ea75eb352ec