### PR TITLE
refactor: use primitive Button and Text

### DIFF
--- a/app/(tabs)/stores.tsx
+++ b/app/(tabs)/stores.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Card, Text, Button } from '@/ui/primitives';
+import { Card } from '@/ui/primitives';
+import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 
 import ErrorBoundary from '@/shared/ErrorBoundary';
 

--- a/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
+++ b/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import Button from '@/ui/primitives/Button';
 import { useLocalSearchParams } from 'expo-router';
 import useAppRouter from 'hooks/useAppRouter';

--- a/app/control/LiveFocusView.tsx
+++ b/app/control/LiveFocusView.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, FlatList } from 'react-native';
+import { View, FlatList } from 'react-native';
+import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 import { RoadmapProvider, useRoadmap } from '../../contexts/RoadmapContext';
 import RoadmapService from '../../services/roadmap';
 import type { RoadmapTask } from '../../types';

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import Button from '@/ui/primitives/Button';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import useAppRouter from 'hooks/useAppRouter';

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, ScrollView } from 'react-native';
+import { View, Pressable, ScrollView } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import { Link } from 'expo-router';
 import useAppRouter from 'hooks/useAppRouter';
 import AppShell from '../components/layout/AppShell';

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -1,6 +1,7 @@
 import { debugLog } from '@/utils/logger';
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import Button from '@/ui/primitives/Button';
 import { useLocalSearchParams } from 'expo-router';
 import { z } from 'zod';

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   TouchableOpacity,
   Platform,
 } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import { useTheme } from '../contexts/ThemeContext';
 import { X } from 'lucide-react-native';
 import Button from '@/ui/primitives/Button';

--- a/components/DisputeResolver.tsx
+++ b/components/DisputeResolver.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Button, ActivityIndicator } from 'react-native';
+import { View, ActivityIndicator } from 'react-native';
+import Button from '@/ui/primitives/Button';
 import OrderService from '../services/orders';
 
 interface Props {

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   TouchableOpacity,
   Animated,
   Platform,
 } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import { useTheme } from '../contexts/ThemeContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { spacing, radius, zIndex, shadows } from '@/shared/ui/tokens';

--- a/components/admin/AdminList.tsx
+++ b/components/admin/AdminList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import { useTheme } from '../../contexts/ThemeContext';
 import Button from '@/ui/primitives/Button';
 

--- a/src/features/auth/components/AgeVerificationModal.tsx
+++ b/src/features/auth/components/AgeVerificationModal.tsx
@@ -2,12 +2,12 @@ import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   Modal,
   ScrollView,
   Platform,
 } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import SmartImage from '@/components/SmartImage';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';

--- a/src/features/auth/components/WalletConnectButton.tsx
+++ b/src/features/auth/components/WalletConnectButton.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 import { chainAdapter } from '@/services/chain';
 
 interface WalletConnectButtonProps {

--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -7,10 +7,10 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import useAppRouter from 'hooks/useAppRouter';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Spinner, Skeleton } from '@/ui/primitives';
-import Text from '@/shared/ui/Text';
+import Text from '@/ui/primitives/Text';
 import Heading from '@/shared/ui/Heading';
 import Button from '@/ui/primitives/Button';
-import { spacing, radius } from '@/shared/ui/tokens';
+import { spacing, radius, typography } from '@/ui/tokens';
 
 
 const SmartImage = lazy(() => import('@/components/SmartImage'));
@@ -71,17 +71,19 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
           <View style={styles.heroContent}>
             {item.discount ? (
               <Text
-                variant="xs"
-                weight="600"
-                style={{
-                  paddingHorizontal: 8,
-                  paddingVertical: 4,
-                  borderRadius: 8,
-                  alignSelf: 'flex-start',
-                  marginBottom: 8,
-                  color: colors.text.inverse,
-                  backgroundColor: colors.gold,
-                }}
+                style={[
+                  typography.xs,
+                  {
+                    fontWeight: '600',
+                    paddingHorizontal: 8,
+                    paddingVertical: 4,
+                    borderRadius: 8,
+                    alignSelf: 'flex-start',
+                    marginBottom: 8,
+                    color: colors.text.inverse,
+                    backgroundColor: colors.gold,
+                  },
+                ]}
               >
                 {item.discount} הנחה
               </Text>
@@ -90,7 +92,7 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
               {item.title}
             </Heading>
 
-            <Text variant="sm" style={{ marginTop: 4, color: colors.gold }}>
+            <Text style={[typography.sm, { marginTop: 4, color: colors.gold }]}> 
               {item.subtitle}
             </Text>
           </View>
@@ -138,9 +140,10 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
           >
             <Plus size={20} color={colors.text.primary} />
             <Text
-              variant="sm"
-              weight="600"
-              style={{ marginStart: spacing.spacer8, color: colors.text.primary }}
+              style={[
+                typography.sm,
+                { fontWeight: '600', marginStart: spacing.spacer8, color: colors.text.primary },
+              ]}
             >
               {t('banner.addBanner')}
             </Text>

--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Pressable, Image, View, StyleSheet, ViewStyle } from 'react-native';
 import { Star } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
-import Text from '@/shared/ui/Text';
+import Text from '@/ui/primitives/Text';
 import Button from '@/ui/primitives/Button';
-import { spacing, radius } from '@/shared/ui/tokens';
+import { spacing, radius, typography } from '@/ui/tokens';
 import { Skeleton } from '@/ui/primitives';
 import { Product } from '@/types';
 
@@ -31,26 +31,20 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
       )}
       <View style={styles.content}>
         <Text
-          variant="sm"
-          weight="500"
           numberOfLines={1}
-          style={{ color: colors.text.primary }}
+          style={[typography.sm, { fontWeight: '500', color: colors.text.primary }]}
         >
           {product.name}
         </Text>
         <Text
-          variant="md"
-          weight="600"
-          style={{ marginTop: spacing.spacer4, color: colors.text.primary }}
+          style={[typography.md, { fontWeight: '600', marginTop: spacing.spacer4, color: colors.text.primary }]}
         >
           {product.price}
         </Text>
         <View style={styles.ratingRow}>
           <Star size={12} color={colors.gold} />
           <Text
-            variant="xs"
-            weight="500"
-            style={{ marginStart: spacing.spacer4, color: colors.text.primary }}
+            style={[typography.xs, { fontWeight: '500', marginStart: spacing.spacer4, color: colors.text.primary }]}
           >
             {product.rating ?? 0}
           </Text>

--- a/src/shared/ErrorBoundary.tsx
+++ b/src/shared/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import { useTheme } from '@/contexts/ThemeContext';
 import { spacing } from '@/shared/ui/tokens';
 import Button from '@/ui/primitives/Button';

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import type { LucideProps } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import Button from '@/ui/primitives/Button';

--- a/src/ui/primitives/index.ts
+++ b/src/ui/primitives/index.ts
@@ -1,5 +1,3 @@
-export { default as Button } from './Button';
-export { default as Text } from './Text';
 export { default as Heading } from './Heading';
 export { default as TextField } from './TextField';
 export { default as Card } from './Card';


### PR DESCRIPTION
## Summary
- import Button components from `@/ui/primitives/Button`
- switch text nodes to `@/ui/primitives/Text`
- drop Button and Text exports from primitives index

## Testing
- `npm test` *(fails: Jest configuration errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acf6559c8326b6198286f7eae7dd