### PR TITLE
feat: add landing query hook

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Pressable, ScrollView } from 'react-native';
 import Text from '@/ui/primitives/Text';
 import { Link } from 'expo-router';
-import { useAppRouter } from '@/services';
+import { useAppRouter, useCategories, useLanding } from '@/services';
 import AppShell from '../components/layout/AppShell';
 import Divider from '@/ui/primitives/Divider';
-import DatabaseService from '@/services/database';
-import { Product, HeroBanner } from '../types';
-import { useCategories } from '@/services';
 import ProductCard from '@/features/products/ProductCard';
 import { useTheme } from '@/ui/ThemeProvider';
 import SmartImage from '../components/SmartImage';
@@ -18,24 +15,10 @@ import { spacing } from '@/shared/ui/tokens';
 export default function Landing() {
   const { push } = useAppRouter();
   const { colors } = useTheme();
-  const [featured, setFeatured] = useState<Product[]>([]);
-  const [banners, setBanners] = useState<HeroBanner[]>([]);
+  const { data } = useLanding();
+  const featured = data?.featured ?? [];
+  const banners = data?.banners ?? [];
   const { data: categories = [] } = useCategories();
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const db = DatabaseService.getInstance();
-        const prods = await db.getProducts();
-        setFeatured(prods.slice(0, 6));
-        try {
-          const hs = await db.getHeroBanners();
-          setBanners(hs);
-        } catch {}
-      } catch {}
-    };
-    load();
-  }, []);
 
   return (
     <ErrorBoundary>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -15,3 +15,4 @@ export * from './useChatRooms';
 export * from './useProfileData';
 export * from './useRequirePlatformAdmin';
 export * from './useReviews';
+export * from './useLanding';

--- a/src/services/useLanding.ts
+++ b/src/services/useLanding.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import DatabaseService from '@/services/database';
+import { Product, HeroBanner } from '@/types';
+
+interface LandingData {
+  featured: Product[];
+  banners: HeroBanner[];
+}
+
+export function useLanding() {
+  return useQuery<LandingData>({
+    queryKey: ['landing'],
+    queryFn: async () => {
+      const db = DatabaseService.getInstance();
+      const products = await db.getProducts();
+      let banners: HeroBanner[] = [];
+      try {
+        banners = await db.getHeroBanners();
+      } catch {
+        // ignore errors fetching banners
+      }
+      return { featured: products.slice(0, 6), banners };
+    },
+    initialData: { featured: [], banners: [] },
+  });
+}


### PR DESCRIPTION
## Summary
- add React Query-based hook for landing data
- use landing hook in landing screen

## Testing
- `yarn test` *(fails: command produced lint warnings but tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e14fc4788326a811c1c8afd52e85