### PR TITLE
fix expo router integration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { View, Text } from 'react-native';
-import { Router } from 'expo-router';
+import { ExpoRoot } from 'expo-router';
+import { ctx } from 'expo-router/_ctx';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { Spinner } from '@/ui';
-import { debugLog } from '@/utils/logger';
 import AppProviders from '@/providers/AppProviders';
 
 const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
 
 function RouterApp() {
-  return <Router />;
+  return <ExpoRoot context={ctx} />;
 }
 
 function FallbackScreen() {


### PR DESCRIPTION
## Summary
- replace invalid Router component with ExpoRoot and route context

## Testing
- `yarn lint App.tsx`
- `yarn test` *(fails: Jest encountered an unexpected token; Unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7a3e64408326b87dba25f9404c05