### PR TITLE
feat: localize category chip

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -93,6 +93,9 @@
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
     "becomeSeller": "Become a Seller"
   },
+  "categories": {
+    "all": "All"
+  },
   "product": {
     "inStock": "In Stock ({count})",
     "outOfStock": "Out of Stock",

--- a/src/features/home/components/CategoryChips.tsx
+++ b/src/features/home/components/CategoryChips.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { Category } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 interface CategoryChipsProps {
   categories: Category[];
@@ -15,6 +16,7 @@ export default function CategoryChips({
   setSelectedCategory,
 }: CategoryChipsProps) {
   const { colors } = useTheme();
+  const { t } = useLanguage();
 
   return (
     <View style={styles.container}>
@@ -42,7 +44,7 @@ export default function CategoryChips({
                   : colors.text.primary,
             }}
           >
-            All
+            {t('categories.all')}
           </Text>
         </TouchableOpacity>
         {categories.map((cat) => (

--- a/translations/en.json
+++ b/translations/en.json
@@ -93,6 +93,9 @@
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
     "becomeSeller": "Become a Seller"
   },
+  "categories": {
+    "all": "All"
+  },
   "product": {
     "inStock": "In Stock ({count})",
     "outOfStock": "Out of Stock",

--- a/translations/he.json
+++ b/translations/he.json
@@ -93,6 +93,9 @@
     "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש.",
     "becomeSeller": "הפוך למוכר"
   },
+  "categories": {
+    "all": "הכל"
+  },
   "product": {
     "inStock": "במלאי ({count})",
     "outOfStock": "אזל מהמלאי",


### PR DESCRIPTION
## Summary
- use the language context to translate the category list's All option
- add `categories.all` translations in English and Hebrew

## Testing
- `npm test` *(fails: Jest encountered unexpected token / module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de3d79ac8326add29a5867b139c8