### PR TITLE
refactor: replace console logs with debugLog

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import AppProviders from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { useLanguage } from '@/ui/ThemeProvider';
+import { debugLog } from '@/utils/logger';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
@@ -18,8 +19,7 @@ function RouterApp() {
 
     const path = stripTabsPrefix(pathname) ?? pathname;
     const currentTab = segments[0] ?? '';
-    // eslint-disable-next-line no-console
-    console.log('[breadcrumb]', path, currentTab);
+    debugLog(`[breadcrumb] ${path} ${currentTab}`);
   }, [pathname, segments]);
 
   return <Router />;

--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -8,6 +8,7 @@ import FloatingCartWidget from '@/features/cart/components/FloatingCartWidget';
 import { getTabsForAuth } from '@/config/navigation';
 import { useAuth } from '@/features/auth/AuthContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
+import { debugLog } from '@/utils/logger';
 
 export default function TabsLayout() {
   const { t } = useLanguage();
@@ -16,9 +17,7 @@ export default function TabsLayout() {
   const pathname = usePathname();
   const [showCartWidget, setShowCartWidget] = useState(false);
   const tabs = getTabsForAuth(auth);
-  try {
-    console.log('[TabsLayout] route:', pathname, 'tabs:', tabs.map((tb) => tb.name));
-  } catch {}
+  debugLog(`[TabsLayout] route: ${pathname} tabs: ${tabs.map((tb) => tb.name)}`);
 
   useEffect(() => {
     setShowCartWidget(pathname === '/' || pathname === '/index');
@@ -36,7 +35,7 @@ export default function TabsLayout() {
     paddingBottom: 8,
     paddingTop: 8,
   } as const;
-  warnIfTabBarHidden(tabBarStyle as any, 'TabsLayout');
+  warnIfTabBarHidden(tabBarStyle as any, TabsLayout.name);
 
   const screenOptions = {
     headerShown: false,
@@ -89,8 +88,6 @@ function mapTitle(t: (key: string) => string, raw: string) {
     Categories: t('navigation.categories'),
     Notifications: t('navigation.notifications'),
     Reviews: t('navigation.reviews'),
-    Dashboard: 'Dashboard',
-    Catalog: 'Catalog',
   };
   return map[raw] ?? raw;
 }


### PR DESCRIPTION
## Summary
- replace stray console logs in App and TabsLayout with debugLog utility
- remove redundant tab title mappings

## Testing
- `yarn lint`
- `yarn test tests/smoke.test.ts` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c10a3f083268364160fb42cb170