### PR TITLE
refactor: use Avatar primitive in UserAvatar

### DIFF
--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { TouchableOpacity, StyleSheet } from 'react-native';
 import { User, LogOut } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -7,8 +6,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { push, replace } from '@/services/navigation';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import ConfirmationModal from '@/components/ConfirmationModal';
-import { Menu, type MenuItem } from '@/ui/primitives';
-import Text from '@/shared/ui/Text';
+import { Menu, Avatar, type MenuItem } from '@/ui/primitives';
 
 export default function UserAvatar() {
   const { isLoggedIn, user, logout } = useAuth();
@@ -83,23 +81,20 @@ export default function UserAvatar() {
     <>
       <Menu
         trigger={
-          <TouchableOpacity
+          <Avatar
+            size={36}
+            uri={user?.avatar}
+            initials={getInitials()}
             onPress={() => (isLoggedIn ? setMenuOpen(true) : handleLogin())}
-            style={[
-              styles.avatar,
-              {
-                borderColor: getColor('border.primary'),
-                backgroundColor: isLoggedIn
-                  ? getRandomColor()
-                  : getColor('background.secondary'),
-              },
-            ]}
-            data-testid="avatar"
-          >
-            <Text style={{ color: getColor('text.primary'), fontWeight: 'bold' }}>
-              {getInitials()}
-            </Text>
-          </TouchableOpacity>
+            style={{
+              borderColor: getColor('border.primary'),
+              backgroundColor: isLoggedIn
+                ? getRandomColor()
+                : getColor('background.secondary'),
+              borderWidth: 2,
+            }}
+            testID="avatar"
+          />
         }
         open={menuOpen}
         onOpenChange={setMenuOpen}
@@ -118,14 +113,3 @@ export default function UserAvatar() {
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  avatar: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-  },
-});

--- a/src/ui/primitives/Avatar.tsx
+++ b/src/ui/primitives/Avatar.tsx
@@ -1,18 +1,54 @@
 import React from 'react';
-import { Image, StyleProp, ImageStyle } from 'react-native';
+import {
+  Image,
+  Pressable,
+  View,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 import { radius } from '../tokens';
+import Text from './Text';
 
 interface AvatarProps {
-  uri: string;
+  uri?: string | null;
+  initials?: string;
   size?: number;
-  style?: StyleProp<ImageStyle>;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
+  testID?: string;
 }
 
-export default function Avatar({ uri, size = 40, style }: AvatarProps) {
+export default function Avatar({
+  uri,
+  initials,
+  size = 40,
+  style,
+  onPress,
+  testID,
+}: AvatarProps) {
+  const Component = onPress ? Pressable : View;
+
   return (
-    <Image
-      source={{ uri }}
-      style={[{ width: size, height: size, borderRadius: radius.full }, style]}
-    />
+    <Component
+      onPress={onPress}
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: radius.full,
+          overflow: 'hidden',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        style,
+      ]}
+      testID={testID}
+    >
+      {uri ? (
+        <Image source={{ uri }} style={{ width: '100%', height: '100%' }} />
+      ) : initials ? (
+        <Text style={{ fontWeight: 'bold' }}>{initials}</Text>
+      ) : null}
+    </Component>
   );
 }


### PR DESCRIPTION
## Summary
- replace custom touchable avatar with `Avatar` primitive and feed initials or photo uri
- enhance `Avatar` primitive to support initials, press handlers, and test ID

## Testing
- `yarn test` *(fails: Jest encountered parsing errors and missing modules; smoke test unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af8f0e1483268f11902d93a07265