### PR TITLE
chore: clean services directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,8 +18,6 @@ module.exports = {
     '^@features/(.*)$': '<rootDir>/src/features/$1',
     '^@shared/(.*)$': '<rootDir>/src/shared/$1',
     '^@ui/(.*)$': '<rootDir>/src/ui/$1',
-    '^@services/(.*)$': ['<rootDir>/src/services/$1', '<rootDir>/services/$1'],
-    '^@services$': '<rootDir>/src/services/index',
     '^@providers/(.*)$': '<rootDir>/src/providers/$1',
     '^@/features/(.*)$': '<rootDir>/src/features/$1',
     '^@/shared/(.*)$': '<rootDir>/src/shared/$1',

--- a/services/chain.ts
+++ b/services/chain.ts
@@ -1,1 +1,0 @@
-export { default, chainAdapter, assertNearChain } from '@services/chain';

--- a/services/nearLake.ts
+++ b/services/nearLake.ts
@@ -1,6 +1,0 @@
-// @ts-nocheck
-import { startStream } from 'near-lake-framework';
-
-export function initLake(config: any) {
-  return startStream(config);
-}

--- a/services/pgClient.ts
+++ b/services/pgClient.ts
@@ -1,8 +1,0 @@
-import { Pool } from 'pg';
-import { errorLog } from '@/utils/logger';
-
-export const pgPool = new Pool();
-
-pgPool.on('error', (err: unknown) => {
-  errorLog('Postgres pool error', err);
-});

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -39,8 +39,8 @@ jest.mock('@features/cart/components/CartModal', () => () => null);
 jest.mock('@features/products/components/ProductFormModal', () => () => null);
 jest.mock('@/components/SmartImage', () => () => null);
 jest.mock('@/components/InfoModal', () => () => null);
-jest.mock('@services/database', () => ({}));
-jest.mock('@services/chain', () => 'near');
+jest.mock('@/services/database', () => ({}));
+jest.mock('@/services/chain', () => 'near');
 jest.mock('@features/products/services/nearCategories', () => ({
   listCategories: jest.fn().mockResolvedValue([]),
 }));

--- a/tests/nearAdapter.test.ts
+++ b/tests/nearAdapter.test.ts
@@ -1,4 +1,4 @@
-import { nearAdapter } from '@services/chain/near';
+import { nearAdapter } from '@/services/chain/near';
 
 describe('NearAdapter.getBalance', () => {
   it('returns balance from RPC response', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,13 +31,6 @@
       "@shared/*": [
         "src/shared/*"
       ],
-      "@services/*": [
-        "src/services/*",
-        "services/*"
-      ],
-      "@services": [
-        "src/services/index.ts"
-      ],
       "@providers/*": [
         "src/providers/*"
       ],


### PR DESCRIPTION
## Summary
- drop legacy `@services` alias usage in tests and config
- remove unused service stubs `chain.ts`, `nearLake.ts`, and `pgClient.ts`

## Testing
- `yarn test` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a55123e88326bead20ff43c7dee2