### PR TITLE
feat: wire signup form

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -8,6 +8,7 @@ import TextField from '@/ui/primitives/TextField';
 import Button from '@/ui/primitives/Button';
 import { validateAll } from '@/utils/validation';
 import ErrorBoundary from '@/shared/ErrorBoundary';
+import { signupUser } from './signupLogic';
 
 export default function SignupScreen() {
   const { colors } = useTheme();
@@ -19,7 +20,7 @@ export default function SignupScreen() {
     setValues((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const newErrors = validateAll({
       username: { value: values.username, rules: { required: t('auth.username') + ' required' } },
       email: {
@@ -33,7 +34,11 @@ export default function SignupScreen() {
     });
     setErrors(newErrors);
     if (Object.keys(newErrors).length === 0) {
-      // TODO: integrate signup logic
+      try {
+        await signupUser(values);
+      } catch (err) {
+        setErrors({ submit: (err as Error).message });
+      }
     }
   };
 
@@ -70,6 +75,7 @@ export default function SignupScreen() {
           {errors.password && <HelperText error>{errors.password}</HelperText>}
         </Field>
         <Button title={t('auth.signup')} onPress={handleSubmit} />
+        {errors.submit && <HelperText error>{errors.submit}</HelperText>}
       </Form>
     </View>
     </ErrorBoundary>

--- a/app/signupLogic.ts
+++ b/app/signupLogic.ts
@@ -1,0 +1,20 @@
+import usersAgent from '@/agents/users-agent';
+import bcrypt from 'bcryptjs';
+
+export interface SignupValues {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export async function signupUser(values: SignupValues) {
+  const passwordHash = bcrypt.hashSync(values.password, 10);
+  await usersAgent.add({
+    id: values.username,
+    username: values.username,
+    displayName: values.username,
+    email: values.email,
+    passwordHash,
+    isAdmin: false,
+  });
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,6 +45,7 @@ module.exports = {
     '<rootDir>/tests/smoke.test.ts',
     '<rootDir>/tests/navigation.test.ts',
     '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
+    '<rootDir>/tests/signupLogic.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/src/ui/primitives/TextField.tsx
+++ b/src/ui/primitives/TextField.tsx
@@ -8,9 +8,10 @@ interface TextFieldProps {
   onChangeText?: (text: string) => void;
   placeholder?: string;
   style?: StyleProp<TextStyle>;
+  secureTextEntry?: boolean;
 }
 
-export default function TextField({ value, onChangeText, placeholder, style }: TextFieldProps) {
+export default function TextField({ value, onChangeText, placeholder, style, secureTextEntry }: TextFieldProps) {
   const { colors } = useTheme();
   return (
     <TextInput
@@ -18,6 +19,7 @@ export default function TextField({ value, onChangeText, placeholder, style }: T
       onChangeText={onChangeText}
       placeholder={placeholder}
       placeholderTextColor={colors.text.tertiary}
+      secureTextEntry={secureTextEntry}
       style={[
         {
           backgroundColor: colors.surface.primary,

--- a/tests/signupLogic.test.ts
+++ b/tests/signupLogic.test.ts
@@ -1,0 +1,34 @@
+import { signupUser } from '@/app/signupLogic';
+const t = (s: string) => s;
+
+jest.mock('@/agents/users-agent', () => ({
+  add: jest.fn(),
+}));
+
+jest.mock('bcryptjs', () => ({
+  hashSync: jest.fn(() => 'hashed'),
+}));
+
+describe(t('signupUser'), () => {
+  const values = { username: 'alice', email: 'alice@example.com', password: 'secret' };
+
+  beforeEach(() => {
+    const { add } = require('@/agents/users-agent');
+    add.mockReset();
+  });
+
+  it(t('adds user via agent'), async () => {
+    const { add } = require('@/agents/users-agent');
+    await signupUser(values);
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'alice', email: 'alice@example.com', passwordHash: 'hashed' }),
+    );
+  });
+
+  it(t('throws when agent fails'), async () => {
+    const { add } = require('@/agents/users-agent');
+    add.mockRejectedValueOnce(new Error('fail'));
+    await expect(signupUser(values)).rejects.toThrow('fail');
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "types": [
       "react",
       "jest",
-      "node"
+      "node",
+      "bcryptjs"
     ],
     "skipLibCheck": true,
     "baseUrl": ".",

--- a/types/bcryptjs.d.ts
+++ b/types/bcryptjs.d.ts
@@ -1,0 +1,2 @@
+declare module 'bcryptjs';
+


### PR DESCRIPTION
## Summary
- add signup logic wired to users agent
- support secure password fields and bcrypt type
- cover signup success and failure cases

## Testing
- `yarn test tests/signupLogic.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcaa00e4608326b20b32aa94c79ff1