### PR TITLE
Wrap admin and cart screens with ErrorBoundary

### DIFF
--- a/app/(tabs)/cart.tsx
+++ b/app/(tabs)/cart.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import AppShell from '../../components/layout/AppShell';
 import { useLanguage } from '@/ui/ThemeProvider';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function CartScreen() {
   const { t } = useLanguage();
   return (
-    <AppShell showSearch={false}>
-      <View>
-        <Text>{t('cart.title')}</Text>
-      </View>
-    </AppShell>
+    <ErrorBoundary>
+      <AppShell showSearch={false}>
+        <View>
+          <Text>{t('cart.title')}</Text>
+        </View>
+      </AppShell>
+    </ErrorBoundary>
   );
 }
 

--- a/app/admin/compliance.tsx
+++ b/app/admin/compliance.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/ui/ThemeProvider';
 import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '../../components/RequireWallet';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function Compliance() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
+  const { t } = useLanguage();
   return (
-    <RequireWallet>
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <Text style={{ color: colors.text.primary }}>Compliance tools coming soon.</Text>
-      </View>
-    </RequireWallet>
+    <ErrorBoundary>
+      <RequireWallet>
+        <View style={[styles.container, { backgroundColor: colors.background }]}> 
+          <Text style={{ color: colors.text.primary }}>{t('admin.complianceSoon')}</Text>
+        </View>
+      </RequireWallet>
+    </ErrorBoundary>
   );
 }
 

--- a/app/admin/fees.tsx
+++ b/app/admin/fees.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/ui/ThemeProvider';
 import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '../../components/RequireWallet';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function Fees() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
+  const { t } = useLanguage();
   return (
-    <RequireWallet>
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <Text style={{ color: colors.text.primary }}>Fees management coming soon.</Text>
-      </View>
-    </RequireWallet>
+    <ErrorBoundary>
+      <RequireWallet>
+        <View style={[styles.container, { backgroundColor: colors.background }]}> 
+          <Text style={{ color: colors.text.primary }}>{t('admin.feesSoon')}</Text>
+        </View>
+      </RequireWallet>
+    </ErrorBoundary>
   );
 }
 

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,7 +1,12 @@
 import { Redirect } from 'expo-router';
 import { useRequirePlatformAdmin } from '@/services';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function AdminIndex() {
   useRequirePlatformAdmin();
-  return <Redirect href="/admin/overview" />;
+  return (
+    <ErrorBoundary>
+      <Redirect href="/admin/overview" />
+    </ErrorBoundary>
+  );
 }

--- a/app/admin/overview.tsx
+++ b/app/admin/overview.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/ui/ThemeProvider';
 import { useRequirePlatformAdmin } from '@/services';
 import RequireWallet from '../../components/RequireWallet';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function AdminOverview() {
   useRequirePlatformAdmin();
   const { colors } = useTheme();
+  const { t } = useLanguage();
   return (
-    <RequireWallet>
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <Text style={[styles.title, { color: colors.text.primary }]}>Platform Overview</Text>
-      </View>
-    </RequireWallet>
+    <ErrorBoundary>
+      <RequireWallet>
+        <View style={[styles.container, { backgroundColor: colors.background }]}> 
+          <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.platformOverview')}</Text>
+        </View>
+      </RequireWallet>
+    </ErrorBoundary>
   );
 }
 

--- a/app/admin/user-directory.tsx
+++ b/app/admin/user-directory.tsx
@@ -6,6 +6,7 @@ import { useRequirePlatformAdmin, useUsers } from '@/services';
 import RequireWallet from '@/components/RequireWallet';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Users } from 'lucide-react-native';
+import ErrorBoundary from '@/shared/ErrorBoundary';
 
 export default function UserDirectory() {
   useRequirePlatformAdmin();
@@ -14,23 +15,25 @@ export default function UserDirectory() {
   const { data: users = [], isLoading } = useUsers();
 
   return (
-    <RequireWallet>
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        {users.length === 0 && !isLoading ? (
-          <EmptyState
-            icon={Users}
-            title={t('admin.noUsers') as string}
-            message={t('admin.noUsersFound') as string}
-          />
-        ) : (
-          users.map((u) => (
-            <Text key={u.id} style={{ color: colors.text.primary }}>
-              {u.displayName || u.id}
-            </Text>
-          ))
-        )}
-      </View>
-    </RequireWallet>
+    <ErrorBoundary>
+      <RequireWallet>
+        <View style={[styles.container, { backgroundColor: colors.background }]}> 
+          {users.length === 0 && !isLoading ? (
+            <EmptyState
+              icon={Users}
+              title={t('admin.noUsers') as string}
+              message={t('admin.noUsersFound') as string}
+            />
+          ) : (
+            users.map((u) => (
+              <Text key={u.id} style={{ color: colors.text.primary }}>
+                {u.displayName || u.id}
+              </Text>
+            ))
+          )}
+        </View>
+      </RequireWallet>
+    </ErrorBoundary>
   );
 }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -338,6 +338,9 @@
     "copyOrderDetails": "Copy Order Details",
     "noUsers": "No users",
     "noUsersFound": "No users found",
+    "platformOverview": "Platform Overview",
+    "complianceSoon": "Compliance tools coming soon.",
+    "feesSoon": "Fees management coming soon.",
     "productCount": "Products: {count}",
     "viewOrders": "View Orders"
   },

--- a/translations/he.json
+++ b/translations/he.json
@@ -312,6 +312,11 @@
     "kycApproved": "אימות KYC אושר בהצלחה",
     "kycRejected": "אימות KYC נדחה",
     "copyOrderDetails": "העתק פרטי הזמנה",
+    "noUsers": "אין משתמשים",
+    "noUsersFound": "לא נמצאו משתמשים",
+    "platformOverview": "סקירת פלטפורמה",
+    "complianceSoon": "כלי ציות יגיעו בקרוב.",
+    "feesSoon": "ניהול עמלות יגיע בקרוב.",
     "productCount": "מוצרים: {count}",
     "viewOrders": "צפייה בהזמנות"
   },


### PR DESCRIPTION
## Summary
- wrap cart and admin routes in shared ErrorBoundary component for resilient fallback UI
- add missing translations for new admin messages

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module '@waku/sdk' and SyntaxError: Unexpected token '<')*


------
https://chatgpt.com/codex/tasks/task_e_68bb412398708326a1d75db02c7a573e