### PR TITLE
Add navigation stripTabsPrefix tests and router push codemod

### DIFF
--- a/scripts/router-push-to-navigation.js
+++ b/scripts/router-push-to-navigation.js
@@ -1,0 +1,39 @@
+const fs = require('fs').promises;
+const { globby } = require('globby');
+
+async function run() {
+  const files = await globby([
+    'app/**/*.{ts,tsx,js,jsx}',
+    'apps/**/*.{ts,tsx,js,jsx}',
+    'src/**/*.{ts,tsx,js,jsx}',
+    'components/**/*.{ts,tsx,js,jsx}',
+    'contexts/**/*.{ts,tsx,js,jsx}',
+  ], {
+    ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],
+  });
+
+  for (const file of files) {
+    let text = await fs.readFile(file, 'utf8');
+    const pushRegex = /router\.push\(\s*(['"`])([^'"`]+)\1\s*\)/g;
+    if (!pushRegex.test(text)) continue;
+
+    let updated = text.replace(pushRegex, (_m, quote, path) => `navigation.push(${quote}${path}${quote})`);
+
+    if (!updated.match(/import\s+\*\s+as\s+navigation\s+from\s+['"]@\/services\/navigation['"]/)) {
+      const lines = updated.split('\n');
+      let lastImport = -1;
+      for (let i = 0; i < lines.length; i++) {
+        if (/^import\s/.test(lines[i])) lastImport = i;
+      }
+      lines.splice(lastImport + 1, 0, "import * as navigation from '@/services/navigation';");
+      updated = lines.join('\n');
+    }
+
+    await fs.writeFile(file, updated);
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import { stripTabsPrefix, push, replace } from '@/services/navigation';
 
 jest.mock('expo-router', () => ({
@@ -7,7 +8,30 @@ jest.mock('expo-router', () => ({
   },
 }));
 
-describe('navigation', () => {
+describe('stripTabsPrefix', () => {
+  it('removes group prefix when present', () => {
+    expect(stripTabsPrefix('/(tabs)/profile')).toBe('/profile');
+  });
+
+  it('returns undefined for nullish values', () => {
+    expect(stripTabsPrefix(undefined)).toBeUndefined();
+    expect(stripTabsPrefix(null)).toBeUndefined();
+  });
+
+  it('leaves path unchanged if no prefix', () => {
+    expect(stripTabsPrefix('/profile')).toBe('/profile');
+  });
+
+  it('does not alter root group path without trailing slash', () => {
+    expect(stripTabsPrefix('/(tabs)')).toBe('/(tabs)');
+  });
+
+  it('handles nested routes and query strings', () => {
+    expect(stripTabsPrefix('/(tabs)/orders/123?foo=bar')).toBe('/orders/123?foo=bar');
+  });
+});
+
+describe('navigation helpers', () => {
   const { router } = require('expo-router');
 
   beforeEach(() => {
@@ -15,22 +39,14 @@ describe('navigation', () => {
     router.replace.mockReset();
   });
 
-  it('stripTabsPrefix removes group prefix', () => {
-    // eslint-disable-next-line no-restricted-syntax
-    expect(stripTabsPrefix('/(tabs)/profile')).toBe('/profile');
-    expect(stripTabsPrefix('/profile')).toBe('/profile');
-    expect(stripTabsPrefix(undefined)).toBeUndefined();
-  });
-
   it('push strips group prefix before routing', () => {
-    // eslint-disable-next-line no-restricted-syntax
     push('/(tabs)/orders');
     expect(router.push).toHaveBeenCalledWith('/orders');
   });
 
   it('replace strips group prefix in pathname objects', () => {
-    // eslint-disable-next-line no-restricted-syntax
     replace({ pathname: '/(tabs)/orders', params: { foo: 'bar' } });
     expect(router.replace).toHaveBeenCalledWith({ pathname: '/orders', params: { foo: 'bar' } });
   });
 });
+


### PR DESCRIPTION
## Summary
- expand stripTabsPrefix test coverage
- add codemod script to replace router.push string paths with navigation.push

## Testing
- `yarn test tests/navigation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5897c288326826a28ace02d0730