### PR TITLE
Memoize product grids and landing lists

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, ScrollView } from 'react-native';
 import Text from '@/ui/primitives/Text';
 import { useAppRouter, useLanding } from '@/services';
@@ -12,14 +12,104 @@ import ErrorBoundary from '@/shared/ErrorBoundary';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { routes } from '@/utils/routes';
 import { t } from '@/services/i18n';
+import { HeroBanner, Category } from '@/types';
+import { Link } from 'expo-router';
+
+export const BannerItem = React.memo(
+  ({ banner, colors }: { banner: HeroBanner; colors: any }) => {
+    const containerStyle = useMemo(
+      () => ({
+        width: 280,
+        height: 140,
+        borderRadius: 12,
+        overflow: 'hidden',
+        borderWidth: 1,
+        borderColor: colors.border.primary,
+        backgroundColor: colors.surface.primary,
+      }),
+      [colors]
+    );
+
+    return (
+      <View style={containerStyle}>
+        {banner.image ? (
+          <SmartImage uri={banner.image} width={280} height={140} contentFit="cover" />
+        ) : (
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ color: colors.gold, fontWeight: '800' }}>{banner.title}</Text>
+            {banner.subtitle ? (
+              <Text style={{ color: colors.text.secondary, marginTop: 4 }}>
+                {banner.subtitle}
+              </Text>
+            ) : null}
+          </View>
+        )}
+      </View>
+    );
+  }
+);
+
+export const CategoryButton = React.memo(
+  ({
+    category,
+    onPress,
+    colors,
+  }: {
+    category: Category;
+    onPress: (id: string) => void;
+    colors: any;
+  }) => {
+    const style = useMemo(
+      () => ({
+        paddingHorizontal: spacing.spacer12,
+        paddingVertical: spacing.spacer8,
+        borderRadius: radius.xl,
+        borderWidth: 1,
+        borderColor: colors.border.primary,
+        backgroundColor: colors.surface.primary,
+      }),
+      [colors]
+    );
+    const textStyle = useMemo(
+      () => ({ color: colors.text.primary, fontWeight: '600' }),
+      [colors]
+    );
+    const handlePress = useCallback(() => onPress(category.id), [category.id, onPress]);
+
+    return (
+      <Button
+        title={category.name}
+        onPress={handlePress}
+        style={style}
+        textStyle={textStyle}
+      />
+    );
+  }
+);
 
 export default function Landing() {
   const { push } = useAppRouter();
   const { colors } = useTheme();
   const { data } = useLanding();
   const featured = data?.featured ?? [];
-  const banners = data?.banners ?? [];
-  const categories = data?.categories ?? [];
+  const banners = useMemo(() => data?.banners ?? [], [data?.banners]);
+  const categories = useMemo(() => data?.categories ?? [], [data?.categories]);
+
+  const handleCategoryPress = useCallback(
+    (id: string) => {
+      push(routes.category(id));
+    },
+    [push]
+  );
+
+  const bannerRowStyle = useMemo(
+    () => ({ flexDirection: 'row', gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }),
+    []
+  );
+  const categoryRowStyle = useMemo(
+    () => ({ flexDirection: 'row', gap: spacing.spacer8 }),
+    []
+  );
 
   return (
     <ErrorBoundary>
@@ -81,31 +171,9 @@ export default function Landing() {
           />
           <View style={{ marginTop: spacing.spacer12 }}>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-              <View style={{ flexDirection: 'row', gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }}>
-                {banners.map((b) => (
-                  <View
-                    key={b.id}
-                    style={{
-                      width: 280,
-                      height: 140,
-                      borderRadius: 12,
-                      overflow: 'hidden',
-                      borderWidth: 1,
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                    }}
-                  >
-                    {b.image ? (
-                      <SmartImage uri={b.image} width={280} height={140} contentFit="cover" />
-                    ) : (
-                      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-                        <Text style={{ color: colors.gold, fontWeight: '800' }}>{b.title}</Text>
-                        {b.subtitle ? (
-                          <Text style={{ color: colors.text.secondary, marginTop: 4 }}>{b.subtitle}</Text>
-                        ) : null}
-                      </View>
-                    )}
-                  </View>
+              <View style={bannerRowStyle}>
+                {banners.map((b: HeroBanner) => (
+                  <BannerItem key={b.id} banner={b} colors={colors} />
                 ))}
               </View>
             </ScrollView>
@@ -128,22 +196,9 @@ export default function Landing() {
           />
           <View style={{ marginTop: spacing.spacer12 }}>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-              <View style={{ flexDirection: 'row', gap: spacing.spacer8 }}>
-                {categories.map((c) => (
-                  <Button
-                    key={c.id}
-                    title={c.name}
-                    onPress={() => push(routes.category(c.id))}
-                    style={{
-                      paddingHorizontal: spacing.spacer12,
-                      paddingVertical: spacing.spacer8,
-                      borderRadius: radius.xl,
-                      borderWidth: 1,
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                    }}
-                    textStyle={{ color: colors.text.primary, fontWeight: '600' }}
-                  />
+              <View style={categoryRowStyle}>
+                {categories.map((c: Category) => (
+                  <CategoryButton key={c.id} category={c} colors={colors} onPress={handleCategoryPress} />
                 ))}
               </View>
             </ScrollView>

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -18,6 +18,17 @@ interface ProductGridProps {
   loading?: boolean;
 }
 
+const rowStyles = StyleSheet.create({
+  flex: { flex: 1 },
+  card: { marginBottom: spacing.spacer12 },
+});
+
+const ProductRow = React.memo(({ item }: { item: Product }) => (
+  <View style={rowStyles.flex}>
+    <ProductCard product={item} style={rowStyles.card} />
+  </View>
+));
+
 export default function ProductGrid({
   products,
   categories,
@@ -30,11 +41,7 @@ export default function ProductGrid({
 }: ProductGridProps) {
   const { t } = useLanguage();
   const renderItem = useCallback(
-    ({ item }: { item: Product }) => (
-      <View style={rowStyles.flex}>
-        <ProductCard key={item.id} product={item} style={{ marginBottom: spacing.spacer12 }} />
-      </View>
-    ),
+    ({ item }: { item: Product }) => <ProductRow item={item} />,
     []
   );
 
@@ -101,6 +108,4 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
 });
-
-const rowStyles = StyleSheet.create({ flex: { flex: 1 } });
 

--- a/tests/memoization.test.tsx
+++ b/tests/memoization.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import ProductGrid from '@features/home/components/ProductGrid';
+import { CategoryButton, BannerItem } from '@app/landing';
+import { Product, Category, HeroBanner } from '@/types';
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => ({ t: (s: string) => s }),
+  useTheme: () => ({
+    colors: {
+      border: { primary: 'red' },
+      surface: { primary: 'blue' },
+      text: { primary: 'green', secondary: 'gray' },
+      gold: 'pink',
+    },
+  }),
+}));
+
+let productCardRender = 0;
+jest.mock('@features/products', () => ({
+  ProductCard: (props: any) => {
+    productCardRender++;
+    return React.createElement('view', props);
+  },
+  ProductCardSkeleton: () => null,
+}));
+
+let buttonRender = 0;
+jest.mock('@/ui/primitives/Button', () => (props: any) => {
+  buttonRender++;
+  return React.createElement('view', props);
+});
+
+let smartImageRender = 0;
+jest.mock('@app/components/SmartImage', () => (props: any) => {
+  smartImageRender++;
+  return React.createElement('view', props);
+});
+
+describe('memoization', () => {
+  beforeEach(() => {
+    productCardRender = 0;
+    buttonRender = 0;
+    smartImageRender = 0;
+  });
+
+  it('grid', () => {
+    const product: Product = {
+      id: '1',
+      name: 'Prod',
+      price: 1,
+      description: 'desc',
+      category: 'cat',
+      images: [],
+      rating: 0,
+      reviews: 0,
+      storeId: 's',
+      stock: 1,
+    };
+    const categories: Category[] = [];
+    const props = {
+      products: [product],
+      categories,
+      isStoreOwner: false,
+      onEdit: () => {},
+      getItemWidth: () => '50%',
+      searchQuery: '',
+      onAddProduct: () => {},
+      loading: false,
+    };
+    const component = renderer.create(<ProductGrid {...props} />);
+    act(() => {
+      component.update(<ProductGrid {...props} />);
+    });
+    expect(productCardRender).toBe(1);
+  });
+
+  it('category', () => {
+    const category: Category = { id: '1', name: 'Cat', icon: '' };
+    const colors = {
+      border: { primary: 'red' },
+      surface: { primary: 'blue' },
+      text: { primary: 'green', secondary: 'gray' },
+      gold: 'pink',
+    };
+    const onPress = () => {};
+    const component = renderer.create(
+      <CategoryButton category={category} onPress={() => onPress()} colors={colors} />
+    );
+    act(() => {
+      component.update(
+        <CategoryButton category={category} onPress={() => onPress()} colors={colors} />
+      );
+    });
+    expect(buttonRender).toBe(1);
+  });
+
+  it('banner', () => {
+    const banner: HeroBanner = {
+      id: 'b1',
+      image: 'img.png',
+      title: 't',
+      subtitle: 's',
+    };
+    const colors = {
+      border: { primary: 'red' },
+      surface: { primary: 'blue' },
+      text: { primary: 'green', secondary: 'gray' },
+      gold: 'pink',
+    };
+    const component = renderer.create(<BannerItem banner={banner} colors={colors} />);
+    act(() => {
+      component.update(<BannerItem banner={banner} colors={colors} />);
+    });
+    expect(smartImageRender).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- reduce home `ProductGrid` re-renders with memoized rows
- memoize landing banner and category lists
- add tests profiling render counts

## Testing
- `yarn lint`
- `yarn test` *(fails: unexpected token, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ba731db9a08326a45637d8032537d3