### PR TITLE
feat: prepare landing data

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, ScrollView } from 'react-native';
 import Text from '@/ui/primitives/Text';
 import { Link } from 'expo-router';
-import { useAppRouter, useCategories, useLanding } from '@/services';
+import { useAppRouter, useLanding } from '@/services';
 import AppShell from '../components/layout/AppShell';
 import Divider from '@/ui/primitives/Divider';
 import ProductCard from '@/features/products/ProductCard';
@@ -19,7 +19,7 @@ export default function Landing() {
   const { data } = useLanding();
   const featured = data?.featured ?? [];
   const banners = data?.banners ?? [];
-  const { data: categories = [] } = useCategories();
+  const categories = data?.categories ?? [];
 
   return (
     <ErrorBoundary>
@@ -82,10 +82,7 @@ export default function Landing() {
           <View style={{ marginTop: spacing.spacer12 }}>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
               <View style={{ flexDirection: 'row', gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }}>
-                {(banners.length ? banners : [
-                  { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
-                  { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
-                ] as any[]).map((b) => (
+                {banners.map((b) => (
                   <View
                     key={b.id}
                     style={{
@@ -132,14 +129,7 @@ export default function Landing() {
           <View style={{ marginTop: spacing.spacer12 }}>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
               <View style={{ flexDirection: 'row', gap: spacing.spacer8 }}>
-                {(categories.length ? categories.slice(0, 8) : [
-                  { id: 'electronics', name: 'Electronics' },
-                  { id: 'fashion', name: 'Fashion' },
-                  { id: 'home', name: 'Home' },
-                  { id: 'beauty', name: 'Beauty' },
-                  { id: 'sports', name: 'Sports' },
-                  { id: 'books', name: 'Books' },
-                ] as any[]).map((c) => (
+                {categories.map((c) => (
                   <Button
                     key={c.id}
                     title={c.name}

--- a/src/services/useLanding.ts
+++ b/src/services/useLanding.ts
@@ -1,27 +1,52 @@
 import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
-import { Product, HeroBanner } from '@/types';
+import chain from '@/services/chain';
+import { Product, HeroBanner, Category } from '@/types';
 
 interface LandingData {
   featured: Product[];
   banners: HeroBanner[];
+  categories: Category[];
 }
+
+let listCategories: (() => Promise<Category[]>) | undefined;
+if (chain === 'near') {
+  ({ listCategories } = require('@/features/products/services/nearCategories'));
+}
+
+const defaultBanners: HeroBanner[] = [
+  { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
+  { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
+];
+
+const defaultCategories: Category[] = [
+  { id: 'electronics', name: 'Electronics' },
+  { id: 'fashion', name: 'Fashion' },
+  { id: 'home', name: 'Home' },
+  { id: 'beauty', name: 'Beauty' },
+  { id: 'sports', name: 'Sports' },
+  { id: 'books', name: 'Books' },
+];
 
 export function useLanding() {
   return useQuery<LandingData>({
     queryKey: ['landing'],
     queryFn: async () => {
       const db = DatabaseService.getInstance();
-      const products = await db.getProducts();
-      let banners: HeroBanner[] = [];
-      try {
-        banners = await db.getHeroBanners();
-      } catch {
-        // ignore errors fetching banners
-      }
-      return { featured: products.slice(0, 6), banners };
+
+      const [products, bannersRaw, categoriesRaw] = await Promise.all([
+        db.getProducts(),
+        db.getHeroBanners().catch(() => [] as HeroBanner[]),
+        listCategories ? listCategories().catch(() => [] as Category[]) : Promise.resolve([]),
+      ]);
+
+      const featured = products.slice(0, 6);
+      const banners = bannersRaw.length ? bannersRaw : defaultBanners;
+      const categories = (categoriesRaw.length ? categoriesRaw : defaultCategories).slice(0, 8);
+
+      return { featured, banners, categories };
     },
-    initialData: { featured: [], banners: [] },
+    initialData: { featured: [], banners: defaultBanners, categories: defaultCategories },
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
- preload landing data with default banners and categories
- consume landing data directly without placeholder arrays

## Testing
- `yarn test` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc055c388326a1e672ee33a4a6ea