### PR TITLE
chore: remove obsolete files

### DIFF
--- a/EmptyHMRClient.ts
+++ b/EmptyHMRClient.ts
@@ -1,5 +1,0 @@
-export default {
-  registerBundle: () => {},
-  enable: () => {},
-  log: () => {},
-};

--- a/README.md
+++ b/README.md
@@ -202,10 +202,6 @@ TypeScript and webpack use the same aliases so all tools reference the wrapper
 consistently. Polyfills are initialized at the app entry point, so the HMR
 runtime runs within the already-prepared environment.
 
-Metro also maps `react-native/Libraries/Utilities/HMRClient` to a stub
-`EmptyHMRClient.ts` with no-op methods so bundling succeeds even when the native
-implementation isn't available.
-
 ### Debugging & Logs
 
 Call `debugLog()` for development-only messages. When

--- a/app/store/[storeId]/admin/_DisputesScreen.tsx
+++ b/app/store/[storeId]/admin/_DisputesScreen.tsx
@@ -10,7 +10,7 @@ import { Order } from '../../../../types';
 import DisputeEvidence from '../../../../components/DisputeEvidence';
 import DisputeResolver from '../../../../components/DisputeResolver';
 import commonStyles from '@/constants/styles';
-import { t } from '@/services/i18n';
+import { t } from '@/i18n';
 
 export default function AdminDisputesScreen() {
   const { colors } = useTheme();

--- a/components/DisputeEvidence.tsx
+++ b/components/DisputeEvidence.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
-import { t } from '@/services/i18n';
+import { t } from '@/i18n';
 
 interface Props {
   uri?: string;

--- a/metro.config.js
+++ b/metro.config.js
@@ -50,10 +50,6 @@ config.resolver.unstable_enablePackageExports = true;
     __dirname,
     'HMRClient.ts'
   ),
-  'react-native/Libraries/Utilities/HMRClient': path.resolve(
-    __dirname,
-    'EmptyHMRClient.ts'
-  ),
   '@noble/hashes': path.resolve(__dirname, 'node_modules/@noble/hashes'),
   '@noble/ed25519': path.resolve(__dirname, 'node_modules/@noble/ed25519'),
   '@noble/hashes/hkdf': require.resolve('@noble/hashes/hkdf'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,9 +73,6 @@
       ],
       "@expo/metro-runtime/src/HMRClient.ts": [
         "./HMRClient.ts"
-      ],
-      "react-native/Libraries/Utilities/HMRClient": [
-        "./EmptyHMRClient.ts"
       ]
     },
     "customConditions": [


### PR DESCRIPTION
## Summary
- drop unused EmptyHMRClient stub and its metro/tsconfig references
- fix stale i18n imports

## Testing
- `yarn typecheck` *(fails: App.tsx(5,10): error TS2724: '"expo-router"' has no exported member named 'Router'. Did you mean 'router'?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c347ac4832694dcb050615625fb