### PR TITLE
Show spinner during initial suspense

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { View, Text } from 'react-native';
 import { Router, usePathname, useSegments } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { useLanguage } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
 import { debugLog } from '@/utils/logger';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
@@ -37,7 +38,7 @@ function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <React.Suspense fallback={null}>
+        <React.Suspense fallback={<Spinner />}>
           {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
         </React.Suspense>
       </SafeAreaProvider>

--- a/tests/appSpinner.test.tsx
+++ b/tests/appSpinner.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '@/App';
+const t = (s: string) => s;
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  return { GestureHandlerRootView: ({ children }: any) => React.createElement(React.Fragment, null, children) };
+});
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return { SafeAreaProvider: ({ children }: any) => React.createElement(React.Fragment, null, children) };
+});
+
+jest.mock('expo-router', () => ({
+  Router: () => {
+    throw new Promise(() => {});
+  },
+  usePathname: () => '/',
+  useSegments: () => [],
+}));
+
+jest.mock('@/services/navigation', () => ({ stripTabsPrefix: (s: string) => s }));
+jest.mock('@/ui/ThemeProvider', () => ({ useLanguage: () => ({ t: (s: string) => s }) }));
+jest.mock('@/utils/logger', () => ({ debugLog: jest.fn() }));
+jest.mock('@/ui/primitives', () => ({ Spinner: () => 'spinner' }));
+
+describe(t('App cold start'), () => {
+  it(t('renders spinner while loading'), () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(JSON.stringify(tree)).toContain('spinner');
+  });
+});


### PR DESCRIPTION
## Summary
- import and render `Spinner` in the app-level Suspense fallback so a loading indicator is shown on cold start
- add a test ensuring the spinner appears when the router is suspending

## Testing
- `yarn lint`
- `yarn test` *(fails: unexpected token and missing module @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68bade2a2ff0832685790a9f31201ba9