### PR TITLE
docs: add public env template and .env.local guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,12 @@
-# Web
+# Public defaults for the app.
+# Secrets like RPC URLs, keys, or IDs belong in .env.local which is git-ignored.
+EXPO_PUBLIC_USE_ROUTER=1
+EXPO_PUBLIC_TRANSPORT=http
+EXPO_PUBLIC_RELAYER_URL=http://localhost:8787
+EXPO_PUBLIC_WAKU_BOOTSTRAP=auto
+EXPO_PUBLIC_WAKU_DISABLE=0
 EXPO_PUBLIC_CHAIN=near
 EXPO_PUBLIC_CONTRACT_ID=marketplace.<acct>.testnet
-# Optional: enforce strict contract checks (default 0 in dev, 1 in prod)
-# NEAR_STRICT=0
-EXPO_PUBLIC_TRANSPORT=http   # http | waku
-EXPO_PUBLIC_RELAYER_URL=http://localhost:8787
-EXPO_PUBLIC_WALLET_URL=https://testnet.mynearwallet.com  # optional override
-EXPO_PUBLIC_WAKU_BOOTSTRAP=enr:...,enr:...   # comma-separated
 EXPO_PUBLIC_FEATURE_WALLET=1
 EXPO_PUBLIC_DEFAULT_STORE=alpha
 EXPO_PUBLIC_DEBUG_LOGS=1
-
-# Relayer
-NEAR_RPC_URL=https://rpc.testnet.near.org
-CONTRACT_ID=marketplace.<acct>.testnet
-RELAYER_ACCOUNT_ID=<acct>.testnet
-RELAYER_PRIVATE_KEY=ed25519:...
-PORT=8787
-MAX_GAS=150000000000000
-MAX_DEPOSIT_YOCTO=5000000000000000000000000
-RATE_LIMIT_RPS=10
-
-# Lake Bridge
-CONTRACT_ID=marketplace.<acct>.testnet
-NEAR_LAKE_BUCKET=near-lake-data-testnet
-NEAR_LAKE_REGION=eu-central-1
-NEAR_LAKE_START_BLOCK=0
-STATE_PATH=.state/lake.json          # persists last height
-DEDUPE_PATH=.state/dedupe.sqlite3    # optional tiny key-value; or use .json
-# Waku (dev-friendly)
-# Disable in dev:
-# WAKU_DISABLE=1
-# Or use default peers automatically:
-# EXPO_PUBLIC_WAKU_BOOTSTRAP=auto
-# Provide a key for signing (prod) | dev falls back to ephemeral:
-# WAKU_PUBLISHER_KEY=hex:...
-
-# Fees
-FEE_BPS=100

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ const { tokens, colors } = useTheme();
    yarn install
    ```
 
-2. *(Optional)* **Create a `.env` for customization**
+2. **Set up environment files**
 
    ```sh
-   cp .env.example .env
+   cp .env.example .env          # public defaults
+   touch .env.local              # secrets (git-ignored)
    ```
 
-   Only needed for advanced overrides such as custom Waku peers. See
+   Public `EXPO_PUBLIC_*` values live in `.env`. API keys, RPC URLs, and other
+   secrets belong in `.env.local`. See
    [Environment Variables](#environment-variables).
 
 3. **Start the Expo project**
@@ -76,7 +78,7 @@ const { tokens, colors } = useTheme();
 
 5. **Admin onboarding**
 
-   - The wallet specified in `ADMIN_WALLET_ADDRESS` receives admin rights on first run.
+   - The wallet specified in `ADMIN_WALLET_ADDRESS` (in `.env.local`) receives admin rights on first run.
    - To add more admins, open **Admin → Settings** and add additional wallet addresses or use `SettingsAgent.setAdmins()`.
 
 All data is ephemeral and synchronized between peers over Waku and written to NEAR smart contracts when needed; no external services or local database are required. All state is held in memory and hydrated from the Waku message history on boot. No database setup or SQL migrations are required, and all prior SQLite migration files have been removed from this repository.
@@ -98,10 +100,12 @@ yarn husky install
 
 ### Environment Variables
 
-The app ships with sensible defaults and runs without a `.env` file. Environment
-variables let you customize behavior or override settings for development and
-deployment. To supply overrides locally, copy `.env.example` to `.env` and set
-the desired values:
+The app ships with sensible defaults and runs without a `.env` file. Public
+overrides such as `EXPO_PUBLIC_*` values live in `.env` (copy from
+`.env.example`). Secrets like RPC URLs or API keys should be placed in
+`.env.local`, which is git-ignored.
+
+Common variables include:
 
 | Variable | Required | Description |
 | -------- | -------- | ----------- |


### PR DESCRIPTION
## Summary
- minimize `.env.example` to public `EXPO_PUBLIC_*` defaults
- document using git-ignored `.env.local` for secrets
- update setup instructions to mention `.env` and `.env.local`

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Property 'icon' is missing in type..., etc.)*
- `yarn test` *(fails: SyntaxError unexpected token '<', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bddf7033048326adafc1279119411b