### PR TITLE
fix: correct config import paths

### DIFF
--- a/src/features/auth/services/nearAuth.ts
+++ b/src/features/auth/services/nearAuth.ts
@@ -5,7 +5,7 @@ import { setupWalletSelector } from '@near-wallet-selector/core';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
 import { Buffer } from 'buffer';
-import { requireEnv } from '../../services/config';
+import { requireEnv } from '@/services/config';
 
 // Expose for test injection where needed
 export let selector: WalletSelector | null = null;

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { Product, Category } from '@/types';
 import { useProducts } from '@/services/useProducts';
 import { useCategories } from '@/services/useCategories';
-import { requireEnv } from '../../services/config';
+import { requireEnv } from '@/services/config';
 
 export function useHome() {
   const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');


### PR DESCRIPTION
## Summary
- fix auth service to import config via alias
- fix home hook to import config via alias

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected token; moduleNameMapper issues; missing @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68b898dc62548326b6354d050c11ca45