### PR TITLE
refactor product service to use chain adapter

### DIFF
--- a/src/features/products/services/ProductAdapter.ts
+++ b/src/features/products/services/ProductAdapter.ts
@@ -1,0 +1,9 @@
+import { Product } from '@/types';
+
+export interface ProductAdapter {
+  listProducts(storeId: string): Promise<Product[]>;
+  setProduct(storeId: string, product: Product): Promise<void>;
+  removeProduct(storeId: string, id: string): Promise<void>;
+}
+
+export default ProductAdapter;

--- a/src/features/products/services/index.ts
+++ b/src/features/products/services/index.ts
@@ -1,0 +1,19 @@
+import CHAIN from '@/config/chain';
+import type { ProductAdapter } from './ProductAdapter';
+import { listProducts as nearListProducts, setProduct as nearSetProduct, removeProduct as nearRemoveProduct } from './nearProducts';
+
+const unsupported: ProductAdapter = {
+  async listProducts() { return []; },
+  async setProduct() { /* no-op */ },
+  async removeProduct() { /* no-op */ },
+};
+
+export const productsAdapter: ProductAdapter = CHAIN === 'near'
+  ? {
+      listProducts: nearListProducts,
+      setProduct: nearSetProduct,
+      removeProduct: nearRemoveProduct,
+    }
+  : unsupported;
+
+export type { ProductAdapter };

--- a/src/services/useProducts.ts
+++ b/src/services/useProducts.ts
@@ -1,14 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
-import chain from '@/services/chain';
+import { productsAdapter } from '@/features/products/services';
 import { Product } from '@/types';
-
-let listProducts: ((storeId: string) => Promise<Product[]>) | undefined;
-let setProduct: ((storeId: string, product: Product) => Promise<void>) | undefined;
-let removeProduct: ((storeId: string, id: string) => Promise<void>) | undefined;
-if (chain === 'near') {
-  ({ listProducts, setProduct, removeProduct } = require('@/features/products/services/nearProducts'));
-}
 
 export function useProducts(storeId: string) {
   return useQuery({
@@ -16,9 +9,9 @@ export function useProducts(storeId: string) {
     queryFn: async () => {
       const db = DatabaseService.getInstance();
       let data = await db.getProducts();
-      if (data.length === 0 && listProducts) {
+      if (data.length === 0) {
         try {
-          data = await listProducts(storeId);
+          data = await productsAdapter.listProducts(storeId);
         } catch {}
       }
       return data;
@@ -34,15 +27,14 @@ export function useProductMutations(storeId: string) {
 
   const upsert = useMutation({
     mutationFn: (product: Product) =>
-      setProduct ? setProduct(storeId, product) : Promise.resolve(),
+      productsAdapter.setProduct(storeId, product),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['products', storeId] });
     },
   });
 
   const remove = useMutation({
-    mutationFn: (id: string) =>
-      removeProduct ? removeProduct(storeId, id) : Promise.resolve(),
+    mutationFn: (id: string) => productsAdapter.removeProduct(storeId, id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['products', storeId] });
     },


### PR DESCRIPTION
## Summary
- add chain-aware product adapter with static imports
- use adapter in useProducts hook and drop dynamic require

## Testing
- `npm test` *(fails: Cannot find module '@waku/sdk'; unexpected token in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7318f3448326a17de59d92ee6eba