### PR TITLE
feat: add portal overlay primitives

### DIFF
--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -3,14 +3,13 @@ import {
   View,
   Text,
   StyleSheet,
-  Modal,
   TouchableOpacity,
-  TouchableWithoutFeedback,
   Platform,
 } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { X } from 'lucide-react-native';
 import Button from './ui/Button';
+import { Portal, Overlay } from '@/ui/primitives';
 
 interface ConfirmationModalProps {
   visible: boolean;
@@ -38,66 +37,63 @@ export default function ConfirmationModal({
   if (!visible) return null;
 
   return (
-    <Modal
-      visible={visible}
-      transparent={true}
-      animationType="fade"
-      onRequestClose={onCancel}
-    >
-      <TouchableWithoutFeedback onPress={onCancel}>
-        <View style={styles.overlay}>
-          <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-            <View style={[styles.modalContainer, { backgroundColor: colors.surface.elevated }]}>
-              <View style={styles.header}>
-                <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
-                <TouchableOpacity
-                  onPress={onCancel}
-                  style={styles.closeButton}
-                  accessibilityRole="button"
-                >
-                  <X size={20} color={colors.text.secondary} />
-                </TouchableOpacity>
-              </View>
-              
-              <View style={styles.content}>
-                <Text style={[styles.message, { color: colors.text.secondary }]}>
-                  {message}
-                </Text>
-              </View>
-              
-              <View style={styles.actions}>
-                <Button
-                  title={cancelText}
-                  variant="secondary"
-                  onPress={onCancel}
-                  style={{ flex: 1 }}
-                  accessibilityRole="button"
-                />
+    <Portal>
+      <Overlay style={styles.overlay} />
+      <View style={styles.center} pointerEvents="box-none">
+        <View
+          style={[styles.modalContainer, { backgroundColor: colors.surface.elevated }]}
+        >
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
+            <TouchableOpacity
+              onPress={onCancel}
+              style={styles.closeButton}
+              accessibilityRole="button"
+            >
+              <X size={20} color={colors.text.secondary} />
+            </TouchableOpacity>
+          </View>
 
-                <Button
-                  title={confirmText}
-                  onPress={onConfirm}
-                  style={{
-                    flex: 1,
-                    backgroundColor: destructive
-                      ? colors.status.error
-                      : colors.interactive.primary,
-                  }}
-                  accessibilityRole="button"
-                />
-              </View>
-            </View>
-          </TouchableWithoutFeedback>
+          <View style={styles.content}>
+            <Text style={[styles.message, { color: colors.text.secondary }]}>
+              {message}
+            </Text>
+          </View>
+
+          <View style={styles.actions}>
+            <Button
+              title={cancelText}
+              variant="secondary"
+              onPress={onCancel}
+              style={{ flex: 1 }}
+              accessibilityRole="button"
+            />
+
+            <Button
+              title={confirmText}
+              onPress={onConfirm}
+              style={{
+                flex: 1,
+                backgroundColor: destructive
+                  ? colors.status.error
+                  : colors.interactive.primary,
+              }}
+              accessibilityRole="button"
+            />
+          </View>
         </View>
-      </TouchableWithoutFeedback>
-    </Modal>
+      </View>
+    </Portal>
   );
 }
 
 const styles = StyleSheet.create({
   overlay: {
-    flex: 1,
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  center: {
+    ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -3,9 +3,7 @@ import {
   View,
   Text,
   StyleSheet,
-  Modal,
   TouchableOpacity,
-  TouchableWithoutFeedback,
   Animated,
   Platform,
 } from 'react-native';
@@ -14,6 +12,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { spacing, radius, zIndex, shadows } from '@/shared/ui/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 import Button from '@/components/ui/Button';
+import { Portal, Overlay } from '@/ui/primitives';
 
 type InfoType = 'success' | 'error' | 'info' | 'warning';
 
@@ -100,64 +99,59 @@ export default function InfoModal({
 
   const { icon, color } = getIconAndColor();
 
+  if (!visible) return null;
+
   return (
-    <Modal
-      visible={visible}
-      transparent={true}
-      animationType="none"
-      onRequestClose={onClose}
-    >
-      <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.overlay}>
-          <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-            <Animated.View
-              style={[
-                styles.modalContainer,
-                {
-                  backgroundColor: colors.surface.elevated,
-                  transform: [{ scale: scaleAnim }],
-                  opacity: opacityAnim,
-                }
-              ]}
-            >
-              <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-                <X size={20} color={colors.text.secondary} />
-              </TouchableOpacity>
+    <Portal>
+      <Overlay style={styles.overlay} />
+      <View style={styles.center} pointerEvents="box-none">
+        <Animated.View
+          style={[
+            styles.modalContainer,
+            {
+              backgroundColor: colors.surface.elevated,
+              transform: [{ scale: scaleAnim }],
+              opacity: opacityAnim,
+            }
+          ]}
+        >
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <X size={20} color={colors.text.secondary} />
+          </TouchableOpacity>
 
-              <View style={styles.iconContainer}>
-                {icon}
-              </View>
+          <View style={styles.iconContainer}>{icon}</View>
 
-              <Text style={[styles.title, { color: colors.text.primary }]}>
-                {title}
-              </Text>
+          <Text style={[styles.title, { color: colors.text.primary }]}>
+            {title}
+          </Text>
 
-              <Text style={[styles.message, { color: colors.text.secondary }]}> 
-                {message}
-              </Text>
+          <Text style={[styles.message, { color: colors.text.secondary }]}>
+            {message}
+          </Text>
 
-              <Button
-                title={buttonLabel}
-                onPress={onClose}
-                style={{
-                  minWidth: 120,
-                  paddingHorizontal: spacing.spacer24,
-                  borderRadius: radius.lg,
-                  backgroundColor: color,
-                }}
-              />
-            </Animated.View>
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
-    </Modal>
+          <Button
+            title={buttonLabel}
+            onPress={onClose}
+            style={{
+              minWidth: 120,
+              paddingHorizontal: spacing.spacer24,
+              borderRadius: radius.lg,
+              backgroundColor: color,
+            }}
+          />
+        </Animated.View>
+      </View>
+    </Portal>
   );
 }
 
 const styles = StyleSheet.create({
   overlay: {
-    flex: 1,
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  center: {
+    ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
     alignItems: 'center',
     padding: spacing.spacer20,

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -11,6 +11,7 @@ import {
 import { X } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { spacing, zIndex } from '@/shared/ui/tokens';
+import { Portal, Overlay } from '@/ui/primitives';
 
 interface NotificationPopupProps {
   title: string;
@@ -88,26 +89,29 @@ export default function NotificationPopup({
   };
 
   return (
-    <Animated.View 
-      style={[
-        styles.container, 
-        { 
-          transform: [{ translateY }],
-          opacity,
-          backgroundColor: getBackgroundColor()
-        }
-      ]}
-    >
-      <View style={styles.content}>
-        <View style={styles.textContainer}>
-          <Text style={[styles.title, { color: colors.text.inverse }]}>{title}</Text>
-          <Text style={[styles.message, { color: colors.text.inverse }]} numberOfLines={2}>{message}</Text>
+    <Portal>
+      <Overlay />
+      <Animated.View
+        style={[
+          styles.container,
+          {
+            transform: [{ translateY }],
+            opacity,
+            backgroundColor: getBackgroundColor()
+          }
+        ]}
+      >
+        <View style={styles.content}>
+          <View style={styles.textContainer}>
+            <Text style={[styles.title, { color: colors.text.inverse }]}>{title}</Text>
+            <Text style={[styles.message, { color: colors.text.inverse }]} numberOfLines={2}>{message}</Text>
+          </View>
+          <TouchableOpacity style={styles.closeButton} onPress={dismiss}>
+            <X size={20} color={colors.text.inverse} />
+          </TouchableOpacity>
         </View>
-        <TouchableOpacity style={styles.closeButton} onPress={dismiss}>
-          <X size={20} color={colors.text.inverse} />
-        </TouchableOpacity>
-      </View>
-    </Animated.View>
+      </Animated.View>
+    </Portal>
   );
 }
 

--- a/components/ui/Menu.tsx
+++ b/components/ui/Menu.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Modal, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import Text from '@/shared/ui/Text';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { useTheme } from '../../contexts/ThemeContext';
+import { Portal, Overlay } from '@/ui/primitives';
 
 export interface MenuItem {
   label: string;
@@ -24,49 +25,47 @@ export default function Menu({ trigger, open, onOpenChange, items }: MenuProps) 
   return (
     <>
       {trigger}
-      <Modal
-        visible={open}
-        transparent
-        animationType="fade"
-        onRequestClose={() => onOpenChange(false)}
-      >
-        <TouchableOpacity style={styles.overlay} onPress={() => onOpenChange(false)}>
-          <View
-            style={[
-              styles.menu,
-              {
-                backgroundColor: getColor('background.secondary'),
-                borderColor: getColor('border.primary'),
-              },
-            ]}
-          >
-            {items.map((item) => (
-              <TouchableOpacity
-                key={item.label}
-                style={styles.item}
-                onPress={() => {
-                  onOpenChange(false);
-                  item.onPress();
-                }}
-              >
-                {item.icon}
-                <Text
-                  style={[
-                    styles.label,
-                    {
-                      color: item.destructive
-                        ? getColor('status.error')
-                        : getColor('text.primary'),
-                    },
-                  ]}
+      {open && (
+        <Portal>
+          <Overlay />
+          <View style={styles.overlay} pointerEvents="box-none">
+            <View
+              style={[
+                styles.menu,
+                {
+                  backgroundColor: getColor('background.secondary'),
+                  borderColor: getColor('border.primary'),
+                },
+              ]}
+            >
+              {items.map((item) => (
+                <TouchableOpacity
+                  key={item.label}
+                  style={styles.item}
+                  onPress={() => {
+                    onOpenChange(false);
+                    item.onPress();
+                  }}
                 >
-                  {item.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
+                  {item.icon}
+                  <Text
+                    style={[
+                      styles.label,
+                      {
+                        color: item.destructive
+                          ? getColor('status.error')
+                          : getColor('text.primary'),
+                      },
+                    ]}
+                  >
+                    {item.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
           </View>
-        </TouchableOpacity>
-      </Modal>
+        </Portal>
+      )}
     </>
   );
 }

--- a/src/ui/primitives/Overlay.tsx
+++ b/src/ui/primitives/Overlay.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
+
+interface OverlayProps {
+  style?: StyleProp<ViewStyle>;
+}
+
+export default function Overlay({ style }: OverlayProps) {
+  return <View pointerEvents="none" style={[StyleSheet.absoluteFill, style]} />;
+}

--- a/src/ui/primitives/Portal.tsx
+++ b/src/ui/primitives/Portal.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react';
+import { Modal, Platform, StyleSheet, View } from 'react-native';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+export default function Portal({ children }: PortalProps) {
+  if (Platform.OS === 'web') {
+    return createPortal(
+      <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+        {children}
+      </View>,
+      document.body
+    );
+  }
+
+  return (
+    <Modal transparent>
+      <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+        {children}
+      </View>
+    </Modal>
+  );
+}

--- a/src/ui/primitives/index.ts
+++ b/src/ui/primitives/index.ts
@@ -7,3 +7,5 @@ export { default as Avatar } from './Avatar';
 export { default as Badge } from './Badge';
 export { default as Chip } from './Chip';
 export { default as Divider } from './Divider';
+export { default as Portal } from './Portal';
+export { default as Overlay } from './Overlay';


### PR DESCRIPTION
## Summary
- add Portal and Overlay primitives with non-intercepting overlay layer
- render menu, notification popup, and info/confirmation modals through Portal/Overlay
- remove touch blockers from overlay implementations

## Testing
- `yarn lint`
- `yarn test` *(fails: pretest lint runs but no tests execute)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c840c5c832699f18ff5ed2b8adb