### PR TITLE
Memoize tabs and verify role-based navigation

### DIFF
--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -2,13 +2,12 @@ import { Tabs } from 'expo-router';
 import * as Lucide from 'lucide-react-native';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { usePathname } from 'expo-router';
 import { FloatingCartWidget } from '@/features/cart';
 import { getTabsForAuth } from '@/config/navigation';
 import { useAuth } from '@/features/auth/AuthContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import { debugLog } from '@/utils/logger';
 
 export default function TabsLayout() {
   const { t } = useLanguage();
@@ -16,8 +15,7 @@ export default function TabsLayout() {
   const auth = useAuth();
   const pathname = usePathname();
   const [showCartWidget, setShowCartWidget] = useState(false);
-  const tabs = getTabsForAuth(auth);
-  debugLog(`[TabsLayout] route: ${pathname} tabs: ${tabs.map((tb) => tb.name)}`);
+  const tabs = useMemo(() => getTabsForAuth(auth), [auth]);
 
   useEffect(() => {
     setShowCartWidget(pathname === '/' || pathname === '/index');

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import { stripTabsPrefix, push, replace, toTab } from '@/services/navigation';
+import { getTabsForAuth, consumerTabs, ownerTabs, adminTabs } from '@/config/navigation';
 
 jest.mock('expo-router', () => ({
   router: {
@@ -8,30 +9,30 @@ jest.mock('expo-router', () => ({
   },
 }));
 
-describe('stripTabsPrefix', () => {
-  it('removes group prefix when present', () => {
+describe('strip-tabs-prefix', () => {
+  it('removes-group-prefix-when-present', () => {
     expect(stripTabsPrefix('/(tabs)/profile')).toBe('/profile');
   });
 
-  it('returns undefined for nullish values', () => {
+  it('returns-undefined-for-nullish-values', () => {
     expect(stripTabsPrefix(undefined)).toBeUndefined();
     expect(stripTabsPrefix(null)).toBeUndefined();
   });
 
-  it('leaves path unchanged if no prefix', () => {
+  it('leaves-path-unchanged-if-no-prefix', () => {
     expect(stripTabsPrefix('/profile')).toBe('/profile');
   });
 
-  it('does not alter root group path without trailing slash', () => {
+  it('does-not-alter-root-group-path-without-trailing-slash', () => {
     expect(stripTabsPrefix('/(tabs)')).toBe('/(tabs)');
   });
 
-  it('handles nested routes and query strings', () => {
+  it('handles-nested-routes-and-query-strings', () => {
     expect(stripTabsPrefix('/(tabs)/orders/123?foo=bar')).toBe('/orders/123?foo=bar');
   });
 });
 
-describe('navigation helpers', () => {
+describe('navigation-helpers', () => {
   const { router } = require('expo-router');
 
   beforeEach(() => {
@@ -39,18 +40,32 @@ describe('navigation helpers', () => {
     router.replace.mockReset();
   });
 
-  it('push strips group prefix before routing', () => {
+  it('push-strips-group-prefix-before-routing', () => {
     push('/(tabs)/orders');
     expect(router.push).toHaveBeenCalledWith('/orders');
   });
 
-  it('replace strips group prefix in pathname objects', () => {
+  it('replace-strips-group-prefix-in-pathname-objects', () => {
     replace({ pathname: '/(tabs)/orders', params: { foo: 'bar' } });
     expect(router.replace).toHaveBeenCalledWith({ pathname: '/orders', params: { foo: 'bar' } });
   });
 
-  it('toTab removes group prefix', () => {
+  it('totab-removes-group-prefix', () => {
     expect(toTab('/(tabs)/profile')).toBe('/profile');
+  });
+});
+
+describe('get-tabs-for-auth', () => {
+  it('returns-admin-tabs-for-admin-role', () => {
+    expect(getTabsForAuth({ isAdmin: true })).toBe(adminTabs);
+  });
+
+  it('returns-owner-tabs-for-store-owner-role', () => {
+    expect(getTabsForAuth({ isStoreOwner: true })).toBe(ownerTabs);
+  });
+
+  it('returns-consumer-tabs-by-default', () => {
+    expect(getTabsForAuth({})).toBe(consumerTabs);
   });
 });
 


### PR DESCRIPTION
## Summary
- memoize tab configuration with `useMemo` to recalc when auth changes
- drop verbose debug logging
- cover `getTabsForAuth` with role-based tests

## Testing
- `yarn test tests/navigation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba731a4850832699cdb63652809c78