### PR TITLE
refactor: use primitives for rpc settings

### DIFF
--- a/components/settings/RpcSettings.tsx
+++ b/components/settings/RpcSettings.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, TextInput, StyleSheet } from 'react-native';
+import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 import { Server } from 'lucide-react-native';
 import Card from '../Card';
 import SettingsAgent from '../../agents/settings-agent';
@@ -89,13 +91,13 @@ const RpcSettings: React.FC<Props> = ({ colors }) => {
             placeholderTextColor={colors.text.tertiary}
           />
         </View>
-        <TouchableOpacity
-          style={[styles.saveButton, { backgroundColor: colors.gold }]}
+        <Button
+          title="Save RPC URLs"
           onPress={save}
           disabled={saving}
-        >
-          <Text style={[styles.saveButtonText, { color: colors.text.inverse }]}>Save RPC URLs</Text>
-        </TouchableOpacity>
+          style={[styles.saveButton, { backgroundColor: colors.gold }]}
+          textStyle={[styles.saveButtonText, { color: colors.text.inverse }]}
+        />
       </View>
     </Card>
   );

--- a/src/ui/primitives/index.ts
+++ b/src/ui/primitives/index.ts
@@ -11,3 +11,5 @@ export { default as Spinner } from './Spinner';
 export { default as Skeleton } from './Skeleton';
 export { default as Menu } from './Menu';
 export type { MenuItem } from './Menu';
+export { default as Button } from './Button';
+export { default as Text } from './Text';


### PR DESCRIPTION
## Summary
- refactor RPC settings to use Button and Text primitives
- re-export Button and Text from primitives index

## Testing
- `npm test` *(fails: Unable to reach server, syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af8d65448326ae12596dcb89c60c