### PR TITLE
feat: localize category picker and store orders

### DIFF
--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '../../../../contexts/ThemeContext';
 import chain from '../../../../services/chain';
 import { Order } from '../../../../types';
 import { useAccountId } from '@/features/auth/services/nearAuth';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 let listOrdersBySeller:
   | ((storeId: string, sellerId: string) => Promise<Order[]>)
@@ -19,6 +20,7 @@ export default function StoreOrdersScreen() {
   const { colors } = useTheme();
   const [orders, setOrders] = useState<Order[]>([]);
   const address = useAccountId();
+  const { t } = useLanguage();
 
   const handlePress = (order: Order) => {
     debugLog('Pressed order', order.id);
@@ -46,7 +48,7 @@ export default function StoreOrdersScreen() {
           { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
         ]}
       >
-        <Text style={{ color: colors.text.primary }}>יש להתחבר לארנק המתאים</Text>
+        <Text style={{ color: colors.text.primary }}>{t('orders.connectWallet')}</Text>
       </View>
     );
   }
@@ -69,10 +71,14 @@ export default function StoreOrdersScreen() {
         </TouchableOpacity>
       )}
       ListEmptyComponent={
-        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>אין הזמנות</Text>
+        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+          {t('orders.emptyTitle')}
+        </Text>
       }
       ListHeaderComponent={
-        <Text style={[styles.title, { color: colors.text.primary }]}>הזמנות</Text>
+        <Text style={[styles.title, { color: colors.text.primary }]}>
+          {t('navigation.orders')}
+        </Text>
       }
     />
   );

--- a/src/features/products/components/SubcategoryPicker.tsx
+++ b/src/features/products/components/SubcategoryPicker.tsx
@@ -10,6 +10,7 @@ import {
 import { X, Plus } from 'lucide-react-native';
 import { Subcategory } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 interface SubcategoryPickerProps {
   visible: boolean;
@@ -27,6 +28,7 @@ export default function SubcategoryPicker({
   onClose,
 }: SubcategoryPickerProps) {
   const { colors } = useTheme();
+  const { t } = useLanguage();
 
   return (
     <Modal
@@ -38,7 +40,9 @@ export default function SubcategoryPicker({
       <View style={styles.overlay}>
         <View style={[styles.content, { backgroundColor: colors.surface.elevated }]}>
           <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text.primary }]}>בחר תת-קטגוריה</Text>
+            <Text style={[styles.title, { color: colors.text.primary }]}>
+              {t('category.selectSubcategory')}
+            </Text>
             <TouchableOpacity onPress={onClose}>
               <X size={24} color={colors.text.primary} />
             </TouchableOpacity>
@@ -60,7 +64,9 @@ export default function SubcategoryPicker({
               ))
             ) : (
               <View style={styles.itemContent}>
-                <Text style={[styles.itemText, { color: colors.text.secondary }]}>אין תת-קטגוריות זמינות</Text>
+                <Text style={[styles.itemText, { color: colors.text.secondary }]}>
+                  {t('category.noSubcategoriesAvailable')}
+                </Text>
               </View>
             )}
             {onAdd && (
@@ -70,7 +76,9 @@ export default function SubcategoryPicker({
               >
                 <View style={styles.itemContent}>
                   <Plus size={20} color={colors.gold} />
-                  <Text style={[styles.itemText, { color: colors.gold }]}>הוסף תת-קטגוריה חדשה</Text>
+                  <Text style={[styles.itemText, { color: colors.gold }]}>
+                    {t('category.addNewSubcategory')}
+                  </Text>
                 </View>
               </TouchableOpacity>
             )}

--- a/translations/en.json
+++ b/translations/en.json
@@ -127,6 +127,8 @@
     "addSubcategory": "Add Subcategory",
     "editSubcategory": "Edit Subcategory",
     "addNewSubcategory": "Add New Subcategory",
+    "selectSubcategory": "Select Subcategory",
+    "noSubcategoriesAvailable": "No subcategories available",
     "subcategoryId": "Subcategory ID",
     "subcategoryName": "Subcategory Name",
     "icon": "Icon (Emoji)",
@@ -435,6 +437,7 @@
     "shopNow": "Start Shopping",
     "loginRequiredTitle": "Login Required",
     "loginRequiredMessage": "You must log in to view your orders",
+    "connectWallet": "Please connect with the correct wallet",
     "myOrders": "My Orders"
   },
   "stores": {

--- a/translations/he.json
+++ b/translations/he.json
@@ -127,6 +127,8 @@
     "addSubcategory": "הוסף תת-קטגוריה",
     "editSubcategory": "עריכת תת-קטגוריה",
     "addNewSubcategory": "הוספת תת-קטגוריה חדשה",
+    "selectSubcategory": "בחר תת-קטגוריה",
+    "noSubcategoriesAvailable": "אין תת-קטגוריות זמינות",
     "subcategoryId": "מזהה תת-קטגוריה",
     "subcategoryName": "שם תת-הקטגוריה",
     "icon": "אייקון (אמוג'י)",
@@ -435,6 +437,7 @@
     "shopNow": "התחל לקנות",
     "loginRequiredTitle": "נדרשת התחברות",
     "loginRequiredMessage": "עליך להתחבר כדי לראות את ההזמנות שלך",
+    "connectWallet": "יש להתחבר לארנק המתאים",
     "myOrders": "ההזמנות שלי"
   },
   "stores": {


### PR DESCRIPTION
## Summary
- import useLanguage in subcategory picker and store orders screen
- replace Hebrew strings with translation keys and add missing translations

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e083d8bc832696b143fe707dd106