### PR TITLE
fix: alias waku core message module

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -96,11 +96,11 @@ config.resolver.extraNodeModules = {
 // which cause the "Couldn't register the navigator" error.
 config.resolver.alias = {
   ...(config.resolver.alias || {}),
-  '@waku/core/lib/message/version_0': resolvePosix(
+  '@waku/core/lib/message/version_0': path.resolve(
     __dirname,
     'node_modules/@waku/core/dist/lib/message/version_0.js'
   ),
-  '@waku/core$': resolvePosix(
+  '@waku/core$': path.resolve(
     __dirname,
     'node_modules/@waku/core/dist/index.js'
   ),


### PR DESCRIPTION
## Summary
- map `@waku/core` message module and root for Metro bundling

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected token in Expo routes and missing @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5eec5c0c8326821b7d42de78fa8a