### PR TITLE
refactor: remove direct router usage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,23 +9,23 @@ import { AuthModalProvider } from '@/features/auth/AuthModalContext';
 import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
 import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
-import { Router, usePathname, useRouter, useSegments } from 'expo-router';
+import { Router, usePathname, useSegments } from 'expo-router';
+import { stripTabsPrefix } from '@/services/navigation';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
 function RouterApp() {
-  const router = useRouter();
   const pathname = usePathname();
   const segments = useSegments();
 
   React.useEffect(() => {
     if (!__DEV__) return;
 
-    const path = (router as any).getPath?.() ?? pathname;
+    const path = stripTabsPrefix(pathname) ?? pathname;
     const currentTab = segments[0] ?? '';
     // eslint-disable-next-line no-console
     console.log('[breadcrumb]', path, currentTab);
-  }, [router, pathname, segments]);
+  }, [pathname, segments]);
 
   return <Router />;
 }


### PR DESCRIPTION
## Summary
- remove direct expo-router usage in App and rely on navigation helpers

## Testing
- `npx eslint App.tsx`
- `yarn test tests/admin-store-detail.test.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b988791704832682aaa64b938c6844