### PR TITLE
refactor: centralize route builders

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ const InfoModal = lazy(() => import('@/components/InfoModal'));
 import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters';
 import { spacing } from '@/shared/ui/tokens';
 import { Screen, ScrollArea, Container, Stack } from '@/ui/layout';
+import { routes } from '@/utils/routes';
 
 
 function HomeScreenContent() {
@@ -169,7 +170,7 @@ function HomeScreenContent() {
   const renderCategory = ({ item }: { item: Category }) => (
     <TouchableOpacity
       style={[styles.categoryCard]}
-      onPress={() => push(`/category/${item.id}`)}
+      onPress={() => push(routes.category(item.id))}
     >
       <View
         style={[
@@ -195,7 +196,7 @@ function HomeScreenContent() {
                 borderColor: colors.gold,
               },
             ]}
-            onPress={() => push(`/category/${item.id}`)}
+            onPress={() => push(routes.category(item.id))}
           >
             <Pencil size={10} color={colors.gold} />
           </TouchableOpacity>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -35,6 +35,7 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import { useProfileData } from '@/services';
 import ErrorBoundary from '@/shared/ErrorBoundary';
+import { routes } from '@/utils/routes';
 
 
 
@@ -261,9 +262,9 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() =>
-                storeId && push(`/store/${storeId}/admin/dashboard`)
-              }
+                onPress={() =>
+                  storeId && push(routes.storeAdminDashboard(storeId))
+                }
             >
               <View style={styles.menuItemContent}>
                 <Shield size={24} color={colors.gold} />
@@ -280,9 +281,9 @@ export default function ProfileScreen() {
                   borderColor: colors.border.primary,
                 },
               ]}
-              onPress={() =>
-                storeId && push(`/store/${storeId}/admin/deliveries`)
-              }
+                onPress={() =>
+                  storeId && push(routes.storeAdminDeliveries(storeId))
+                }
             >
               <View style={styles.menuItemContent}>
                 <Package size={24} color={colors.gold} />

--- a/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
+++ b/app/admin/stores/[storeId]/_StoreDetailScreen.tsx
@@ -7,6 +7,7 @@ import { useAppRouter } from '@/services';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useRequirePlatformAdmin } from '@/services';
 import { useStore } from '@/features/products/hooks';
+import { routes } from '@/utils/routes';
 
 export default function StoreDetail() {
   useRequirePlatformAdmin();
@@ -24,7 +25,7 @@ export default function StoreDetail() {
       <Text style={[styles.value, { color: colors.text.primary }]}>{store.owner}</Text>
       <Button
         title="Impersonate"
-        onPress={() => push(`/store/${store.id}/admin/dashboard?impersonate=true`)}
+        onPress={() => push(routes.storeAdminDashboard(store.id, true))}
         style={{ marginTop: 24 }}
       />
     </View>

--- a/app/admin/stores/[storeId]/impersonate.tsx
+++ b/app/admin/stores/[storeId]/impersonate.tsx
@@ -3,6 +3,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '../../../../components/RequireWallet';
+import { routes } from '@/utils/routes';
 
 export default function ImpersonateStore() {
   useRequirePlatformAdmin();
@@ -11,7 +12,7 @@ export default function ImpersonateStore() {
 
   useEffect(() => {
     if (storeId) {
-      replace(`/store/${storeId}/admin/dashboard?impersonate=true`);
+      replace(routes.storeAdminDashboard(storeId, true));
     }
   }, [storeId, replace]);
 

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -10,6 +10,7 @@ import ErrorBoundary from '@/shared/ErrorBoundary';
 import { useCategories } from '@/services';
 import Text from '@/ui/primitives/Text';
 import { spacing } from '@/ui/tokens';
+import { routes } from '@/utils/routes';
 
 export default function Categories() {
   const { colors } = useTheme();
@@ -23,11 +24,11 @@ export default function Categories() {
         {categories.length > 0 ? (
           <ScrollView style={{ backgroundColor: colors.canvas }} contentContainerStyle={styles.list}>
             {categories.map((c) => (
-              <Pressable
-                key={c.id}
-                onPress={() => push(`/category/${c.id}`)}
-                style={[styles.item, { borderColor: colors.border.primary }]}
-              >
+                <Pressable
+                  key={c.id}
+                  onPress={() => push(routes.category(c.id))}
+                  style={[styles.item, { borderColor: colors.border.primary }]}
+                >
                 <Text style={[styles.itemText, { color: colors.text.primary }]}>{c.name}</Text>
               </Pressable>
             ))}

--- a/app/category/[id].tsx
+++ b/app/category/[id].tsx
@@ -22,6 +22,7 @@ import InfoModal from '../../components/InfoModal';
 import { Spinner } from '@/ui/primitives';
 import commonStyles from '@/constants/styles';
 import { useCategoryDetail } from '@/services';
+import { routes } from '@/utils/routes';
 
 const validateParams = createValidateParams(z.object({ id: z.string() }));
 
@@ -152,11 +153,11 @@ export default function CategoryScreen() {
   const renderSubcategory = (item: Subcategory) => (
     <TouchableOpacity
       key={item.id}
-      style={[styles.subcategoryCard, { 
+      style={[styles.subcategoryCard, {
         backgroundColor: colors.surface.primary,
-        borderColor: colors.border.primary 
+        borderColor: colors.border.primary
       }]}
-      onPress={() => push(`/subcategory/${item.id}`)}
+      onPress={() => push(routes.subcategory(item.id))}
     >
       <View style={[styles.subcategoryIcon, { 
         backgroundColor: colors.interactive.secondary,

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -11,6 +11,7 @@ import SmartImage from '../components/SmartImage';
 import Button from '@/ui/primitives/Button';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { spacing } from '@/shared/ui/tokens';
+import { routes } from '@/utils/routes';
 
 export default function Landing() {
   const { push } = useAppRouter();
@@ -141,7 +142,7 @@ export default function Landing() {
                 ] as any[]).map((c) => (
                   <Pressable
                     key={c.id}
-                    onPress={() => push(`/category/${c.id}`)}
+                    onPress={() => push(routes.category(c.id))}
                     style={{
                       paddingHorizontal: spacing.spacer12,
                       paddingVertical: spacing.spacer8,

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -25,6 +25,7 @@ import commonStyles from '@/constants/styles';
 import Card from '@/ui/primitives/Card';
 import SmartImage from '../../components/SmartImage';
 import ErrorBoundary from '@/shared/ErrorBoundary';
+import { routes } from '@/utils/routes';
 
 
 
@@ -296,8 +297,8 @@ export default function ReviewsScreen() {
       <View style={styles.reviewHeader}>
         <TouchableOpacity 
           style={styles.productInfo}
-          onPress={() => push(`/product/${item.productId}`)}
-        >
+            onPress={() => push(routes.product(item.productId))}
+          >
           <SmartImage
             uri={item.productImage}
             width={40}

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -7,6 +7,7 @@ import chain from '@/services/chain';
 import OrderRevenueMetrics from '@/components/OrderRevenueMetrics';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useStore } from '@/features/products/hooks';
+import { routes } from '@/utils/routes';
 
 let listProducts: (() => Promise<any[]>) | undefined;
 if (chain === 'near') {
@@ -27,7 +28,7 @@ export default function StoreDashboardScreen() {
       if (!storeId || !store || !listProducts) return;
       const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
       if (store.owner !== user?.address && !isAdmin) {
-        replace(`/store/${storeId}`);
+        replace(routes.store(storeId));
         return;
       }
       setAuthorized(true);
@@ -51,16 +52,16 @@ export default function StoreDashboardScreen() {
         {storeId && <OrderRevenueMetrics storeId={storeId} />}
       </View>
       <View style={styles.nav}>
-        <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/products`)}
-        >
+          <TouchableOpacity
+            style={[styles.navButton, { borderColor: colors.border.primary }]}
+            onPress={() => push(routes.storeAdminProducts(storeId))}
+          >
           <Text style={{ color: colors.text.primary }}>ניהול מוצרים</Text>
         </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/orders`)}
-        >
+          <TouchableOpacity
+            style={[styles.navButton, { borderColor: colors.border.primary }]}
+            onPress={() => push(routes.storeAdminOrders(storeId))}
+          >
           <Text style={{ color: colors.text.primary }}>צפייה בהזמנות</Text>
         </TouchableOpacity>
       </View>

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -38,6 +38,7 @@ import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import commonStyles from '@/constants/styles';
 import Card from '@/ui/primitives/Card';
+import { routes } from '@/utils/routes';
 import SmartImage from '@/components/SmartImage';
 
 const validateParams = createValidateParams(z.object({ id: z.string() }));
@@ -541,7 +542,7 @@ export default function SubcategoryScreen() {
         currencySymbol={currencySymbol}
         pricingTiers={pricingTiers}
         isStoreOwner={isStoreOwner}
-        onPress={() => push(`/product/${item.id}`)}
+        onPress={() => push(routes.product(item.id))}
         onEdit={editProduct}
       />
     ),
@@ -1056,7 +1057,7 @@ export default function SubcategoryScreen() {
                 }]}
                 onPress={() => {
                   setShowSubcategorySelector(false);
-                  push(`/category/${newProduct.category}`);
+                  push(routes.category(newProduct.category));
                 }}
               >
                 <View style={styles.categorySelectorItemContent}>
@@ -1117,7 +1118,7 @@ export default function SubcategoryScreen() {
                 onPress={() => {
                   setShowPricingTierSelector(false);
                   if (storeId) {
-                    push(`/store/${storeId}/admin/pricing-tiers`);
+                    push(routes.storeAdminPricingTiers(storeId));
                   }
                 }}
               >

--- a/src/features/cart/components/WishlistModal.tsx
+++ b/src/features/cart/components/WishlistModal.tsx
@@ -15,6 +15,7 @@ import { WishlistItem } from '@/types';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import useWishlist from '../hooks/useWishlist';
+import { routes } from '@/utils/routes';
 
 interface WishlistModalProps {
   visible: boolean;
@@ -34,7 +35,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
 
   const viewProduct = (productId: string) => {
     onClose();
-    push(`/product/${productId}`);
+    push(routes.product(productId));
   };
 
   const ITEM_HEIGHT = 118;

--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -8,6 +8,7 @@ import { useAppRouter } from '@/services';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Spinner, Skeleton, Text, Heading, Button } from '@/ui';
 import { spacing, radius, typography } from '@/ui/tokens';
+import { routes } from '@/utils/routes';
 
 
 const SmartImage = lazy(() => import('@/components/SmartImage'));
@@ -48,7 +49,7 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
     <View key={item.id} style={styles.heroBanner}>
       <TouchableOpacity
         style={styles.bannerTouchable}
-        onPress={() => push(`/category/${item.category}`)}
+        onPress={() => push(routes.category(item.category))}
       >
         <Suspense fallback={<Spinner />}>
           <SmartImage

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -37,6 +37,7 @@ import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
 import { useAccountId } from '../../auth/services/nearAuth';
 import { useAppRouter } from '@/services';
+import { routes } from '@/utils/routes';
 
 interface ProductFormModalProps {
   visible: boolean;
@@ -651,9 +652,9 @@ export default function ProductFormModal({
         onClose={() => setShowSubcategorySelector(false)}
         onAdd={() => {
           setShowSubcategorySelector(false);
-          if (editingProduct.category) {
-            push(`/category/${editingProduct.category}`);
-          }
+            if (editingProduct.category) {
+              push(routes.category(editingProduct.category));
+            }
         }}
       />
 

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -1,0 +1,14 @@
+export const routes = {
+  category: (id: string | number) => `/category/${id}`,
+  subcategory: (id: string | number) => `/subcategory/${id}`,
+  product: (id: string | number) => `/product/${id}`,
+  store: (id: string | number) => `/store/${id}`,
+  storeAdminDashboard: (storeId: string | number, impersonate = false) =>
+    `/store/${storeId}/admin/dashboard${impersonate ? '?impersonate=true' : ''}`,
+  storeAdminProducts: (storeId: string | number) => `/store/${storeId}/admin/products`,
+  storeAdminOrders: (storeId: string | number) => `/store/${storeId}/admin/orders`,
+  storeAdminDeliveries: (storeId: string | number) => `/store/${storeId}/admin/deliveries`,
+  storeAdminPricingTiers: (storeId: string | number) => `/store/${storeId}/admin/pricing-tiers`,
+};
+
+export type Routes = typeof routes;


### PR DESCRIPTION
## Summary
- add `routes` helpers for category, product, and store admin paths
- refactor screens to use `routes` object instead of hardcoded strings

## Testing
- `yarn lint`
- `yarn test` *(fails: command terminated without results)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e58be9208326820debc1fa208aa0