### PR TITLE
feat: add subcategories hook

### DIFF
--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -21,7 +21,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import InfoModal from '../../components/InfoModal';
 import { Spinner } from '@/ui/primitives';
 import commonStyles from '@/constants/styles';
-import { useCategories, useCategory } from '@/services';
+import { useSubcategories } from '@/services';
 
 const validateParams = createValidateParams(z.object({ id: z.string() }));
 
@@ -31,15 +31,14 @@ export default function CategoryScreen() {
   const { push, back } = useAppRouter();
   const params = validateParams(useLocalSearchParams());
   const id = params.success ? params.data.id : undefined;
-  const { data: categories = [], isLoading: categoriesLoading } = useCategories();
-  const category = categories.find((cat) => cat.id === id) || null;
-  const subcategories = category?.subcategories || [];
   const {
+    category,
+    subcategories,
     addSubcategory: addSubcategoryMutation,
     updateSubcategory: updateSubcategoryMutation,
     deleteSubcategory: deleteSubcategoryMutation,
-    isPending: mutationLoading,
-  } = useCategory(category);
+    isLoading: loading,
+  } = useSubcategories(id);
   const [showSubcategoryModal, setShowSubcategoryModal] = useState(false);
   const [editingSubcategory, setEditingSubcategory] = useState<Subcategory | null>(null);
   const [newSubcategory, setNewSubcategory] = useState<Partial<Subcategory>>({
@@ -50,7 +49,6 @@ export default function CategoryScreen() {
   });
   const { isStoreOwner } = useAuth();
   const { colors } = useTheme();
-  const loading = categoriesLoading || mutationLoading;
 
   // Modal states
   const [infoModal, setInfoModal] = useState({

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@ export * from './useProducts';
 export * from './useStores';
 export * from './useCategories';
 export * from './useCategory';
+export * from './useSubcategories';
 export * from './usePricingTiers';
 export * from './useCart';
 export * from './useOrders';

--- a/src/services/useSubcategories.ts
+++ b/src/services/useSubcategories.ts
@@ -1,0 +1,24 @@
+import { useCategories } from './useCategories';
+import { useCategory } from './useCategory';
+import { Subcategory } from '@/types';
+
+export function useSubcategories(categoryId?: string) {
+  const { data: categories = [], isLoading: categoriesLoading } = useCategories();
+  const category = categories.find((cat) => cat.id === categoryId) || null;
+  const subcategories: Subcategory[] = category?.subcategories ?? [];
+  const {
+    addSubcategory,
+    updateSubcategory,
+    deleteSubcategory,
+    isPending,
+  } = useCategory(category);
+
+  return {
+    category,
+    subcategories,
+    addSubcategory,
+    updateSubcategory,
+    deleteSubcategory,
+    isLoading: categoriesLoading || isPending,
+  };
+}


### PR DESCRIPTION
## Summary
- create `useSubcategories` hook that composes existing category services
- simplify category screen by using new hook
- export subcategories hook from services index

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b97f332f048326a48729cf362c47f2