### PR TITLE
Localize dispute screens

### DIFF
--- a/app/store/[storeId]/admin/_DisputesScreen.tsx
+++ b/app/store/[storeId]/admin/_DisputesScreen.tsx
@@ -10,6 +10,7 @@ import { Order } from '../../../../types';
 import DisputeEvidence from '../../../../components/DisputeEvidence';
 import DisputeResolver from '../../../../components/DisputeResolver';
 import commonStyles from '@/constants/styles';
+import { t } from '@/services/i18n';
 
 export default function AdminDisputesScreen() {
   const { colors } = useTheme();
@@ -53,7 +54,7 @@ export default function AdminDisputesScreen() {
           <ArrowLeft size={24} color={colors.text.primary} />
         </TouchableOpacity>
         <Text style={{ flex: 1, textAlign: 'center', fontSize: 18, color: colors.text.primary }}>
-          Disputes
+          {t('disputes.title')}
         </Text>
         <View style={commonStyles.spacer24} />
       </View>
@@ -68,13 +69,15 @@ export default function AdminDisputesScreen() {
               padding: 16,
             }}
           >
-            <Text style={{ color: colors.text.primary }}>Order: {order.id}</Text>
+            <Text style={{ color: colors.text.primary }}>
+              {t('orders.orderNumber', { id: order.id })}
+            </Text>
             <DisputeEvidence uri={order.disputeEvidenceUri} />
             <DisputeResolver orderId={order.id} />
           </View>
         ))}
         {orders.length === 0 && (
-          <Text style={{ color: colors.text.secondary }}>No disputes</Text>
+          <Text style={{ color: colors.text.secondary }}>{t('disputes.noDisputes')}</Text>
         )}
       </ScrollView>
     </SafeAreaView>

--- a/components/DisputeEvidence.tsx
+++ b/components/DisputeEvidence.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
+import { t } from '@/services/i18n';
 
 interface Props {
   uri?: string;
@@ -27,8 +28,8 @@ export default function DisputeEvidence({ uri }: Props) {
     };
   }, [uri]);
 
-  if (!uri) return <Text>No evidence</Text>;
-  if (content == null) return <Text>Loading evidence...</Text>;
+  if (!uri) return <Text>{t('disputes.noEvidence')}</Text>;
+  if (content == null) return <Text>{t('disputes.loadingEvidence')}</Text>;
   return (
     <View>
       <Text selectable>{content}</Text>

--- a/translations/en.json
+++ b/translations/en.json
@@ -507,6 +507,12 @@
     "transactionCancelled": "Transaction cancelled",
     "createSuccess": "Store created successfully"
   },
+  "disputes": {
+    "title": "Disputes",
+    "noDisputes": "No disputes",
+    "noEvidence": "No evidence",
+    "loadingEvidence": "Loading evidence..."
+  },
   "proofUploader": {
     "permissionRequired": "Permission Required",
     "permissionMessage": "Please allow access to media on the device.",


### PR DESCRIPTION
## Summary
- localize dispute evidence component and admin disputes screen
- add dispute-related strings to English translations

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token)*
- `TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","resolveJsonModule":true,"esModuleInterop":true}' node -e "require('ts-node/register'); const { t, initI18n } = require('./src/services/i18n.ts'); (async () => { await initI18n('fr'); console.log(t('common.save')); })();"

------
https://chatgpt.com/codex/tasks/task_e_68bb36268fec8326be97847829ebce83