### PR TITLE
feat(auth): add user directory hook

### DIFF
--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -1,34 +1,28 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/ui/ThemeProvider';
 import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '@/components/RequireWallet';
-import chain from '@/services/chain';
-import { User } from '@/types';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Users } from 'lucide-react-native';
-
-let listUsers: (() => Promise<User[]>) | undefined;
-if (chain === 'near') {
-  ({ listUsers } = require('@/features/auth/services/nearUsers'));
-}
+import { useUserDirectory } from '@/features/auth/hooks/useUserDirectory';
 
 export default function UserDirectory() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
-  const [users, setUsers] = useState<User[]>([]);
-
-  useEffect(() => {
-    if (listUsers) {
-      listUsers().then(setUsers).catch(() => {});
-    }
-  }, []);
+  const { t } = useLanguage();
+  const { data: users = [], isLoading } = useUserDirectory();
 
   return (
     <RequireWallet>
       <View style={[styles.container, { backgroundColor: colors.background }]}>
-        {users.length === 0 ? (
-          <EmptyState icon={Users} title="No users" message="No users found." />
+        {users.length === 0 && !isLoading ? (
+          <EmptyState
+            icon={Users}
+            title={t('admin.noUsers') as string}
+            message={t('admin.noUsersFound') as string}
+          />
         ) : (
           users.map((u) => (
             <Text key={u.id} style={{ color: colors.text.primary }}>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -278,7 +278,9 @@
     "noKycRequests": "No pending KYC requests",
     "kycApproved": "KYC approved successfully",
     "kycRejected": "KYC rejected",
-    "copyOrderDetails": "Copy Order Details"
+    "copyOrderDetails": "Copy Order Details",
+    "noUsers": "No users",
+    "noUsersFound": "No users found"
   },
   "chat": {
     "customerSupport": "Customer Support",

--- a/src/features/auth/hooks/useUserDirectory.ts
+++ b/src/features/auth/hooks/useUserDirectory.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import chain from '@/services/chain';
+import { User } from '@/types';
+
+let listUsers: (() => Promise<User[]>) | undefined;
+if (chain === 'near') {
+  ({ listUsers } = require('../services/nearUsers'));
+}
+
+export function useUserDirectory() {
+  const { data = [], isLoading, error } = useQuery<User[]>({
+    queryKey: ['user-directory'],
+    queryFn: () => (listUsers ? listUsers() : Promise.resolve([])),
+  });
+
+  return { data, isLoading, error } as const;
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -333,7 +333,9 @@
     "noKycRequests": "No pending KYC requests",
     "kycApproved": "KYC approved successfully",
     "kycRejected": "KYC rejected",
-    "copyOrderDetails": "Copy Order Details"
+    "copyOrderDetails": "Copy Order Details",
+    "noUsers": "No users",
+    "noUsersFound": "No users found"
   },
   "chat": {
     "customerSupport": "Customer Support",


### PR DESCRIPTION
## Summary
- add `useUserDirectory` hook wrapping `nearUsers` service with React Query
- make admin user directory screen presentational by using the hook
- add i18n strings for admin user directory empty state

## Testing
- `CI=1 yarn test` *(fails: process hangs after starting test script; no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2c780d8c832680b8c7a3b18264a5