### PR TITLE
refactor: use categories hook

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -7,7 +7,8 @@ import AppShell from '../components/layout/AppShell';
 import Section from '../components/ui/Section';
 import GoldDivider from '../components/ui/GoldDivider';
 import DatabaseService from '../services/database';
-import { Product, Category, HeroBanner } from '../types';
+import { Product, HeroBanner } from '../types';
+import { useCategories } from '@/services';
 import ProductCard from '@/features/products/ProductCard';
 import { useTheme } from '../contexts/ThemeContext';
 import SmartImage from '../components/SmartImage';
@@ -19,8 +20,8 @@ export default function Landing() {
   const { push } = useAppRouter();
   const { colors } = useTheme();
   const [featured, setFeatured] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
   const [banners, setBanners] = useState<HeroBanner[]>([]);
+  const { data: categories = [] } = useCategories();
 
   useEffect(() => {
     const load = async () => {
@@ -28,10 +29,6 @@ export default function Landing() {
         const db = DatabaseService.getInstance();
         const prods = await db.getProducts();
         setFeatured(prods.slice(0, 6));
-        try {
-          const cats = await db.getCategories();
-          setCategories(cats.slice(0, 8));
-        } catch {}
         try {
           const hs = await db.getHeroBanners();
           setBanners(hs);
@@ -98,7 +95,7 @@ export default function Landing() {
         <Section title="Categories">
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <View style={{ flexDirection: 'row', gap: spacing.spacer8 }}>
-              {(categories.length ? categories : [
+              {(categories.length ? categories.slice(0, 8) : [
                 { id: 'electronics', name: 'Electronics' },
                 { id: 'fashion', name: 'Fashion' },
                 { id: 'home', name: 'Home' },

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -15,13 +15,14 @@ import {
 } from 'react-native';
 import { push } from '@/services/navigation';
 import { X, Save, Trash2, Plus } from 'lucide-react-native';
-import { Product, Category, Subcategory, PricingTier, ProductIndexItem } from '@/types';
+import { Product, Subcategory, PricingTier, ProductIndexItem } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import DatabaseService from '@/services/database';
 import PinataService from '@/services/pinata';
 import ipfsService from '@/services/ipfsService';
 import chain from '@/services/chain';
+import { useCategories } from '@/services';
 
 let setProductBatch:
   | ((items: ProductIndexItem[]) => Promise<void>)
@@ -62,7 +63,7 @@ export default function ProductFormModal({
   const [videoError, setVideoError] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [videoPreview, setVideoPreview] = useState<string | null>(null);
-  const [categories, setCategories] = useState<Category[]>([]);
+  const { data: categories = [] } = useCategories();
   const pinata = PinataService.getInstance();
 
   const toHttpUrl = (uri: string) =>
@@ -87,7 +88,6 @@ export default function ProductFormModal({
   useEffect(() => {
     if (visible) {
       initForm();
-      loadCategories();
       loadPricingTiers();
     }
   }, [visible, product, address]);
@@ -114,20 +114,6 @@ export default function ProductFormModal({
     setImageUrls((product?.images || []).join('\n'));
     setVideoUrls((product?.videos || []).join('\n'));
     setVariants(product?.variants || []);
-  };
-
-  const loadCategories = async () => {
-    try {
-      const db = DatabaseService.getInstance();
-      const data = await db.getCategories();
-      setCategories(data);
-      if (editingProduct.category) {
-        const category = data.find(c => c.id === editingProduct.category);
-        setAvailableSubcategories(category?.subcategories || []);
-      }
-    } catch (error) {
-      errorLog('Error loading categories:', error);
-    }
   };
 
   const loadPricingTiers = async () => {


### PR DESCRIPTION
## Summary
- use `useCategories` hook in ProductFormModal instead of manual fetch
- rely on categories hook in landing page and drop custom fetching

## Testing
- `npm test` *(fails: Unexpected token '<' in various test files; Cannot find module '@waku/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c2fc3c5c8326acab7da5626470a0