### PR TITLE
refactor: centralize UI primitive exports

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useMemo } from 'react';
 import { View, ScrollView } from 'react-native';
-import Text from '@/ui/primitives/Text';
+import { Text, Divider, Button } from '@/ui';
 import { useAppRouter, useLanding } from '@/services';
 import AppShell from '../components/layout/AppShell';
-import Divider from '@/ui/primitives/Divider';
 import { ProductCard } from '@/features/products';
 import { useTheme } from '@/ui/ThemeProvider';
 import SmartImage from '../components/SmartImage';
-import Button from '@/ui/primitives/Button';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { routes } from '@/utils/routes';
 import { t } from '@/services/i18n';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,20 +1,4 @@
-export {
-  Avatar,
-  Badge,
-  Button,
-  Card,
-  Chip,
-  Divider,
-  Heading,
-  Menu,
-  type MenuItem,
-  Overlay,
-  Portal,
-  Skeleton,
-  Spinner,
-  Text,
-  TextField,
-} from './primitives';
+export * from './primitives';
 
 export {
   Container,


### PR DESCRIPTION
## Summary
- re-export all primitives from `src/ui`
- consume primitives via the `@/ui` barrel import

## Testing
- `yarn lint`
- `yarn test` *(fails: missing modules and unexpected token syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bae09f694483268b8792f00ee4ba86