### PR TITLE
Translate invalid product message

### DIFF
--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -4,17 +4,19 @@ import { useLocalSearchParams } from 'expo-router';
 import { z } from 'zod';
 import { createValidateParams } from '@/lib/validateParams';
 import { Spinner } from '@/ui/primitives';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const ProductScreen = React.lazy(() => import('./_ProductScreen'));
 const validateParams = createValidateParams(z.object({ id: z.string() }));
 
 export default function ProductScreenRoute() {
+  const { t } = useLanguage();
   const params = validateParams(useLocalSearchParams());
   if (!params.success) {
-    return <Text>Invalid product</Text>;
+    return <Text>{t('product.invalid')}</Text>;
   }
   return (
-    <Suspense fallback={<Spinner />}> 
+    <Suspense fallback={<Spinner />}>
       <ProductScreen id={params.data.id} />
     </Suspense>
   );

--- a/translations/en.json
+++ b/translations/en.json
@@ -117,6 +117,7 @@
     "deleteSuccess": "Product deleted successfully",
     "updateSuccess": "Product updated successfully",
     "updateError": "Product update failed",
+    "invalid": "Invalid product",
     "fillRequired": "Please fill in all required fields"
   },
   "category": {

--- a/translations/he.json
+++ b/translations/he.json
@@ -117,6 +117,7 @@
     "deleteSuccess": "המוצר נמחק בהצלחה",
     "updateSuccess": "המוצר עודכן בהצלחה",
     "updateError": "עדכון המוצר נכשל",
+    "invalid": "מוצר לא תקין",
     "fillRequired": "אנא מלא את כל השדות הנדרשים"
   },
   "category": {


### PR DESCRIPTION
## Summary
- localize invalid product message using LanguageContext
- add `product.invalid` translations in English and Hebrew

## Testing
- `yarn lint`
- `node scripts/app.js test tests/not-found.test.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de3bbe3c8326bd7eb4061224f32c