### PR TITLE
Wrap root layout with app providers

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,41 @@
+import React from 'react';
 import { Slot } from 'expo-router';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { AppInfoProvider } from '@/contexts/AppInfoContext';
+import { ConfigProvider } from '@/contexts/ConfigContext';
+import { AuthProvider } from '@/features/auth/AuthContext';
+import { AuthModalProvider } from '@/features/auth/AuthModalContext';
+import { CurrencyProvider } from '@/contexts/CurrencyContext';
+import { NotificationProvider } from '@/components/NotificationContext';
+import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
 
 export default function RootLayout() {
-  return <Slot />;
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <AppInfoProvider>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppProviders>
+                <ConfigProvider>
+                  <AuthProvider>
+                    <AuthModalProvider>
+                      <CurrencyProvider>
+                        <NotificationProvider>
+                          <React.Suspense fallback={null}>
+                            <Slot />
+                          </React.Suspense>
+                        </NotificationProvider>
+                      </CurrencyProvider>
+                    </AuthModalProvider>
+                  </AuthProvider>
+                </ConfigProvider>
+              </AppProviders>
+            </LanguageProvider>
+          </ThemeProvider>
+        </AppInfoProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap Expo Router root layout with shared providers including QueryClient

## Testing
- `yarn lint app/_layout.tsx`
- `yarn test` *(fails: Jest encountered an unexpected token, unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b9884a6fcc83268206d5f8a9a6c23b