### PR TITLE
chore: alias waku core modules

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -97,6 +97,14 @@ config.resolver.extraNodeModules = {
 // which cause the "Couldn't register the navigator" error.
 config.resolver.alias = {
   ...(config.resolver.alias || {}),
+  '@waku/core/lib/message/version_0': resolvePosix(
+    __dirname,
+    'node_modules/@waku/core/dist/lib/message/version_0.js'
+  ),
+  '@waku/core': resolvePosix(
+    __dirname,
+    'node_modules/@waku/core/dist/index.js'
+  ),
   '@react-navigation/native-stack/node_modules/@react-navigation/core':
     resolvePosix(__dirname, 'node_modules/@react-navigation/core'),
   '@react-navigation/native/node_modules/@react-navigation/core': resolvePosix(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,14 @@ module.exports = async function (env, argv) {
       __dirname,
       'node_modules/@waku/utils/dist/bytes/index.js'
     ),
+    '@waku/core/lib/message/version_0': path.resolve(
+      __dirname,
+      'node_modules/@waku/core/dist/lib/message/version_0.js'
+    ),
+    '@waku/core': path.resolve(
+      __dirname,
+      'node_modules/@waku/core/dist/index.js'
+    ),
     '@blue-ocean/utils': path.resolve(__dirname, 'shims/bo-utils.js'),
     'fs/promises': false,
     // Avoid bundling Node-only NEAR provider in web builds


### PR DESCRIPTION
## Summary
- alias @waku/core imports for metro bundler
- alias @waku/core imports for webpack

## Testing
- `EXPO_WEB_BUNDLER=metro EXPO_PUBLIC_USE_ROUTER=1 npx expo export --platform web --output-dir dist2`
- `yarn lint metro.config.js webpack.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc58324af083269d1c23c9b7751ce1