### PR TITLE
refactor: modularize home screen logic

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Suspense, lazy } from 'react';
+import React, { Suspense, lazy } from 'react';
 import {
   View,
   Text,
@@ -8,12 +8,13 @@ import {
   RefreshControl,
   useWindowDimensions,
 } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { Plus, X, ArrowUpDown } from 'lucide-react-native';
 import { Product, Category, HeroBanner } from '@/types';
 import { useHome } from '@/features/home/hooks/useHome';
 import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
+import { useHomeModals } from '@/features/home/hooks/useHomeModals';
+import { useHomeRefresh } from '@/features/home/hooks/useHomeRefresh';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
@@ -43,47 +44,42 @@ import { routes } from '@/utils/routes';
 
 function HomeScreenContent() {
   const { push } = useAppRouter();
-  const params = useLocalSearchParams<{ showCart?: string }>();
   const { width: windowWidth } = useWindowDimensions();
+  const home = useHome();
+  const banners = useHomeBanners();
+  const { refreshing, refresh, error } = useHomeRefresh(home, banners);
   const {
-    products,
-    categories,
-    refreshing: dataRefreshing,
-    refresh: refreshData,
-    upsertProduct,
-    removeProduct,
-    error: dataError,
-    loading: productsLoading,
-  } = useHome();
-  const {
-    heroBanners,
-    refreshing: bannersRefreshing,
-    refresh: refreshBanners,
-    upsertBanner,
-    removeBanner,
-    error: bannersError,
-    loading: bannersLoading,
-  } = useHomeBanners();
-  const refreshing = dataRefreshing || bannersRefreshing;
-  const refresh = async () => {
-    await Promise.all([refreshData(), refreshBanners()]);
-  };
-  const error = dataError || bannersError;
-  const [bannerFormVisible, setBannerFormVisible] = useState(false);
-  const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
-  const [productFormVisible, setProductFormVisible] = useState(false);
-  const [productToEdit, setProductToEdit] = useState<Product | null>(null);
-  const [showCartModal, setShowCartModal] = useState(false);
-  const [infoModal, setInfoModal] = useState({
-    visible: false,
-    title: '',
-    message: '',
-    type: 'info' as 'success' | 'error' | 'info' | 'warning',
-    buttonText: undefined as string | undefined,
-  });
+    bannerFormVisible,
+    editingBanner,
+    openBannerForm,
+    closeBannerForm,
+    productFormVisible,
+    productToEdit,
+    openProductForm,
+    closeProductForm,
+    showCartModal,
+    closeCartModal,
+    infoModal,
+    closeInfoModal,
+  } = useHomeModals(error);
   const { isStoreOwner } = useAuth();
   const { t } = useLanguage();
   const { colors } = useTheme();
+
+  const {
+    products,
+    categories,
+    upsertProduct,
+    removeProduct,
+    loading: productsLoading,
+  } = home;
+
+  const {
+    heroBanners,
+    upsertBanner,
+    removeBanner,
+    loading: bannersLoading,
+  } = banners;
 
   const {
     filteredProducts,
@@ -114,53 +110,12 @@ function HomeScreenContent() {
     { id: 'b1', image: '', title: 'Welcome to Blue Ocean', subtitle: 'Own your store on NEAR' },
     { id: 'b2', image: '', title: 'Decentralized by design', subtitle: 'Fast, P2P and secure' },
   ];
-
-  useEffect(() => {
-    // Check if we should show the cart modal from URL params
-    if (params.showCart === 'true') {
-      setShowCartModal(true);
-    }
-  }, [params.showCart]);
-
-  useEffect(() => {
-    if (error) {
-      setInfoModal({
-        visible: true,
-        title: t('common.error'),
-        message: t('home.loadErrorMessage'),
-        type: 'error',
-        buttonText: t('common.reload'),
-      });
-    }
-  }, [error, t]);
-
-
-  const addBanner = () => {
-    setEditingBanner(null);
-    setBannerFormVisible(true);
-  };
-
-  const editBanner = (banner: HeroBanner) => {
-    setEditingBanner(banner);
-    setBannerFormVisible(true);
-  };
-
   const handleBannerSaved = (b: HeroBanner, isNew: boolean) => {
     upsertBanner(b, isNew);
   };
 
   const handleBannerDeleted = (id: string) => {
     removeBanner(id);
-  };
-
-  const addProduct = () => {
-    setProductToEdit(null);
-    setProductFormVisible(true);
-  };
-
-  const editProduct = (product: Product) => {
-    setProductToEdit(product);
-    setProductFormVisible(true);
   };
 
   const handleProductSaved = (p: Product, isNew: boolean) => {
@@ -238,7 +193,7 @@ function HomeScreenContent() {
   };
 
   const handleReload = () => {
-    setInfoModal((prev) => ({ ...prev, visible: false }));
+    closeInfoModal();
     refresh();
   };
 
@@ -267,8 +222,8 @@ function HomeScreenContent() {
       <BannerArea
         heroBanners={heroBanners}
         isStoreOwner={isStoreOwner}
-        onAddBanner={addBanner}
-        onEditBanner={editBanner}
+        onAddBanner={openBannerForm}
+        onEditBanner={openBannerForm}
         loading={bannersLoading}
       />
 
@@ -339,7 +294,7 @@ function HomeScreenContent() {
                       borderColor: colors.gold,
                     },
                   ]}
-                  onPress={addProduct}
+                    onPress={openProductForm}
                 >
                   <Plus size={16} color={colors.gold} />
                 </TouchableOpacity>
@@ -352,10 +307,10 @@ function HomeScreenContent() {
               products={filteredProducts}
               categories={categories}
               isStoreOwner={isStoreOwner}
-              onEdit={editProduct}
+              onEdit={openProductForm}
               getItemWidth={getProductItemWidth}
               searchQuery={searchQuery}
-              onAddProduct={addProduct}
+              onAddProduct={openProductForm}
               loading={productsLoading}
             />
           </Suspense>
@@ -365,7 +320,7 @@ function HomeScreenContent() {
       <Suspense fallback={<Spinner />}>
         <BannerFormModal
           visible={bannerFormVisible}
-          onClose={() => setBannerFormVisible(false)}
+          onClose={closeBannerForm}
           banner={editingBanner || undefined}
           categories={categories}
           onSaved={handleBannerSaved}
@@ -375,7 +330,7 @@ function HomeScreenContent() {
       <Suspense fallback={<Spinner />}>
         <ProductFormModal
           visible={productFormVisible}
-          onClose={() => setProductFormVisible(false)}
+          onClose={closeProductForm}
           product={productToEdit || undefined}
           onSaved={handleProductSaved}
           onDeleted={handleProductDeleted}
@@ -475,7 +430,7 @@ function HomeScreenContent() {
       <Suspense fallback={<Spinner />}>
         <CartModal
           visible={showCartModal}
-          onClose={() => setShowCartModal(false)}
+          onClose={closeCartModal}
         />
       </Suspense>
     </Screen>

--- a/src/features/home/hooks/useHomeModals.ts
+++ b/src/features/home/hooks/useHomeModals.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useLocalSearchParams } from 'expo-router';
+import { HeroBanner, Product } from '@/types';
+import { useLanguage } from '@/ui/ThemeProvider';
+
+export function useHomeModals(error?: Error | null) {
+  const params = useLocalSearchParams<{ showCart?: string }>();
+  const { t } = useLanguage();
+
+  const [bannerFormVisible, setBannerFormVisible] = useState(false);
+  const [editingBanner, setEditingBanner] = useState<HeroBanner | null>(null);
+  const openBannerForm = useCallback((banner?: HeroBanner) => {
+    setEditingBanner(banner ?? null);
+    setBannerFormVisible(true);
+  }, []);
+  const closeBannerForm = useCallback(() => setBannerFormVisible(false), []);
+
+  const [productFormVisible, setProductFormVisible] = useState(false);
+  const [productToEdit, setProductToEdit] = useState<Product | null>(null);
+  const openProductForm = useCallback((product?: Product) => {
+    setProductToEdit(product ?? null);
+    setProductFormVisible(true);
+  }, []);
+  const closeProductForm = useCallback(() => setProductFormVisible(false), []);
+
+  const [showCartModal, setShowCartModal] = useState(false);
+  const closeCartModal = useCallback(() => setShowCartModal(false), []);
+
+  const [infoModal, setInfoModal] = useState({
+    visible: false,
+    title: '',
+    message: '',
+    type: 'info' as 'success' | 'error' | 'info' | 'warning',
+    buttonText: undefined as string | undefined,
+  });
+  const closeInfoModal = useCallback(
+    () => setInfoModal((prev) => ({ ...prev, visible: false })),
+    [],
+  );
+
+  useEffect(() => {
+    if (params.showCart === 'true') {
+      setShowCartModal(true);
+    }
+  }, [params.showCart]);
+
+  useEffect(() => {
+    if (error) {
+      setInfoModal({
+        visible: true,
+        title: t('common.error'),
+        message: t('home.loadErrorMessage'),
+        type: 'error',
+        buttonText: t('common.reload'),
+      });
+    }
+  }, [error, t]);
+
+  return {
+    bannerFormVisible,
+    editingBanner,
+    openBannerForm,
+    closeBannerForm,
+    productFormVisible,
+    productToEdit,
+    openProductForm,
+    closeProductForm,
+    showCartModal,
+    closeCartModal,
+    infoModal,
+    closeInfoModal,
+  } as const;
+}
+
+export type UseHomeModalsReturn = ReturnType<typeof useHomeModals>;

--- a/src/features/home/hooks/useHomeRefresh.ts
+++ b/src/features/home/hooks/useHomeRefresh.ts
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+import type { UseHomeReturn } from './useHome';
+import type { UseHomeBannersReturn } from './useHomeBanners';
+
+export function useHomeRefresh(
+  data: UseHomeReturn,
+  banners: UseHomeBannersReturn,
+) {
+  const refreshing = data.refreshing || banners.refreshing;
+  const refresh = useCallback(async () => {
+    await Promise.all([data.refresh(), banners.refresh()]);
+  }, [data, banners]);
+  const error = data.error || banners.error;
+  return { refreshing, refresh, error } as const;
+}
+
+export type UseHomeRefreshReturn = ReturnType<typeof useHomeRefresh>;


### PR DESCRIPTION
## Summary
- add `useHomeRefresh` to combine product and banner refresh state
- add `useHomeModals` for banner/product/cart/error modals from URL and errors
- refactor home screen to consume new hooks and compose presentational pieces

## Testing
- `yarn test` *(fails: hangs running lint)*
- `yarn lint` *(fails: hangs running lint)*


------
https://chatgpt.com/codex/tasks/task_e_68bb2c7bf04c8326aacbd8a61d43dd30