### PR TITLE
feat: add wishlist and pricing tier hook

### DIFF
--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -16,12 +16,12 @@ interface ProductCardProps {
 
 function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) {
   const { colors } = useTheme();
-  const { isInWishlist, toggleWishlist, price, originalPrice } = useProductCard(product);
-
-  const handleWishlistPress = (e: any) => {
-    e.stopPropagation();
-    toggleWishlist();
-  };
+  const {
+    isInWishlist,
+    handleWishlistPress,
+    price,
+    originalPrice,
+  } = useProductCard(product);
 
   return (
     <Pressable

--- a/src/features/products/hooks/useProductCard.ts
+++ b/src/features/products/hooks/useProductCard.ts
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import CartService from '@/features/cart/services/cart';
 import { useCurrency } from '@/contexts/CurrencyContext';
-import { Product } from '@/types';
+import { Product, PricingTier } from '@/types';
+import { usePricingTiers } from '@/services/usePricingTiers';
 
 export function useProductCard(product: Product) {
   const [isInWishlist, setIsInWishlist] = useState(false);
   const { currencySymbol } = useCurrency();
+  const { data: pricingTiers = [] } = usePricingTiers();
 
   useEffect(() => {
     const cartService = CartService.getInstance();
@@ -28,6 +30,21 @@ export function useProductCard(product: Product) {
     }
   }, [isInWishlist, product]);
 
+  const handleWishlistPress = useCallback(
+    (e?: any) => {
+      e?.stopPropagation();
+      toggleWishlist();
+    },
+    [toggleWishlist],
+  );
+
+  const pricingTier: PricingTier | null = useMemo(() => {
+    if (!product.pricingTier) return null;
+    return (
+      pricingTiers.find(t => t.id === product.pricingTier) || null
+    );
+  }, [product.pricingTier, pricingTiers]);
+
   const price = useMemo(
     () => `${currencySymbol}${product.price.toFixed(2)}`,
     [currencySymbol, product.price]
@@ -40,7 +57,14 @@ export function useProductCard(product: Product) {
     return undefined;
   }, [currencySymbol, product.originalPrice]);
 
-  return { isInWishlist, toggleWishlist, price, originalPrice };
+  return {
+    isInWishlist,
+    pricingTier,
+    toggleWishlist,
+    handleWishlistPress,
+    price,
+    originalPrice,
+  };
 }
 
 export default useProductCard;


### PR DESCRIPTION
## Summary
- expose pricing tier, wishlist toggle, and event handler in `useProductCard`
- simplify `ProductCard` to rely on hook data and handlers

## Testing
- `npm test` *(fails: Unable to reach server; Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e3f067708326a14c5e467fd9b465