### PR TITLE
fix: expose tabbed home at root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ EXPO_PUBLIC_WAKU_BOOTSTRAP=enr:...,enr:...   # comma-separated
 EXPO_PUBLIC_FEATURE_WALLET=1
 EXPO_PUBLIC_DEFAULT_STORE=alpha
 EXPO_PUBLIC_DEBUG_LOGS=1
+EXPO_PUBLIC_USE_ROUTER=1
 
 # Relayer
 NEAR_RPC_URL=https://rpc.testnet.near.org

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,0 @@
-import { Redirect } from 'expo-router';
-
-export default function Index() {
-  // Use a dedicated Redirect component to avoid navigating before the
-  // root layout has mounted, which previously triggered errors.
-  return <Redirect href="/(tabs)" />; // eslint-disable-line no-restricted-syntax
-}


### PR DESCRIPTION
## Summary
- remove root redirect so tab layout handles `/`
- document EXPO_PUBLIC_USE_ROUTER in env example

## Testing
- `CI=1 yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ab819bc832687d8552428c6cdca