### PR TITLE
refactor: use useAppRouter for navigation

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import SmartImage from './SmartImage';
 import { Heart, Search, Star } from 'lucide-react-native';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAppInfo } from '../contexts/AppInfoContext';
@@ -33,6 +33,7 @@ export default function GlobalHeader({
   const { colors } = useTheme();
   const { appName, logoCid } = useAppInfo();
   const { progress } = useRoadmap();
+  const { push } = useAppRouter();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
 

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -17,7 +17,7 @@ import { Order, OrderStatus } from '../types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useCurrency } from '../contexts/CurrencyContext';
 import OrderService from '../services/orders';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import * as Clipboard from 'expo-clipboard';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -38,6 +38,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
   const { t } = useLanguage();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const { push } = useAppRouter();
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
 

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -3,7 +3,7 @@ import { User, LogOut } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useTheme } from '@/contexts/ThemeContext';
-import { push, replace } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { Menu, Avatar, type MenuItem } from '@/ui/primitives';
@@ -13,6 +13,7 @@ export default function UserAvatar() {
   const { t } = useLanguage();
   const { getColor } = useTheme();
   const { openAuthModal } = useAuthModal();
+  const { push, replace } = useAppRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [logoutConfirmVisible, setLogoutConfirmVisible] = useState(false);
 

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -45,7 +45,7 @@ import commonStyles from '@/constants/styles';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { useNotifications } from '@/components/NotificationContext';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
 
@@ -76,6 +76,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const { currencySymbol } = useCurrency();
   const { showNotification } = useNotifications();
   const { t } = useLanguage();
+  const { push } = useAppRouter();
   const scrollViewRef = useRef<ScrollView>(null);
 
   // Info/confirm modals

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -15,7 +15,7 @@ import { ShoppingCart, X, Plus, Minus } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import useCart from '../hooks/useCart';
 
 const { width } = Dimensions.get('window');
@@ -29,6 +29,7 @@ export default function FloatingCartWidget() {
   const { t } = useLanguage();
   const isRTL = I18nManager.isRTL;
   const { cartItems, updateQuantity, removeItem, getTotal, getTotalItems } = useCart();
+  const { push } = useAppRouter();
 
   useEffect(() => {
     if (cartItems.length > 0) {

--- a/src/features/cart/components/WishlistModal.tsx
+++ b/src/features/cart/components/WishlistModal.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import { X, Heart, ShoppingCart, Trash2 } from 'lucide-react-native';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import { WishlistItem } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
@@ -25,6 +25,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
   const { wishlistItems, removeFromWishlist, addToCart } = useWishlist(visible);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const { push } = useAppRouter();
 
   const handleAddToCart = async (item: WishlistItem) => {
     await addToCart(item);

--- a/src/features/home/components/CTABecomeSeller.tsx
+++ b/src/features/home/components/CTABecomeSeller.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import Button from '@/ui/primitives/Button';
 
 export default function CTABecomeSeller() {
   const { t } = useLanguage();
+  const { push } = useAppRouter();
 
   return (
     <Button

--- a/src/features/products/components/ProductCard.tsx
+++ b/src/features/products/components/ProductCard.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import { Heart, Pencil, ShoppingCart, Tag } from 'lucide-react-native';
-import { push } from '@/services/navigation';
+import useAppRouter from 'hooks/useAppRouter';
 import { Product, PricingTier } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrency } from '@/contexts/CurrencyContext';
@@ -53,6 +53,7 @@ function ProductCard({
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const address = useAccountId();
+  const { push } = useAppRouter();
   const variants = useMemo(() => product.variants || [], [product.variants]);
   const selectedVariant = useMemo(() => variants[selectedVariantIndex], [variants, selectedVariantIndex]);
   const stock = useMemo(() => (selectedVariant ? selectedVariant.stock : product.stock), [selectedVariant, product.stock]);
@@ -118,7 +119,7 @@ function ProductCard({
 
   const handlePress = useCallback(() => {
     push(`/product/${product.id}`);
-  }, [product.id]);
+  }, [product.id, push]);
 
   const handleEdit = useCallback(
     (e: any) => {

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -13,7 +13,6 @@ import {
   Image,
   Platform,
 } from 'react-native';
-import { push } from '@/services/navigation';
 import { X, Save, Trash2, Plus } from 'lucide-react-native';
 import { Product, Subcategory, PricingTier, ProductIndexItem } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -37,6 +36,7 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
 import { useAccountId } from '../../auth/services/nearAuth';
+import useAppRouter from 'hooks/useAppRouter';
 
 interface ProductFormModalProps {
   visible: boolean;
@@ -56,6 +56,7 @@ export default function ProductFormModal({
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const address = useAccountId();
+  const { push } = useAppRouter();
   const [editingProduct, setEditingProduct] = useState<Partial<Product>>({});
   const [imageUrls, setImageUrls] = useState('');
   const [videoUrls, setVideoUrls] = useState('');


### PR DESCRIPTION
## Summary
- switch components to use `useAppRouter` instead of direct `push`
- clean up unused navigation imports

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected token and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dca645588326b1db703d4153d207