### PR TITLE
refactor: consolidate tab definitions

### DIFF
--- a/config/navigation/tabs.ts
+++ b/config/navigation/tabs.ts
@@ -1,12 +1,9 @@
-import type { ComponentType } from 'react';
-
 export type TabDef = {
   name: string; // file-based route under (tabs)
   title: string; // display title
   icon: string; // lucide icon name mapping
 };
-
-export const consumerTabs: TabDef[] = [
+export const baseTabs: TabDef[] = [
   { name: 'index', title: 'Home', icon: 'Home' },
   { name: 'stores', title: 'Stores', icon: 'Store' },
   { name: 'cart', title: 'Cart', icon: 'ShoppingCart' },
@@ -14,21 +11,9 @@ export const consumerTabs: TabDef[] = [
   { name: 'profile', title: 'Profile', icon: 'User' },
 ];
 
-export const ownerTabs: TabDef[] = [
-  { name: 'index', title: 'Home', icon: 'Home' },
-  { name: 'stores', title: 'Stores', icon: 'Store' },
-  { name: 'cart', title: 'Cart', icon: 'ShoppingCart' },
-  { name: 'orders', title: 'Orders', icon: 'Package' },
-  { name: 'profile', title: 'Profile', icon: 'User' },
-];
-
-export const adminTabs: TabDef[] = [
-  { name: 'index', title: 'Home', icon: 'Home' },
-  { name: 'stores', title: 'Stores', icon: 'Store' },
-  { name: 'cart', title: 'Cart', icon: 'ShoppingCart' },
-  { name: 'orders', title: 'Orders', icon: 'Package' },
-  { name: 'profile', title: 'Profile', icon: 'User' },
-];
+export const consumerTabs: TabDef[] = [...baseTabs];
+export const ownerTabs: TabDef[] = [...baseTabs];
+export const adminTabs: TabDef[] = [...baseTabs];
 
 export function getTabsForAuth(auth: { isAdmin?: boolean; isStoreOwner?: boolean }) {
   if (auth?.isAdmin) return adminTabs;


### PR DESCRIPTION
## Summary
- consolidate shared tab entries into `baseTabs`
- export `consumerTabs`, `ownerTabs`, and `adminTabs` from the base set

## Testing
- `yarn lint config/navigation/tabs.ts`
- `yarn test config/navigation/tabs.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8e0877ff88326ba080a3635eca416