### PR TITLE
feat: optimize list rendering

### DIFF
--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -1,5 +1,21 @@
-import React, { useState, useEffect, useRef, Suspense, lazy } from 'react';
-import { View, ScrollView, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
+import React, {
+  memo,
+  useState,
+  useEffect,
+  useRef,
+  Suspense,
+  lazy,
+  useCallback,
+} from 'react';
+import {
+  View,
+  FlatList,
+  TouchableOpacity,
+  Dimensions,
+  StyleSheet,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from 'react-native';
 import { Plus, Pencil } from 'lucide-react-native';
 import { HeroBanner } from '@/types';
 import { useTheme } from '@/ui/ThemeProvider';
@@ -25,11 +41,11 @@ interface BannerAreaProps {
   loading?: boolean;
 }
 
-export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, loading }: BannerAreaProps) {
+function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, loading }: BannerAreaProps) {
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { push } = useAppRouter();
-  const bannerScrollRef = useRef<ScrollView>(null);
+  const bannerScrollRef = useRef<FlatList<HeroBanner>>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
@@ -37,80 +53,95 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
       const bannerInterval = setInterval(() => {
         setCurrentIndex((prevIndex) => {
           const nextIndex = (prevIndex + 1) % heroBanners.length;
-          bannerScrollRef.current?.scrollTo({ x: nextIndex * (width - 32), animated: true });
+          bannerScrollRef.current?.scrollToOffset({
+            offset: nextIndex * (width - 32),
+            animated: true,
+          });
           return nextIndex;
         });
       }, 5000);
       return () => clearInterval(bannerInterval);
     }
   }, [heroBanners.length]);
-
-  const renderBanner = (item: HeroBanner) => (
-    <View key={item.id} style={styles.heroBanner}>
-      <TouchableOpacity
-        style={styles.bannerTouchable}
-        onPress={() => push(routes.category(item.category))}
-      >
-        <Suspense fallback={<Spinner />}>
-          <SmartImage
-            uri={item.image}
-            width={BANNER_WIDTH}
-            height={BANNER_HEIGHT}
-            contentFit="cover"
-          />
-        </Suspense>
-        <View
-          pointerEvents="none"
-          style={[
-            styles.heroOverlay,
-            { backgroundColor: colors.background + '66' },
-          ]}
+  const renderBanner = useCallback(
+    ({ item }: { item: HeroBanner }) => (
+      <View style={styles.heroBanner}>
+        <TouchableOpacity
+          style={styles.bannerTouchable}
+          onPress={() => push(routes.category(item.category))}
         >
-          <View style={styles.heroContent}>
-            {item.discount ? (
-              <Text
-                style={[
-                  typography.xs,
-                  {
-                    fontWeight: '600',
-                    paddingHorizontal: 8,
-                    paddingVertical: 4,
-                    borderRadius: 8,
-                    alignSelf: 'flex-start',
-                    marginBottom: 8,
-                    color: colors.text.inverse,
-                    backgroundColor: colors.gold,
-                  },
-                ]}
-              >
-                {item.discount} הנחה
-              </Text>
-            ) : null}
-            <Heading size="lg" style={{ color: colors.gold }}>
-              {item.title}
-            </Heading>
-
-            <Text style={[typography.sm, { marginTop: 4, color: colors.gold }]}> 
-              {item.subtitle}
-            </Text>
-          </View>
-        </View>
-      </TouchableOpacity>
-
-      {isStoreOwner && (
-        <View style={styles.bannerAdminActions}>
-          <TouchableOpacity
+          <Suspense fallback={<Spinner />}>
+            <SmartImage
+              uri={item.image}
+              width={BANNER_WIDTH}
+              height={BANNER_HEIGHT}
+              contentFit="cover"
+            />
+          </Suspense>
+          <View
+            pointerEvents="none"
             style={[
-              styles.bannerAdminButton,
-              { backgroundColor: colors.background + 'CC' },
+              styles.heroOverlay,
+              { backgroundColor: colors.background + '66' },
             ]}
-            onPress={() => onEditBanner(item)}
           >
-            <Pencil size={16} color="#FFFFFF" />
-          </TouchableOpacity>
-        </View>
-      )}
-    </View>
+            <View style={styles.heroContent}>
+              {item.discount ? (
+                <Text
+                  style={[
+                    typography.xs,
+                    {
+                      fontWeight: '600',
+                      paddingHorizontal: 8,
+                      paddingVertical: 4,
+                      borderRadius: 8,
+                      alignSelf: 'flex-start',
+                      marginBottom: 8,
+                      color: colors.text.inverse,
+                      backgroundColor: colors.gold,
+                    },
+                  ]}
+                >
+              {t('product.percentOff', { percent: item.discount })}
+                </Text>
+              ) : null}
+              <Heading size="lg" style={{ color: colors.gold }}>
+                {item.title}
+              </Heading>
+
+              <Text style={[typography.sm, { marginTop: 4, color: colors.gold }]}>
+                {item.subtitle}
+              </Text>
+            </View>
+          </View>
+        </TouchableOpacity>
+
+        {isStoreOwner && (
+          <View style={styles.bannerAdminActions}>
+            <TouchableOpacity
+              style={[
+                styles.bannerAdminButton,
+                { backgroundColor: colors.background + 'CC' },
+              ]}
+              onPress={() => onEditBanner(item)}
+            >
+            <Pencil size={16} color={colors.text.inverse} />
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    ),
+    [colors, isStoreOwner, onEditBanner, push, t]
+  );
+
+  const keyExtractor = useCallback((item: HeroBanner) => item.id, []);
+
+  const handleMomentumScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const newIndex = Math.round(event.nativeEvent.contentOffset.x / (width - 32));
+      setCurrentIndex(newIndex);
+    },
+    []
   );
 
   if (loading) {
@@ -151,21 +182,17 @@ export default function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onE
 
       {heroBanners.length > 0 ? (
         <>
-          <ScrollView
+          <FlatList
             ref={bannerScrollRef}
+            data={heroBanners}
             horizontal
             pagingEnabled
             showsHorizontalScrollIndicator={false}
-            onMomentumScrollEnd={(event) => {
-              const newIndex = Math.round(
-                event.nativeEvent.contentOffset.x / (width - 32)
-              );
-              setCurrentIndex(newIndex);
-            }}
+            onMomentumScrollEnd={handleMomentumScrollEnd}
+            renderItem={renderBanner}
+            keyExtractor={keyExtractor}
             contentContainerStyle={styles.bannerScrollContent}
-          >
-            {heroBanners.map((item) => renderBanner(item))}
-          </ScrollView>
+          />
 
           {heroBanners.length > 1 && (
             <View pointerEvents="none" style={styles.bannerIndicators}>
@@ -241,7 +268,7 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#ccc',
+    backgroundColor: colors.border.primary,
     marginHorizontal: 4,
   },
   activeIndicator: {},
@@ -260,4 +287,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
+export default memo(BannerArea);
 

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { View, StyleSheet, FlatList } from 'react-native';
 import { ProductCard, ProductCardSkeleton } from '@/features/products';
 import { Product, Category } from '@/types';
@@ -29,7 +29,7 @@ const ProductRow = React.memo(({ item }: { item: Product }) => (
   </View>
 ));
 
-export default function ProductGrid({
+function ProductGrid({
   products,
   categories,
   isStoreOwner,
@@ -97,6 +97,8 @@ export default function ProductGrid({
     />
   );
 }
+
+export default memo(ProductGrid);
 
 const styles = StyleSheet.create({
   productsGrid: {

--- a/src/features/products/components/ProductGrid.tsx
+++ b/src/features/products/components/ProductGrid.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { FlatList, View, StyleSheet } from 'react-native';
 import EmptyState from '@/shared/ui/EmptyState';
 import ProductCard from '../ProductCard';
 import { Product } from '@/types';
-import { useTheme } from '@/ui/ThemeProvider';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Package } from 'lucide-react-native';
 import { spacing } from '@/shared/ui/tokens';
 
@@ -21,8 +21,9 @@ const ProductRow = React.memo(
   )
 );
 
-export default function ProductGrid({ products }: { products: Product[] }) {
+function ProductGrid({ products }: { products: Product[] }) {
   const { colors } = useTheme();
+  const { t } = useLanguage();
 
   const borderColor = colors.border.primary;
   const renderItem = useCallback(
@@ -47,8 +48,8 @@ export default function ProductGrid({ products }: { products: Product[] }) {
     return (
       <EmptyState
         icon={Package}
-        title="No products yet"
-        message="When the owner adds items, they will appear here."
+        title={t('subcategory.noProducts')}
+        message={t('home.productsComingSoon')}
       />
     );
   }
@@ -64,4 +65,6 @@ export default function ProductGrid({ products }: { products: Product[] }) {
     />
   );
 }
+
+export default memo(ProductGrid);
 


### PR DESCRIPTION
## Summary
- memoize product grids and banner area to reduce re-renders
- add stable keys and callbacks for list items
- use translations and theme colors in product grid and banner area

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token in admin-store-detail and storeDashboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4128f7088326a7c4cad16cb42320