### PR TITLE
refactor: standardize empty and loading UIs

### DIFF
--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -5,6 +5,8 @@ import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '@/components/RequireWallet';
 import chain from '@/services/chain';
 import { User } from '@/types';
+import EmptyState from '@/shared/ui/EmptyState';
+import { Users } from 'lucide-react-native';
 
 let listUsers: (() => Promise<User[]>) | undefined;
 if (chain === 'near') {
@@ -25,13 +27,14 @@ export default function UserDirectory() {
   return (
     <RequireWallet>
       <View style={[styles.container, { backgroundColor: colors.background }]}>
-        {users.map((u) => (
-          <Text key={u.id} style={{ color: colors.text.primary }}>
-            {u.displayName || u.id}
-          </Text>
-        ))}
-        {users.length === 0 && (
-          <Text style={{ color: colors.text.secondary }}>No users found.</Text>
+        {users.length === 0 ? (
+          <EmptyState icon={Users} title="No users" message="No users found." />
+        ) : (
+          users.map((u) => (
+            <Text key={u.id} style={{ color: colors.text.primary }}>
+              {u.displayName || u.id}
+            </Text>
+          ))
         )}
       </View>
     </RequireWallet>

--- a/app/store/[storeId]/admin/_UserManagementScreen.tsx
+++ b/app/store/[storeId]/admin/_UserManagementScreen.tsx
@@ -9,7 +9,6 @@ import {
   TextInput,
   Modal,
   Alert,
-  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppRouter } from '@/services';
@@ -525,7 +524,7 @@ export default function UserManagementScreen() {
                     disabled={loading}
                   >
                     {loading ? (
-                      <ActivityIndicator size="small" color={colors.text.inverse} />
+                      <Spinner size="small" color={colors.text.inverse} />
                     ) : (
                       <>
                         <UserCheck size={20} color={colors.text.inverse} />
@@ -695,7 +694,7 @@ export default function UserManagementScreen() {
                   disabled={loading}
                 >
                   {loading ? (
-                    <ActivityIndicator size="small" color={colors.text.inverse} />
+                    <Spinner size="small" color={colors.text.inverse} />
                   ) : (
                     <>
                       <Save size={20} color={colors.text.inverse} />

--- a/app/subcategory/[id].tsx
+++ b/app/subcategory/[id].tsx
@@ -10,7 +10,6 @@ import {
   Modal,
   TextInput,
   Platform,
-  ActivityIndicator,
   Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -859,7 +858,7 @@ export default function SubcategoryScreen() {
                 disabled={loading}
               >
                 {loading ? (
-                  <ActivityIndicator size="small" color={colors.text.inverse} />
+                  <Spinner size="small" color={colors.text.inverse} />
                 ) : (
                   <>
                     <Save size={20} color={colors.text.inverse} />
@@ -936,7 +935,7 @@ export default function SubcategoryScreen() {
                 disabled={loading}
               >
                 {loading ? (
-                  <ActivityIndicator size="small" color={colors.text.inverse} />
+                  <Spinner size="small" color={colors.text.inverse} />
                 ) : (
                   <>
                     <Save size={20} color={colors.text.inverse} />

--- a/components/DisputeResolver.tsx
+++ b/components/DisputeResolver.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { View, ActivityIndicator } from 'react-native';
+import { View } from 'react-native';
 import { Button } from '@/ui';
+import { Spinner } from '@/ui/primitives';
 import OrderService from '@/services/orders';
 
 interface Props {
@@ -22,7 +23,7 @@ export default function DisputeResolver({ orderId }: Props) {
   if (loading) {
     return (
       <View>
-        <ActivityIndicator />
+        <Spinner />
       </View>
     );
   }

--- a/components/MediaUploader.tsx
+++ b/components/MediaUploader.tsx
@@ -8,13 +8,13 @@ import {
   ScrollView,
   Alert,
   Platform,
-  ActivityIndicator,
 } from 'react-native';
 import SmartImage from './SmartImage';
 import { Camera, Upload, X, Play, Video } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '@/ui/ThemeProvider';
 import MediaService from '@/services/media';
+import { Spinner } from '@/ui/primitives';
 
 interface MediaItem {
   id: string;
@@ -287,7 +287,7 @@ export default function MediaUploader({
               disabled={uploading || !pinataConfigured}
             >
               {uploading ? (
-                <ActivityIndicator size="small" color={colors.gold} />
+                <Spinner size="small" color={colors.gold} />
               ) : (
                 <>
                   <Upload size={20} color={colors.gold} />

--- a/components/ProofUploader.tsx
+++ b/components/ProofUploader.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  ActivityIndicator,
   Alert,
   Platform
 } from 'react-native';
@@ -16,6 +15,7 @@ import { Upload, Camera, File as FileIcon } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import MediaService from '@/services/media';
 import DatabaseService from '@/services/database';
+import { Spinner } from '@/ui/primitives';
 
 interface ProofUploaderProps {
   jobId: string;
@@ -121,7 +121,7 @@ export default function ProofUploader({ jobId, proofUri, onUploaded }: ProofUplo
             disabled={uploading || !pinataConfigured}
           >
             {uploading ? (
-              <ActivityIndicator size="small" color={colors.gold} />
+              <Spinner size="small" color={colors.gold} />
             ) : (
               <>
                 <Upload size={20} color={colors.gold} />

--- a/components/admin/AdminList.tsx
+++ b/components/admin/AdminList.tsx
@@ -2,6 +2,8 @@ import React, { memo, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Text, Button } from '@/ui';
 import { spacing, radius, colors } from '@/shared/ui/tokens';
+import EmptyState from '@/shared/ui/EmptyState';
+import { Inbox } from 'lucide-react-native';
 
 export type AdminListItem = {
   id: string;
@@ -32,7 +34,7 @@ function AdminList({ items, emptyText = 'Nothing yet.' }: Props) {
   if (!items.length) {
     return (
       <View style={styles.container}>
-        <Text style={secondaryTextColor}>{emptyText}</Text>
+        <EmptyState icon={Inbox} title="No items" message={emptyText} />
       </View>
     );
   }

--- a/src/features/auth/components/UserProfileModal.tsx
+++ b/src/features/auth/components/UserProfileModal.tsx
@@ -6,12 +6,12 @@ import {
   Modal,
   TouchableOpacity,
   TouchableWithoutFeedback,
-  ActivityIndicator,
   Platform,
 } from 'react-native';
 import { X } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import DatabaseService from '@/services/database';
+import { Spinner } from '@/ui/primitives';
 
 interface UserProfileModalProps {
   visible: boolean;
@@ -74,7 +74,7 @@ export default function UserProfileModal({ visible, userId, onClose, isAdmin = f
                 <X size={20} color={colors.text.secondary} />
               </TouchableOpacity>
               {loading ? (
-                <ActivityIndicator size="large" color={colors.gold} style={styles.loader} />
+                <Spinner size="large" color={colors.gold} style={styles.loader} />
               ) : profile ? (
                 <>
                   <Text style={[styles.username, { color: colors.text.primary }]}>@{profile.username}</Text>

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -9,7 +9,6 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
-  ActivityIndicator,
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import {
@@ -38,6 +37,7 @@ if (chain === 'near') {
 
 import OrderService from '@/services/orders';
 import eventBus from '@/services/eventBus';
+import { Spinner } from '@/ui/primitives';
 const MoonPayButton = require('@/features/payments/components/MoonPayButton').default;
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '@/ui/ThemeProvider';
@@ -1008,7 +1008,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           disabled={loading}
         >
           {loading ? (
-            <ActivityIndicator size="small" color={colors.text.inverse} />
+            <Spinner size="small" color={colors.text.inverse} />
           ) : (
             <Text style={[styles.completeOrderText, { color: colors.text.inverse }]}> 
               {t('cart.completeOrder')}

--- a/src/features/products/components/PricingTierFormModal.tsx
+++ b/src/features/products/components/PricingTierFormModal.tsx
@@ -9,13 +9,13 @@ import {
   ScrollView,
   TextInput,
   SafeAreaView,
-  ActivityIndicator,
 } from 'react-native';
 import { X, Save, Trash2 } from 'lucide-react-native';
 import { PricingTier } from '@/types';
 import { useTheme } from '@/ui/ThemeProvider';
 import DatabaseService from '@/services/database';
 import InfoModal from '@/components/InfoModal';
+import { Spinner } from '@/ui/primitives';
 
 interface PricingTierFormModalProps {
   visible: boolean;
@@ -323,7 +323,7 @@ export default function PricingTierFormModal({
                 disabled={loading}
               >
                 {loading ? (
-                  <ActivityIndicator size="small" color={colors.text.inverse} style={styles.buttonSpinner} />
+                <Spinner size="small" color={colors.text.inverse} style={styles.buttonSpinner} />
                 ) : (
                   <>
                     <Save size={20} color={colors.text.inverse} />

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -9,7 +9,6 @@ import {
   ScrollView,
   TextInput,
   SafeAreaView,
-  ActivityIndicator,
   Image,
   Platform,
 } from 'react-native';
@@ -38,6 +37,7 @@ import SubcategoryPicker from './SubcategoryPicker';
 import { useAccountId } from '../../auth/services/nearAuth';
 import { useAppRouter } from '@/services';
 import { routes } from '@/utils/routes';
+import { Spinner } from '@/ui/primitives';
 
 interface ProductFormModalProps {
   visible: boolean;
@@ -619,7 +619,7 @@ export default function ProductFormModal({
               >
                 {loading ? (
                   <>
-                    <ActivityIndicator
+                    <Spinner
                       size="small"
                       color={colors.text.inverse}
                       style={styles.buttonSpinner}

--- a/src/ui/primitives/Button.tsx
+++ b/src/ui/primitives/Button.tsx
@@ -6,11 +6,11 @@ import {
   ViewStyle,
   TextStyle,
   PressableProps,
-  ActivityIndicator,
   PressableStateCallbackType,
 } from 'react-native';
 import { useTheme } from '../ThemeProvider';
 import { spacing, radius, typography } from '../tokens';
+import Spinner from './Spinner';
 
 interface ButtonProps extends PressableProps {
   title?: string;
@@ -51,7 +51,7 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
         {...rest}
       >
         {loading ? (
-          <ActivityIndicator color={colors.text.inverse} />
+          <Spinner color={colors.text.inverse} />
         ) : children ? (
           children
         ) : (


### PR DESCRIPTION
## Summary
- replace ActivityIndicator usages with `ui/primitives/Spinner`
- use shared `EmptyState` for user directory and admin lists
- eliminate duplicate loading implementations in `Button` component

## Testing
- `npm test` *(fails: unable to reach server, missing modules, syntax errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9fa40bcf88326bd3b9e75394f43f0