### PR TITLE
test: cover navigation tabs stripping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,6 +42,7 @@ module.exports = {
     '<rootDir>/tests/nearAdapter.test.ts',
     '<rootDir>/tests/i18n-offline.test.ts',
     '<rootDir>/tests/smoke.test.ts',
+    '<rootDir>/tests/navigation.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -17,7 +17,7 @@ export function push(...args: Parameters<typeof router.push>) {
   } else if (typeof args[0] === 'object' && args[0] !== null && 'pathname' in args[0]) {
     args[0] = { ...args[0], pathname: stripTabsPrefix(args[0].pathname) } as any;
   }
-  router.push(...(args as any));
+  (router as any).push(...args);
 }
 
 export function replace(...args: Parameters<typeof router.replace>) {
@@ -26,6 +26,6 @@ export function replace(...args: Parameters<typeof router.replace>) {
   } else if (typeof args[0] === 'object' && args[0] !== null && 'pathname' in args[0]) {
     args[0] = { ...args[0], pathname: stripTabsPrefix(args[0].pathname) } as any;
   }
-  router.replace(...(args as any));
+  (router as any).replace(...args);
 }
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -1,0 +1,36 @@
+import { stripTabsPrefix, push, replace } from '@/services/navigation';
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    replace: jest.fn(),
+  },
+}));
+
+describe('navigation', () => {
+  const { router } = require('expo-router');
+
+  beforeEach(() => {
+    router.push.mockReset();
+    router.replace.mockReset();
+  });
+
+  it('stripTabsPrefix removes group prefix', () => {
+    // eslint-disable-next-line no-restricted-syntax
+    expect(stripTabsPrefix('/(tabs)/profile')).toBe('/profile');
+    expect(stripTabsPrefix('/profile')).toBe('/profile');
+    expect(stripTabsPrefix(undefined)).toBeUndefined();
+  });
+
+  it('push strips group prefix before routing', () => {
+    // eslint-disable-next-line no-restricted-syntax
+    push('/(tabs)/orders');
+    expect(router.push).toHaveBeenCalledWith('/orders');
+  });
+
+  it('replace strips group prefix in pathname objects', () => {
+    // eslint-disable-next-line no-restricted-syntax
+    replace({ pathname: '/(tabs)/orders', params: { foo: 'bar' } });
+    expect(router.replace).toHaveBeenCalledWith({ pathname: '/orders', params: { foo: 'bar' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for stripTabsPrefix and navigation wrappers
- adjust navigation service to forward calls using `router` casts
- register new navigation test in jest config

## Testing
- `yarn test --runTestsByPath tests/navigation.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9887a7fe0832699bffc7ab2ee066c