### PR TITLE
feat: centralize env config access

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,10 @@
+# Configuration
+
+Use `requireEnv(key, fallback?)` from `src/services/config.ts` to read environment variables. Missing keys will throw unless a fallback is provided.
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `EXPO_PUBLIC_DEFAULT_STORE` | Default store identifier | `default` |
+| `EXPO_PUBLIC_NETWORK` | NEAR network override (`mainnet` or `testnet`) | inferred from contract ID |
+| `EXPO_PUBLIC_CONTRACT_ID` | NEAR contract account | none |
+| `EXPO_PUBLIC_WALLET_URL` | Optional wallet URL | based on network |

--- a/src/features/auth/services/nearAuth.ts
+++ b/src/features/auth/services/nearAuth.ts
@@ -5,6 +5,7 @@ import { setupWalletSelector } from '@near-wallet-selector/core';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
 import { Buffer } from 'buffer';
+import { requireEnv } from '../../services/config';
 
 // Expose for test injection where needed
 export let selector: WalletSelector | null = null;
@@ -15,14 +16,14 @@ async function init() {
   if (!selector) {
     // Resolve wallet URL: prefer env override, then infer from contract/network
     const resolveNetwork = () => {
-      const explicit = process.env.EXPO_PUBLIC_NETWORK;
+      const explicit = requireEnv('EXPO_PUBLIC_NETWORK', '');
       if (explicit === 'mainnet' || explicit === 'testnet') return explicit;
-      const cid = process.env.EXPO_PUBLIC_CONTRACT_ID || '';
+      const cid = requireEnv('EXPO_PUBLIC_CONTRACT_ID', '');
       return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
     };
 
     const getWalletUrl = () => {
-      const override = process.env.EXPO_PUBLIC_WALLET_URL;
+      const override = requireEnv('EXPO_PUBLIC_WALLET_URL', '');
       if (override) return override;
       const net = resolveNetwork();
       return net === 'mainnet'
@@ -41,7 +42,7 @@ async function init() {
 export async function signIn(): Promise<void> {
   const sel = await init();
   const wallet = await sel.wallet('near-wallet');
-  const contractId = process.env.EXPO_PUBLIC_CONTRACT_ID || 'example.testnet';
+  const contractId = requireEnv('EXPO_PUBLIC_CONTRACT_ID', 'example.testnet');
   const baseUrl = typeof window !== 'undefined'
     ? window.location.origin + (window.location.pathname || '/')
     : undefined;

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -2,9 +2,10 @@ import { useState, useCallback, useEffect } from 'react';
 import { Product, Category } from '@/types';
 import { useProducts } from '@/services/useProducts';
 import { useCategories } from '@/services/useCategories';
+import { requireEnv } from '../../services/config';
 
 export function useHome() {
-  const defaultStore = process.env.EXPO_PUBLIC_DEFAULT_STORE || 'default';
+  const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');
   const productsQuery = useProducts(defaultStore);
   const categoriesQuery = useCategories();
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,0 +1,12 @@
+export function requireEnv(key: string, fallback?: string): string {
+  const value = process.env[key];
+  if (value === undefined || value === '') {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+export default requireEnv;


### PR DESCRIPTION
## Summary
- add `requireEnv` helper to validate environment variables
- use `requireEnv` in home and NEAR auth services
- document runtime configuration keys

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c431e1c8326a2ac93ddbec83e78