### PR TITLE
fix missing chain module

### DIFF
--- a/services/chain.ts
+++ b/services/chain.ts
@@ -1,0 +1,1 @@
+export { assertNearChain } from '@blue-ocean/utils';


### PR DESCRIPTION
## Summary
- add `services/chain.ts` to re-export `assertNearChain`

## Testing
- `yarn test tests/smoke.test.ts` *(fails: Unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ac4fd9548326984c69cc08e5ab28