### PR TITLE
refactor: memoize home data and use chain adapter

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,11 +10,12 @@ import {
 } from 'react-native';
 import { useAppRouter } from '@/services';
 import { Plus, X, ArrowUpDown } from 'lucide-react-native';
-import { Product, Category, HeroBanner } from '@/types';
+import { Product, HeroBanner } from '@/types';
 import { useHome } from '@/features/home/hooks/useHome';
 import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
 import { useHomeModals } from '@/features/home/hooks/useHomeModals';
 import { useHomeRefresh } from '@/features/home/hooks/useHomeRefresh';
+import { useHomeData } from '@/features/home/hooks/useHomeData';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import PriceRange from '@/features/home/components/PriceRange';
@@ -79,6 +80,10 @@ function HomeScreenContent() {
     loading: bannersLoading,
   } = banners;
 
+  const { fallbackCategories, fallbackBanners } = useHomeData();
+  const categoriesToShow = categories.length ? categories : fallbackCategories;
+  const heroBannersToShow = heroBanners.length ? heroBanners : fallbackBanners;
+
   const {
     filteredProducts,
     searchQuery,
@@ -95,29 +100,6 @@ function HomeScreenContent() {
     setShowSortModal,
   } = useHomeFilters(products);
 
-  // Fallback content to guarantee a rich homepage even with empty services
-  const fallbackCategories: Category[] = [
-    { id: 'electronics', name: t('categories.electronics'), icon: String.fromCodePoint(0x1F4F1) } as any,
-    { id: 'fashion', name: t('categories.fashion'), icon: String.fromCodePoint(0x1F457) } as any,
-    { id: 'home', name: t('categories.home'), icon: String.fromCodePoint(0x1F3E0) } as any,
-    { id: 'beauty', name: t('categories.beauty'), icon: String.fromCodePoint(0x1F484) } as any,
-    { id: 'sports', name: t('categories.sports'), icon: String.fromCodePoint(0x1F3C0) } as any,
-    { id: 'books', name: t('categories.books'), icon: String.fromCodePoint(0x1F4DA) } as any,
-  ];
-  const fallbackBanners: Partial<HeroBanner & { id: string }>[] = [
-    {
-      id: 'b1',
-      image: '',
-      title: t('home.fallbackBanner1Title'),
-      subtitle: t('home.fallbackBanner1Subtitle'),
-    },
-    {
-      id: 'b2',
-      image: '',
-      title: t('home.fallbackBanner2Title'),
-      subtitle: t('home.fallbackBanner2Subtitle'),
-    },
-  ];
   const handleBannerSaved = (b: HeroBanner, isNew: boolean) => {
     upsertBanner(b, isNew);
   };
@@ -218,7 +200,7 @@ function HomeScreenContent() {
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
       >
       <CategoryChips
-        categories={categories}
+        categories={categoriesToShow}
         selectedCategory={selectedCategory}
         setSelectedCategory={setSelectedCategory}
       />
@@ -230,7 +212,7 @@ function HomeScreenContent() {
         />
       <CTABecomeSeller />
       <BannerArea
-        heroBanners={heroBanners}
+        heroBanners={heroBannersToShow}
         isStoreOwner={isStoreOwner}
         onAddBanner={openBannerForm}
         onEditBanner={openBannerForm}
@@ -250,13 +232,13 @@ function HomeScreenContent() {
             </TouchableOpacity>
           </Stack>
 
-          {categories.length > 0 ? (
+          {categoriesToShow.length > 0 ? (
             <ScrollArea
               horizontal
               showsHorizontalScrollIndicator={false}
               contentContainerStyle={styles.categoriesList}
             >
-              {categories.slice(0, 4).map((item) => (
+              {categoriesToShow.slice(0, 4).map((item) => (
                 <View key={item.id} style={styles.categoryWrapper}>
                   {renderCategory({ item })}
                 </View>
@@ -315,7 +297,7 @@ function HomeScreenContent() {
           <Suspense fallback={<Spinner />}>
             <ProductGrid
               products={filteredProducts}
-              categories={categories}
+              categories={categoriesToShow}
               isStoreOwner={isStoreOwner}
               onEdit={openProductForm}
               getItemWidth={getProductItemWidth}
@@ -332,7 +314,7 @@ function HomeScreenContent() {
           visible={bannerFormVisible}
           onClose={closeBannerForm}
           banner={editingBanner || undefined}
-          categories={categories}
+          categories={categoriesToShow}
           onSaved={handleBannerSaved}
           onDeleted={handleBannerDeleted}
         />

--- a/src/features/home/hooks/useHomeData.ts
+++ b/src/features/home/hooks/useHomeData.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { Category, HeroBanner } from '@/types';
+import { useLanguage } from '@/ui/ThemeProvider';
+
+export function useHomeData() {
+  const { t } = useLanguage();
+
+  const fallbackCategories = useMemo(
+    () => [
+      { id: 'electronics', name: t('categories.electronics'), icon: String.fromCodePoint(0x1F4F1) } as Category,
+      { id: 'fashion', name: t('categories.fashion'), icon: String.fromCodePoint(0x1F457) } as Category,
+      { id: 'home', name: t('categories.home'), icon: String.fromCodePoint(0x1F3E0) } as Category,
+      { id: 'beauty', name: t('categories.beauty'), icon: String.fromCodePoint(0x1F484) } as Category,
+      { id: 'sports', name: t('categories.sports'), icon: String.fromCodePoint(0x1F3C0) } as Category,
+      { id: 'books', name: t('categories.books'), icon: String.fromCodePoint(0x1F4DA) } as Category,
+    ],
+    [t]
+  );
+
+  const fallbackBanners = useMemo(
+    () => [
+      {
+        id: 'b1',
+        image: '',
+        title: t('home.fallbackBanner1Title'),
+        subtitle: t('home.fallbackBanner1Subtitle'),
+      },
+      {
+        id: 'b2',
+        image: '',
+        title: t('home.fallbackBanner2Title'),
+        subtitle: t('home.fallbackBanner2Subtitle'),
+      },
+    ],
+    [t]
+  );
+
+  return { fallbackCategories, fallbackBanners } as const;
+}
+
+export type UseHomeDataReturn = ReturnType<typeof useHomeData>;

--- a/src/features/stores/components/OrderRevenueMetrics.tsx
+++ b/src/features/stores/components/OrderRevenueMetrics.tsx
@@ -1,15 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme } from '@/ui/ThemeProvider';
-import chain from '@/services/chain';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { chainAdapter } from '@/services/chain';
 import { Order } from '@/types';
-
-let listOrdersBySeller:
-  | ((storeId: string, sellerId: string) => Promise<Order[]>)
-  | undefined;
-if (chain === 'near') {
-  ({ listOrdersBySeller } = require('@/services/nearOrders'));
-}
 
 interface Props {
   storeId: string;
@@ -17,12 +10,13 @@ interface Props {
 
 export default function OrderRevenueMetrics({ storeId }: Props) {
   const { colors } = useTheme();
+  const { t } = useLanguage();
   const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
     const load = async () => {
-      if (!storeId || !listOrdersBySeller) return;
-      const list = await listOrdersBySeller(storeId, storeId);
+      if (!storeId || !chainAdapter.listOrdersBySeller) return;
+      const list = await chainAdapter.listOrdersBySeller(storeId, storeId);
       setOrders(list);
     };
     load();
@@ -33,8 +27,12 @@ export default function OrderRevenueMetrics({ storeId }: Props) {
 
   return (
     <View style={styles.container}>
-      <Text style={[styles.stat, { color: colors.text.primary }]}>Orders: {totalOrders}</Text>
-      <Text style={[styles.stat, { color: colors.text.primary }]}>Revenue: {totalRevenue.toFixed(2)}</Text>
+      <Text style={[styles.stat, { color: colors.text.primary }]}> 
+        {t('stores.metrics.orders')} {totalOrders}
+      </Text>
+      <Text style={[styles.stat, { color: colors.text.primary }]}> 
+        {t('stores.metrics.revenue')} {totalRevenue.toFixed(2)}
+      </Text>
     </View>
   );
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -508,7 +508,11 @@
     "transactionFailed": "Transaction failed",
     "insufficientFunds": "Insufficient funds to deploy the store",
     "transactionCancelled": "Transaction cancelled",
-    "createSuccess": "Store created successfully"
+    "createSuccess": "Store created successfully",
+    "metrics": {
+      "orders": "Orders:",
+      "revenue": "Revenue:"
+    }
   },
   "disputes": {
     "title": "Disputes",

--- a/translations/he.json
+++ b/translations/he.json
@@ -484,7 +484,11 @@
     "transactionFailed": "העסקה נכשלה",
     "insufficientFunds": "אין מספיק כספים לפריסת החנות",
     "transactionCancelled": "העסקה בוטלה",
-    "createSuccess": "החנות נוצרה בהצלחה"
+    "createSuccess": "החנות נוצרה בהצלחה",
+    "metrics": {
+      "orders": "הזמנות:",
+      "revenue": "הכנסות:"
+    }
   },
   "proofUploader": {
     "permissionRequired": "נדרשת הרשאה",


### PR DESCRIPTION
## Summary
- memoize home screen fallback content via new `useHomeData`
- route store revenue metrics through chain adapter and translations

## Testing
- `npm test` *(fails: Jest encountered unexpected token & missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8c010a408326a9a25168d7dd6a57