### PR TITLE
Simplify home route to render tabs at root

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,5 +3,5 @@ import { Redirect } from 'expo-router';
 export default function Index() {
   // Use a dedicated Redirect component to avoid navigating before the
   // root layout has mounted, which previously triggered errors.
-  return <Redirect href="/(tabs)" />; // eslint-disable-line no-restricted-syntax
+  return <Redirect href="/" />; // eslint-disable-line no-restricted-syntax
 }


### PR DESCRIPTION
## Summary
- redirect root index to `/`

## Testing
- `yarn test` *(fails: Jest encountered unexpected token in several test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ab819bc832687d8552428c6cdca