### PR TITLE
feat: centralize app provider stack

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { stripTabsPrefix } from '@/services/navigation';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { Spinner } from '@/ui/primitives';
 import { debugLog } from '@/utils/logger';
+import AppProviders from '@/providers/AppProviders';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
@@ -38,9 +39,11 @@ function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <React.Suspense fallback={<Spinner />}>
-          {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-        </React.Suspense>
+        <AppProviders>
+          <React.Suspense fallback={<Spinner />}>
+            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+          </React.Suspense>
+        </AppProviders>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Slot } from 'expo-router';
-import AppProviders from '@/providers/AppProviders';
 
+// Root layout renders only the current route. Providers live in App.tsx.
 export default function RootLayout() {
-  return (
-    <AppProviders>
-      <Slot />
-    </AppProviders>
-  );
+  return <Slot />;
 }


### PR DESCRIPTION
## Summary
- wrap Router with AppProviders at the top level
- simplify root layout to render Slot only

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token and missing module '@waku/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68babd9cb1c48326b81420df894771ff