### PR TITLE
feat(cart): add wishlist count hook

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { View, StyleSheet, Pressable, TextInput } from 'react-native';
 import { Text, Button } from '@/ui';
 import SmartImage from './SmartImage';
@@ -9,8 +9,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useAppInfo } from '../contexts/AppInfoContext';
 import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
-import { WishlistModal } from '@/features/cart';
-import CartService from '@/features/cart/services/cart';
+import { WishlistModal, useWishlistCount } from '@/features/cart';
 import { spacing, radius, typography } from '@/ui/tokens';
 
 interface GlobalHeaderProps {
@@ -30,20 +29,7 @@ export default function GlobalHeader({
   const { progress } = useRoadmap();
   const { push } = useAppRouter();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
-  const [wishlistItemsCount, setWishlistItemsCount] = useState(0);
-
-  useEffect(() => {
-    const cartService = CartService.getInstance();
-
-    const updateCounts = () => {
-      setWishlistItemsCount(cartService.getWishlistItemsCount());
-    };
-
-    updateCounts();
-    cartService.addListener(updateCounts);
-
-    return () => cartService.removeListener(updateCounts);
-  }, []);
+  const wishlistItemsCount = useWishlistCount();
 
   const navigateToReviews = () => {
     push('/reviews');

--- a/src/features/cart/hooks/useWishlistCount.ts
+++ b/src/features/cart/hooks/useWishlistCount.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import CartService from '../services/cart';
+
+export default function useWishlistCount() {
+  const [count, setCount] = useState(() =>
+    CartService.getInstance().getWishlistItemsCount(),
+  );
+
+  const updateCount = useCallback(() => {
+    const newCount = CartService.getInstance().getWishlistItemsCount();
+    setCount((prev) => (prev === newCount ? prev : newCount));
+  }, []);
+
+  useEffect(() => {
+    const cartService = CartService.getInstance();
+    cartService.addListener(updateCount);
+    updateCount();
+    return () => {
+      cartService.removeListener(updateCount);
+    };
+  }, [updateCount]);
+
+  return useMemo(() => count, [count]);
+}

--- a/src/features/cart/index.ts
+++ b/src/features/cart/index.ts
@@ -4,3 +4,4 @@ export { default as WishlistModal } from './components/WishlistModal';
 export { default as useCart } from './hooks/useCart';
 export { default as useCartStores } from './hooks/useCartStores';
 export { default as useWishlist } from './hooks/useWishlist';
+export { default as useWishlistCount } from './hooks/useWishlistCount';


### PR DESCRIPTION
## Summary
- add useWishlistCount hook to track wishlist item count with listener cleanup
- refactor GlobalHeader to use useWishlistCount
- export useWishlistCount from cart feature index

## Testing
- `yarn test` *(fails: Jest unexpected token and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bb303b145483268d53663ec19f9e12