### PR TITLE
refactor: centralize providers and add query provider test

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from '@/features/auth/AuthContext';
 import { AuthModalProvider } from '@/features/auth/AuthModalContext';
 import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
-import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
+import AppProviders from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { initI18n } from '@/services/i18n';
@@ -44,25 +44,21 @@ function MainApp() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <AppInfoProvider>
-          <ThemeProvider>
-            <LanguageProvider>
-              <AppProviders>
-                <ConfigProvider>
-                  <AuthProvider>
-                    <AuthModalProvider>
-                      <CurrencyProvider>
-                        <NotificationProvider>
-                          <React.Suspense fallback={null}>
-                            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-                          </React.Suspense>
-                        </NotificationProvider>
-                      </CurrencyProvider>
-                    </AuthModalProvider>
-                  </AuthProvider>
-                </ConfigProvider>
-              </AppProviders>
-            </LanguageProvider>
-          </ThemeProvider>
+          <AppProviders>
+            <ConfigProvider>
+              <AuthProvider>
+                <AuthModalProvider>
+                  <CurrencyProvider>
+                    <NotificationProvider>
+                      <React.Suspense fallback={null}>
+                        {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+                      </React.Suspense>
+                    </NotificationProvider>
+                  </CurrencyProvider>
+                </AuthModalProvider>
+              </AuthProvider>
+            </ConfigProvider>
+          </AppProviders>
         </AppInfoProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,32 +8,28 @@ import { AuthProvider } from '@/features/auth/AuthContext';
 import { AuthModalProvider } from '@/features/auth/AuthModalContext';
 import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
-import { AppProviders, ThemeProvider, LanguageProvider } from '@/providers';
+import AppProviders from '@/providers';
 
 export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <AppInfoProvider>
-          <ThemeProvider>
-            <LanguageProvider>
-              <AppProviders>
-                <ConfigProvider>
-                  <AuthProvider>
-                    <AuthModalProvider>
-                      <CurrencyProvider>
-                        <NotificationProvider>
-                          <React.Suspense fallback={null}>
-                            <Slot />
-                          </React.Suspense>
-                        </NotificationProvider>
-                      </CurrencyProvider>
-                    </AuthModalProvider>
-                  </AuthProvider>
-                </ConfigProvider>
-              </AppProviders>
-            </LanguageProvider>
-          </ThemeProvider>
+          <AppProviders>
+            <ConfigProvider>
+              <AuthProvider>
+                <AuthModalProvider>
+                  <CurrencyProvider>
+                    <NotificationProvider>
+                      <React.Suspense fallback={null}>
+                        <Slot />
+                      </React.Suspense>
+                    </NotificationProvider>
+                  </CurrencyProvider>
+                </AuthModalProvider>
+              </AuthProvider>
+            </ConfigProvider>
+          </AppProviders>
         </AppInfoProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
     '<rootDir>/tests/i18n-offline.test.ts',
     '<rootDir>/tests/smoke.test.ts',
     '<rootDir>/tests/navigation.test.ts',
+    '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -4,17 +4,33 @@ import { WakuProvider } from '@/contexts/WakuContext';
 import { QueryClient } from '@tanstack/react-query';
 import { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 import ErrorBoundary from '@/shared/ErrorBoundary';
+import { ThemeProvider, LanguageProvider } from '../ui/ThemeProvider';
 
+/**
+ * Composes the core providers used across the app.
+ *
+ * Provider order is important:
+ * 1. `ErrorBoundary` – captures errors from all descendants.
+ * 2. `ThemeProvider` – applies theming before any UI renders.
+ * 3. `LanguageProvider` – sets up i18n and text direction.
+ * 4. `WalletProvider` – supplies wallet context for network layers.
+ * 5. `CheckedQueryClientProvider` – enforces a single React Query client.
+ * 6. `WakuProvider` – depends on the wallet and query client.
+ */
 export default function AppProviders({ children }: React.PropsWithChildren) {
   const [queryClient] = React.useState(() => new QueryClient());
 
   return (
     <ErrorBoundary>
-      <WalletProvider>
-        <CheckedQueryClientProvider client={queryClient}>
-          <WakuProvider>{children}</WakuProvider>
-        </CheckedQueryClientProvider>
-      </WalletProvider>
+      <ThemeProvider>
+        <LanguageProvider>
+          <WalletProvider>
+            <CheckedQueryClientProvider client={queryClient}>
+              <WakuProvider>{children}</WakuProvider>
+            </CheckedQueryClientProvider>
+          </WalletProvider>
+        </LanguageProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/src/providers/CheckedQueryClientProvider.tsx
+++ b/src/providers/CheckedQueryClientProvider.tsx
@@ -22,5 +22,5 @@ export function CheckedQueryClientProvider(props: QueryClientProviderProps) {
     };
   }, []);
 
-  return <BaseQueryClientProvider {...props} />;
+  return React.createElement(BaseQueryClientProvider, props);
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,4 @@
-export { default as AppProviders } from './AppProviders';
+export { default, default as AppProviders } from './AppProviders';
 export { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 export { WalletProvider } from './WalletProvider';
 export { ThemeProvider, LanguageProvider } from '../ui/ThemeProvider';

--- a/tests/CheckedQueryClientProvider.test.tsx
+++ b/tests/CheckedQueryClientProvider.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { QueryClient } from '@tanstack/react-query';
+import { CheckedQueryClientProvider } from '@/providers/CheckedQueryClientProvider';
+
+describe('CheckedQueryClientProvider', () => {
+  const originalDev = (globalThis as any).__DEV__;
+
+  beforeEach(() => {
+    (globalThis as any).__DEV__ = true;
+  });
+
+  afterEach(() => {
+    (globalThis as any).__DEV__ = originalDev;
+  });
+
+  it('throws when multiple instances mount', () => {
+    let first: renderer.ReactTestRenderer;
+    act(() => {
+      first = renderer.create(
+        React.createElement(
+          CheckedQueryClientProvider,
+          { client: new QueryClient() },
+          React.createElement(React.Fragment),
+        ),
+      );
+    });
+
+    expect(() => {
+      act(() => {
+        renderer.create(
+          React.createElement(
+            CheckedQueryClientProvider,
+            { client: new QueryClient() },
+            React.createElement(React.Fragment),
+          ),
+        );
+      });
+    }).toThrow('Multiple QueryClientProvider instances detected');
+
+    act(() => {
+      first.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- document and wrap global provider order
- export providers via barrel and simplify layout imports
- test that CheckedQueryClientProvider mounts only once

## Testing
- `yarn lint`
- `yarn test tests/CheckedQueryClientProvider.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9cf13111c832693db85a58155b208