### PR TITLE
refactor: centralize storefront data loading

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -1,61 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, I18nManager } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import storesAgent, { selectStore } from '../../../agents/stores-agent';
-import { getProducts } from '../../../agents/products-agent';
-import reviewAgent from '../../../agents/review-agent';
 import { useTheme } from '@/ui/ThemeProvider';
-import { Store, Product } from '../../../types';
 import StoreHeader from '@/features/stores/components/store/StoreHeader';
 import StoreTabs from '@/features/stores/components/store/StoreTabs';
 import ProductGrid from '@/features/products/components/ProductGrid';
-
-interface ReviewMap {
-  [productId: string]: { rating: number; count: number };
-}
+import { useStoreData } from '@/services/useStoreData';
 
 export default function StorefrontStoreScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
-  const [store, setStore] = useState<Store | null>(null);
-  const [score, setScore] = useState(0);
-  const [products, setProducts] = useState<Product[]>([]);
-  const [reviews, setReviews] = useState<ReviewMap>({});
+  const { store, products, score } = useStoreData(storeId);
   const [tab, setTab] = useState<'products' | 'about' | 'reviews'>('products');
-
-  useEffect(() => {
-    let callback: ((sid: string, s: number) => void) | undefined;
-    const load = async () => {
-      if (!storeId) return;
-      const s = await selectStore(storeId);
-      setStore(s);
-      setScore(storesAgent.getReputationScore(storeId));
-      const all = await getProducts();
-      const filtered = all.filter((p) => p.storeId === storeId);
-      setProducts(filtered);
-      const entries = await Promise.all(
-        filtered.map(async (p) => {
-          const revs = await reviewAgent.getByProduct(p.id);
-          const count = revs.length;
-          const rating = count > 0 ? revs.reduce((a, r) => a + r.rating, 0) / count : 0;
-          return [p.id, { rating, count }] as [string, { rating: number; count: number }];
-        })
-      );
-      const map: ReviewMap = {};
-      entries.forEach(([pid, data]) => {
-        map[pid] = data;
-      });
-      setReviews(map);
-      callback = (sid: string, sc: number) => {
-        if (sid === storeId) setScore(sc);
-      };
-      storesAgent.subscribe(callback);
-    };
-    load();
-    return () => {
-      if (callback) storesAgent.unsubscribe(callback);
-    };
-  }, [storeId]);
 
   if (!store) {
     return (

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './useProductPricing';
 export * from './useCart';
 export * from './useOrders';
 export * from './useUser';
+export * from './useStoreData';

--- a/src/services/useStoreData.ts
+++ b/src/services/useStoreData.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import storesAgent, { selectStore } from '@/agents/stores-agent';
+import { getProducts } from '@/agents/products-agent';
+import reviewAgent from '@/agents/review-agent';
+import { Store, Product } from '@/types';
+
+interface ReviewInfo {
+  rating: number;
+  count: number;
+}
+
+export type ReviewMap = Record<string, ReviewInfo>;
+
+export function useStoreData(storeId?: string) {
+  const [store, setStore] = useState<Store | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [reviews, setReviews] = useState<ReviewMap>({});
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    let callback: ((id: string, score: number) => void) | undefined;
+    const load = async () => {
+      if (!storeId) return;
+      const s = await selectStore(storeId);
+      setStore(s);
+      setScore(storesAgent.getReputationScore(storeId));
+      const all = await getProducts();
+      const filtered = all.filter((p) => p.storeId === storeId);
+      setProducts(filtered);
+      const entries = await Promise.all(
+        filtered.map(async (p) => {
+          const revs = await reviewAgent.getByProduct(p.id);
+          const count = revs.length;
+          const rating = count > 0 ? revs.reduce((a, r) => a + r.rating, 0) / count : 0;
+          return [p.id, { rating, count }] as [string, ReviewInfo];
+        })
+      );
+      const map: ReviewMap = {};
+      entries.forEach(([pid, info]) => {
+        map[pid] = info;
+      });
+      setReviews(map);
+      callback = (sid, sc) => {
+        if (sid === storeId) setScore(sc);
+      };
+      storesAgent.subscribe(callback);
+    };
+    void load();
+    return () => {
+      if (callback) storesAgent.unsubscribe(callback);
+    };
+  }, [storeId]);
+
+  return { store, products, reviews, score };
+}
+


### PR DESCRIPTION
## Summary
- add `useStoreData` hook to gather store, products, reviews and score using agents
- refactor store screen to use new hook
- export hook from services

## Testing
- `yarn test` *(fails: Jest encountered unexpected token / missing modules / unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b9844e143483269bc5d8fc8b19c53f