### PR TITLE
Expose wallet public key in NEAR adapter

### DIFF
--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -9,10 +9,10 @@ assertNearChain();
 
 class ModerationAgent {
   private async ensureWallet() {
-    const { address } = await ensureNearWallet(
+    const { address, publicKey } = await ensureNearWallet(
       'Please connect your NEAR wallet to report items.',
     );
-    return { address };
+    return { address, publicKey };
   }
 
   async reportProduct(productId: string, reason: string): Promise<void> {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -163,10 +163,10 @@ class ProductsAgent {
   }
 
   private async ensureWallet() {
-    const { address } = await ensureNearWallet(
+    const { address, publicKey } = await ensureNearWallet(
       'Please connect your NEAR wallet to manage products.',
     );
-    return { address };
+    return { address, publicKey };
   }
 
   private async assertStoreOwner(storeId: string) {

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -24,7 +24,10 @@ export type UsersAgentMessage =
 
 class UsersAgent {
   private async ensureWallet() {
-    return ensureNearWallet('Please connect your NEAR wallet to manage users.');
+    const { address, publicKey } = await ensureNearWallet(
+      'Please connect your NEAR wallet to manage users.',
+    );
+    return { address, publicKey };
   }
 
   async add(user: User): Promise<void> {

--- a/src/services/chain/ChainAdapter.ts
+++ b/src/services/chain/ChainAdapter.ts
@@ -11,6 +11,8 @@ export interface ChainAdapter {
   useAccountId(): string | null;
   /** Synchronously get the current account identifier */
   getAccountId(): string | null;
+  /** Synchronously get the current public key */
+  getPublicKey(): string | null;
   /** Return underlying wallet selector or provider */
   getSelector(): any;
   /** Fetch the balance for the given account in smallest unit */

--- a/src/services/chain/index.ts
+++ b/src/services/chain/index.ts
@@ -8,6 +8,7 @@ const unsupported: ChainAdapter = {
   useAccount() { return null; },
   useAccountId() { return null; },
   getAccountId() { return null; },
+  getPublicKey() { return null; },
   getSelector() { return null; },
   async getBalance() { return '0'; },
   async signMessage() { throw new Error('Unsupported chain'); },

--- a/src/services/chain/near.ts
+++ b/src/services/chain/near.ts
@@ -86,6 +86,10 @@ function getAccountId(): string | null {
   return selector?.store.getState().accounts[0]?.accountId || null;
 }
 
+function getPublicKey(): string | null {
+  return selector?.store.getState().accounts[0]?.publicKey || null;
+}
+
 function getSelector() {
   return selector;
 }
@@ -132,6 +136,7 @@ export const nearAdapter: ChainAdapter = {
   useAccount,
   useAccountId,
   getAccountId,
+  getPublicKey,
   getSelector,
   getBalance,
   signMessage,

--- a/utils/ensureNearWallet.ts
+++ b/utils/ensureNearWallet.ts
@@ -3,12 +3,14 @@ import { chainAdapter } from '@/services/chain';
 // Ensures a NEAR wallet session, prompting sign-in if necessary.
 export default async function ensureNearWallet(errorMessage: string) {
   let address = chainAdapter.getAccountId();
-  if (!address) {
+  let publicKey = chainAdapter.getPublicKey();
+  if (!address || !publicKey) {
     await chainAdapter.openModal();
     address = chainAdapter.getAccountId();
+    publicKey = chainAdapter.getPublicKey();
   }
-  if (!address) {
+  if (!address || !publicKey) {
     throw new Error(errorMessage);
   }
-  return { address };
+  return { address, publicKey };
 }


### PR DESCRIPTION
## Summary
- expose `getPublicKey` on `ChainAdapter` and NEAR adapter
- return address and public key from `ensureNearWallet`
- adjust agents to consume wallet public key

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token '<'; Unable to reach server)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcae56c16c8326ad45d688f2181296