### PR TITLE
feat: add form components and signup validation

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { spacing } from '@/ui/tokens';
+import { Form, Field, Label, HelperText } from '@/ui/form';
+import TextField from '@/ui/primitives/TextField';
+import Button from '@/ui/primitives/Button';
+import { validateAll } from '@/utils/validation';
+
+export default function SignupScreen() {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const [values, setValues] = useState({ username: '', email: '', password: '' });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleChange = (field: string, value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = () => {
+    const newErrors = validateAll({
+      username: { value: values.username, rules: { required: t('auth.username') + ' required' } },
+      email: {
+        value: values.email,
+        rules: {
+          required: t('auth.email') + ' required',
+          pattern: { value: /\S+@\S+\.\S+/, message: t('auth.email') + ' invalid' },
+        },
+      },
+      password: { value: values.password, rules: { required: t('auth.password') + ' required' } },
+    });
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // TODO: integrate signup logic
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: spacing.spacer16, backgroundColor: colors.canvas }}>
+      <Form>
+        <Field>
+          <Label>{t('auth.username')}</Label>
+          <TextField
+            value={values.username}
+            onChangeText={(text) => handleChange('username', text)}
+            placeholder={t('auth.usernamePlaceholder')}
+          />
+          {errors.username && <HelperText error>{errors.username}</HelperText>}
+        </Field>
+        <Field>
+          <Label>{t('auth.email')}</Label>
+          <TextField
+            value={values.email}
+            onChangeText={(text) => handleChange('email', text)}
+            placeholder={t('auth.email')}
+          />
+          {errors.email && <HelperText error>{errors.email}</HelperText>}
+        </Field>
+        <Field>
+          <Label>{t('auth.password')}</Label>
+          <TextField
+            value={values.password}
+            onChangeText={(text) => handleChange('password', text)}
+            placeholder={t('auth.createPasswordPlaceholder')}
+            secureTextEntry
+          />
+          {errors.password && <HelperText error>{errors.password}</HelperText>}
+        </Field>
+        <Button title={t('auth.signup')} onPress={handleSubmit} />
+      </Form>
+    </View>
+  );
+}

--- a/src/ui/form/Field.tsx
+++ b/src/ui/form/Field.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View, StyleProp, ViewStyle } from 'react-native';
+import { spacing } from '../tokens';
+
+interface FieldProps {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export default function Field({ children, style }: FieldProps) {
+  return <View style={[{ marginBottom: spacing.spacer16 }, style]}>{children}</View>;
+}

--- a/src/ui/form/Form.tsx
+++ b/src/ui/form/Form.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, StyleProp, ViewStyle } from 'react-native';
+
+interface FormProps {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export default function Form({ children, style }: FormProps) {
+  return <View style={style}>{children}</View>;
+}

--- a/src/ui/form/HelperText.tsx
+++ b/src/ui/form/HelperText.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Text, StyleProp, TextStyle } from 'react-native';
+import { useTheme } from '../ThemeProvider';
+import { spacing, typography } from '../tokens';
+
+interface HelperTextProps {
+  children: React.ReactNode;
+  error?: boolean;
+  style?: StyleProp<TextStyle>;
+}
+
+export default function HelperText({ children, error, style }: HelperTextProps) {
+  const { colors } = useTheme();
+  return (
+    <Text
+      style={[
+        { marginTop: spacing.spacer4, ...typography.xs, color: error ? colors.status.error : colors.text.secondary },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/src/ui/form/Label.tsx
+++ b/src/ui/form/Label.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, StyleProp, TextStyle } from 'react-native';
+import { useTheme } from '../ThemeProvider';
+import { spacing, typography } from '../tokens';
+
+interface LabelProps {
+  children: React.ReactNode;
+  style?: StyleProp<TextStyle>;
+}
+
+export default function Label({ children, style }: LabelProps) {
+  const { colors } = useTheme();
+  return (
+    <Text style={[{ color: colors.text.secondary, marginBottom: spacing.spacer4, ...typography.sm }, style]}>
+      {children}
+    </Text>
+  );
+}

--- a/src/ui/form/index.ts
+++ b/src/ui/form/index.ts
@@ -1,0 +1,4 @@
+export { default as Form } from './Form';
+export { default as Field } from './Field';
+export { default as Label } from './Label';
+export { default as HelperText } from './HelperText';

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,0 +1,30 @@
+export interface ValidationRule {
+  required?: string | boolean;
+  pattern?: {
+    value: RegExp;
+    message?: string;
+  };
+}
+
+export function validate(value: string, rules: ValidationRule): string | null {
+  if (rules.required && !value.trim()) {
+    return typeof rules.required === 'string' ? rules.required : 'Required';
+  }
+  if (rules.pattern && !rules.pattern.value.test(value)) {
+    return rules.pattern.message || 'Invalid format';
+  }
+  return null;
+}
+
+export function validateAll(
+  fields: Record<string, { value: string; rules: ValidationRule }>
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const key of Object.keys(fields)) {
+    const error = validate(fields[key].value, fields[key].rules);
+    if (error) {
+      errors[key] = error;
+    }
+  }
+  return errors;
+}


### PR DESCRIPTION
## Summary
- add Form, Field, Label, and HelperText UI components
- add simple validation helper for required and pattern rules
- implement signup screen using new form primitives

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8942d8374832688bd3eb9e1fbc4d2