### PR TITLE
Refactor cart widget utilities

### DIFF
--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import {
-  View,
-  StyleSheet,
-  TouchableOpacity,
-  Platform,
-} from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Text, Button, Portal, Overlay } from '@/ui';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
-import { spacing, radius, shadows, typography } from '@/shared/ui/tokens';
+import { spacing, radius, typography } from '@/shared/ui/tokens';
+import { platformShadow } from '@/utils/shadow';
 import { X } from 'lucide-react-native';
 
 interface ConfirmationModalProps {
@@ -106,7 +102,7 @@ const styles = StyleSheet.create({
     maxWidth: 400,
     borderRadius: radius.xl,
     overflow: 'hidden',
-    ...Platform.select(shadows.md),
+    ...platformShadow('md'),
   },
   header: {
     flexDirection: 'row',

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -9,7 +9,8 @@ import {
 import { Text, Button, Portal, Overlay } from '@/ui';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
-import { spacing, radius, zIndex, shadows, typography } from '@/shared/ui/tokens';
+import { spacing, radius, zIndex, typography } from '@/shared/ui/tokens';
+import { platformShadow } from '@/utils/shadow';
 import { X, CircleCheck as CheckCircle, CircleAlert as AlertCircle, Info, TriangleAlert as AlertTriangle } from 'lucide-react-native';
 
 type InfoType = 'success' | 'error' | 'info' | 'warning';
@@ -160,7 +161,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     padding: spacing.spacer24,
     alignItems: 'center',
-    ...Platform.select(shadows.md),
+    ...platformShadow('md'),
   },
   closeButton: {
     position: 'absolute',

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -31,12 +31,17 @@ export const shadows = {
   sm: {
     ios: { elevation: 2 },
     android: { elevation: 2 },
-    web: { boxShadow: '0px 2px 4px rgba(0,0,0,0.1)' },
+    web: { boxShadow: `0px 2px 4px rgba(0,0,0,0.1)` },
   },
   md: {
     ios: { elevation: 5 },
     android: { elevation: 5 },
-    web: { boxShadow: '0px 4px 12px rgba(0,0,0,0.15)' },
+    web: { boxShadow: `0px 4px 12px rgba(0,0,0,0.15)` },
+  },
+  lg: {
+    ios: { elevation: 12 },
+    android: { elevation: 12 },
+    web: { boxShadow: `0px 4px 8px rgba(0,0,0,0.3)` },
   },
 };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '^@/layout/(.*)$': '<rootDir>/src/layout/$1',
     '^@/services$': '<rootDir>/src/services/index',
     '^@/services/(.*)$': ['<rootDir>/src/services/$1', '<rootDir>/services/$1'],
+    '^@/utils/(.*)$': ['<rootDir>/src/utils/$1', '<rootDir>/utils/$1'],
     '^@/providers/(.*)$': '<rootDir>/src/providers/$1',
     '^@/providers$': '<rootDir>/src/providers/index',
     '^@/i18n$': '<rootDir>/src/i18n',

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -6,8 +6,6 @@ import {
   TouchableOpacity,
   Animated,
   ScrollView,
-  Dimensions,
-  Platform,
   I18nManager,
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
@@ -17,21 +15,17 @@ import { useCurrency } from '@/contexts/CurrencyContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import useCart from '../hooks/useCart';
-import { spacing, radius } from '@/shared/ui/tokens';
+import { spacing, radius, zIndex } from '@/shared/ui/tokens';
+import debounce from '@/utils/debounce';
+import { platformShadow } from '@/utils/shadow';
+import { Card } from '@/ui/primitives';
+import { Stack } from '@/ui/layout';
 
-function debounce<T extends (...args: any[]) => void>(fn: T, delay: number) {
-  let timeout: ReturnType<typeof setTimeout>;
-  return (...args: Parameters<T>) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => fn(...args), delay);
-  };
-}
-
-const { width } = Dimensions.get('window');
+const AnimatedCard = Animated.createAnimatedComponent(Card);
 
 export default function FloatingCartWidget() {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [animatedHeight] = useState(new Animated.Value(60));
+  const [animatedHeight] = useState(new Animated.Value(spacing.spacer20 * 3));
   const [animatedOpacity] = useState(new Animated.Value(0));
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
@@ -61,7 +55,12 @@ export default function FloatingCartWidget() {
   const animateHeight = useCallback(
     (expanded: boolean, count: number) => {
       Animated.timing(animatedHeight, {
-        toValue: expanded ? Math.min(300, count * 80 + 120) : 60,
+        toValue: expanded
+          ? Math.min(
+              spacing.spacer40 * 7 + spacing.spacer20,
+              count * spacing.spacer40 * 2 + spacing.spacer40 * 3
+            )
+          : spacing.spacer20 * 3,
         duration: 300,
         useNativeDriver: false,
       }).start();
@@ -100,7 +99,7 @@ export default function FloatingCartWidget() {
   }
 
   return (
-    <Animated.View 
+    <AnimatedCard
       style={[
         styles.container,
         {
@@ -108,20 +107,17 @@ export default function FloatingCartWidget() {
           height: animatedHeight,
           backgroundColor: colors.surface.elevated,
           borderColor: colors.border.primary,
-          ...Platform.select({
-            ios: { elevation: 12 },
-            android: { elevation: 12 },
-            web: { boxShadow: `0px 4px 8px rgba(0, 0, 0, 0.3)` }
-          }),
-        }
+          ...platformShadow('lg'),
+        },
       ]}
     >
-      {/* Header */}
-      <TouchableOpacity style={styles.header} onPress={toggleExpanded}>
+      <Stack>
+        {/* Header */}
+        <TouchableOpacity style={styles.header} onPress={toggleExpanded}>
         <View style={styles.headerLeft}>
           <View style={[styles.cartIcon, { backgroundColor: colors.gold }]}>
             <ShoppingCart
-              size={20}
+              size={spacing.spacer20}
               color={colors.text.inverse}
               style={{ transform: [{ scaleX: isRTL ? -1 : 1 }] }}
             />
@@ -146,12 +142,12 @@ export default function FloatingCartWidget() {
               <SmartImage
                 key={item.id}
                 uri={item.product.images[0]}
-                width={32}
-                height={32}
+                width={spacing.spacer16 * 2}
+                height={spacing.spacer16 * 2}
                 style={[
                   styles.previewImage,
                   {
-                    marginStart: index > 0 ? -8 : 0,
+                    marginStart: index > 0 ? -spacing.spacer8 : 0,
                     zIndex: 3 - index,
                     borderColor: colors.background,
                   }
@@ -164,7 +160,7 @@ export default function FloatingCartWidget() {
                 style={[
                   styles.moreItems,
                   {
-                    marginStart: -8,
+                    marginStart: -spacing.spacer8,
                     borderColor: colors.background,
                     backgroundColor: colors.interactive.disabled,
                   }
@@ -190,8 +186,8 @@ export default function FloatingCartWidget() {
               }]}>
                 <SmartImage
                   uri={item.product.images[0]}
-                  width={40}
-                  height={40}
+                  width={spacing.spacer40}
+                  height={spacing.spacer40}
                   style={styles.itemImage}
                   contentFit="cover"
                 />
@@ -219,7 +215,7 @@ export default function FloatingCartWidget() {
                     }]}
                     onPress={() => updateQuantity(item.id, item.quantity - 1)}
                   >
-                    <Minus size={12} color={colors.text.primary} />
+                    <Minus size={spacing.spacer12} color={colors.text.primary} />
                   </TouchableOpacity>
                   
                   <Text style={[styles.quantity, { color: colors.text.primary }]}>{item.quantity}</Text>
@@ -231,7 +227,7 @@ export default function FloatingCartWidget() {
                     }]}
                     onPress={() => updateQuantity(item.id, item.quantity + 1)}
                   >
-                    <Plus size={12} color={colors.text.primary} />
+                    <Plus size={spacing.spacer12} color={colors.text.primary} />
                   </TouchableOpacity>
                 </View>
 
@@ -242,7 +238,7 @@ export default function FloatingCartWidget() {
                   }]}
                   onPress={() => removeItem(item.id)}
                 >
-                  <X size={12} color={colors.status.error} />
+                  <X size={spacing.spacer12} color={colors.status.error} />
                 </TouchableOpacity>
               </View>
             ))}
@@ -258,28 +254,30 @@ export default function FloatingCartWidget() {
             </TouchableOpacity>
           </View>
         </View>
-      )}
-    </Animated.View>
+        )}
+      </Stack>
+    </AnimatedCard>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    bottom: 170,
+    bottom: spacing.spacer40 * 4 + spacing.spacer20 / 2,
     start: spacing.spacer16,
     end: spacing.spacer16,
     borderRadius: radius.xl,
-    zIndex: 999,
+    zIndex: zIndex.modal,
     borderWidth: 1,
     overflow: 'hidden',
+    padding: 0,
   },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: spacing.spacer16,
-    height: 60,
+    height: spacing.spacer20 * 3,
   },
   headerLeft: {
     flexDirection: 'row',
@@ -335,8 +333,8 @@ const styles = StyleSheet.create({
     borderWidth: 2,
   },
   moreItems: {
-    width: 32,
-    height: 32,
+    width: spacing.spacer16 * 2,
+    height: spacing.spacer16 * 2,
     borderRadius: radius.xl,
     justifyContent: 'center',
     alignItems: 'center',
@@ -352,7 +350,7 @@ const styles = StyleSheet.create({
   },
   itemsList: {
     flex: 1,
-    maxHeight: 200,
+    maxHeight: spacing.spacer40 * 5,
   },
   cartItem: {
     flexDirection: 'row',

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,7 @@
+export default function debounce<T extends (...args: any[]) => void>(fn: T, delay: number) {
+  let timeout: ReturnType<typeof setTimeout>;
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/src/utils/shadow.ts
+++ b/src/utils/shadow.ts
@@ -1,0 +1,8 @@
+import { Platform } from 'react-native';
+import { shadows } from '@/ui/tokens';
+
+type ShadowKey = keyof typeof shadows;
+
+export function platformShadow(level: ShadowKey) {
+  return shadows[level][Platform.OS];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,10 @@
         "src/services/*",
         "services/*"
       ],
+      "@/utils/*": [
+        "src/utils/*",
+        "utils/*"
+      ],
       "@/providers": [
         "src/providers/index.ts"
       ],


### PR DESCRIPTION
## Summary
- add reusable debounce and platform shadow helpers
- restyle floating cart widget using Card/Stack and tokens
- update modals to use shared shadow helper

## Testing
- `npm test` *(fails: Unexpected token in app modules; Cannot find module '@waku/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68bb55f90d648326996df19db9d162f3