### PR TITLE
refactor: centralize app providers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { View, Text } from 'react-native';
-import { AppInfoProvider } from '@/contexts/AppInfoContext';
-import { ConfigProvider } from '@/contexts/ConfigContext';
-import { AuthProvider } from '@/features/auth/AuthContext';
-import { AuthModalProvider } from '@/features/auth/AuthModalContext';
-import { CurrencyProvider } from '@/contexts/CurrencyContext';
-import { NotificationProvider } from '@/components/NotificationContext';
 import AppProviders from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
@@ -44,23 +38,11 @@ function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <AppInfoProvider>
-          <AppProviders>
-            <ConfigProvider>
-              <AuthProvider>
-                <AuthModalProvider>
-                  <CurrencyProvider>
-                    <NotificationProvider>
-                      <React.Suspense fallback={null}>
-                        {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-                      </React.Suspense>
-                    </NotificationProvider>
-                  </CurrencyProvider>
-                </AuthModalProvider>
-              </AuthProvider>
-            </ConfigProvider>
-          </AppProviders>
-        </AppInfoProvider>
+        <AppProviders>
+          <React.Suspense fallback={null}>
+            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+          </React.Suspense>
+        </AppProviders>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,53 +2,15 @@ import React from 'react';
 import { Slot } from 'expo-router';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { AppInfoProvider } from '@/contexts/AppInfoContext';
-import { ConfigProvider } from '@/contexts/ConfigContext';
-import { AuthProvider } from '@/features/auth/AuthContext';
-import { AuthModalProvider } from '@/features/auth/AuthModalContext';
-import { CurrencyProvider } from '@/contexts/CurrencyContext';
-import { NotificationProvider } from '@/components/NotificationContext';
 import { AppProviders } from '@/providers';
-import { View } from 'react-native';
-import { useTheme } from '@/ui/ThemeProvider';
-import { Spinner } from '@/ui/primitives';
 
 export default function RootLayout() {
-  const { colors } = useTheme();
-
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <AppInfoProvider>
-          <AppProviders>
-            <ConfigProvider>
-              <AuthProvider>
-                <AuthModalProvider>
-                  <CurrencyProvider>
-                    <NotificationProvider>
-                      <React.Suspense
-                        fallback={
-                          <View
-                            style={{
-                              flex: 1,
-                              justifyContent: 'center',
-                              alignItems: 'center',
-                              backgroundColor: colors.background,
-                            }}
-                          >
-                            <Spinner color={colors.gold} />
-                          </View>
-                        }
-                      >
-                        <Slot />
-                      </React.Suspense>
-                    </NotificationProvider>
-                  </CurrencyProvider>
-                </AuthModalProvider>
-              </AuthProvider>
-            </ConfigProvider>
-          </AppProviders>
-        </AppInfoProvider>
+        <AppProviders>
+          <Slot />
+        </AppProviders>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -5,32 +5,56 @@ import { QueryClient } from '@tanstack/react-query';
 import { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { ThemeProvider, LanguageProvider } from '../ui/ThemeProvider';
+import { AppInfoProvider } from '@/contexts/AppInfoContext';
+import { ConfigProvider } from '@/contexts/ConfigContext';
+import { AuthProvider } from '@/features/auth/AuthContext';
+import { AuthModalProvider } from '@/features/auth/AuthModalContext';
+import { CurrencyProvider } from '@/contexts/CurrencyContext';
+import { NotificationProvider } from '@/components/NotificationContext';
 
 /**
  * Composes the core providers used across the app.
  *
  * Provider order is important:
- * 1. `ErrorBoundary` – captures errors from all descendants.
- * 2. `ThemeProvider` – applies theming before any UI renders.
- * 3. `LanguageProvider` – sets up i18n and text direction.
- * 4. `WalletProvider` – supplies wallet context for network layers.
- * 5. `CheckedQueryClientProvider` – enforces a single React Query client.
- * 6. `WakuProvider` – depends on the wallet and query client.
+ * 1. `AppInfoProvider` – supplies branding and app configuration to theming.
+ * 2. `ConfigProvider` – exposes static runtime configuration.
+ * 3. `ErrorBoundary` – captures errors from all descendants.
+ * 4. `ThemeProvider` – applies theming before any UI renders.
+ * 5. `LanguageProvider` – sets up i18n and text direction.
+ * 6. `WalletProvider` – supplies wallet context for network layers.
+ * 7. `CheckedQueryClientProvider` – enforces a single React Query client.
+ * 8. `WakuProvider` – depends on the wallet and query client.
+ * 9. `AuthProvider` – manages authentication state.
+ * 10. `AuthModalProvider` – handles auth modal display.
+ * 11. `CurrencyProvider` – stores selected currency.
+ * 12. `NotificationProvider` – listens for notifications and displays popups.
  */
 export default function AppProviders({ children }: React.PropsWithChildren) {
   const [queryClient] = React.useState(() => new QueryClient());
 
   return (
-    <ErrorBoundary>
-      <ThemeProvider>
-        <LanguageProvider>
-          <WalletProvider>
-            <CheckedQueryClientProvider client={queryClient}>
-              <WakuProvider>{children}</WakuProvider>
-            </CheckedQueryClientProvider>
-          </WalletProvider>
-        </LanguageProvider>
-      </ThemeProvider>
-    </ErrorBoundary>
+    <AppInfoProvider>
+      <ConfigProvider>
+        <ErrorBoundary>
+          <ThemeProvider>
+            <LanguageProvider>
+              <WalletProvider>
+                <CheckedQueryClientProvider client={queryClient}>
+                  <WakuProvider>
+                    <AuthProvider>
+                      <AuthModalProvider>
+                        <CurrencyProvider>
+                          <NotificationProvider>{children}</NotificationProvider>
+                        </CurrencyProvider>
+                      </AuthModalProvider>
+                    </AuthProvider>
+                  </WakuProvider>
+                </CheckedQueryClientProvider>
+              </WalletProvider>
+            </LanguageProvider>
+          </ThemeProvider>
+        </ErrorBoundary>
+      </ConfigProvider>
+    </AppInfoProvider>
   );
 }


### PR DESCRIPTION
## Summary
- streamline root layout to only gesture handler, safe area, and app providers
- compose Auth, Currency, Notification and other providers within `AppProviders`
- remove suspense spinner to prevent flash on initial paint and simplify App entry

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest failed to parse JSX and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7d450cc8326bbe770fd293e8576