### PR TITLE
feat: persist KV store via NEAR Lake

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,7 @@ module.exports = {
     '<rootDir>/tests/navigation.test.ts',
     '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
     '<rootDir>/tests/signupLogic.test.ts',
+    '<rootDir>/tests/nearKvPersistence.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/runtime": "^7.27.6",
     "@blue-ocean/sdk-near": "file:packages/sdk-near",
     "@blue-ocean/utils": "file:packages/utils",
+    "@aws-sdk/client-s3": "^3.614.0",
     "@expo/metro-runtime": "~3.1.3",
     "@expo/vector-icons": "^14.1.0",
     "@expo/webpack-config": "^19.0.1",

--- a/services/nearKvStore.ts
+++ b/services/nearKvStore.ts
@@ -1,23 +1,33 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+
 import { assertNearChain } from './chain';
 import { initLake } from './nearLake';
 
 assertNearChain();
 
-// Placeholder in-memory store backed by NEAR Lake stream initialization.
-// Future implementations can replace this with actual on-chain persistence.
-const store: Map<string, Map<string, string>> = new Map();
-
 let lakeStarted = false;
+let s3: S3Client | null = null;
+const bucket = process.env.NEAR_LAKE_BUCKET;
+const region = process.env.NEAR_LAKE_REGION || 'eu-central-1';
+const localDir = process.env.NEAR_LAKE_DIR;
+
 function ensureLake() {
   if (lakeStarted) return;
-  // Best-effort start of NEAR Lake; ignore failures so tests can run offline.
   try {
-    const bucket = process.env.NEAR_LAKE_BUCKET;
-    if (bucket) {
+    const bucketName = bucket;
+    if (bucketName) {
       initLake({
-        s3BucketName: bucket,
-        s3RegionName: process.env.NEAR_LAKE_REGION || 'eu-central-1',
+        s3BucketName: bucketName,
+        s3RegionName: region,
         startBlockHeight: BigInt(process.env.NEAR_LAKE_START_BLOCK || '0'),
+      });
+      s3 = new S3Client({
+        region,
+        endpoint: process.env.NEAR_LAKE_ENDPOINT,
+        forcePathStyle: !!process.env.NEAR_LAKE_ENDPOINT,
       });
     }
   } catch {
@@ -26,37 +36,109 @@ function ensureLake() {
   lakeStarted = true;
 }
 
+function objectKey(address: string, key: string): string {
+  return `${address}/${key}`;
+}
+
+function localFile(address: string, key: string): string {
+  if (!localDir) throw new Error('missing_lake_dir');
+  return path.join(localDir, address, key);
+}
+
+async function streamToString(stream: Readable | Uint8Array | string | undefined): Promise<string> {
+  if (!stream) return '';
+  if (typeof stream === 'string') return stream;
+  if (stream instanceof Uint8Array) return Buffer.from(stream).toString('utf-8');
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
 export async function setValue(address: string, key: string, value: string) {
   ensureLake();
-  if (!store.has(address)) {
-    store.set(address, new Map());
+  if (s3 && bucket) {
+    const Key = objectKey(address, key);
+    if (value === '') {
+      await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key })).catch(() => {});
+    } else {
+      await s3.send(new PutObjectCommand({ Bucket: bucket, Key, Body: value }));
+    }
+    return;
   }
-  const m = store.get(address)!;
+  const file = localFile(address, key);
   if (value === '') {
-    m.delete(key);
+    await fs.rm(file, { force: true }).catch(() => {});
   } else {
-    m.set(key, value);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, value, 'utf-8');
   }
 }
 
 export async function removeValue(address: string, key: string) {
   ensureLake();
-  const m = store.get(address);
-  m?.delete(key);
+  if (s3 && bucket) {
+    await s3
+      .send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey(address, key) }))
+      .catch(() => {});
+    return;
+  }
+  const file = localFile(address, key);
+  await fs.rm(file, { force: true }).catch(() => {});
 }
 
 export async function getValue(address: string, key: string): Promise<string | null> {
   ensureLake();
-  const m = store.get(address);
-  return m?.get(key) ?? null;
+  if (s3 && bucket) {
+    try {
+      const res = await s3.send(
+        new GetObjectCommand({ Bucket: bucket, Key: objectKey(address, key) }),
+      );
+      return await streamToString(res.Body as Readable);
+    } catch {
+      return null;
+    }
+  }
+  const file = localFile(address, key);
+  try {
+    return await fs.readFile(file, 'utf-8');
+  } catch {
+    return null;
+  }
 }
 
 export async function listValues(
   address: string,
 ): Promise<{ key: string; value: string }[]> {
   ensureLake();
-  const m = store.get(address);
-  if (!m) return [];
-  return Array.from(m.entries()).map(([key, value]) => ({ key, value }));
+  if (s3 && bucket) {
+    const prefix = `${address}/`;
+    const res = await s3
+      .send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }))
+      .catch(() => ({ Contents: [] } as any));
+    const contents = res.Contents ?? [];
+    const out: { key: string; value: string }[] = [];
+    for (const obj of contents) {
+      const fullKey = obj.Key!;
+      const key = fullKey.substring(prefix.length);
+      const val = await getValue(address, key);
+      if (val !== null) out.push({ key, value: val });
+    }
+    return out;
+  }
+  const dir = path.join(localDir || '', address);
+  try {
+    const files = await fs.readdir(dir);
+    const entries = await Promise.all(
+      files.map(async (f) => ({
+        key: f,
+        value: await fs.readFile(path.join(dir, f), 'utf-8'),
+      })),
+    );
+    return entries;
+  } catch {
+    return [];
+  }
 }
 

--- a/tests/nearKvPersistence.test.ts
+++ b/tests/nearKvPersistence.test.ts
@@ -1,0 +1,58 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const tmpDir = path.join(os.tmpdir(), 'near-kv-store-test');
+
+function runScript(code: string): string {
+  const tsOptions = JSON.stringify({ module: 'commonjs' });
+  const res = spawnSync(
+    'node',
+    ['-r', 'ts-node/register', '-e', code],
+    {
+      cwd: path.resolve(__dirname, '..'),
+      env: {
+        ...process.env,
+        NEAR_LAKE_DIR: tmpDir,
+        TS_NODE_COMPILER_OPTIONS: tsOptions,
+      },
+      encoding: 'utf-8',
+    },
+  );
+  if (res.status !== 0) {
+    throw new Error(res.stderr);
+  }
+  return res.stdout.trim();
+}
+
+  describe('kv_persistence', () => {
+  beforeEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+    it('persists_across_runs', () => {
+    runScript(
+      "const kv=require('./services/nearKvStore'); (async()=>{await kv.setValue('addr1','foo','bar');})();",
+    );
+    const out = runScript(
+      "const kv=require('./services/nearKvStore'); (async()=>{const v=await kv.getValue('addr1','foo'); console.log(v ?? '')})();",
+    );
+    expect(out).toBe('bar');
+  });
+
+    it('removes_persistently', () => {
+    runScript(
+      "const kv=require('./services/nearKvStore'); (async()=>{await kv.setValue('addr2','baz','qux'); await kv.removeValue('addr2','baz');})();",
+    );
+    const out = runScript(
+      "const kv=require('./services/nearKvStore'); (async()=>{const v=await kv.getValue('addr2','baz'); console.log(v ?? '')})();",
+    );
+    expect(out).toBe('');
+  });
+});
+


### PR DESCRIPTION
## Summary
- store key/value pairs in S3 or local NEAR Lake directory
- add tests confirming data survives across app restarts

## Testing
- `yarn test tests/nearKvPersistence.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bcb06a4b1483269d06283bb16f081d