### PR TITLE
feat: add category detail hook

### DIFF
--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -21,7 +21,7 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import InfoModal from '../../components/InfoModal';
 import { Spinner } from '@/ui/primitives';
 import commonStyles from '@/constants/styles';
-import { useSubcategories } from '@/services';
+import { useCategoryDetail } from '@/services';
 
 const validateParams = createValidateParams(z.object({ id: z.string() }));
 
@@ -38,7 +38,7 @@ export default function CategoryScreen() {
     updateSubcategory: updateSubcategoryMutation,
     deleteSubcategory: deleteSubcategoryMutation,
     isLoading: loading,
-  } = useSubcategories(id);
+  } = useCategoryDetail(id);
   const [showSubcategoryModal, setShowSubcategoryModal] = useState(false);
   const [editingSubcategory, setEditingSubcategory] = useState<Subcategory | null>(null);
   const [newSubcategory, setNewSubcategory] = useState<Partial<Subcategory>>({

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,7 +2,7 @@ export * from './useProducts';
 export * from './useStores';
 export * from './useCategories';
 export * from './useCategory';
-export * from './useSubcategories';
+export * from './useCategoryDetail';
 export * from './usePricingTiers';
 export * from './useProductPricing';
 export * from './useCart';

--- a/src/services/useCategoryDetail.ts
+++ b/src/services/useCategoryDetail.ts
@@ -1,0 +1,72 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import chain from '@/services/chain';
+import type { Category, Subcategory } from '@/types';
+
+let getCategory: ((id: string) => Promise<Category | null>) | undefined;
+let setCategory: ((category: Category) => Promise<void>) | undefined;
+if (chain === 'near') {
+  ({ getCategory, setCategory } = require('@/features/products/services/nearCategories'));
+}
+
+export function useCategoryDetail(id?: string) {
+  const queryClient = useQueryClient();
+
+  const { data: category = null, isLoading } = useQuery({
+    queryKey: ['category', id],
+    queryFn: () => (id && getCategory ? getCategory(id) : Promise.resolve(null)),
+    enabled: !!id,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (updated: Category) =>
+      setCategory ? setCategory(updated) : Promise.resolve(),
+    onSuccess: (_data, updated) => {
+      queryClient.invalidateQueries({ queryKey: ['category', updated.id] });
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+
+  const addSubcategory = async (subcategory: Subcategory) => {
+    if (!category) return;
+    const updated: Category = {
+      ...category,
+      subcategories: [...(category.subcategories ?? []), subcategory],
+    };
+    await mutation.mutateAsync(updated);
+  };
+
+  const updateSubcategory = async (
+    subcategoryId: string,
+    subcategory: Subcategory,
+  ) => {
+    if (!category) return;
+    const updated: Category = {
+      ...category,
+      subcategories: (category.subcategories ?? []).map((s) =>
+        s.id === subcategoryId ? subcategory : s,
+      ),
+    };
+    await mutation.mutateAsync(updated);
+  };
+
+  const deleteSubcategory = async (subcategoryId: string) => {
+    if (!category) return;
+    const updated: Category = {
+      ...category,
+      subcategories: (category.subcategories ?? []).filter(
+        (s) => s.id !== subcategoryId,
+      ),
+    };
+    await mutation.mutateAsync(updated);
+  };
+
+  return {
+    category,
+    subcategories: category?.subcategories ?? [],
+    addSubcategory,
+    updateSubcategory,
+    deleteSubcategory,
+    isLoading: isLoading || mutation.isPending,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `useCategoryDetail` hook to manage category state and mutations
- use the new hook in category page
- expose hook from services index

## Testing
- `npm test` (fails: Jest encountered unexpected token and missing modules)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1524cfc832683728129bdf33966