### PR TITLE
feat: enhance service hooks with caching and mutations

### DIFF
--- a/src/services/useCart.ts
+++ b/src/services/useCart.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import CartService from '@/features/cart/services/cart';
-import { CartItem } from '@/types';
+import { CartItem, Product } from '@/types';
 
 export function useCart() {
   return useQuery<CartItem[]>({
@@ -10,5 +10,50 @@ export function useCart() {
       return svc.getCartItems();
     },
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useCartMutations() {
+  const queryClient = useQueryClient();
+  const svc = CartService.getInstance();
+
+  const add = useMutation({
+    mutationFn: ({ product, quantity = 1 }: { product: Product; quantity?: number }) =>
+      svc.addToCart(product, quantity),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (itemId: string) => svc.removeFromCart(itemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] });
+    },
+  });
+
+  const updateQty = useMutation({
+    mutationFn: ({ itemId, quantity }: { itemId: string; quantity: number }) =>
+      svc.updateCartItemQuantity(itemId, quantity),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] });
+    },
+  });
+
+  const clear = useMutation({
+    mutationFn: () => svc.clearCart(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] });
+    },
+  });
+
+  return {
+    addToCart: add.mutateAsync,
+    removeFromCart: remove.mutateAsync,
+    updateCartItemQuantity: updateQty.mutateAsync,
+    clearCart: clear.mutateAsync,
+    isPending: add.isPending || remove.isPending || updateQty.isPending || clear.isPending,
+  };
 }

--- a/src/services/useCategories.ts
+++ b/src/services/useCategories.ts
@@ -12,5 +12,7 @@ export function useCategories() {
     queryKey: ['categories'],
     queryFn: () => (listCategories ? listCategories() : Promise.resolve([])),
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 }

--- a/src/services/useCategoryDetail.ts
+++ b/src/services/useCategoryDetail.ts
@@ -15,6 +15,8 @@ export function useCategoryDetail(id?: string) {
     queryKey: ['category', id],
     queryFn: () => (id && getCategory ? getCategory(id) : Promise.resolve(null)),
     enabled: !!id,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 
   const mutation = useMutation({

--- a/src/services/useLanding.ts
+++ b/src/services/useLanding.ts
@@ -22,5 +22,7 @@ export function useLanding() {
       return { featured: products.slice(0, 6), banners };
     },
     initialData: { featured: [], banners: [] },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 }

--- a/src/services/useOrders.ts
+++ b/src/services/useOrders.ts
@@ -1,10 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Order } from '@/types';
 
 let listOrders: ((storeId: string) => Promise<Order[]>) | undefined;
+let setOrder: ((storeId: string, order: Order) => Promise<void>) | undefined;
+let removeOrder: ((storeId: string, id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
-  ({ listOrders } = require('@/services/nearOrders'));
+  ({ listOrders, setOrder, removeOrder } = require('@/services/nearOrders'));
 }
 
 export function useOrders(storeId: string) {
@@ -12,5 +14,33 @@ export function useOrders(storeId: string) {
     queryKey: ['orders', storeId],
     queryFn: () => (listOrders ? listOrders(storeId) : Promise.resolve([])),
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useOrderMutations(storeId: string) {
+  const queryClient = useQueryClient();
+
+  const upsert = useMutation({
+    mutationFn: (order: Order) =>
+      setOrder ? setOrder(storeId, order) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders', storeId] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) =>
+      removeOrder ? removeOrder(storeId, id) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders', storeId] });
+    },
+  });
+
+  return {
+    setOrder: upsert.mutateAsync,
+    removeOrder: remove.mutateAsync,
+    isPending: upsert.isPending || remove.isPending,
+  };
 }

--- a/src/services/usePricingTiers.ts
+++ b/src/services/usePricingTiers.ts
@@ -10,5 +10,7 @@ export function usePricingTiers() {
       return db.getPricingTiers();
     },
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 }

--- a/src/services/useProducts.ts
+++ b/src/services/useProducts.ts
@@ -1,11 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import chain from '@/services/chain';
 import { Product } from '@/types';
 
 let listProducts: ((storeId: string) => Promise<Product[]>) | undefined;
+let setProduct: ((storeId: string, product: Product) => Promise<void>) | undefined;
+let removeProduct: ((storeId: string, id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
-  ({ listProducts } = require('@/features/products/services/nearProducts'));
+  ({ listProducts, setProduct, removeProduct } = require('@/features/products/services/nearProducts'));
 }
 
 export function useProducts(storeId: string) {
@@ -22,5 +24,33 @@ export function useProducts(storeId: string) {
       return data;
     },
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useProductMutations(storeId: string) {
+  const queryClient = useQueryClient();
+
+  const upsert = useMutation({
+    mutationFn: (product: Product) =>
+      setProduct ? setProduct(storeId, product) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['products', storeId] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) =>
+      removeProduct ? removeProduct(storeId, id) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['products', storeId] });
+    },
+  });
+
+  return {
+    setProduct: upsert.mutateAsync,
+    removeProduct: remove.mutateAsync,
+    isPending: upsert.isPending || remove.isPending,
+  };
 }

--- a/src/services/useStores.ts
+++ b/src/services/useStores.ts
@@ -1,10 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Store } from '@/types';
 
 let listStores: ((storeId: string) => Promise<Store[]>) | undefined;
+let setStore: ((storeId: string, store: Store) => Promise<void>) | undefined;
+let removeStore: ((storeId: string, id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
-  ({ listStores } = require('@/features/stores/services/nearStores'));
+  ({ listStores, setStore, removeStore } = require('@/features/stores/services/nearStores'));
 }
 
 export function useStores(storeId: string) {
@@ -12,5 +14,33 @@ export function useStores(storeId: string) {
     queryKey: ['stores', storeId],
     queryFn: () => (listStores ? listStores(storeId) : Promise.resolve([])),
     select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useStoreMutations(storeId: string) {
+  const queryClient = useQueryClient();
+
+  const upsert = useMutation({
+    mutationFn: (store: Store) =>
+      setStore ? setStore(storeId, store) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['stores', storeId] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) =>
+      removeStore ? removeStore(storeId, id) : Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['stores', storeId] });
+    },
+  });
+
+  return {
+    setStore: upsert.mutateAsync,
+    removeStore: remove.mutateAsync,
+    isPending: upsert.isPending || remove.isPending,
+  };
 }

--- a/src/services/useUser.ts
+++ b/src/services/useUser.ts
@@ -1,15 +1,43 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { User } from '@/types';
 
 let getUser: ((id: string) => Promise<User | null>) | undefined;
+let setUser: ((user: User) => Promise<void>) | undefined;
+let removeUser: ((id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
-  ({ getUser } = require('@/features/auth/services/nearUsers'));
+  ({ getUser, setUser, removeUser } = require('@/features/auth/services/nearUsers'));
 }
 
 export function useUser(id: string) {
   return useQuery({
     queryKey: ['user', id],
     queryFn: () => (getUser ? getUser(id) : Promise.resolve(null)),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useUserMutations() {
+  const queryClient = useQueryClient();
+
+  const upsert = useMutation({
+    mutationFn: (user: User) => (setUser ? setUser(user) : Promise.resolve()),
+    onSuccess: (_data, user) => {
+      queryClient.invalidateQueries({ queryKey: ['user', user.id] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => (removeUser ? removeUser(id) : Promise.resolve()),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['user', id] });
+    },
+  });
+
+  return {
+    setUser: upsert.mutateAsync,
+    removeUser: remove.mutateAsync,
+    isPending: upsert.isPending || remove.isPending,
+  };
 }


### PR DESCRIPTION
## Summary
- add staleTime and gcTime to service queries
- add useMutation helpers that invalidate related queries

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e3f1bf3c8326ab409e6865df9fd6