### PR TITLE
fix: alias waku version shim for metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,24 @@
+const path = require('path');
 const { getDefaultConfig } = require('expo/metro-config');
 const config = getDefaultConfig(__dirname);
-if (!config.resolver.sourceExts.includes('mjs')) config.resolver.sourceExts.push('mjs');
-if (!config.resolver.sourceExts.includes('cjs')) config.resolver.sourceExts.push('cjs');
+
+config.resolver.extraNodeModules = {
+  ...(config.resolver.extraNodeModules || {}),
+  '@waku/core/lib/message/version_0':
+    path.resolve(
+      __dirname,
+      'node_modules/@waku/core/dist/lib/message/version_0.js'
+    ),
+  '@waku/core/lib/message/version-0':
+    path.resolve(
+      __dirname,
+      'node_modules/@waku/core/dist/lib/message/version_0.js'
+    ),
+};
+
+if (!config.resolver.sourceExts.includes('mjs'))
+  config.resolver.sourceExts.push('mjs');
+if (!config.resolver.sourceExts.includes('cjs'))
+  config.resolver.sourceExts.push('cjs');
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- alias @waku/core version shim in metro bundler so version_0 module resolves

## Testing
- `yarn test` *(fails: TS2322 typing error, Jest failed to parse modules, missing @waku/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68bcff3ca5448326be3b41305e6725fc