### PR TITLE
refactor: persist query client for hot reloads

### DIFF
--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -12,6 +12,15 @@ import { AuthModalProvider } from '@/features/auth/AuthModalContext';
 import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
 
+declare global {
+  // React Native fast refresh re-evaluates modules; store the client globally to avoid recreation.
+  // eslint-disable-next-line no-var
+  var __queryClient: QueryClient | undefined;
+}
+
+export const queryClient =
+  globalThis.__queryClient ?? (globalThis.__queryClient = new QueryClient());
+
 /**
  * Composes the core providers used across the app.
  *
@@ -30,8 +39,6 @@ import { NotificationProvider } from '@/components/NotificationContext';
  * 12. `NotificationProvider` – listens for notifications and displays popups.
  */
 export default function AppProviders({ children }: React.PropsWithChildren) {
-  const [queryClient] = React.useState(() => new QueryClient());
-
   return (
     <AppInfoProvider>
       <ConfigProvider>


### PR DESCRIPTION
## Summary
- create a single QueryClient instance outside of AppProviders and store it globally
- pass that QueryClient into CheckedQueryClientProvider to avoid recreation on hot reloads

## Testing
- `npm test` *(fails: Cannot find module '@waku/sdk' from 'services/eventBus.ts')*
- `npx jest tests/admin-disputes.test.tsx` *(fails: Cannot find module '@waku/sdk' from 'services/eventBus.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bad3dddad4832680f203c4a83c1f94