### PR TITLE
refactor: centralize UI exports and simplify imports

### DIFF
--- a/components/BannerFormModal.tsx
+++ b/components/BannerFormModal.tsx
@@ -14,7 +14,7 @@ import { X, Save, Trash2 } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import { HeroBanner, Category } from '../types';
 import DatabaseService from '@/services/database';
-import { Spinner } from '@/ui/primitives';
+import { Spinner } from '@/ui';
 import InfoModal from './InfoModal';
 import ConfirmationModal from './ConfirmationModal';
 

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -5,11 +5,9 @@ import {
   TouchableOpacity,
   Platform,
 } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Button, Portal, Overlay } from '@/ui';
 import { useTheme } from '@/ui/ThemeProvider';
 import { X } from 'lucide-react-native';
-import Button from '@/ui/primitives/Button';
-import { Portal, Overlay } from '@/ui/primitives';
 
 interface ConfirmationModalProps {
   visible: boolean;

--- a/components/DisputeResolver.tsx
+++ b/components/DisputeResolver.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, ActivityIndicator } from 'react-native';
-import Button from '@/ui/primitives/Button';
+import { Button } from '@/ui';
 import OrderService from '@/services/orders';
 
 interface Props {

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -6,13 +6,11 @@ import {
   Animated,
   Platform,
 } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Button, Portal, Overlay } from '@/ui';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { spacing, radius, zIndex, shadows } from '@/shared/ui/tokens';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
-import Button from '@/ui/primitives/Button';
-import { Portal, Overlay } from '@/ui/primitives';
 
 type InfoType = 'success' | 'error' | 'info' | 'warning';
 

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -5,7 +5,7 @@ import NotificationService from '@/services/notification';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useAuth } from '@/features/auth/AuthContext';
 import { spacing } from '@/shared/ui/tokens';
-import Badge from '@/ui/primitives/Badge';
+import { Badge } from '@/ui';
 
 interface NotificationBadgeProps {
   size?: number;

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -11,7 +11,7 @@ import {
 import { X } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import { spacing, zIndex } from '@/shared/ui/tokens';
-import { Portal, Overlay } from '@/ui/primitives';
+import { Portal, Overlay } from '@/ui';
 
 interface NotificationPopupProps {
   title: string;

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import ConfirmationModal from '@/components/ConfirmationModal';
-import { Menu, Avatar, type MenuItem } from '@/ui/primitives';
+import { Menu, Avatar, type MenuItem } from '@/ui';
 
 export default function UserAvatar() {
   const { isLoggedIn, user, logout } = useAuth();

--- a/components/admin/AdminList.tsx
+++ b/components/admin/AdminList.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Text from '@/ui/primitives/Text';
-import Button from '@/ui/primitives/Button';
+import { Text, Button } from '@/ui';
 import { spacing, radius, colors } from '@/shared/ui/tokens';
 
 export type AdminListItem = {

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '@/ui/ThemeProvider';
-import Divider from '@/ui/primitives/Divider';
+import { Divider } from '@/ui';
 
 export default function AdminShell({ title, children, actions }: {
   title: string;

--- a/components/chat/MessageInput.tsx
+++ b/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, TextInput, StyleSheet } from 'react-native';
-import Button from '@/ui/primitives/Button';
+import { Button } from '@/ui';
 
 interface Props {
   value: string;

--- a/components/settings/BrandingSettings.tsx
+++ b/components/settings/BrandingSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity, Platform, StyleSheet } from 'react-native';
 import { Settings as SettingsIcon } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   name: string;

--- a/components/settings/CurrencySettings.tsx
+++ b/components/settings/CurrencySettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { DollarSign } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   currencySymbol: string;

--- a/components/settings/EnvironmentSettings.tsx
+++ b/components/settings/EnvironmentSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Settings as SettingsIcon } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   colors: any;

--- a/components/settings/LanguageSettings.tsx
+++ b/components/settings/LanguageSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Globe } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   colors: any;

--- a/components/settings/MoonPaySettings.tsx
+++ b/components/settings/MoonPaySettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { Settings as SettingsIcon } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   fiatKeyInput: string;

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Bell } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   colors: any;

--- a/components/settings/PaymentFactorySettings.tsx
+++ b/components/settings/PaymentFactorySettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { Settings as SettingsIcon } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 interface Props {
   paymentFactoryAddress: string;

--- a/components/settings/RpcSettings.tsx
+++ b/components/settings/RpcSettings.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, TextInput, StyleSheet } from 'react-native';
-import Text from '@/ui/primitives/Text';
-import Button from '@/ui/primitives/Button';
+import { Text, Button, Card } from '@/ui';
 import { Server } from 'lucide-react-native';
-import Card from '@/ui/primitives/Card';
 import SettingsAgent from '../../agents/settings-agent';
 import { errorLog } from '@/utils/logger';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     '^@providers/(.*)$': '<rootDir>/src/providers/$1',
     '^@/features/(.*)$': '<rootDir>/src/features/$1',
     '^@/shared/(.*)$': '<rootDir>/src/shared/$1',
+    '^@/ui$': '<rootDir>/src/ui/index',
     '^@/ui/(.*)$': '<rootDir>/src/ui/$1',
     '^@/layout/(.*)$': '<rootDir>/src/layout/$1',
     '^@/services$': '<rootDir>/src/services/index',

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, ReactNode, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
-import { Spinner } from '@/ui/primitives';
+import { Spinner } from '@/ui';
 import DatabaseService from '@/services/database';
 import { User } from '@/types';
 import { errorLog } from '@/utils/logger';

--- a/src/features/auth/components/AgeVerificationModal.tsx
+++ b/src/features/auth/components/AgeVerificationModal.tsx
@@ -7,7 +7,7 @@ import {
   ScrollView,
   Platform,
 } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Button } from '@/ui';
 import SmartImage from '@/components/SmartImage';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Shield, Calendar } from 'lucide-react-native';
@@ -16,7 +16,6 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useAppInfo } from '@/contexts/AppInfoContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { spacing, typography } from '@/constants/styles';
-import Button from '@/ui/primitives/Button';
 
 const AGE_VERIFICATION_KEY = 'age_verified';
 

--- a/src/features/auth/components/WalletConnectButton.tsx
+++ b/src/features/auth/components/WalletConnectButton.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Text from '@/ui/primitives/Text';
-import Button from '@/ui/primitives/Button';
+import { Text, Button } from '@/ui';
 import { chainAdapter } from '@/services/chain';
 
 interface WalletConnectButtonProps {

--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -6,10 +6,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import EmptyState from '@/shared/ui/EmptyState';
-import { Spinner, Skeleton } from '@/ui/primitives';
-import Text from '@/ui/primitives/Text';
-import Heading from '@/ui/primitives/Heading';
-import Button from '@/ui/primitives/Button';
+import { Spinner, Skeleton, Text, Heading, Button } from '@/ui';
 import { spacing, radius, typography } from '@/ui/tokens';
 
 

--- a/src/features/home/components/CTABecomeSeller.tsx
+++ b/src/features/home/components/CTABecomeSeller.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
-import Button from '@/ui/primitives/Button';
+import { Button } from '@/ui';
 
 export default function CTABecomeSeller() {
   const { t } = useLanguage();

--- a/src/features/home/components/PriceRange.tsx
+++ b/src/features/home/components/PriceRange.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import TextField from '@/ui/primitives/TextField';
+import { TextField } from '@/ui';
 import { spacing } from '@/shared/ui/tokens';
 
 interface PriceRangeProps {

--- a/src/features/home/components/SearchBar.tsx
+++ b/src/features/home/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { useLanguage } from '@/ui/ThemeProvider';
-import TextField from '@/ui/primitives/TextField';
+import { TextField } from '@/ui';
 
 interface SearchBarProps {
   searchQuery: string;

--- a/src/features/payments/components/MoonPayButton.tsx
+++ b/src/features/payments/components/MoonPayButton.tsx
@@ -1,6 +1,6 @@
 import { errorLog } from '@/utils/logger';
 import React, { useState } from 'react';
-import Button from '@/ui/primitives/Button';
+import { Button } from '@/ui';
 import { useAppInfo } from '@/contexts/AppInfoContext';
 import { chainAdapter } from '@/services/chain';
 import MoonPayModal from './MoonPayModal';

--- a/src/features/payments/components/MoonPayModal.tsx
+++ b/src/features/payments/components/MoonPayModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Modal, View, StyleSheet, Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
-import { Spinner } from '@/ui/primitives';
+import { Spinner } from '@/ui';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useAppInfo } from '@/contexts/AppInfoContext';
 

--- a/src/features/payments/components/PayPrivatelyButton.tsx
+++ b/src/features/payments/components/PayPrivatelyButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Button from '@/ui/primitives/Button';
+import { Button } from '@/ui';
 import { chainAdapter } from '@/services/chain';
 
 interface PayPrivatelyButtonProps {

--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { Pressable, Image, View, StyleSheet, ViewStyle } from 'react-native';
 import { Star } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
-import Text from '@/ui/primitives/Text';
-import Button from '@/ui/primitives/Button';
+import { Text, Button, Skeleton } from '@/ui';
 import { spacing, radius, typography } from '@/ui/tokens';
-import { Skeleton } from '@/ui/primitives';
 import { Product } from '@/types';
 
 interface ProductCardProps {

--- a/src/features/products/components/ProductCard.tsx
+++ b/src/features/products/components/ProductCard.tsx
@@ -19,7 +19,7 @@ import DatabaseService from '@/services/database';
 import MediaService from '@/services/media';
 import { useAccountId } from '../../auth/services/nearAuth';
 import productsAgent from '@/agents/products-agent';
-import Card from '@/ui/primitives/Card';
+import { Card } from '@/ui';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const CARD_WIDTH = (SCREEN_WIDTH - 32 - 12) / 2;

--- a/src/shared/ErrorBoundary.tsx
+++ b/src/shared/ErrorBoundary.tsx
@@ -1,9 +1,8 @@
 import React, { ReactNode } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Button } from '@/ui';
 import { useTheme } from '@/ui/ThemeProvider';
 import { spacing } from '@/shared/ui/tokens';
-import Button from '@/ui/primitives/Button';
 import { usePathname } from 'expo-router';
 import { replace } from '@/services/navigation';
 import { errorLog } from '@/utils/logger';

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Button } from '@/ui';
 import type { LucideProps } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
-import Button from '@/ui/primitives/Button';
 
 type IconComponent = React.ComponentType<LucideProps>;
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './primitives';
+export * from './layout';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,9 @@
       "@/shared/*": [
         "src/shared/*"
       ],
+      "@/ui": [
+        "src/ui/index.ts"
+      ],
       "@/ui/*": [
         "src/ui/*"
       ],


### PR DESCRIPTION
## Summary
- add central `src/ui/index.ts` re-exporting primitives and layout
- alias `@/ui` for easier component imports
- update components and features to consume UI elements from `@/ui`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d3ed3e348326a3e07e1995833e4e