### PR TITLE
Initialize i18n before app providers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,9 @@ import { NotificationProvider } from '@/components/NotificationContext';
 import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
+import { initI18n } from '@/services/i18n';
+
+await initI18n('en');
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 


### PR DESCRIPTION
## Summary
- import and invoke `initI18n` at module load to ensure translations are ready

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token / missing @waku/sdk module)*

------
https://chatgpt.com/codex/tasks/task_e_68b98b4f0184832688c62bf6938816d0