### PR TITLE
fix: correct ErrorBoundary import

### DIFF
--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -7,7 +7,7 @@ import { usePathname } from 'expo-router';
 import FloatingCartWidget from '@/features/cart/components/FloatingCartWidget';
 import { getTabsForAuth } from '@/config/navigation/tabs';
 import { useAuth } from '@/features/auth/AuthContext';
-import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function TabsLayout() {
   const { t } = useLanguage();


### PR DESCRIPTION
## Summary
- fix incorrect ErrorBoundary import in TabsLayout to use shared component

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b89ab8ad008326b0ce03585bbe1298