### PR TITLE
fix: prevent self-redirect loop

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,5 +3,5 @@ import { Redirect } from 'expo-router';
 export default function Index() {
   // Use a dedicated Redirect component to avoid navigating before the
   // root layout has mounted, which previously triggered errors.
-  return <Redirect href="/" />; // eslint-disable-line no-restricted-syntax
+  return <Redirect href="/landing" />; // eslint-disable-line no-restricted-syntax
 }


### PR DESCRIPTION
## Summary
- avoid redirecting the root route to itself to stop navigation loops

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Type '"end"' is not assignable to type '"center" | "left" | "right" | undefined')*
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b86d4c950883269ca06d7158e188a4