### PR TITLE
feat: hydrate waku messages on startup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,7 @@ module.exports = {
     '<rootDir>/tests/admin-store-detail.test.tsx',
     '<rootDir>/tests/not-found.test.tsx',
     '<rootDir>/tests/wakuErrorLogging.test.ts',
+    '<rootDir>/tests/wakuHydration.test.ts',
     '<rootDir>/tests/nearAdapter.test.ts',
     '<rootDir>/tests/i18n-offline.test.ts',
     '<rootDir>/tests/smoke.test.ts',

--- a/packages/sdk-near/src/waku/index.ts
+++ b/packages/sdk-near/src/waku/index.ts
@@ -1,17 +1,89 @@
-// Minimal Waku-backed read helpers (optional). These stubs allow the SDK to
-// build even when Waku is not enabled. Implementations can be filled in later.
+// Basic helpers for reading data from the Waku store. These functions intentionally
+// avoid depending on the rest of the application so that the SDK can be used on
+// its own. The logic here mirrors the higher level Waku utilities found in the
+// app source but is trimmed down for size and to avoid React dependencies.
 
+import type { LightNode } from '@waku/sdk';
+import { createLightNode, waitForRemotePeer, Protocols, createDecoder } from '@waku/sdk';
+import { Buffer } from 'buffer';
+import { topicFor } from '@blue-ocean/utils';
+
+// In-memory cache of messages keyed by topic. Each topic also tracks a set of
+// previously seen payloads to avoid duplications when `hydrateMessages` is called
+// multiple times.
+const messageCache = new Map<string, any[]>();
+const seenCache = new Map<string, Set<string>>();
+let node: LightNode | null = null;
+
+async function ensureNode(): Promise<LightNode | null> {
+  if (node) return node;
+  try {
+    const bootstrap = (
+      process.env.WAKU_BOOTSTRAP ||
+      process.env.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
+      ''
+      )
+        .split(String.fromCharCode(44))
+        .map((s) => s.trim())
+      .filter(Boolean);
+    node = await createLightNode({ libp2p: { bootstrap } } as any);
+    await node.start();
+    // The Store protocol is required to query historical messages.
+    await waitForRemotePeer(node, [Protocols.Store]);
+    return node;
+  } catch {
+    node = null;
+    return null;
+  }
+}
+
+/**
+ * Fetch and cache all historical messages for a given topic.
+ * Subsequent calls only append new unseen messages, preventing duplicates.
+ */
+export async function hydrateMessages(topic: string): Promise<any[]> {
+  const n = await ensureNode();
+  if (!n) return messageCache.get(topic) || [];
+  const decoder = createDecoder(topic);
+  const existing = messageCache.get(topic) || [];
+  const seen = seenCache.get(topic) || new Set<string>();
+  for await (const batch of (n.store.queryGenerator as any)({ decoder })) {
+    for (const msg of (batch.messages || [])) {
+      if (!msg.payload) continue;
+      const key = Buffer.from(msg.payload).toString('hex');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      try {
+        const parsed = JSON.parse(Buffer.from(msg.payload).toString('utf8'));
+        existing.push(parsed);
+      } catch {
+        // ignore unparsable messages
+      }
+    }
+  }
+  seenCache.set(topic, seen);
+  messageCache.set(topic, existing);
+  return existing;
+}
+
+// Convenience function used by the SDK's `getListings` method. It hydrates the
+// listings topic for the given store and returns the cached messages formatted
+// as Listing objects.
 export async function getListingsFromWaku(storeId: string) {
   try {
-    // TODO: Implement Waku hydration on demand.
-    // For now, return an empty list to keep the app functional when transport=waku.
-    console.warn('[sdk-near] Waku getListings stub used for storeId=', storeId);
-    return [] as any[];
-  } catch (e) {
-    console.warn('[sdk-near] Waku getListings failed:', e);
+    const network = process.env.EXPO_PUBLIC_NETWORK || 'testnet';
+    const topic = topicFor(network, storeId, 'listings');
+    const msgs = await hydrateMessages(topic);
+    return msgs.map((m) => ({
+      id: Number(m.itemId ?? 0),
+      seller: m.seller || '',
+      price: Number(m.priceYocto ?? 0),
+    }));
+    } catch (e) {
+      console.warn('sdk-near', 'waku', 'get_listings_failed', e);
     return [] as any[];
   }
 }
 
-export default { getListingsFromWaku };
+export default { getListingsFromWaku, hydrateMessages };
 

--- a/tests/wakuHydration.test.ts
+++ b/tests/wakuHydration.test.ts
@@ -1,0 +1,37 @@
+import { Buffer } from 'buffer';
+
+const queryGenerator = jest.fn(() => {
+  return (async function* () {
+    const payload1 = Buffer.from(JSON.stringify({ itemId: 1, seller: 'alice', priceYocto: '5' }));
+    const payload2 = Buffer.from(JSON.stringify({ itemId: 2, seller: 'bob', priceYocto: '7' }));
+    yield { messages: [{ payload: payload1 }, { payload: payload2 }] } as any;
+  })();
+});
+
+jest.mock(
+  '@waku/sdk',
+  () => ({
+    createLightNode: jest.fn(async () => ({
+      start: jest.fn(),
+      store: { queryGenerator },
+    })),
+    waitForRemotePeer: jest.fn(),
+    Protocols: { Store: 'store' },
+    createDecoder: jest.fn(() => ({})),
+  }),
+  { virtual: true },
+);
+
+import { hydrateMessages } from '../packages/sdk-near/src/waku';
+
+const TOPIC = '/blueocean/testnet/test/listings';
+
+describe('hydrate_messages', () => {
+  it('populates_cache_without_duplicates', async () => {
+    const first = await hydrateMessages(TOPIC);
+    expect(first).toHaveLength(2);
+    const second = await hydrateMessages(TOPIC);
+    expect(second).toHaveLength(2);
+    expect(queryGenerator).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Waku node helpers and `hydrateMessages` to pull historical data and dedupe
- load listings from Waku topics
- test that hydration avoids duplicate messages

## Testing
- `npm test tests/wakuHydration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bcaa0205b08326af296a026900e22e