### PR TITLE
refactor: relocate chat messages hook

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useAuth } from '@/features/auth/AuthContext';
 import useChatRooms from '../hooks/useChatRooms';
-import useChatMessages from '../hooks/useChatMessages';
+import useChatMessages from '@features/chat/services/useChatMessages';
 import { useWaku } from '@/contexts/WakuContext';
 import { ChatMessage, ChatRoom } from '../types';
 import SettingsAgent from '../agents/settings-agent';

--- a/src/features/chat/services/useChatMessages.ts
+++ b/src/features/chat/services/useChatMessages.ts
@@ -1,7 +1,7 @@
 import { errorLog } from '@/utils/logger';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import DatabaseService from '@/services/database';
-import { ChatMessage, ChatRoom, User } from '../types';
+import { ChatMessage, ChatRoom, User } from '@/types';
 import { useWaku } from '@/contexts/WakuContext';
 
 export function useChatMessages(selectedRoom: ChatRoom | null, user: User | null | undefined, isAdmin: boolean) {


### PR DESCRIPTION
## Summary
- move `useChatMessages` into `src/features/chat/services`
- update chat widget to use relocated hook
- remove old `hooks/useChatMessages` file

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token in several test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b98452824483269f32f0e0390df686