### PR TITLE
refactor: dynamic Waku resolver

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -116,9 +116,28 @@ config.resolver.alias = {
   ),
 };
 
+const tryResolve = (specifier) => {
+  try {
+    return require.resolve(specifier);
+  } catch {
+    return null;
+  }
+};
+
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (moduleName === '@waku/core/lib/message/version_0') {
-    moduleName = '@waku/core/lib/message/version-0';
+    const candidates = [
+      '@waku/core/lib/message/version_0',
+      '@waku/core/lib/message/version-0',
+      '@waku/core/dist/message/version_0',
+      '@waku/core/dist/message/version-0',
+    ];
+    for (const candidate of candidates) {
+      const resolved = tryResolve(candidate);
+      if (resolved) {
+        return resolve(context, resolved, platform);
+      }
+    }
   }
   return resolve(context, moduleName, platform);
 };


### PR DESCRIPTION
## Summary
- replace hardcoded Waku resolver with dynamic lookup

## Testing
- `node --conditions=import -p "require.resolve('@waku/core/lib/message/version_0')"`
- `yarn test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8fc26ab88326aa90ca9fdcf52dc6