### PR TITLE
refactor: centralize tabs path trimming

### DIFF
--- a/apps/web/contexts/TenantContext.tsx
+++ b/apps/web/contexts/TenantContext.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { stripTabsPrefix } from '@/services/navigation';
 
 export function useTenant() {
   if (typeof window !== 'undefined') {
-    const m = window.location.pathname.match(/^\/store\/([^/]+)/);
+    const path = stripTabsPrefix(window.location.pathname) ?? window.location.pathname;
+    const m = path.match(/^\/store\/([^/]+)/);
     if (!m) throw new Error('storeId missing');
     return { storeId: decodeURIComponent(m[1]) } as const;
   }

--- a/components/RequireWallet.tsx
+++ b/components/RequireWallet.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { usePathname, useSearchParams } from 'expo-router';
-import { replace } from '@/services/navigation';
+import { replace, stripTabsPrefix } from '@/services/navigation';
 import { useAccountId } from '@/features/auth/services/nearAuth';
 
 interface Props {
@@ -14,7 +14,7 @@ export default function RequireWallet({ children }: Props) {
 
   useEffect(() => {
     if (!accountId) {
-      let dest = pathname;
+      let dest = stripTabsPrefix(pathname) ?? pathname;
       const query = params.toString();
       if (query) dest += `?${query}`;
       replace(`/login?redirect=${encodeURIComponent(dest)}`); // eslint-disable-line no-restricted-syntax

--- a/contexts/TenantContext.tsx
+++ b/contexts/TenantContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { usePathname } from 'expo-router';
+import { stripTabsPrefix } from '@/services/navigation';
 import { loadTenantSettings } from '@/constants/tenant';
 
 interface TenantContextType {
@@ -23,7 +24,8 @@ export function TenantProvider({ children }: Props) {
   const pathname = usePathname();
 
   useEffect(() => {
-    const match = pathname.match(/^\/store\/([^\/]+)/);
+    const path = stripTabsPrefix(pathname) ?? pathname;
+    const match = path.match(/^\/store\/([^\/]+)/);
     setStoreId(match ? match[1] : null);
   }, [pathname]);
 

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -2,7 +2,7 @@ import { router } from 'expo-router';
 
 const TABS_PREFIX = '/' + '(' + 'tabs' + ')';
 
-function stripTabsPrefix(path?: string | null): string | undefined {
+export function stripTabsPrefix(path?: string | null): string | undefined {
   if (typeof path !== 'string') return path ?? undefined;
   return path.startsWith(`${TABS_PREFIX}/`) ? path.replace(`${TABS_PREFIX}`, '') : path;
 }


### PR DESCRIPTION
## Summary
- export `stripTabsPrefix` helper from navigation service
- use `stripTabsPrefix` when deriving paths for login redirects and tenant resolution

## Testing
- `npm test` *(fails: process exited before tests could run, warnings shown)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de3650c88326bf82b1cb16291ee8