### PR TITLE
feat: centralize app provider stack

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { stripTabsPrefix } from '@/services/navigation';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { Spinner } from '@/ui/primitives';
 import { debugLog } from '@/utils/logger';
+import AppProviders from '@/providers/AppProviders';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
@@ -39,7 +40,9 @@ function MainApp() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <React.Suspense fallback={<Spinner />}>
-          {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+          <AppProviders>
+            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
+          </AppProviders>
         </React.Suspense>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,8 +16,7 @@ import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
 import { useHomeModals } from '@/features/home/hooks/useHomeModals';
 import { useHomeRefresh } from '@/features/home/hooks/useHomeRefresh';
 import { useAuth } from '@/features/auth/AuthContext';
-import { useLanguage } from '@/ui/ThemeProvider';
-import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import CTABecomeSeller from '@/features/home/components/CTABecomeSeller';
@@ -63,7 +62,7 @@ function HomeScreenContent() {
   } = useHomeModals(error);
   const { isStoreOwner } = useAuth();
   const { t } = useLanguage();
-  const { colors } = useTheme();
+  const { colors: themeColors } = useTheme();
 
   const {
     products,
@@ -144,14 +143,14 @@ function HomeScreenContent() {
         style={[
           styles.categoryIcon,
           {
-            backgroundColor: colors.interactive.secondary,
-            borderColor: colors.gold,
+            backgroundColor: themeColors.interactive.secondary,
+            borderColor: themeColors.gold,
           },
         ]}
       >
         <Text style={styles.categoryEmoji}>{item.icon}</Text>
       </View>
-      <Text style={[styles.categoryName, { color: colors.text.primary }]}>
+      <Text style={[styles.categoryName, { color: themeColors.text.primary }]}>
         {item.name}
       </Text>
       {isStoreOwner && (
@@ -160,13 +159,13 @@ function HomeScreenContent() {
             style={[
               styles.categoryAdminButton,
               {
-                backgroundColor: colors.background,
-                borderColor: colors.gold,
+                backgroundColor: themeColors.background,
+                borderColor: themeColors.gold,
               },
             ]}
             onPress={() => push(routes.category(item.id))}
           >
-            <Pencil size={10} color={colors.gold} />
+            <Pencil size={10} color={themeColors.gold} />
           </TouchableOpacity>
         </View>
       )}
@@ -214,7 +213,7 @@ function HomeScreenContent() {
     >
       <ScrollArea
         testID="home-root"
-        backgroundColor={colors.canvas}
+        backgroundColor={themeColors.canvas}
         showsVerticalScrollIndicator={false}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
       >
@@ -241,11 +240,11 @@ function HomeScreenContent() {
         {/* Categories Section */}
         <Container style={styles.section}>
           <Stack direction="horizontal" style={styles.sectionHeader}>
-            <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+            <Text style={[styles.sectionTitle, { color: themeColors.text.primary }]}>
               {t('home.categories')}
             </Text>
             <TouchableOpacity onPress={() => push('/categories')}>
-              <Text style={[styles.seeAll, { color: colors.gold }]}>
+              <Text style={[styles.seeAll, { color: themeColors.gold }]}>
                 {t('common.viewAll')}
               </Text>
             </TouchableOpacity>
@@ -275,7 +274,7 @@ function HomeScreenContent() {
         {/* Products Section */}
         <Container style={styles.section}>
           <Stack direction="horizontal" style={styles.sectionHeader}>
-            <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+            <Text style={[styles.sectionTitle, { color: themeColors.text.primary }]}>
               {searchQuery
                 ? t('home.searchResults', { query: searchQuery })
                 : t('home.products')}
@@ -285,14 +284,14 @@ function HomeScreenContent() {
                 style={[
                   styles.sortButton,
                   {
-                    backgroundColor: colors.surface.primary,
-                    borderColor: colors.border.primary,
+                    backgroundColor: themeColors.surface.primary,
+                    borderColor: themeColors.border.primary,
                   },
                 ]}
                 onPress={() => setShowSortModal(true)}
               >
-                <ArrowUpDown size={16} color={colors.gold} />
-                <Text style={[styles.sortText, { color: colors.gold }]}>
+                <ArrowUpDown size={16} color={themeColors.gold} />
+                <Text style={[styles.sortText, { color: themeColors.gold }]}>
                   {getSortLabel()}
                 </Text>
               </TouchableOpacity>
@@ -301,13 +300,13 @@ function HomeScreenContent() {
                   style={[
                     styles.addProductButton,
                     {
-                      backgroundColor: colors.interactive.secondary,
-                      borderColor: colors.gold,
+                      backgroundColor: themeColors.interactive.secondary,
+                      borderColor: themeColors.gold,
                     },
                   ]}
                     onPress={openProductForm}
                 >
-                  <Plus size={16} color={colors.gold} />
+                  <Plus size={16} color={themeColors.gold} />
                 </TouchableOpacity>
               )}
             </Stack>
@@ -358,26 +357,26 @@ function HomeScreenContent() {
         <View
           style={[
             styles.sortModalOverlay,
-            { backgroundColor: colors.background + '80' },
+            { backgroundColor: themeColors.background + '80' },
           ]}
         >
           <View
             style={[
               styles.sortModalContent,
               {
-                backgroundColor: colors.surface.elevated,
-                borderColor: colors.border.primary,
+                backgroundColor: themeColors.surface.elevated,
+                borderColor: themeColors.border.primary,
               },
             ]}
           >
             <View style={styles.sortModalHeader}>
               <Text
-                style={[styles.sortModalTitle, { color: colors.text.primary }]}
+                style={[styles.sortModalTitle, { color: themeColors.text.primary }]}
               >
                 {t('home.sortProducts')}
               </Text>
               <TouchableOpacity onPress={() => setShowSortModal(false)}>
-                <X size={24} color={colors.text.primary} />
+                <X size={24} color={themeColors.text.primary} />
               </TouchableOpacity>
             </View>
 
@@ -391,10 +390,10 @@ function HomeScreenContent() {
                 key={option.key}
                 style={[
                   styles.sortOption,
-                  { borderBottomColor: colors.border.secondary },
+                  { borderBottomColor: themeColors.border.secondary },
                   sortBy === option.key && [
                     styles.selectedSortOption,
-                    { backgroundColor: colors.interactive.secondary },
+                    { backgroundColor: themeColors.interactive.secondary },
                   ],
                 ]}
                 onPress={() => {
@@ -405,8 +404,8 @@ function HomeScreenContent() {
                 <Text
                   style={[
                     styles.sortOptionText,
-                    { color: colors.text.primary },
-                    sortBy === option.key && { color: colors.gold },
+                    { color: themeColors.text.primary },
+                    sortBy === option.key && { color: themeColors.gold },
                   ]}
                 >
                   {option.label}
@@ -415,7 +414,7 @@ function HomeScreenContent() {
                   <View
                     style={[
                       styles.selectedDot,
-                      { backgroundColor: colors.gold },
+                      { backgroundColor: themeColors.gold },
                     ]}
                   />
                 )}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { Slot } from 'expo-router';
-import AppProviders from '@/providers/AppProviders';
 
-export default function RootLayout() {
-  return (
-    <AppProviders>
-      <Slot />
-    </AppProviders>
-  );
-}
+// Root layout renders only the current route.
+// No wrappers allowed before <Slot />; providers live in App.tsx.
+export default () => <Slot />;

--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -9,7 +9,7 @@ import { FloatingCartWidget } from '@/features/cart';
 import { getTabsForAuth } from '@/config/navigation';
 import { useAuth } from '@/features/auth/AuthContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import { spacing, shadows } from '@/shared/ui/tokens';
+import { spacing, shadows, typography } from '@/shared/ui/tokens';
 
 export default function TabsLayout() {
   const { t } = useLanguage();
@@ -44,7 +44,7 @@ export default function TabsLayout() {
     tabBarInactiveTintColor: colors.tabBar.inactive,
     tabBarStyle,
     tabBarLabelStyle: {
-      fontSize: 12,
+      fontSize: typography.xs.fontSize,
       fontWeight: '500',
     },
   } as const;


### PR DESCRIPTION
## Summary
- wrap Router with AppProviders at the top level
- simplify root layout to render Slot only
- adjust App.tsx so AppProviders wrap Router/Fallback inside Suspense
- alias theme colors in home screen to prevent undefined variable errors
- replace numeric tab bar label size with typography token

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected tokens and missing module '@waku/sdk'; web smoke test unable to reach server)*
- `yarn web` *(started Metro Bundler)*
- `yarn android` *(fails: Command "android" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babd9cb1c48326b81420df894771ff