### PR TITLE
fix: narrow waku core alias for web bundling

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -100,7 +100,7 @@ config.resolver.alias = {
     __dirname,
     'node_modules/@waku/core/dist/lib/message/version_0.js'
   ),
-  '@waku/core': resolvePosix(
+  '@waku/core$': resolvePosix(
     __dirname,
     'node_modules/@waku/core/dist/index.js'
   ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,7 @@ module.exports = async function (env, argv) {
       __dirname,
       'node_modules/@waku/core/dist/lib/message/version_0.js'
     ),
-    '@waku/core': path.resolve(
+    '@waku/core$': path.resolve(
       __dirname,
       'node_modules/@waku/core/dist/index.js'
     ),


### PR DESCRIPTION
## Summary
- restrict `@waku/core` alias to root import in webpack and metro configs
- keep explicit subpath alias for `@waku/core/lib/message/version_0`

## Testing
- `yarn lint`
- `CI=1 npx expo start --web` *(starts Metro without module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a3008708326ba040af3a802f6ee