### PR TITLE
docs: document provider order and invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ There is **no centralized backend** and **no SQLite**.
 Configuration such as debug logging and Waku peers is supplied through `EXPO_PUBLIC_*` environment variables.
 All SQL migration files have been removed.
 
+## 🧩 Provider Setup
+
+See [src/providers/README.md](src/providers/README.md) for the order and invariants of React providers.
+
+
 ---
 
 ## 🧠 Core Principles

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -1,0 +1,22 @@
+# Provider Composition
+
+`AppProviders.tsx` composes the core React context providers for the application. Its inline comment documents the required ordering; this README summarizes those invariants for contributors.
+
+## Order
+
+1. **ErrorBoundary** – captures errors from all descendants.
+2. **ThemeProvider** – applies theming before any UI renders.
+3. **LanguageProvider** – sets up i18n and text direction.
+4. **WalletProvider** – supplies wallet context for network layers.
+5. **CheckedQueryClientProvider** – enforces a single React Query client.
+6. **WakuProvider** – depends on the wallet and query client.
+
+## Invariants
+
+- `ErrorBoundary` must wrap everything to surface runtime errors.
+- `ThemeProvider` and `LanguageProvider` must appear before any component that uses theming or i18n.
+- `WalletProvider` precedes providers that rely on wallet state, including React Query and Waku.
+- `CheckedQueryClientProvider` ensures only one `QueryClient` instance; `WakuProvider` relies on the client created here.
+- `WakuProvider` depends on both the wallet and query client and therefore must be last.
+
+See [AppProviders.tsx](./AppProviders.tsx) for the authoritative inline comment.


### PR DESCRIPTION
## Summary
- document provider composition and invariants in src/providers/README
- reference doc from AGENTS overview

## Testing
- `yarn test` *(fails: Jest encountered unexpected token and missing module)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1c0d0ec8326adc93935d2d03a10