### PR TITLE
chore: remove redundant bcryptjs types

### DIFF
--- a/indexers/lake/package.json
+++ b/indexers/lake/package.json
@@ -13,7 +13,6 @@
     "@waku/sdk": "0.0.33"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.0.10",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@expo/cli": "^0.22.26",
     "@faker-js/faker": "^8.4.0",
-    "@types/bcryptjs": "^3.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
     "@types/pg": "^8.10.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
     "types": [
       "react",
       "jest",
-      "node",
-      "bcryptjs"
+      "node"
     ],
     "skipLibCheck": true,
     "baseUrl": ".",

--- a/types/bcryptjs.d.ts
+++ b/types/bcryptjs.d.ts
@@ -1,2 +1,1 @@
 declare module 'bcryptjs';
-


### PR DESCRIPTION
## Summary
- remove bcryptjs from global type list
- drop unused @types/bcryptjs dependencies
- restore simple bcryptjs module stub

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Property 'icon' is missing in type ...)*
- `yarn test` *(fails: Jest encountered an unexpected token ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb08a39d88326ab446b6abb6acda6