### PR TITLE
refactor: use primitives for text and buttons

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,6 +1,8 @@
 import { Redirect, Stack } from 'expo-router';
 import { replace } from '@/services/navigation';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 
 export default function NotFoundScreen() {
   if (__DEV__) {
@@ -12,9 +14,7 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: '404' }} />
       <View style={styles.container}>
         <Text style={styles.text}>404 - Page Not Found</Text>
-        <TouchableOpacity onPress={() => replace('/')}> 
-          <Text style={styles.link}>Go Home</Text>
-        </TouchableOpacity>
+        <Button title="Go Home" onPress={() => replace('/')} />
       </View>
     </>
   );
@@ -30,10 +30,5 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 20,
     fontWeight: '600',
-  },
-  link: {
-    marginTop: 20,
-    fontSize: 16,
-    color: '#007aff',
   },
 });

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, Pressable } from 'react-native';
 import AppShell from '../components/layout/AppShell';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -8,6 +8,8 @@ import EmptyState from '@/shared/ui/EmptyState';
 import { Plus } from 'lucide-react-native';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { useCategories } from '@/services';
+import Text from '@/ui/primitives/Text';
+import { spacing } from '@/ui/tokens';
 
 export default function Categories() {
   const { colors } = useTheme();
@@ -21,13 +23,13 @@ export default function Categories() {
         {categories.length > 0 ? (
           <ScrollView style={{ backgroundColor: colors.canvas }} contentContainerStyle={styles.list}>
             {categories.map((c) => (
-              <TouchableOpacity
+              <Pressable
                 key={c.id}
                 onPress={() => push(`/category/${c.id}`)}
                 style={[styles.item, { borderColor: colors.border.primary }]}
               >
                 <Text style={[styles.itemText, { color: colors.text.primary }]}>{c.name}</Text>
-              </TouchableOpacity>
+              </Pressable>
             ))}
           </ScrollView>
         ) : (
@@ -44,10 +46,10 @@ export default function Categories() {
 
 const styles = StyleSheet.create({
   list: {
-    padding: 16,
+    padding: spacing.spacer16,
   },
   item: {
-    paddingVertical: 12,
+    paddingVertical: spacing.spacer12,
     borderBottomWidth: 1,
   },
   itemText: {

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,11 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  TextInput,
-} from 'react-native';
+import { View, StyleSheet, Pressable, TextInput } from 'react-native';
+import Text from '@/ui/primitives/Text';
 import SmartImage from './SmartImage';
 import { Heart, Search, Star } from 'lucide-react-native';
 import { useAppRouter } from '@/services';
@@ -58,7 +53,7 @@ export default function GlobalHeader({
     <>
       <View style={[styles.header, { backgroundColor: colors.background }]}>
         <View style={styles.headerTop}>
-          <TouchableOpacity
+          <Pressable
             style={styles.logo}
             onPress={() => push('/')}
           >
@@ -72,9 +67,9 @@ export default function GlobalHeader({
             <Text style={[styles.logoText, { color: colors.gold }]}>
               {appName || t('ageVerification.platformName')}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
           <View style={styles.headerIcons}>
-            <TouchableOpacity
+            <Pressable
               style={[
                 styles.iconButton,
                 { backgroundColor: colors.surface.primary },
@@ -82,8 +77,8 @@ export default function GlobalHeader({
               onPress={navigateToReviews}
             >
               <Star size={24} color={colors.text.primary} />
-            </TouchableOpacity>
-            <TouchableOpacity
+            </Pressable>
+            <Pressable
               style={[
                 styles.iconButton,
                 { backgroundColor: colors.surface.primary },
@@ -100,7 +95,7 @@ export default function GlobalHeader({
                   </Text>
                 </View>
               )}
-            </TouchableOpacity>
+            </Pressable>
             <View
               style={[
                 styles.progressContainer,


### PR DESCRIPTION
## Summary
- replace React Native `Text` with design system primitive
- switch `TouchableOpacity` to `Pressable`/`Button` using tokens

## Testing
- `yarn test` *(fails: SyntaxError and module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dca99b0083269880ca4f22161f6b