### PR TITLE
refactor: replace pressables with button

### DIFF
--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Pressable } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import AppShell from '../components/layout/AppShell';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -8,7 +8,7 @@ import EmptyState from '@/shared/ui/EmptyState';
 import { Plus } from 'lucide-react-native';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { useCategories } from '@/services';
-import Text from '@/ui/primitives/Text';
+import Button from '@/ui/primitives/Button';
 import { spacing } from '@/ui/tokens';
 import { routes } from '@/utils/routes';
 
@@ -24,13 +24,19 @@ export default function Categories() {
         {categories.length > 0 ? (
           <ScrollView style={{ backgroundColor: colors.canvas }} contentContainerStyle={styles.list}>
             {categories.map((c) => (
-                <Pressable
+                <Button
                   key={c.id}
+                  title={c.name}
                   onPress={() => push(routes.category(c.id))}
-                  style={[styles.item, { borderColor: colors.border.primary }]}
-                >
-                <Text style={[styles.itemText, { color: colors.text.primary }]}>{c.name}</Text>
-              </Pressable>
+                  style={[
+                    styles.item,
+                    {
+                      borderColor: colors.border.primary,
+                      backgroundColor: 'transparent',
+                    },
+                  ]}
+                  textStyle={[styles.itemText, { color: colors.text.primary }]}
+                />
             ))}
           </ScrollView>
         ) : (
@@ -52,6 +58,7 @@ const styles = StyleSheet.create({
   item: {
     paddingVertical: spacing.spacer12,
     borderBottomWidth: 1,
+    alignItems: 'flex-start',
   },
   itemText: {
     fontWeight: '600',

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Pressable, ScrollView } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import Text from '@/ui/primitives/Text';
 import { Link } from 'expo-router';
 import { useAppRouter, useCategories, useLanding } from '@/services';
@@ -10,7 +10,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import SmartImage from '../components/SmartImage';
 import Button from '@/ui/primitives/Button';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import { spacing } from '@/shared/ui/tokens';
+import { spacing, radius } from '@/shared/ui/tokens';
 import { routes } from '@/utils/routes';
 
 export default function Landing() {
@@ -45,12 +45,12 @@ export default function Landing() {
           />
           <View style={{ flexDirection: 'row', gap: spacing.spacer12, marginTop: spacing.spacer16 }}>
             <Link href="/store/alpha" asChild>
-              <Button title="Open Alpha Store" style={{ borderRadius: 10 }} />
+              <Button title="Open Alpha Store" />
             </Link>
             <Link href="/" asChild>
               <Button
                 title="Browse App"
-                style={{ borderRadius: 10, borderColor: colors.gold, backgroundColor: 'transparent' }}
+                style={{ borderRadius: radius.md, borderColor: colors.gold, backgroundColor: 'transparent' }}
               />
             </Link>
           </View>
@@ -140,20 +140,20 @@ export default function Landing() {
                   { id: 'sports', name: 'Sports' },
                   { id: 'books', name: 'Books' },
                 ] as any[]).map((c) => (
-                  <Pressable
+                  <Button
                     key={c.id}
+                    title={c.name}
                     onPress={() => push(routes.category(c.id))}
                     style={{
                       paddingHorizontal: spacing.spacer12,
                       paddingVertical: spacing.spacer8,
-                      borderRadius: 16,
+                      borderRadius: radius.xl,
                       borderWidth: 1,
                       borderColor: colors.border.primary,
                       backgroundColor: colors.surface.primary,
                     }}
-                  >
-                    <Text style={{ color: colors.text.primary, fontWeight: '600' }}>{c.name}</Text>
-                  </Pressable>
+                    textStyle={{ color: colors.text.primary, fontWeight: '600' }}
+                  />
                 ))}
               </View>
             </ScrollView>

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, Pressable, TextInput } from 'react-native';
-import { Text } from '@/ui';
+import { Text, Button } from '@/ui';
 import SmartImage from './SmartImage';
 import { Heart, Search, Star } from 'lucide-react-native';
 import { useAppRouter } from '@/services';
@@ -69,7 +69,7 @@ export default function GlobalHeader({
             </Text>
           </Pressable>
           <View style={styles.headerIcons}>
-            <Pressable
+            <Button
               style={[
                 styles.iconButton,
                 { backgroundColor: colors.surface.primary },
@@ -77,8 +77,8 @@ export default function GlobalHeader({
               onPress={navigateToReviews}
             >
               <Star size={24} color={colors.text.primary} />
-            </Pressable>
-            <Pressable
+            </Button>
+            <Button
               style={[
                 styles.iconButton,
                 { backgroundColor: colors.surface.primary },
@@ -87,7 +87,7 @@ export default function GlobalHeader({
             >
               <Heart size={24} color={colors.text.primary} />
               {wishlistItemsCount > 0 && (
-                <View style={[styles.badge, { backgroundColor: colors.gold }]}>
+                <View style={[styles.badge, { backgroundColor: colors.gold }]}> 
                   <Text
                     style={[styles.badgeText, { color: colors.text.inverse }]}
                   >
@@ -95,7 +95,7 @@ export default function GlobalHeader({
                   </Text>
                 </View>
               )}
-            </Pressable>
+            </Button>
             <View
               style={[
                 styles.progressContainer,
@@ -185,8 +185,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.full,
     width: spacing.spacer40,
     height: spacing.spacer40,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   badge: {
     position: 'absolute',

--- a/src/ui/primitives/Chip.tsx
+++ b/src/ui/primitives/Chip.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Pressable, Text, StyleProp, ViewStyle, TextStyle } from 'react-native';
+import { StyleProp, ViewStyle, TextStyle } from 'react-native';
 import { useTheme } from '../ThemeProvider';
 import { radius, spacing, typography } from '../tokens';
+import Button from './Button';
 
 interface ChipProps {
   label: string;
@@ -14,9 +15,9 @@ export default function Chip({ label, onPress, style, textStyle }: ChipProps) {
   const { colors } = useTheme();
   const [isFocused, setIsFocused] = React.useState(false);
   return (
-    <Pressable
+    <Button
+      title={label}
       onPress={onPress}
-      accessibilityRole="button"
       accessibilityLabel={label}
       hitSlop={8}
       onFocus={() => setIsFocused(true)}
@@ -38,8 +39,7 @@ export default function Chip({ label, onPress, style, textStyle }: ChipProps) {
           borderWidth: 2,
         },
       ]}
-    >
-      <Text style={[{ color: colors.text.primary, ...typography.sm }, textStyle]}>{label}</Text>
-    </Pressable>
+      textStyle={[{ color: colors.text.primary, ...typography.sm }, textStyle]}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- swap button-like `Pressable` components for shared `Button`
- remove bespoke button padding/alignment in favor of token-based styles
- update `Chip` to wrap `Button`

## Testing
- `CI=true npm test` *(fails: hangs, see warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fa3f233c8326b98332b8acc2a66a