### PR TITLE
refactor: centralize app providers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { View, Text } from 'react-native';
-import AppProviders from '@/providers';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -38,11 +37,9 @@ function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <AppProviders>
-          <React.Suspense fallback={null}>
-            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-          </React.Suspense>
-        </AppProviders>
+        <React.Suspense fallback={null}>
+          {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+        </React.Suspense>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
## Summary
- remove AppProviders wrapper from App.tsx
- keep _layout.tsx as single root with AppProviders + Slot

## Testing
- `yarn lint App.tsx app/_layout.tsx`
- `yarn test` *(fails: Jest encountered an unexpected token / missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bad3b654a48326963e078718db49f8