### PR TITLE
refactor tests to use navigation helpers

### DIFF
--- a/tests/admin-impersonate.test.tsx
+++ b/tests/admin-impersonate.test.tsx
@@ -3,32 +3,47 @@ import renderer, { act } from 'react-test-renderer';
 import Impersonate from '@app/admin/stores/[storeId]/impersonate';
 import { routes } from '@/utils/routes';
 
-jest.mock('expo-router', () => ({
-  useLocalSearchParams: jest.fn(),
-  router: { replace: jest.fn() },
-}));
-
-jest.mock('@/services', () => {
-  const { router } = require('expo-router');
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn(), push: jest.fn(), back: jest.fn() };
   return {
-    useRequirePlatformAdmin: jest.fn(),
-    useAppRouter: () => ({ replace: router.replace, push: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: jest.fn(),
+    useRouter: () => router,
+    router,
   };
 });
 
+jest.mock('@/services/navigation', () => {
+  const actual = jest.requireActual('@/services/navigation');
+  return {
+    ...actual,
+    push: jest.fn(actual.push),
+    replace: jest.fn(actual.replace),
+  };
+});
+
+jest.mock('@/services', () => {
+  const actual = jest.requireActual('@/services');
+  return { ...actual, useRequirePlatformAdmin: jest.fn() };
+});
+
 describe('Admin store impersonation', () => {
-  const { useLocalSearchParams, router } = require('expo-router');
+  const { useLocalSearchParams } = require('expo-router');
+  const navigation = require('@/services/navigation');
+  const TAB_GROUP = '(' + 'tabs' + ')';
 
   beforeEach(() => {
     useLocalSearchParams.mockReturnValue({ storeId: 's1' });
-    router.replace.mockReset();
+    navigation.replace.mockClear();
   });
 
   it('redirects to store admin dashboard with impersonate flag', async () => {
     await act(async () => {
-      renderer.create(<Impersonate />);
+      renderer.create(React.createElement(Impersonate));
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith(routes.storeAdminDashboard('s1', true));
+    expect(navigation.replace).toHaveBeenCalledWith(
+      routes.storeAdminDashboard('s1', true),
+    );
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
   });
 });

--- a/tests/admin-store-detail.test.tsx
+++ b/tests/admin-store-detail.test.tsx
@@ -2,10 +2,23 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import StoreDetail from '@app/admin/stores/[storeId]/index';
 
-jest.mock('expo-router', () => ({
-  useLocalSearchParams: jest.fn(),
-  router: { replace: jest.fn(), push: jest.fn() },
-}));
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn(), push: jest.fn(), back: jest.fn() };
+  return {
+    useLocalSearchParams: jest.fn(),
+    useRouter: () => router,
+    router,
+  };
+});
+
+jest.mock('@/services/navigation', () => {
+  const actual = jest.requireActual('@/services/navigation');
+  return {
+    ...actual,
+    push: jest.fn(actual.push),
+    replace: jest.fn(actual.replace),
+  };
+});
 
 jest.mock('@/ui/ThemeProvider', () => ({
   useTheme: () => ({
@@ -22,14 +35,16 @@ jest.mock('@/features/stores/services/nearStores', () => ({ getStore: jest.fn() 
 jest.mock('@/features/auth/AuthContext', () => ({ useAuth: jest.fn() }));
 
 describe('Admin store detail access control', () => {
-  const { useLocalSearchParams, router } = require('expo-router');
+  const { useLocalSearchParams } = require('expo-router');
+  const navigation = require('@/services/navigation');
   const { getStore } = require('@/features/stores/services/nearStores');
   const { useAuth } = require('@/features/auth/AuthContext');
+  const TAB_GROUP = '(' + 'tabs' + ')';
 
   beforeEach(() => {
     useLocalSearchParams.mockReturnValue({ storeId: 's1' });
-    router.replace.mockReset();
-    router.push.mockReset();
+    navigation.replace.mockClear();
+    navigation.push.mockClear();
     getStore.mockReset();
     useAuth.mockReset();
   });
@@ -39,10 +54,11 @@ describe('Admin store detail access control', () => {
     getStore.mockResolvedValue({ id: 's1', name: 'Store', owner: 'owner1' });
 
     await act(async () => {
-      renderer.create(<StoreDetail />);
+      renderer.create(React.createElement(StoreDetail));
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
   });
 
   it('allows platform admin', async () => {
@@ -51,10 +67,10 @@ describe('Admin store detail access control', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StoreDetail />);
+      root = renderer.create(React.createElement(StoreDetail));
     });
     await act(async () => {});
-    expect(router.replace).not.toHaveBeenCalled();
+    expect(navigation.replace).not.toHaveBeenCalled();
     const str = JSON.stringify(root!.toJSON());
     expect(str).toContain('Impersonate');
   });

--- a/tests/not-found.test.tsx
+++ b/tests/not-found.test.tsx
@@ -2,18 +2,37 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import NotFoundScreen from '@app/+not-found';
 
-jest.mock('expo-router', () => ({
-  router: { replace: jest.fn() },
-  Stack: { Screen: () => null },
-}));
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn(), push: jest.fn(), back: jest.fn() };
+  return {
+    router,
+    Stack: { Screen: () => null },
+    useRouter: () => router,
+    Redirect: ({ href }: any) => {
+      const { replace } = require('@/services/navigation');
+      replace(href);
+      return null;
+    },
+  };
+});
+
+jest.mock('@/services/navigation', () => {
+  const actual = jest.requireActual('@/services/navigation');
+  return {
+    ...actual,
+    push: jest.fn(actual.push),
+    replace: jest.fn(actual.replace),
+  };
+});
 
 describe('NotFoundScreen', () => {
-  const { router } = require('expo-router');
+  const navigation = require('@/services/navigation');
   const { TouchableOpacity } = require('react-native');
   const originalDev = (globalThis as any).__DEV__;
+  const TAB_GROUP = '(' + 'tabs' + ')';
 
   beforeEach(() => {
-    router.replace.mockReset();
+    navigation.replace.mockClear();
   });
 
   afterEach(() => {
@@ -23,22 +42,24 @@ describe('NotFoundScreen', () => {
   it('redirects home in dev', () => {
     (globalThis as any).__DEV__ = true;
     act(() => {
-      renderer.create(<NotFoundScreen />);
+      renderer.create(React.createElement(NotFoundScreen));
     });
-    expect(router.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
   });
 
   it('renders Go Home button in production', () => {
     (globalThis as any).__DEV__ = false;
     let tree: renderer.ReactTestRenderer | undefined;
     act(() => {
-      tree = renderer.create(<NotFoundScreen />);
+      tree = renderer.create(React.createElement(NotFoundScreen));
     });
     const button = tree!.root.findByType(TouchableOpacity);
-    expect(router.replace).not.toHaveBeenCalled();
+    expect(navigation.replace).not.toHaveBeenCalled();
     act(() => {
       button.props.onPress();
     });
-    expect(router.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
   });
 });

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -3,10 +3,23 @@ import renderer, { act } from 'react-test-renderer';
 import StoreDashboardScreen from '@app/store/[storeId]/admin/dashboard';
 import { routes } from '@/utils/routes';
 
-jest.mock('expo-router', () => ({
-  useLocalSearchParams: jest.fn(),
-  router: { replace: jest.fn(), push: jest.fn() },
-}));
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn(), push: jest.fn(), back: jest.fn() };
+  return {
+    useLocalSearchParams: jest.fn(),
+    useRouter: () => router,
+    router,
+  };
+});
+
+jest.mock('@/services/navigation', () => {
+  const actual = jest.requireActual('@/services/navigation');
+  return {
+    ...actual,
+    push: jest.fn(actual.push),
+    replace: jest.fn(actual.replace),
+  };
+});
 
 jest.mock('@/ui/ThemeProvider', () => ({
   useTheme: () => ({
@@ -29,14 +42,16 @@ jest.mock('@/features/stores/components/OrderRevenueMetrics', () => ({
 }));
 
 describe('StoreDashboardScreen', () => {
-  const { useLocalSearchParams, router } = require('expo-router');
+  const { useLocalSearchParams } = require('expo-router');
+  const navigation = require('@/services/navigation');
   const { getStore } = require('@/features/stores/services/nearStores');
   const { listProducts } = require('@/features/products/services/nearProducts');
   const { useAuth } = require('@/features/auth/AuthContext');
+  const TAB_GROUP = '(' + 'tabs' + ')';
 
   beforeEach(() => {
     useLocalSearchParams.mockReturnValue({ storeId: 's1' });
-    router.replace.mockReset();
+    navigation.replace.mockClear();
     listProducts.mockReset();
     getStore.mockReset();
     useAuth.mockReset();
@@ -52,13 +67,13 @@ describe('StoreDashboardScreen', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StoreDashboardScreen />);
+      root = renderer.create(React.createElement(StoreDashboardScreen));
     });
     await act(async () => {});
     const str = JSON.stringify(root!.toJSON());
     expect(str).toContain('מוצרים: 2');
     expect(str).toContain('metrics');
-    expect(router.replace).not.toHaveBeenCalled();
+    expect(navigation.replace).not.toHaveBeenCalled();
   });
 
   it('redirects if not owner', async () => {
@@ -68,10 +83,11 @@ describe('StoreDashboardScreen', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StoreDashboardScreen />);
+      root = renderer.create(React.createElement(StoreDashboardScreen));
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith(routes.store('s1'));
+    expect(navigation.replace).toHaveBeenCalledWith(routes.store('s1'));
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
     expect(root!.toJSON()).toBeNull();
   });
 
@@ -82,10 +98,11 @@ describe('StoreDashboardScreen', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StoreDashboardScreen />);
+      root = renderer.create(React.createElement(StoreDashboardScreen));
     });
     await act(async () => {});
-    expect(router.replace).toHaveBeenCalledWith(routes.store('s1'));
+    expect(navigation.replace).toHaveBeenCalledWith(routes.store('s1'));
+    expect(navigation.replace.mock.calls[0][0]).not.toContain(TAB_GROUP);
     expect(root!.toJSON()).toBeNull();
   });
 
@@ -100,11 +117,11 @@ describe('StoreDashboardScreen', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StoreDashboardScreen />);
+      root = renderer.create(React.createElement(StoreDashboardScreen));
     });
     await act(async () => {});
     const str = JSON.stringify(root!.toJSON());
     expect(str).toContain('מוצרים: 2');
-    expect(router.replace).not.toHaveBeenCalled();
+    expect(navigation.replace).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update navigation-related tests to use navigation service push/replace helpers
- ensure URLs under test omit the (tabs) route group

## Testing
- `yarn test` *(fails: missing @waku/sdk module, unparsed JSX in route files, smoke test server unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb361a3a68832693f5a956d79a3fe0