### PR TITLE
refactor: apply AppShell layout

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,8 +17,6 @@ import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
-import HomeHeader from '@/features/home/components/HomeHeader';
-import SearchBar from '@/features/home/components/SearchBar';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import CTABecomeSeller from '@/features/home/components/CTABecomeSeller';
@@ -37,8 +35,9 @@ const ProductFormModal = lazy(() =>
 const InfoModal = lazy(() => import('@/components/InfoModal'));
 import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters';
 import { spacing } from '@/shared/ui/tokens';
-import { Screen, ScrollArea, Container, Stack } from '@/ui/layout';
+import { ScrollArea, Container, Stack } from '@/ui/layout';
 import { routes } from '@/utils/routes';
+import AppShell from '@/components/layout/AppShell';
 
 
 function HomeScreenContent() {
@@ -103,16 +102,26 @@ function HomeScreenContent() {
 
   // Fallback content to guarantee a rich homepage even with empty services
   const fallbackCategories: Category[] = [
-    { id: 'electronics', name: 'Electronics', icon: '📱' } as any,
-    { id: 'fashion', name: 'Fashion', icon: '👗' } as any,
-    { id: 'home', name: 'Home', icon: '🏠' } as any,
-    { id: 'beauty', name: 'Beauty', icon: '💄' } as any,
-    { id: 'sports', name: 'Sports', icon: '🏀' } as any,
-    { id: 'books', name: 'Books', icon: '📚' } as any,
+    { id: 'electronics', name: t('categories.electronics'), icon: String.fromCodePoint(0x1F4F1) } as any,
+    { id: 'fashion', name: t('categories.fashion'), icon: String.fromCodePoint(0x1F457) } as any,
+    { id: 'home', name: t('categories.home'), icon: String.fromCodePoint(0x1F3E0) } as any,
+    { id: 'beauty', name: t('categories.beauty'), icon: String.fromCodePoint(0x1F484) } as any,
+    { id: 'sports', name: t('categories.sports'), icon: String.fromCodePoint(0x1F3C0) } as any,
+    { id: 'books', name: t('categories.books'), icon: String.fromCodePoint(0x1F4DA) } as any,
   ];
   const fallbackBanners: Partial<HeroBanner & { id: string }>[] = [
-    { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
-    { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
+    {
+      id: 'b1',
+      image: '',
+      title: t('home.fallbackBanner1Title'),
+      subtitle: t('home.fallbackBanner1Subtitle'),
+    },
+    {
+      id: 'b2',
+      image: '',
+      title: t('home.fallbackBanner2Title'),
+      subtitle: t('home.fallbackBanner2Subtitle'),
+    },
   ];
 
   useEffect(() => {
@@ -243,11 +252,13 @@ function HomeScreenContent() {
   };
 
   return (
-    <Screen testID="home-root" style={styles.container}>
-      <HomeHeader />
-      <SearchBar searchQuery={searchQuery} onSearchChange={setSearchQuery} />
-
+    <AppShell
+      showSearch
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+    >
       <ScrollArea
+        testID="home-root"
         backgroundColor={colors.canvas}
         showsVerticalScrollIndicator={false}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
@@ -408,7 +419,7 @@ function HomeScreenContent() {
               <Text
                 style={[styles.sortModalTitle, { color: colors.text.primary }]}
               >
-                מיון מוצרים
+                {t('home.sortProducts')}
               </Text>
               <TouchableOpacity onPress={() => setShowSortModal(false)}>
                 <X size={24} color={colors.text.primary} />
@@ -478,7 +489,7 @@ function HomeScreenContent() {
           onClose={() => setShowCartModal(false)}
         />
       </Suspense>
-    </Screen>
+    </AppShell>
   );
 }
 
@@ -493,9 +504,6 @@ export default function HomeScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   section: {
     paddingHorizontal: spacing.spacer16,
     marginBottom: spacing.spacer24,

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { View, ScrollView } from 'react-native';
 import { Text, Divider, Button } from '@/ui';
 import { useAppRouter, useLanding } from '@/services';
-import AppShell from '../components/layout/AppShell';
+import AppShell from '@/components/layout/AppShell';
 import { ProductCard } from '@/features/products';
 import { useTheme } from '@/ui/ThemeProvider';
 import SmartImage from '../components/SmartImage';
@@ -109,7 +109,7 @@ export default function Landing() {
   );
 
   return (
-    <AppShell>
+    <AppShell showSearch={false}>
         <ScrollView style={{ backgroundColor: colors.canvas }} showsVerticalScrollIndicator={false}>
           {/* Hero */}
         <View style={{ paddingHorizontal: spacing.spacer16, paddingTop: spacing.spacer24, paddingBottom: spacing.spacer12, alignItems: 'center' }}>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -9,15 +9,26 @@ import GlobalHeader from '../GlobalHeader';
 interface AppShellProps {
   children: React.ReactNode;
   showSearch?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
 }
 
-export default function AppShell({ children, showSearch = true }: AppShellProps) {
+export default function AppShell({
+  children,
+  showSearch = true,
+  searchQuery,
+  onSearchChange,
+}: AppShellProps) {
   const { theme, colors } = useTheme();
   return (
     <ErrorBoundary>
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
         <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
-        <GlobalHeader showSearch={showSearch} />
+        <GlobalHeader
+          showSearch={showSearch}
+          searchQuery={searchQuery}
+          onSearchChange={onSearchChange}
+        />
         <View style={{ flex: 1, backgroundColor: colors.canvas }}>{children}</View>
       </SafeAreaView>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- Use shared AppShell layout across landing and home tabs screens
- Support search handling props in AppShell

## Testing
- `yarn test` *(fails: Cannot find module '@waku/sdk'; Unexpected token '<'; Unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2c7743a88326b388543bcc5b70b8