### PR TITLE
refactor: route NEAR calls through chain adapter

### DIFF
--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -13,7 +13,7 @@ import InfoModal from '../../components/InfoModal';
 import OrderService from '@/services/orders';
 import { Order, OrderStatus, ShippingAddress } from '../../types';
 import { ALLOWED_STATUS_TRANSITIONS } from '../../agents/orders-agent';
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { decryptOrderShipping } from '@/features/stores/services/sellerTools';
 
 const validateParams = createValidateParams(z.object({ id: z.string() }));
@@ -39,7 +39,7 @@ export default function OrderDetailScreen() {
       let decrypted = raw as Order | null;
       if (raw && raw.shipAddrEnc && isSeller) {
         try {
-          const sig = await nearAuth.signMessage(Buffer.from(raw.id));
+          const sig = await chainAdapter.signMessage?.(Buffer.from(raw.id));
           if (sig) {
             const addr = await decryptOrderShipping(raw);
             if (addr) {

--- a/app/product/_ProductScreen.tsx
+++ b/app/product/_ProductScreen.tsx
@@ -37,7 +37,7 @@ import InfoModal from '../../components/InfoModal';
 import { ProductFormModal, useProductDetail } from '@/features/products';
 import { Spinner } from '@/ui/primitives';
 import CartService from '@/features/cart/services/cart';
-import { useAccountId } from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import chatAgent from '../../agents/chat-agent';
 import moderationAgent from '../../agents/moderation-agent';
 import commonStyles from '@/constants/styles';
@@ -76,7 +76,7 @@ export default function ProductDetailScreen({ id }: { id: string }) {
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { currencySymbol } = useCurrency();
-  const address = useAccountId();
+  const address = chainAdapter.useAccountId();
   const reviews = useReviews(id);
 
   // Modal states

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -3,23 +3,15 @@ import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native
 import { debugLog } from '@/utils/logger';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '@/ui/ThemeProvider';
-import chain from '@/services/chain';
-import { Order } from '../../../../types';
-import { useAccountId } from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
+import type { Order } from '../../../../types';
 import { useLanguage } from '@/ui/ThemeProvider';
-
-let listOrdersBySeller:
-  | ((storeId: string, sellerId: string) => Promise<Order[]>)
-  | undefined;
-if (chain === 'near') {
-  ({ listOrdersBySeller } = require('@/services/nearOrders'));
-}
 
 export default function StoreOrdersScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
   const [orders, setOrders] = useState<Order[]>([]);
-  const address = useAccountId();
+  const address = chainAdapter.useAccountId();
   const { t } = useLanguage();
 
   const handlePress = (order: Order) => {
@@ -32,8 +24,8 @@ export default function StoreOrdersScreen() {
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || address !== storeId || !listOrdersBySeller) return;
-      const all = await listOrdersBySeller(storeId, storeId);
+      if (!storeId || address !== storeId || !chainAdapter.listOrdersBySeller) return;
+      const all = await chainAdapter.listOrdersBySeller(storeId, storeId);
       setOrders(all);
     };
     load();

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -6,7 +6,7 @@ import { Product } from '../../../../types';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { useProducts } from '@/services/useProducts';
 import { ProductCard, ProductFormModal } from '@/features/products';
-import { useAccountId } from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { useAuth } from '@/features/auth/AuthContext';
 
 const ITEM_HEIGHT = 200;
@@ -36,7 +36,7 @@ export default function StoreProductsScreen() {
   const [products, setProducts] = useState<Product[]>(initialProducts);
   const [formVisible, setFormVisible] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
-  const address = useAccountId();
+  const address = chainAdapter.useAccountId();
   const { isStoreOwner } = useAuth();
 
   useEffect(() => {

--- a/apps/web/components/WalletButton.tsx
+++ b/apps/web/components/WalletButton.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 
 export default function WalletButton() {
   const [acct, setAcct] = React.useState<string | null>(null);
   React.useEffect(() => {
     try {
-      setAcct(nearAuth.getAccountId());
+      setAcct(chainAdapter.getAccountId());
     } catch {}
   }, []);
   return (
@@ -19,8 +19,8 @@ export default function WalletButton() {
       }}
       onClick={async () => {
         try {
-          await nearAuth.signIn();
-          setAcct(nearAuth.getAccountId());
+          await chainAdapter.openModal();
+          setAcct(chainAdapter.getAccountId());
         } catch {}
       }}
     >

--- a/components/RequireWallet.tsx
+++ b/components/RequireWallet.tsx
@@ -2,14 +2,14 @@ import React, { useEffect } from 'react';
 import { usePathname, useSearchParams } from 'expo-router';
 import { stripTabsPrefix } from '@/services/navigation';
 import { useAppRouter } from '@/services';
-import { useAccountId } from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 
 interface Props {
   children: React.ReactNode;
 }
 
 export default function RequireWallet({ children }: Props) {
-  const accountId = useAccountId();
+  const accountId = chainAdapter.useAccountId();
   const pathname = usePathname();
   const params = useSearchParams();
   const { replace } = useAppRouter();

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -10,7 +10,7 @@ import {
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { uuid } from '../utils/uuid';
 import { sha256 } from '@noble/hashes/sha256';
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 
 const STABLE_BOOTSTRAP = [
   '/dns4/node.waku.nodes.status.im/tcp/443/wss/p2p/16Uiu2HAmSWvkpawuUxEe7dBDEu79SU1YEYTbSsfXrVvjJAnGqsRP',
@@ -52,7 +52,7 @@ export async function publish(
   if (!n) return;
   try {
     const encoder = createEncoder({ contentTopic });
-    const addr = nearAuth.getAccountId();
+    const addr = chainAdapter.getAccountId();
     const event = {
       id: uuid(),
       timestamp: Date.now(),

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -1,5 +1,5 @@
 import { errorLog } from '@/utils/logger';
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { fetchSettings } from './nearSettings';
 import { assertNearChain } from './chain';
 
@@ -18,7 +18,7 @@ export async function getOrderPaymentFactoryAddress(): Promise<string> {
 }
 
 async function sendNear(message: string): Promise<string> {
-  return nearAuth.signMessage(message);
+  return chainAdapter.signMessage?.(message) || '';
 }
 
 export async function deployOrderPayment(

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -13,7 +13,7 @@ import {
 import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from '@/features/stores/services/nearStores';
 import { getProduct, setProduct } from '@/features/products/services/nearProducts';
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { adminResolve, deployOrderPayment } from './nearContract';
 import config from '../utils/appConfig';
 import { calculateCardFees } from '@/features/payments/services/card';
@@ -126,15 +126,15 @@ class OrderService {
 
     let pay = payment;
     if (pay?.method === 'near' && (!pay.contractAddress || !pay.txHash)) {
-      if (!nearAuth.getAccountId()) {
-        await nearAuth.signIn();
+      if (!chainAdapter.getAccountId()) {
+        await chainAdapter.openModal();
       }
       const { contractAddress, txHash } = await deployOrderPayment(total);
       pay = { ...pay, contractAddress, txHash };
     }
 
     if (!pay?.buyerAddress) {
-      pay = { ...pay, buyerAddress: nearAuth.getAccountId() || undefined };
+      pay = { ...pay, buyerAddress: chainAdapter.getAccountId() || undefined };
     }
 
     const orderId = uuid();
@@ -192,18 +192,18 @@ class OrderService {
         paymentMethod === 'near'
           ? {
               method: 'near' as const,
-              buyerAddress: nearAuth.getAccountId() || undefined,
+              buyerAddress: chainAdapter.getAccountId() || undefined,
               sellerAddress: store?.owner,
             }
           : paymentMethod === 'card'
           ? {
               method: 'card' as const,
-              buyerAddress: nearAuth.getAccountId() || undefined,
+              buyerAddress: chainAdapter.getAccountId() || undefined,
               sellerAddress: store?.owner,
             }
           : {
               method: 'cash_on_delivery' as const,
-              buyerAddress: nearAuth.getAccountId() || undefined,
+              buyerAddress: chainAdapter.getAccountId() || undefined,
               sellerAddress: store?.owner,
             };
       const order = await this.createOrder(
@@ -292,7 +292,7 @@ class OrderService {
   async resolveDispute(orderId: string, toSeller: boolean): Promise<void> {
     const order = await ordersAgent.get(orderId);
     if (!order || !order.escrowAddr) return;
-    const actor = nearAuth.getAccountId();
+    const actor = chainAdapter.getAccountId();
     const network =
       (config.NEAR_NETWORK || process.env.NEAR_NETWORK || 'mainnet').toLowerCase();
     const legacy =

--- a/src/features/cart/services/cart.ts
+++ b/src/features/cart/services/cart.ts
@@ -4,7 +4,7 @@ import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup
 import DatabaseService from '@/services/database';
 import cartAgent, { getCartItems } from '@/agents/cart-agent';
 import eventBus from '@/services/eventBus';
-import nearAuth from '../../auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
  
 
 const CART_STORAGE_KEY = 'cart_items';
@@ -20,7 +20,7 @@ class CartService {
 
   private async getCurrentUserId(): Promise<string | null> {
     try {
-      const addr = nearAuth.getAccountId?.();
+      const addr = chainAdapter.getAccountId?.();
       return addr ?? null;
     } catch (err) {
       errorLog('Failed to get current user', err);

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -19,8 +19,7 @@ import { useCurrency } from '@/contexts/CurrencyContext';
 import DatabaseService from '@/services/database';
 import PinataService from '@/services/pinata';
 import ipfsService from '@/services/ipfsService';
-import chain from '@/services/chain';
-import { useCategories } from '@/services';
+import chain, { chainAdapter } from '@/services/chain';
 
 let setProductBatch:
   | ((items: ProductIndexItem[]) => Promise<void>)
@@ -34,7 +33,7 @@ import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
-import { useAccountId } from '../../auth/services/nearAuth';
+import { useCategories } from '@/services';
 import { useAppRouter } from '@/services';
 import { routes } from '@/utils/routes';
 import { Spinner } from '@/ui/primitives';
@@ -56,7 +55,7 @@ export default function ProductFormModal({
 }: ProductFormModalProps) {
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
-  const address = useAccountId();
+  const address = chainAdapter.useAccountId();
   const { push } = useAppRouter();
   const [editingProduct, setEditingProduct] = useState<Partial<Product>>({});
   const [imageUrls, setImageUrls] = useState('');

--- a/src/features/products/hooks/useProductDetail.ts
+++ b/src/features/products/hooks/useProductDetail.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import CartService from '@/features/cart/services/cart';
 import { Product, PricingTier } from '@/types';
-import { useAccountId } from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { useProduct } from './useProduct';
 import { useProductPricing } from '@/services/useProductPricing';
 import { useProductMedia } from '@/services/useProductMedia';
@@ -28,7 +28,7 @@ interface ProductDetailResult {
 
 export function useProductDetail(id: string): ProductDetailResult {
   const { data: fetchedProduct, isLoading } = useProduct(id);
-  const address = useAccountId();
+  const address = chainAdapter.useAccountId();
 
   const [product, setProduct] = useState<Product | null>(null);
   const [quantity, setQuantity] = useState(1);

--- a/src/features/products/services/nearProductIndex.ts
+++ b/src/features/products/services/nearProductIndex.ts
@@ -1,7 +1,6 @@
 import { Buffer } from 'buffer';
 import { ProductIndexItem } from '@/types';
-import nearAuth from '../../auth/services/nearAuth';
-import { assertNearChain } from '@/services/chain';
+import { chainAdapter, assertNearChain } from '@/services/chain';
 
 assertNearChain();
 
@@ -25,7 +24,7 @@ export async function setProductBatch(
   items: ProductIndexItem[],
 ): Promise<void> {
   const payload = buildBatch(items);
-  await nearAuth.signMessage(Buffer.from(payload));
+  await chainAdapter.signMessage?.(Buffer.from(payload));
 }
 
 export function estimateSetProductBatch(items: ProductIndexItem[]): number {

--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -12,7 +12,7 @@ import { useAppRouter } from '@/services';
 import { useQueryClient } from '@tanstack/react-query';
 import { useLanguage } from '@/ui/ThemeProvider';
 import storesAgent from '@/agents/stores-agent';
-import nearAuth from '../../auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import { errorLog } from '@/utils/logger';
 
 const StoreCreation: React.FC = () => {
@@ -23,14 +23,14 @@ const StoreCreation: React.FC = () => {
 
   const mintStore = async () => {
     if (!name) return;
-    const owner = nearAuth.getAccountId();
+    const owner = chainAdapter.getAccountId();
     if (!owner) {
-      await nearAuth.signIn();
+      await chainAdapter.openModal();
       return;
     }
     try {
       const id = Date.now().toString();
-      await nearAuth.signMessage(`MintStore:${id}`);
+      await chainAdapter.signMessage?.(`MintStore:${id}`);
       await storesAgent.add({ id, name, owner, nftId: id });
       setName('');
       Alert.alert(t('common.success'), t('stores.createSuccess'));

--- a/src/services/chain/ChainAdapter.ts
+++ b/src/services/chain/ChainAdapter.ts
@@ -1,3 +1,5 @@
+import type { Order } from '@/types';
+
 export interface ChainAdapter {
   /** Initialize wallet or chain connection */
   init(): Promise<{ selector?: any; error?: Error | null }>;
@@ -5,10 +7,18 @@ export interface ChainAdapter {
   openModal(): Promise<void>;
   /** React hook returning the current account identifier */
   useAccount(): string | null;
+  /** React hook returning the current account identifier */
+  useAccountId(): string | null;
+  /** Synchronously get the current account identifier */
+  getAccountId(): string | null;
   /** Return underlying wallet selector or provider */
   getSelector(): any;
   /** Fetch the balance for the given account in smallest unit */
   getBalance(address: string): Promise<string>;
+  /** Sign an arbitrary message */
+  signMessage?(message: Uint8Array | string): Promise<string>;
+  /** List orders for a given seller */
+  listOrdersBySeller?(storeId: string, sellerId: string): Promise<Order[]>;
   /** Optional chain specific payment helper */
   payPrivately?(args: any): Promise<any>;
 }

--- a/src/services/chain/index.ts
+++ b/src/services/chain/index.ts
@@ -6,8 +6,12 @@ const unsupported: ChainAdapter = {
   async init() { throw new Error('Unsupported chain'); },
   async openModal() { throw new Error('Unsupported chain'); },
   useAccount() { return null; },
+  useAccountId() { return null; },
+  getAccountId() { return null; },
   getSelector() { return null; },
   async getBalance() { return '0'; },
+  async signMessage() { throw new Error('Unsupported chain'); },
+  async listOrdersBySeller() { throw new Error('Unsupported chain'); },
   async payPrivately() { throw new Error('Unsupported chain'); },
 };
 

--- a/src/services/chain/near.ts
+++ b/src/services/chain/near.ts
@@ -1,7 +1,9 @@
 import { setupWalletSelector, WalletSelector } from '@near-wallet-selector/core';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import { useEffect, useState } from 'react';
+import { Buffer } from 'buffer';
 import { payPrivately as nearPayPrivately } from '@blue-ocean/sdk-near';
+import { listOrdersBySeller as nearListOrdersBySeller } from '@/services/nearOrders';
 import type { ChainAdapter } from './ChainAdapter';
 
 let selector: WalletSelector | null = null;
@@ -76,6 +78,14 @@ function useAccount(): string | null {
   return accountId;
 }
 
+function useAccountId(): string | null {
+  return useAccount();
+}
+
+function getAccountId(): string | null {
+  return selector?.store.getState().accounts[0]?.accountId || null;
+}
+
 function getSelector() {
   return selector;
 }
@@ -104,12 +114,28 @@ async function getBalance(address: string): Promise<string> {
   return json.result?.amount || '0';
 }
 
+async function signMessage(message: Uint8Array | string): Promise<string> {
+  const { selector, error } = await init();
+  if (!selector) {
+    throw (error || new Error('Wallet initialization failed'));
+  }
+  const wallet = await selector.wallet();
+  const res: any = await (wallet as any).signMessage({
+    message: typeof message === 'string' ? Buffer.from(message) : message,
+  });
+  return res.signature as string;
+}
+
 export const nearAdapter: ChainAdapter = {
   init,
   openModal,
   useAccount,
+  useAccountId,
+  getAccountId,
   getSelector,
   getBalance,
+  signMessage,
+  listOrdersBySeller: nearListOrdersBySeller,
   payPrivately: nearPayPrivately,
 };
 

--- a/utils/ensureNearWallet.ts
+++ b/utils/ensureNearWallet.ts
@@ -1,11 +1,11 @@
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 
 // Ensures a NEAR wallet session, prompting sign-in if necessary.
 export default async function ensureNearWallet(errorMessage: string) {
-  let address = nearAuth.getAccountId();
+  let address = chainAdapter.getAccountId();
   if (!address) {
-    await nearAuth.signIn();
-    address = nearAuth.getAccountId();
+    await chainAdapter.openModal();
+    address = chainAdapter.getAccountId();
   }
   if (!address) {
     throw new Error(errorMessage);

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,8 +1,8 @@
-import nearAuth from '@/features/auth/services/nearAuth';
+import { chainAdapter } from '@/services/chain';
 import SettingsAgent from '../agents/settings-agent';
 
 export default async function isAdmin(): Promise<boolean> {
-  const address = nearAuth.getAccountId();
+  const address = chainAdapter.getAccountId();
   if (!address) return false;
   const admins = await SettingsAgent.getInstance().getAdmins();
   return admins.includes(address);


### PR DESCRIPTION
## Summary
- expose `useAccountId`, `getAccountId`, `signMessage`, and `listOrdersBySeller` on the chain adapter
- replace direct `nearAuth`/`nearOrders` usage in screens and services with chain adapter calls

## Testing
- `yarn test` *(fails: Jest encountered unexpected tokens and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7e0e5e28832698bb485e73ab56ec