### PR TITLE
chore: robust waku version0 resolution in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,37 @@
 // webpack.config.js
 const path = require('path');
+const fs = require('fs');
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 const webpack = require('webpack');
 
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
-  const version0 = require.resolve('@waku/core/lib/message/version-0', {
-    paths: [__dirname],
-  });
+  const version0 = (() => {
+    const candidates = [
+      path.resolve(
+        __dirname,
+        'node_modules/@waku/core/dist/lib/message/version_0.js'
+      ),
+      path.resolve(
+        __dirname,
+        'node_modules/@waku/core/lib/message/version_0.js'
+      ),
+      path.resolve(
+        __dirname,
+        'node_modules/@waku/core/dist/lib/message/version-0.js'
+      ),
+      path.resolve(
+        __dirname,
+        'node_modules/@waku/core/lib/message/version-0.js'
+      ),
+    ];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    throw new Error('Unable to resolve @waku/core message version 0');
+  })();
   const wakuCore = require.resolve('@waku/core', { paths: [__dirname] });
 
   // Use source maps in all modes to avoid eval-based tooling which can violate CSP
@@ -71,7 +95,9 @@ module.exports = async function (env, argv) {
     'tslib/modules/index.js': path.resolve(__dirname, 'tslib-polyfill.js'),
   };
 
-  config.module.rules.push({ test: /\.mjs$/, type: 'javascript/auto' });
+  if (!config.module.rules.some((r) => String(r.test) === '/\\.mjs$/')) {
+    config.module.rules.push({ test: /\.mjs$/, type: 'javascript/auto' });
+  }
 
   // Ensure Expo Router's Babel plugin sees the app root
   config.plugins.push(


### PR DESCRIPTION
## Summary
- robustly resolve `@waku/core` version 0 message by checking multiple candidate paths
- alias both hyphen and underscore subpaths to the resolved module
- avoid duplicate `.mjs` rule in webpack config

## Testing
- `npx eslint webpack.config.js`
- `yarn test --runTestsByPath webpack.config.js --passWithNoTests`
- `NODE_OPTIONS=--conditions=import node -e "require('./webpack.config.js')({mode:'development'}, {}).then(c=>console.log(c.resolve.alias['@waku/core/lib/message/version_0']))"`
- `EXPO_WEB_BUNDLER=webpack npx expo export --platform web --output-dir dist` *(fails: Unable to resolve module @waku/core/lib/message/version_0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8fc3f0188326abfa79ef5dbd7e3d