### PR TITLE
feat: improve accessibility for touchable components

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -20,6 +20,7 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
       disabled,
       children,
       accessibilityRole = 'button',
+      accessibilityLabel,
       ...rest
     },
     ref,
@@ -60,13 +61,26 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
     borderRadius: radius.md,
     alignItems: 'center',
     justifyContent: 'center',
+    minHeight: 44,
+    minWidth: 44,
   } as const;
+
+  const focusStyle = {
+    borderColor: getColor('border.focus'),
+    borderWidth: 2,
+  } as const;
+
+  const [isFocused, setIsFocused] = React.useState(false);
 
   return (
     <Pressable
       ref={ref}
       accessibilityRole={accessibilityRole}
-      style={[buttonStyle, { backgroundColor }, borderStyle, style]}
+      accessibilityLabel={accessibilityLabel ?? title}
+      hitSlop={8}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+      style={[buttonStyle, { backgroundColor }, borderStyle, style, isFocused && focusStyle]}
       disabled={isDisabled}
       {...rest}
     >

--- a/src/ui/primitives/Chip.tsx
+++ b/src/ui/primitives/Chip.tsx
@@ -12,17 +12,32 @@ interface ChipProps {
 
 export default function Chip({ label, onPress, style, textStyle }: ChipProps) {
   const { colors } = useTheme();
+  const [isFocused, setIsFocused] = React.useState(false);
   return (
     <Pressable
       onPress={onPress}
-      style={[{
-        borderRadius: radius.full,
-        paddingHorizontal: spacing.spacer12,
-        paddingVertical: spacing.spacer4,
-        backgroundColor: colors.surface.primary,
-        borderWidth: 1,
-        borderColor: colors.border.primary,
-      }, style]}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={8}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+      style={[
+        {
+          borderRadius: radius.full,
+          paddingHorizontal: spacing.spacer12,
+          paddingVertical: spacing.spacer4,
+          backgroundColor: colors.surface.primary,
+          borderWidth: 1,
+          borderColor: colors.border.primary,
+          minHeight: 44,
+          minWidth: 44,
+        },
+        style,
+        isFocused && {
+          borderColor: colors.border.focus,
+          borderWidth: 2,
+        },
+      ]}
     >
       <Text style={[{ color: colors.text.primary, ...typography.sm }, textStyle]}>{label}</Text>
     </Pressable>

--- a/src/ui/primitives/Menu.tsx
+++ b/src/ui/primitives/Menu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Pressable } from 'react-native';
 import Portal from './Portal';
 import Text from './Text';
 import { useTheme } from '../ThemeProvider';
@@ -21,13 +21,20 @@ interface MenuProps {
 
 export default function Menu({ trigger, open, onOpenChange, items }: MenuProps) {
   const { colors } = useTheme();
+  const [focusedIndex, setFocusedIndex] = React.useState<number | null>(null);
 
   return (
     <>
       {trigger}
       {open && (
         <Portal>
-          <TouchableOpacity style={styles.overlay} onPress={() => onOpenChange(false)}>
+          <Pressable
+            style={styles.overlay}
+            onPress={() => onOpenChange(false)}
+            accessibilityRole="button"
+            accessibilityLabel="Close menu"
+            hitSlop={8}
+          >
             <View
               style={[
                 styles.menu,
@@ -37,10 +44,21 @@ export default function Menu({ trigger, open, onOpenChange, items }: MenuProps) 
                 },
               ]}
             >
-              {items.map((item) => (
-                <TouchableOpacity
+              {items.map((item, index) => (
+                <Pressable
                   key={item.label}
-                  style={styles.item}
+                  accessibilityRole="menuitem"
+                  accessibilityLabel={item.label}
+                  hitSlop={8}
+                  onFocus={() => setFocusedIndex(index)}
+                  onBlur={() => setFocusedIndex(null)}
+                  style={[
+                    styles.item,
+                    focusedIndex === index && {
+                      borderColor: colors.border.focus,
+                      borderWidth: 2,
+                    },
+                  ]}
                   onPress={() => {
                     onOpenChange(false);
                     item.onPress();
@@ -59,10 +77,10 @@ export default function Menu({ trigger, open, onOpenChange, items }: MenuProps) 
                   >
                     {item.label}
                   </Text>
-                </TouchableOpacity>
+                </Pressable>
               ))}
             </View>
-          </TouchableOpacity>
+          </Pressable>
         </Portal>
       )}
     </>
@@ -76,6 +94,8 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     paddingTop: 60,
     paddingRight: 16,
+    minHeight: 44,
+    minWidth: 44,
   },
   menu: {
     borderWidth: 1,
@@ -87,6 +107,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: spacing.spacer12,
     paddingHorizontal: spacing.spacer16,
+    minHeight: 44,
+    minWidth: 44,
   },
   label: {
     marginLeft: spacing.spacer12,


### PR DESCRIPTION
## Summary
- ensure base Button touch target is at least 44x44 with hitSlop and focus styles
- add accessibility roles, labels, and keyboard focus feedback to Chip and Menu primitives
- include minimum touch dimensions for Menu overlay and items

## Testing
- `yarn lint`
- `yarn test` (fails: Jest encountered unexpected token / module resolution issues)
- `yarn typecheck` (fails: various TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68b89c7cd8e88326a17323826cd28518