### PR TITLE
chore: enforce i18n and localize landing

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -12,6 +12,7 @@ import Button from '@/ui/primitives/Button';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { routes } from '@/utils/routes';
+import { t } from '@/services/i18n';
 
 export default function Landing() {
   const { push } = useAppRouter();
@@ -28,10 +29,10 @@ export default function Landing() {
           {/* Hero */}
         <View style={{ paddingHorizontal: spacing.spacer16, paddingTop: spacing.spacer24, paddingBottom: spacing.spacer12, alignItems: 'center' }}>
           <Text style={{ color: colors.text.primary, fontSize: 28, fontWeight: '800', textAlign: 'center' }}>
-            Blue Ocean Marketplace
+            {t('landing.title')}
           </Text>
           <Text style={{ color: colors.text.secondary, marginTop: spacing.spacer8, textAlign: 'center' }}>
-            Decentralized commerce on NEAR — own your store, your data, your future.
+            {t('landing.subtitle')}
           </Text>
           <Divider
             style={{
@@ -45,11 +46,11 @@ export default function Landing() {
           />
           <View style={{ flexDirection: 'row', gap: spacing.spacer12, marginTop: spacing.spacer16 }}>
             <Link href={routes.store('alpha')} asChild>
-              <Button title="Open Alpha Store" />
+              <Button title={t('landing.openAlphaStore')} />
             </Link>
             <Link href="/" asChild>
               <Button
-                title="Browse App"
+                title={t('landing.browseApp')}
                 style={{ borderRadius: radius.md, borderColor: colors.gold, backgroundColor: 'transparent' }}
               />
             </Link>
@@ -66,7 +67,7 @@ export default function Landing() {
               textAlign: 'center',
             }}
           >
-            Highlights
+            {t('landing.highlights')}
           </Text>
           <Divider
             style={{
@@ -114,7 +115,7 @@ export default function Landing() {
 
         {/* Categories */}
         <View style={{ paddingHorizontal: spacing.spacer16, paddingVertical: spacing.spacer16 }}>
-          <Text style={{ color: colors.text.primary, fontSize: 18, fontWeight: '700' }}>Categories</Text>
+          <Text style={{ color: colors.text.primary, fontSize: 18, fontWeight: '700' }}>{t('landing.categories')}</Text>
           <Divider
             style={{
               width: 120,
@@ -152,7 +153,7 @@ export default function Landing() {
 
         {/* Featured */}
         <View style={{ paddingHorizontal: spacing.spacer16, paddingVertical: spacing.spacer16 }}>
-          <Text style={{ color: colors.text.primary, fontSize: 18, fontWeight: '700' }}>Featured</Text>
+          <Text style={{ color: colors.text.primary, fontSize: 18, fontWeight: '700' }}>{t('landing.featured')}</Text>
           <Divider
             style={{
               width: 120,
@@ -173,7 +174,7 @@ export default function Landing() {
               ))}
             </View>
             {featured.length === 0 && (
-              <Text style={{ color: colors.text.secondary }}>No featured items yet.</Text>
+              <Text style={{ color: colors.text.secondary }}>{t('landing.noFeaturedItemsYet')}</Text>
             )}
           </View>
         </View>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ts-prune": "node scripts/app.js ts-prune",
     "doctor": "node scripts/app.js doctor",
     "prepare": "husky install",
+    "i18n:check": "node scripts/check-i18n.js",
     "contract:build": "node scripts/app.js contract build",
     "contract:deploy": "node scripts/app.js contract deploy",
     "indexer:dev": "node scripts/app.js indexer dev",
@@ -168,7 +169,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "yarn lint"
+      "yarn lint",
+      "node scripts/check-i18n.js"
     ],
     "**/*": [
       "node scripts/check-no-ton.js"

--- a/scripts/check-i18n.js
+++ b/scripts/check-i18n.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const ts = require('typescript');
+const fs = require('fs');
+
+const files = process.argv.slice(2);
+let hasError = false;
+
+function isWithinT(node) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isCallExpression(current)) {
+      const expr = current.expression;
+      if (ts.isIdentifier(expr) && expr.text === 't') {
+        return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function shouldIgnore(node, text) {
+  const parent = node.parent;
+  if (ts.isImportDeclaration(parent) || ts.isExportDeclaration(parent)) return true;
+  if (ts.isPropertyAssignment(parent)) {
+    const name = parent.name.getText();
+    if (["id", "key", "href"].includes(name)) return true;
+  }
+  if (ts.isJsxAttribute(parent)) {
+    const name = parent.name.getText();
+    if (["href", "src", "testID"].includes(name)) return true;
+  }
+  if (ts.isCallExpression(parent)) {
+    const callee = parent.expression.getText();
+    if (callee.startsWith('routes.')) return true;
+  }
+  if (/^\s*$/.test(text)) return true;
+  if (text.includes('/')) return true;
+  if (/^[a-z0-9_@.%-]+$/.test(text)) return true; // lowercase tokens
+  if (/^[a-zA-Z0-9_-]+$/.test(text) && text.length < 5) return true; // short ids
+  return false;
+}
+
+function checkFile(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const source = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+
+  function report(node, text) {
+    const { line, character } = source.getLineAndCharacterOfPosition(node.getStart());
+    console.error(`${file}:${line + 1}:${character + 1} - Untranslated string: "${text}"`);
+    hasError = true;
+  }
+
+  function visit(node) {
+    if (ts.isJsxText(node)) {
+      const text = node.getText().trim();
+      if (text && !shouldIgnore(node, text)) {
+        report(node, text);
+      }
+    } else if (ts.isStringLiteral(node)) {
+      const text = node.text.trim();
+      if (text && !isWithinT(node) && !shouldIgnore(node, text)) {
+        report(node, text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+}
+
+if (files.length === 0) {
+  console.error('No files provided');
+  process.exit(1);
+}
+
+files.forEach(checkFile);
+if (hasError) {
+  process.exit(1);
+}

--- a/src/services/useLanding.ts
+++ b/src/services/useLanding.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import chain from '@/services/chain';
 import { Product, HeroBanner, Category } from '@/types';
+import { t } from '@/services/i18n';
 
 interface LandingData {
   featured: Product[];
@@ -15,17 +16,27 @@ if (chain === 'near') {
 }
 
 const defaultBanners: HeroBanner[] = [
-  { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
-  { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
+  {
+    id: 'b1',
+    image: '',
+    title: t('landing.defaultBanners.welcome'),
+    subtitle: t('landing.defaultBanners.ownStore'),
+  },
+  {
+    id: 'b2',
+    image: '',
+    title: t('landing.defaultBanners.decentralized'),
+    subtitle: t('landing.defaultBanners.fastSecure'),
+  },
 ];
 
 const defaultCategories: Category[] = [
-  { id: 'electronics', name: 'Electronics' },
-  { id: 'fashion', name: 'Fashion' },
-  { id: 'home', name: 'Home' },
-  { id: 'beauty', name: 'Beauty' },
-  { id: 'sports', name: 'Sports' },
-  { id: 'books', name: 'Books' },
+  { id: 'electronics', name: t('landing.defaultCategories.electronics') },
+  { id: 'fashion', name: t('landing.defaultCategories.fashion') },
+  { id: 'home', name: t('landing.defaultCategories.home') },
+  { id: 'beauty', name: t('landing.defaultCategories.beauty') },
+  { id: 'sports', name: t('landing.defaultCategories.sports') },
+  { id: 'books', name: t('landing.defaultCategories.books') },
 ];
 
 export function useLanding() {

--- a/translations/en.json
+++ b/translations/en.json
@@ -96,6 +96,30 @@
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
     "becomeSeller": "Become a Seller"
   },
+  "landing": {
+    "title": "Blue Ocean Marketplace",
+    "subtitle": "Decentralized commerce on NEAR — own your store, your data, your future.",
+    "openAlphaStore": "Open Alpha Store",
+    "browseApp": "Browse App",
+    "highlights": "Highlights",
+    "categories": "Categories",
+    "featured": "Featured",
+    "noFeaturedItemsYet": "No featured items yet.",
+    "defaultBanners": {
+      "welcome": "Welcome to Blue Ocean",
+      "ownStore": "Own your store on NEAR",
+      "decentralized": "Decentralized by design",
+      "fastSecure": "Fast, P2P and secure"
+    },
+    "defaultCategories": {
+      "electronics": "Electronics",
+      "fashion": "Fashion",
+      "home": "Home",
+      "beauty": "Beauty",
+      "sports": "Sports",
+      "books": "Books"
+    }
+  },
   "categories": {
     "all": "All"
   },


### PR DESCRIPTION
## Summary
- add i18n lint script and hook into lint-staged
- localize landing page strings with translation keys
- provide default translated banners and categories

## Testing
- `yarn lint`
- `yarn i18n:check app/landing.tsx src/services/useLanding.ts`
- `yarn test` *(fails: Unable to reach server; Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6a3ffa2c83269ca1a87ff3c8d76a