### PR TITLE
fix: alias Waku utils bytes for Metro bundler

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -96,6 +96,10 @@ config.resolver.extraNodeModules = {
 // which cause the "Couldn't register the navigator" error.
 config.resolver.alias = {
   ...(config.resolver.alias || {}),
+  '@waku/utils/bytes': path.resolve(
+    __dirname,
+    'node_modules/@waku/utils/dist/bytes/index.js'
+  ),
   '@waku/core/lib/message/version_0': path.resolve(
     __dirname,
     'node_modules/@waku/core/dist/lib/message/version_0.js'


### PR DESCRIPTION
## Summary
- alias `@waku/utils/bytes` to compiled path so Metro can resolve Waku deep import

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67dde99483268330ea91a1eb044d