### PR TITLE
refactor: centralize query client provider

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,11 +12,9 @@ import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
 import { WakuProvider } from '@/contexts/WakuContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Router, usePathname, useRouter, useSegments } from 'expo-router';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
-const queryClient = new QueryClient();
 
 function RouterApp() {
   const router = useRouter();
@@ -57,11 +55,9 @@ export default function App() {
                       <WakuProvider>
                         <NotificationProvider>
                           <ErrorBoundary>
-                            <QueryClientProvider client={queryClient}>
-                              <React.Suspense fallback={null}>
-                                {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-                              </React.Suspense>
-                            </QueryClientProvider>
+                            <React.Suspense fallback={null}>
+                              {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+                            </React.Suspense>
                           </ErrorBoundary>
                         </NotificationProvider>
                       </WakuProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { Slot } from 'expo-router';
-import AppProviders from '../providers/AppProviders';
+import AppProviders from '@/providers/AppProviders';
 
 export default function RootLayout() {
   return (

--- a/providers/AppProviders.tsx
+++ b/providers/AppProviders.tsx
@@ -6,11 +6,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 import GlobalErrorBoundary from '@/components/GlobalErrorBoundary';
 
-interface Props {
-  children: React.ReactNode;
-}
-
-export default function AppProviders({ children }: Props) {
+export default function AppProviders({ children }: React.PropsWithChildren) {
   const [queryClient] = React.useState(() => new QueryClient());
 
   return (


### PR DESCRIPTION
## Summary
- remove duplicate QueryClientProvider from App root
- use CheckedQueryClientProvider in AppProviders and expose children
- wrap router layout with AppProviders

## Testing
- `yarn test` *(fails: SyntaxError: Unexpected token '<', missing modules, Unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3d5a4b0832699a2472a4ad50db6