### PR TITLE
refactor: use routes helpers and restrict raw paths

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -44,7 +44,7 @@ export default function Landing() {
             }}
           />
           <View style={{ flexDirection: 'row', gap: spacing.spacer12, marginTop: spacing.spacer16 }}>
-            <Link href="/store/alpha" asChild>
+            <Link href={routes.store('alpha')} asChild>
               <Button title="Open Alpha Store" />
             </Link>
             <Link href="/" asChild>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,14 @@ module.exports = [
           selector: "MemberExpression[object.name='router']",
           message: "Do not use router directly; use useAppRouter().",
         },
+        {
+          selector: "Literal[value^='/']",
+          message: 'Use routes helper functions instead of hard-coded paths.',
+        },
+        {
+          selector: "TemplateElement[value.raw^='/']",
+          message: 'Use routes helper functions instead of hard-coded paths.',
+        },
       ],
       'no-restricted-imports': [
         'error',
@@ -128,6 +136,14 @@ module.exports = [
         {
           selector: "TemplateElement[value.raw=/\\(tabs\\)/]",
           message: "Avoid using the tabs route group; use root-relative '/' paths instead.",
+        },
+        {
+          selector: "Literal[value^='/']",
+          message: 'Use routes helper functions instead of hard-coded paths.',
+        },
+        {
+          selector: "TemplateElement[value.raw^='/']",
+          message: 'Use routes helper functions instead of hard-coded paths.',
         },
       ],
       'no-restricted-imports': [

--- a/tests/admin-impersonate.test.tsx
+++ b/tests/admin-impersonate.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import Impersonate from '@app/admin/stores/[storeId]/impersonate';
+import { routes } from '@/utils/routes';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: jest.fn(),
@@ -28,6 +29,6 @@ describe('Admin store impersonation', () => {
       renderer.create(<Impersonate />);
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith('/store/s1/admin/dashboard?impersonate=true');
+    expect(router.replace).toHaveBeenCalledWith(routes.storeAdminDashboard('s1', true));
   });
 });

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,5 +1,6 @@
 import { spawn, ChildProcess } from 'child_process';
 import { chromium, Browser, Page } from 'playwright';
+import { routes } from '@/utils/routes';
 
 const PORT = 4173;
 const URL = `http://localhost:${PORT}/`;
@@ -55,7 +56,7 @@ describe('web smoke test', () => {
     await page!.waitForSelector('text=Login');
 
     // category route loads
-    await page!.goto(`${URL}storefront/category/electronics`);
+    await page!.goto(`${URL}storefront${routes.category('electronics')}`);
     await page!.waitForSelector('[data-testid="search-input"]');
   }, 60000);
 });

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import StoreDashboardScreen from '@app/store/[storeId]/admin/dashboard';
+import { routes } from '@/utils/routes';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: jest.fn(),
@@ -70,7 +71,7 @@ describe('StoreDashboardScreen', () => {
       root = renderer.create(<StoreDashboardScreen />);
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith('/store/s1');
+    expect(router.replace).toHaveBeenCalledWith(routes.store('s1'));
     expect(root!.toJSON()).toBeNull();
   });
 
@@ -84,7 +85,7 @@ describe('StoreDashboardScreen', () => {
       root = renderer.create(<StoreDashboardScreen />);
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith('/store/s1');
+    expect(router.replace).toHaveBeenCalledWith(routes.store('s1'));
     expect(root!.toJSON()).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- refactor landing link to use routes.store
- update tests to use routes helpers for navigation paths
- add ESLint rule guarding against raw path strings

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc0b775c832686f2cc322520bde9