### PR TITLE
Wrap lazy routes with ErrorBoundary

### DIFF
--- a/app/admin/stores/[storeId]/index.tsx
+++ b/app/admin/stores/[storeId]/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const StoreDetailScreen = React.lazy(() => import('./_StoreDetailScreen'));
@@ -8,7 +9,9 @@ export default function AdminStoreDetailRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <StoreDetailScreen {...props} />
+        <ErrorBoundary>
+          <StoreDetailScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/admin/stores/index.tsx
+++ b/app/admin/stores/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../components/RequireWallet';
 
 const StoresScreen = React.lazy(() => import('./_StoresScreen'));
@@ -8,7 +9,9 @@ export default function AdminStoresRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <StoresScreen {...props} />
+        <ErrorBoundary>
+          <StoresScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -4,6 +4,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { z } from 'zod';
 import { createValidateParams } from '@/lib/validateParams';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import { useLanguage } from '@/ui/ThemeProvider';
 
 const ProductScreen = React.lazy(() => import('./_ProductScreen'));
@@ -17,7 +18,9 @@ export default function ProductScreenRoute() {
   }
   return (
     <Suspense fallback={<Spinner />}>
-      <ProductScreen id={params.data.id} />
+      <ErrorBoundary>
+        <ProductScreen id={params.data.id} />
+      </ErrorBoundary>
     </Suspense>
   );
 }

--- a/app/store/[storeId]/admin/bulk-upload.tsx
+++ b/app/store/[storeId]/admin/bulk-upload.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const BulkUploadScreen = React.lazy(() => import('./_BulkUploadScreen'));
@@ -8,7 +9,9 @@ export default function BulkUploadRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <BulkUploadScreen {...props} />
+        <ErrorBoundary>
+          <BulkUploadScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const DashboardScreen = React.lazy(() => import('./_DashboardScreen'));
@@ -8,7 +9,9 @@ export default function DashboardRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <DashboardScreen {...props} />
+        <ErrorBoundary>
+          <DashboardScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/deliveries.tsx
+++ b/app/store/[storeId]/admin/deliveries.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 // Lazy-load the deliveries management screen to reduce the main bundle
@@ -13,7 +14,9 @@ export default function DeliveriesRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <DeliveriesScreen {...props} />
+        <ErrorBoundary>
+          <DeliveriesScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/disputes.tsx
+++ b/app/store/[storeId]/admin/disputes.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const DisputesScreen = React.lazy(() => import('./_DisputesScreen'));
@@ -8,7 +9,9 @@ export default function DisputesRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <DisputesScreen {...props} />
+        <ErrorBoundary>
+          <DisputesScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/kyc-approvals.tsx
+++ b/app/store/[storeId]/admin/kyc-approvals.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 // Lazy-load the heavy KYC approvals screen to keep the initial bundle slim
@@ -13,7 +14,9 @@ export default function KycApprovalsRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <KycApprovalsScreen {...props} />
+        <ErrorBoundary>
+          <KycApprovalsScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/orders.tsx
+++ b/app/store/[storeId]/admin/orders.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const OrdersScreen = React.lazy(() => import('./_OrdersScreen'));
@@ -8,7 +9,9 @@ export default function OrdersRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <OrdersScreen {...props} />
+        <ErrorBoundary>
+          <OrdersScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/pricing-tiers.tsx
+++ b/app/store/[storeId]/admin/pricing-tiers.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const PricingTiersScreen = React.lazy(() => import('./_PricingTiersScreen'));
@@ -8,7 +9,9 @@ export default function PricingTiersRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <PricingTiersScreen {...props} />
+        <ErrorBoundary>
+          <PricingTiersScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/products.tsx
+++ b/app/store/[storeId]/admin/products.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const ProductsScreen = React.lazy(() => import('./_ProductsScreen'));
@@ -8,7 +9,9 @@ export default function ProductsRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <ProductsScreen {...props} />
+        <ErrorBoundary>
+          <ProductsScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/settings.tsx
+++ b/app/store/[storeId]/admin/settings.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const SettingsScreen = React.lazy(() => import('./_SettingsScreen'));
@@ -8,7 +9,9 @@ export default function SettingsRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <SettingsScreen {...props} />
+        <ErrorBoundary>
+          <SettingsScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/admin/user-management.tsx
+++ b/app/store/[storeId]/admin/user-management.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 import RequireWallet from '../../../../components/RequireWallet';
 
 const UserManagementScreen = React.lazy(() => import('./_UserManagementScreen'));
@@ -8,7 +9,9 @@ export default function UserManagementRoute(props: any) {
   return (
     <RequireWallet>
       <Suspense fallback={<Spinner />}>
-        <UserManagementScreen {...props} />
+        <ErrorBoundary>
+          <UserManagementScreen {...props} />
+        </ErrorBoundary>
       </Suspense>
     </RequireWallet>
   );

--- a/app/store/[storeId]/index.tsx
+++ b/app/store/[storeId]/index.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 const StoreScreen = React.lazy(() => import('./_StoreScreen'));
 
 export default function StoreRoute(props: any) {
   return (
     <Suspense fallback={<Spinner />}>
-      <StoreScreen {...props} />
+      <ErrorBoundary>
+        <StoreScreen {...props} />
+      </ErrorBoundary>
     </Suspense>
   );
 }

--- a/app/storefront/index.tsx
+++ b/app/storefront/index.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense } from 'react';
 import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 const StorefrontScreen = React.lazy(() => import('./_StorefrontScreen'));
 
 export default function StorefrontRoute(props: any) {
   return (
     <Suspense fallback={<Spinner />}>
-      <StorefrontScreen {...props} />
+      <ErrorBoundary>
+        <StorefrontScreen {...props} />
+      </ErrorBoundary>
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap lazy route screens with ErrorBoundary inside Suspense
- import shared ErrorBoundary for lazy-loaded routes

## Testing
- `yarn lint app/admin/stores/index.tsx app/admin/stores/[storeId]/index.tsx app/storefront/index.tsx app/store/[storeId]/admin/user-management.tsx app/store/[storeId]/admin/bulk-upload.tsx app/store/[storeId]/admin/deliveries.tsx app/store/[storeId]/admin/dashboard.tsx app/store/[storeId]/admin/orders.tsx app/store/[storeId]/admin/kyc-approvals.tsx app/store/[storeId]/admin/settings.tsx app/store/[storeId]/admin/disputes.tsx app/store/[storeId]/admin/pricing-tiers.tsx app/store/[storeId]/admin/products.tsx app/store/[storeId]/index.tsx app/product/[id].tsx`
- `yarn test` *(fails: Jest encountered unexpected token, missing module '@waku/sdk', smoke test cannot reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a5570430832680f40980789dd09a