### PR TITLE
Use POSIX paths for Waku aliases

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -96,15 +96,15 @@ config.resolver.extraNodeModules = {
 // which cause the "Couldn't register the navigator" error.
 config.resolver.alias = {
   ...(config.resolver.alias || {}),
-  '@waku/utils/bytes': path.resolve(
+  '@waku/utils/bytes': resolvePosix(
     __dirname,
     'node_modules/@waku/utils/dist/bytes/index.js'
   ),
-  '@waku/core/lib/message/version_0': path.resolve(
+  '@waku/core/lib/message/version_0': resolvePosix(
     __dirname,
     'node_modules/@waku/core/dist/lib/message/version_0.js'
   ),
-  '@waku/core$': path.resolve(
+  '@waku/core$': resolvePosix(
     __dirname,
     'node_modules/@waku/core/dist/index.js'
   ),


### PR DESCRIPTION
## Summary
- ensure Waku module aliases resolve using POSIX paths in Metro config

## Testing
- `npx expo export --platform web --output-dir dist --clear` *(fails: Unable to resolve module @waku/core/lib/message/version_0)*
- `npm test` *(fails: Test suites failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6fc56d448326a3d55ed4901a9516