### PR TITLE
feat: bootstrap i18n at runtime

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,8 +13,6 @@ import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { initI18n } from '@/services/i18n';
 
-await initI18n('en');
-
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
 function RouterApp() {
@@ -41,7 +39,7 @@ function FallbackScreen() {
   );
 }
 
-export default function App() {
+function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
@@ -69,4 +67,32 @@ export default function App() {
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );
+}
+
+export default function App() {
+  const [ready, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    let mounted = true;
+    initI18n('en').finally(() => {
+      if (mounted) setReady(true);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!ready) {
+    return (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <Text>Loading translations...</Text>
+          </View>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
+    );
+  }
+
+  return <MainApp />;
 }

--- a/tests/i18n-offline.test.ts
+++ b/tests/i18n-offline.test.ts
@@ -1,10 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
 import { initI18n, t } from '@/services/i18n';
+
+function SaveButton() {
+  return React.createElement(Text, null, t('common.save'));
+}
 
 test('falls back to bundled translations when fetch fails', async () => {
   const originalFetch = global.fetch;
   // @ts-ignore
   global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+
   await initI18n('en');
-  expect(t('common.save')).toBe('Save');
+  const root = renderer.create(React.createElement(SaveButton));
+  expect(root.root.findByType(Text).props.children).toBe('Save');
+
   global.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- bootstrap i18n inside App component using useEffect and loading fallback
- test that translations fall back to bundled resources when network fails

## Testing
- `yarn test tests/i18n-offline.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9c57b75d8832692c7da6ef3b19531