### PR TITLE
Add explicit it-stream dependencies for Metro web builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ yarn start      # web
 yarn test
 ```
 
+Metro's web bundler requires `it-all` and `it-pipe` to be listed explicitly in
+`dependencies`; both packages are included in `package.json` for web builds.
+
 Then open `/` to see the Home screen.
 
 ## Design Tokens

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "expo-web-browser": "~12.8.2",
     "form-data": "^4.0.0",
     "fuse.js": "^7.0.0",
+    "it-all": "^3",
+    "it-pipe": "^3",
     "js-cookie": "^3.0.5",
     "lucide-react-native": "^0.475.0",
     "multiformats": "13.4.0",


### PR DESCRIPTION
## Summary
- add `it-all` and `it-pipe` as direct dependencies so Metro's web bundler resolves Waku
- document in README that Metro/web requires explicit `it-all` and `it-pipe`

## Testing
- `yarn install --ignore-engines`
- `node scripts/waku-shim.js`
- `yarn lint` *(warnings)*
- `yarn test` *(fails: TypeError: Cannot read properties of undefined (reading 'sourceFile'))*

------
https://chatgpt.com/codex/tasks/task_e_68bddf6bb1a0832683730b39cc3814bf