### PR TITLE
fix: normalize waku module resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { getDefaultConfig } = require('@expo/metro-config');
+const { resolve } = require('metro-resolver');
 
 // Metro expects POSIX-style paths for module aliases. On Windows, `path.resolve`
 // returns paths with backslashes which can cause `decodeURI` to throw
@@ -11,6 +12,9 @@ const requirePosix = (id) => toPosix(require.resolve(id));
 
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push('wasm', 'sql', 'boc');
+if (!config.resolver.sourceExts.includes('mjs')) {
+  config.resolver.sourceExts.push('mjs');
+}
 // Allow Metro's default hierarchical lookup to avoid breaking deep imports
 // like `react-native-web/dist/exports/*` used in web transforms.
 // If needed, we can revisit this after web bundling is stable.
@@ -100,10 +104,6 @@ config.resolver.alias = {
     __dirname,
     'node_modules/@waku/utils/dist/bytes/index.js'
   ),
-  '@waku/core/lib/message/version_0': resolvePosix(
-    __dirname,
-    'node_modules/@waku/core/dist/lib/message/version_0.js'
-  ),
   '@waku/core$': resolvePosix(
     __dirname,
     'node_modules/@waku/core/dist/index.js'
@@ -114,6 +114,13 @@ config.resolver.alias = {
     __dirname,
     'node_modules/@react-navigation/core'
   ),
+};
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === '@waku/core/lib/message/version_0') {
+    moduleName = '@waku/core/lib/message/version-0';
+  }
+  return resolve(context, moduleName, platform);
 };
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,10 @@ const webpack = require('webpack');
 
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
+  const version0 = require.resolve('@waku/core/lib/message/version-0', {
+    paths: [__dirname],
+  });
+  const wakuCore = require.resolve('@waku/core', { paths: [__dirname] });
 
   // Use source maps in all modes to avoid eval-based tooling which can violate CSP
   config.devtool = 'source-map';
@@ -51,16 +55,9 @@ module.exports = async function (env, argv) {
       __dirname,
       'node_modules/@waku/utils/dist/bytes/index.js'
     ),
-    '@waku/core/lib/message/version_0': require
-      .resolve('./dist/lib/message/version_0.js', {
-        paths: [path.join(__dirname, 'node_modules/@waku/core')],
-      })
-      .replace(/\\/g, '/'),
-    '@waku/core$': require
-      .resolve('./dist/index.js', {
-        paths: [path.join(__dirname, 'node_modules/@waku/core')],
-      })
-      .replace(/\\/g, '/'),
+    '@waku/core/lib/message/version_0': version0,
+    '@waku/core/lib/message/version-0': version0,
+    '@waku/core$': wakuCore,
     '@blue-ocean/utils': path.resolve(__dirname, 'shims/bo-utils.js'),
     'fs/promises': false,
     // Avoid bundling Node-only NEAR provider in web builds
@@ -73,6 +70,8 @@ module.exports = async function (env, argv) {
     tslib: require.resolve('tslib'),
     'tslib/modules/index.js': path.resolve(__dirname, 'tslib-polyfill.js'),
   };
+
+  config.module.rules.push({ test: /\.mjs$/, type: 'javascript/auto' });
 
   // Ensure Expo Router's Babel plugin sees the app root
   config.plugins.push(


### PR DESCRIPTION
## Summary
- ensure Metro resolves Waku version_0 deep import by rewriting to hyphenated file and supporting .mjs
- align Webpack with portable Waku aliases and handle .mjs modules

## Testing
- `yarn test` *(fails: Jest encountered unexpected token / Unable to reach server)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f40c4e48326ba6244cc0d94e875