### PR TITLE
Fix BannerArea color reference

### DIFF
--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -201,6 +201,7 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
                   key={index}
                   style={[
                     styles.indicator,
+                    { backgroundColor: colors.border.primary },
                     index === currentIndex && [
                       styles.activeIndicator,
                       { backgroundColor: colors.gold },
@@ -268,7 +269,6 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: colors.border.primary,
     marginHorizontal: 4,
   },
   activeIndicator: {},


### PR DESCRIPTION
## Summary
- fix BannerArea indicator crash by using theme colors at render time

## Testing
- `CI=1 yarn test` *(fails: Jest encountered unexpected token and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6d0a6dd0832685c7663735906ebb