### PR TITLE
refactor: simplify root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import { Slot } from 'expo-router';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AppProviders } from '@/providers';
 
 export default function RootLayout() {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider>
-        <AppProviders>
-          <Slot />
-        </AppProviders>
-      </SafeAreaProvider>
-    </GestureHandlerRootView>
+    <AppProviders>
+      <Slot />
+    </AppProviders>
   );
 }


### PR DESCRIPTION
## Summary
- remove GestureHandlerRootView and SafeAreaProvider wrappers from app root layout
- render Slot directly beneath core AppProviders

## Testing
- `npm test tests/navigation.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bade2a69b08326abd6a2435cf7b446