### PR TITLE
fix: patch waku paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@react-navigation/native": "~6.1.6",
     "@react-navigation/native-stack": "~6.9.12",
     "@tanstack/react-query": "^5.85.6",
-    "@waku/core": "^0.0.38",
+    "@waku/core": "0.0.33",
     "@waku/sdk": "0.0.33",
     "axios": "^1.6.2",
     "bcryptjs": "^2.4.3",

--- a/scripts/fix-waku-path.js
+++ b/scripts/fix-waku-path.js
@@ -8,7 +8,13 @@ function findCoreRoot() {
   try {
     return path.dirname(require.resolve('@waku/core/package.json'));
   } catch {
-    return null;
+    const fallback = path.join(
+      process.cwd(),
+      'node_modules',
+      '@waku',
+      'core'
+    );
+    return fs.existsSync(fallback) ? fallback : null;
   }
 }
 
@@ -55,8 +61,58 @@ function findMessageFile(coreRoot) {
   return null;
 }
 
+function patchCorePackage(coreRoot, coreFile) {
+  const pkgPath = path.join(coreRoot, 'package.json');
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  } catch {
+    return;
+  }
+  const exportKey = './lib/message/version_0';
+  const rel = './' + posix(path.relative(coreRoot, coreFile));
+  pkg.exports = pkg.exports || {};
+  const entry = pkg.exports[exportKey];
+  if (!entry) return;
+  let changed = false;
+  if (!entry.require || !entry.require.startsWith('./')) {
+    entry.require = rel;
+    changed = true;
+  }
+  if (!entry.default || !entry.default.startsWith('./')) {
+    entry.default = rel;
+    changed = true;
+  }
+  if (changed) {
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+    console.log(
+      `[fix-waku] Updated exports in ${posix(
+        path.relative(process.cwd(), pkgPath)
+      )}`
+    );
+  }
+}
+
 function patchSdk(coreFile) {
-  const sdkPkg = require.resolve('@waku/sdk/package.json');
+  let sdkPkg;
+  try {
+    sdkPkg = require.resolve('@waku/sdk/package.json');
+  } catch {
+    const fallback = path.join(
+      process.cwd(),
+      'node_modules',
+      '@waku',
+      'sdk',
+      'package.json'
+    );
+    if (!fs.existsSync(fallback)) {
+      console.error(
+        '[fix-waku] @waku/sdk is not installed. Ensure install completed.'
+      );
+      return 0;
+    }
+    sdkPkg = fallback;
+  }
   const sdkRoot = path.dirname(sdkPkg);
   const candidates = [
     'dist/index.js',
@@ -117,5 +173,6 @@ function patchSdk(coreFile) {
     );
     process.exit(1);
   }
+  patchCorePackage(coreRoot, coreFile);
   patchSdk(coreFile);
 })();


### PR DESCRIPTION
## Summary
- handle missing `package.json` exports when locating Waku packages
- expose `version_0` from `@waku/core` and patch SDK deep imports
- pin `@waku/core` to version `0.0.33`

## Testing
- `node scripts/fix-waku-path.js`
- `node -p "require.resolve('@waku/core/lib/message/version_0')" || echo no`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc9189a9208326a83ca01b6ebd1bb3