### PR TITLE
chore: re-export language hook from providers

### DIFF
--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 import AppShell from '../components/layout/AppShell';
 import { useTheme } from '@/ui/ThemeProvider';
-import { useLanguage } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/providers';
 import { useAppRouter } from '@/services';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Plus } from 'lucide-react-native';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,4 @@
 export { default, default as AppProviders } from './AppProviders';
 export { CheckedQueryClientProvider } from './CheckedQueryClientProvider';
 export { WalletProvider } from './WalletProvider';
-export { ThemeProvider, LanguageProvider } from '../ui/ThemeProvider';
+export { ThemeProvider, LanguageProvider, useLanguage } from '../ui/ThemeProvider';


### PR DESCRIPTION
## Summary
- re-export useLanguage hook from providers index
- update categories screen to demonstrate importing useLanguage from providers

## Testing
- `yarn test` *(fails: Jest encountered unexpected token and missing @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6a41df9c83269d83352d9ffedf57