### PR TITLE
feat: add hooks for users and product listings

### DIFF
--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
-import { useRequirePlatformAdmin } from '@/services';
+import { useRequirePlatformAdmin, useUsers } from '@/services';
 import RequireWallet from '@/components/RequireWallet';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Users } from 'lucide-react-native';
-import { useUserDirectory } from '@/features/auth/hooks/useUserDirectory';
 
 export default function UserDirectory() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
   const { t } = useLanguage();
-  const { data: users = [], isLoading } = useUserDirectory();
+  const { data: users = [], isLoading } = useUsers();
 
   return (
     <RequireWallet>

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -1,43 +1,35 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import { useAppRouter } from '@/services';
+import { useAppRouter, useProducts } from '@/services';
 import { useTheme } from '@/ui/ThemeProvider';
-import chain from '@/services/chain';
+import { useLanguage } from '@/ui/ThemeProvider';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useStore } from '@/features/products';
 import { routes } from '@/utils/routes';
 
-let listProducts: (() => Promise<any[]>) | undefined;
-if (chain === 'near') {
-  ({ listProducts } = require('@/features/products/services/nearProducts'));
-}
-
 export default function StoreDashboardScreen() {
   const { replace, push } = useAppRouter();
   const { storeId, impersonate } = useLocalSearchParams<{ storeId: string; impersonate?: string }>();
   const { colors } = useTheme();
+  const { t } = useLanguage();
   const { user } = useAuth();
   const [productCount, setProductCount] = useState(0);
   const [authorized, setAuthorized] = useState(false);
   const { data: store } = useStore(storeId);
+  const { data: products = [] } = useProducts(storeId || '');
 
   useEffect(() => {
-    const loadStats = async () => {
-      if (!storeId || !store || !listProducts) return;
-      const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
-      if (store.owner !== user?.address && !isAdmin) {
-        replace(routes.store(storeId));
-        return;
-      }
-      setAuthorized(true);
-      const products = await listProducts();
-      setProductCount(products.filter((p) => p.storeId === storeId).length);
-    };
-
-    loadStats();
-  }, [storeId, store, user?.address]);
+    if (!storeId || !store) return;
+    const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
+    if (store.owner !== user?.address && !isAdmin) {
+      replace(routes.store(storeId));
+      return;
+    }
+    setAuthorized(true);
+    setProductCount(products.filter((p) => p.storeId === storeId).length);
+  }, [storeId, store, user?.address, products]);
   
 
   if (!authorized) {
@@ -46,23 +38,25 @@ export default function StoreDashboardScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Text style={[styles.title, { color: colors.text.primary }]}>לוח חנות</Text>
+      <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
       <View style={styles.stats}>
-        <Text style={[styles.statText, { color: colors.text.primary }]}>מוצרים: {productCount}</Text>
+        <Text style={[styles.statText, { color: colors.text.primary }]}>
+          {t('admin.productCount', { count: productCount })}
+        </Text>
         {storeId && <OrderRevenueMetrics storeId={storeId} />}
       </View>
       <View style={styles.nav}>
-          <TouchableOpacity
-            style={[styles.navButton, { borderColor: colors.border.primary }]}
-            onPress={() => push(routes.storeAdminProducts(storeId))}
-          >
-          <Text style={{ color: colors.text.primary }}>ניהול מוצרים</Text>
+        <TouchableOpacity
+          style={[styles.navButton, { borderColor: colors.border.primary }]}
+          onPress={() => push(routes.storeAdminProducts(storeId))}
+        >
+          <Text style={{ color: colors.text.primary }}>{t('admin.manageProducts')}</Text>
         </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.navButton, { borderColor: colors.border.primary }]}
-            onPress={() => push(routes.storeAdminOrders(storeId))}
-          >
-          <Text style={{ color: colors.text.primary }}>צפייה בהזמנות</Text>
+        <TouchableOpacity
+          style={[styles.navButton, { borderColor: colors.border.primary }]}
+          onPress={() => push(routes.storeAdminOrders(storeId))}
+        >
+          <Text style={{ color: colors.text.primary }}>{t('admin.viewOrders')}</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -16,3 +16,4 @@ export * from './useProfileData';
 export * from './useRequirePlatformAdmin';
 export * from './useReviews';
 export * from './useLanding';
+export * from './useUsers';

--- a/src/services/useProducts.ts
+++ b/src/services/useProducts.ts
@@ -9,6 +9,7 @@ export function useProducts(storeId: string) {
     queryFn: async () => {
       const db = DatabaseService.getInstance();
       let data = await db.getProducts();
+      data = data.filter((p) => p.storeId === storeId);
       if (data.length === 0) {
         try {
           data = await productsAdapter.listProducts(storeId);

--- a/src/services/useUsers.ts
+++ b/src/services/useUsers.ts
@@ -4,14 +4,15 @@ import { User } from '@/types';
 
 let listUsers: (() => Promise<User[]>) | undefined;
 if (chain === 'near') {
-  ({ listUsers } = require('../services/nearUsers'));
+  ({ listUsers } = require('@/features/auth/services/nearUsers'));
 }
 
-export function useUserDirectory() {
-  const { data = [], isLoading, error } = useQuery<User[]>({
-    queryKey: ['user-directory'],
+export function useUsers() {
+  return useQuery<User[]>({
+    queryKey: ['users'],
     queryFn: () => (listUsers ? listUsers() : Promise.resolve([])),
+    select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
-
-  return { data, isLoading, error } as const;
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -335,7 +335,9 @@
     "kycRejected": "KYC rejected",
     "copyOrderDetails": "Copy Order Details",
     "noUsers": "No users",
-    "noUsersFound": "No users found"
+    "noUsersFound": "No users found",
+    "productCount": "Products: {count}",
+    "viewOrders": "View Orders"
   },
   "chat": {
     "customerSupport": "Customer Support",

--- a/translations/he.json
+++ b/translations/he.json
@@ -309,7 +309,9 @@
     "noKycRequests": "אין בקשות אימות ממתינות",
     "kycApproved": "אימות KYC אושר בהצלחה",
     "kycRejected": "אימות KYC נדחה",
-    "copyOrderDetails": "העתק פרטי הזמנה"
+    "copyOrderDetails": "העתק פרטי הזמנה",
+    "productCount": "מוצרים: {count}",
+    "viewOrders": "צפייה בהזמנות"
   },
   "chat": {
     "customerSupport": "תמיכת לקוחות",


### PR DESCRIPTION
## Summary
- add useUsers hook with caching and export
- filter products by store in useProducts and use hook in store dashboard
- switch admin user directory to new useUsers and translate store dashboard strings

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb3039a0dc8326b1a1c6867d0217cf