### PR TITLE
refactor: remove runtime i18n imports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,7 @@ import { NotificationProvider } from '@/components/NotificationContext';
 import AppProviders from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
-import { initI18n } from '@/services/i18n';
+import { useLanguage } from '@/ui/ThemeProvider';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
@@ -32,9 +32,10 @@ function RouterApp() {
 }
 
 function FallbackScreen() {
+  const { t } = useLanguage();
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Router disabled</Text>
+      <Text>{t('app.routerDisabled')}</Text>
     </View>
   );
 }
@@ -66,29 +67,5 @@ function MainApp() {
 }
 
 export default function App() {
-  const [ready, setReady] = React.useState(false);
-
-  React.useEffect(() => {
-    let mounted = true;
-    initI18n('en').finally(() => {
-      if (mounted) setReady(true);
-    });
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ready) {
-    return (
-      <GestureHandlerRootView style={{ flex: 1 }}>
-        <SafeAreaProvider>
-          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-            <Text>Loading translations...</Text>
-          </View>
-        </SafeAreaProvider>
-      </GestureHandlerRootView>
-    );
-  }
-
   return <MainApp />;
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -25,6 +25,9 @@
     "understood": "Understood",
     "reload": "Reload"
   },
+  "app": {
+    "routerDisabled": "Router disabled"
+  },
   "navigation": {
     "home": "Home",
     "stores": "Stores",

--- a/translations/he.json
+++ b/translations/he.json
@@ -25,6 +25,9 @@
     "understood": "הבנתי",
     "reload": "טען מחדש"
   },
+  "app": {
+    "routerDisabled": "הנתב מושבת"
+  },
   "navigation": {
     "home": "בית",
     "stores": "חנויות",


### PR DESCRIPTION
## Summary
- use `useLanguage` hook in app shell
- drop runtime `initI18n` call
- add translation key for router disabled message

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@waku/sdk' and Jest unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e58d122083268812204e7c138749