### PR TITLE
feat: show spinner during suspense

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,8 +9,13 @@ import { AuthModalProvider } from '@/features/auth/AuthModalContext';
 import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
 import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
+import { View } from 'react-native';
+import { useTheme } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
 
 export default function RootLayout() {
+  const { colors } = useTheme();
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
@@ -23,7 +28,20 @@ export default function RootLayout() {
                     <AuthModalProvider>
                       <CurrencyProvider>
                         <NotificationProvider>
-                          <React.Suspense fallback={null}>
+                          <React.Suspense
+                            fallback={
+                              <View
+                                style={{
+                                  flex: 1,
+                                  justifyContent: 'center',
+                                  alignItems: 'center',
+                                  backgroundColor: colors.background,
+                                }}
+                              >
+                                <Spinner color={colors.gold} />
+                              </View>
+                            }
+                          >
                             <Slot />
                           </React.Suspense>
                         </NotificationProvider>


### PR DESCRIPTION
## Summary
- add theme-colored Spinner fallback to React.Suspense in root layout

## Testing
- `npx eslint app/_layout.tsx`
- `yarn test tests/navigation.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9cd39be6083268f38494a6aa8db96