### PR TITLE
feat: add transport abstraction

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -10,7 +10,7 @@ import {
 import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
-import { createEncoder, utf8ToBytes } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { ensureNode, isWakuDisabled } from '@/services/waku';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { errorLog } from '../utils/logger';
@@ -81,9 +81,10 @@ class NotificationsAgent {
     if (!node) return;
     try {
       const topic = buildTopic('analytics', '1');
-      const encoder = createEncoder({ contentTopic: topic });
+      const client = await getClient();
+      const encoder = client.createEncoder({ contentTopic: topic });
       await node.lightPush.send(encoder, {
-        payload: utf8ToBytes(JSON.stringify({ type: event, ...payload })),
+        payload: client.utf8ToBytes(JSON.stringify({ type: event, ...payload })),
       });
     } catch (err) {
       errorLog('Failed to broadcast analytics event', err);
@@ -99,12 +100,13 @@ class NotificationsAgent {
     if (!node) return;
     try {
       const topic = buildTopic('orders', storeId);
-      const encoder = createEncoder({ contentTopic: topic });
+      const client = await getClient();
+      const encoder = client.createEncoder({ contentTopic: topic });
       const payload = event
         ? { type: event, notification: item }
         : item;
       await node.lightPush.send(encoder, {
-        payload: utf8ToBytes(JSON.stringify(payload)),
+        payload: client.utf8ToBytes(JSON.stringify(payload)),
       });
     } catch (err) {
       errorLog('Failed to broadcast notification', err);

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -27,14 +27,8 @@ import { logOrderEvent } from '@/services/eventLog';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import eventBus from '@/services/eventBus';
 import { errorLog, warnLog } from '../utils/logger';
-import {
-  LightNode,
-  createLightNode,
-  waitForRemotePeer,
-  createDecoder,
-  Protocols,
-  bytesToUtf8,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { orderStatusMessageSchema } from '../schemas/waku/order.status';
@@ -103,6 +97,7 @@ class OrdersAgent {
     try {
       const bootstrap = getWakuBootstrapNodes();
       if (bootstrap.length === 0) return null;
+      const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
       this.node = await createLightNode({ libp2p: { bootstrap } as any });
       await this.node.start();
       await waitForRemotePeer(this.node, [Protocols.Relay]);
@@ -118,11 +113,12 @@ class OrdersAgent {
     if (this.subscribedStores.has(storeId)) return;
     const n = await this.ensureNode();
     if (!n) return;
-    const decoder = createDecoder(buildTopic('orders', storeId));
+    const client = await getClient();
+    const decoder = client.createDecoder(buildTopic('orders', storeId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const signed = await verifyBeforeWrite(raw, orderStatusMessageSchema);
         if (!signed) return;
         const { orderId, status } = signed.payload;

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -10,16 +10,8 @@ import {
 } from '@/features/products/services/nearProducts';
 import { getStore } from '@/features/stores/services/nearStores';
 import ensureNearWallet from '@/utils/ensureNearWallet';
-import {
-  LightNode,
-  createLightNode,
-  waitForRemotePeer,
-  createEncoder,
-  createDecoder,
-  Protocols,
-  utf8ToBytes,
-  bytesToUtf8,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { getWakuBootstrapNodes } from '@/utils/appConfig';
 import { verifyBeforeWrite } from '@/utils/verifyBeforeWrite';
 import { productUpdatedSchema } from '../schemas/waku/product.updated';
@@ -62,6 +54,7 @@ class ProductsAgent {
     try {
       const bootstrap = getWakuBootstrapNodes();
       if (bootstrap.length === 0) return null;
+      const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
       this.node = await createLightNode({ libp2p: { bootstrap } as any });
       await this.node.start();
       await waitForRemotePeer(this.node, [Protocols.Relay]);
@@ -77,11 +70,12 @@ class ProductsAgent {
     if (this.subscribedStores.has(storeId)) return;
     const n = await this.ensureNode();
     if (!n) return;
-    const decoder = createDecoder(buildProductTopic(storeId));
+    const client = await getClient();
+    const decoder = client.createDecoder(buildProductTopic(storeId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const signed = await verifyBeforeWrite(raw, productUpdatedSchema);
         if (!signed) return;
         void this.invalidateCache();
@@ -153,9 +147,12 @@ class ProductsAgent {
       );
       const sig = await sign(msgBytes, priv);
       msg.signature = Buffer.from(sig).toString('hex');
-      const encoder = createEncoder({ contentTopic: buildProductTopic(product.storeId) });
+      const client = await getClient();
+      const encoder = client.createEncoder({
+        contentTopic: buildProductTopic(product.storeId),
+      });
       await n.lightPush.send(encoder, {
-        payload: utf8ToBytes(JSON.stringify(msg)),
+        payload: client.utf8ToBytes(JSON.stringify(msg)),
       });
     } catch (err) {
       errorLog('Failed to broadcast product update', err);

--- a/contexts/WakuContext.tsx
+++ b/contexts/WakuContext.tsx
@@ -7,16 +7,8 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import {
-  LightNode,
-  createLightNode,
-  waitForRemotePeer,
-  createEncoder,
-  createDecoder,
-  Protocols,
-  bytesToUtf8,
-  utf8ToBytes,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { encryptMessage, decryptMessage } from '@/utils/chatCrypto';
 import DatabaseService from '@/services/database';
 import { ChatMessage } from '@/types';
@@ -88,6 +80,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
         setStatus('disconnected');
         return;
       }
+      const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
       const node = await createLightNode({ libp2p: { bootstrap } });
       node.libp2p.addEventListener('peer:disconnect', () => {
         setStatus('disconnected');
@@ -134,9 +127,10 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
     await db.sendChatMessage(roomId, { ...full, message: encrypted });
 
     if (nodeRef.current) {
-      const encoder = createEncoder({ contentTopic: chatTopic(roomId) });
+      const client = await getClient();
+      const encoder = client.createEncoder({ contentTopic: chatTopic(roomId) });
       await nodeRef.current.lightPush.send(encoder, {
-        payload: utf8ToBytes(encrypted),
+        payload: client.utf8ToBytes(encrypted),
       });
     }
     return full;
@@ -148,11 +142,12 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
     cb: (msg: ChatMessage) => void,
   ): Promise<() => void> => {
     if (!nodeRef.current) return () => {};
-    const decoder = createDecoder(chatTopic(roomId));
+    const client = await getClient();
+    const decoder = client.createDecoder(chatTopic(roomId));
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
         const signed = await verifyBeforeWrite(raw, schema);
         if (!signed) return;
@@ -192,7 +187,8 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
     before?: number,
   ): Promise<number> => {
     if (!nodeRef.current) return 0;
-    const decoder = createDecoder(chatTopic(roomId));
+    const client = await getClient();
+    const decoder = client.createDecoder(chatTopic(roomId));
     const options: any = { decoder };
     if (after || before) {
       options.timeFilter = {};
@@ -204,7 +200,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       for (const wakuMsg of msgs.messages) {
         if (!wakuMsg.payload) continue;
         try {
-          const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+          const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
           const schema = wakuMessageSchema.extend({ payload: z.string() });
           const signed = await verifyBeforeWrite(raw, schema);
           if (!signed) continue;
@@ -231,23 +227,30 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
 
   const broadcastSystem = useCallback(async (message: string) => {
     if (!nodeRef.current) return;
-    const encoder = createEncoder({ contentTopic: SYSTEM_TOPIC });
-    await nodeRef.current.lightPush.send(encoder, { payload: utf8ToBytes(message) });
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic: SYSTEM_TOPIC });
+    await nodeRef.current.lightPush.send(encoder, {
+      payload: client.utf8ToBytes(message),
+    });
   }, []);
 
   const broadcastOrder = useCallback(async (message: string) => {
     if (!nodeRef.current) return;
-    const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
-    await nodeRef.current.lightPush.send(encoder, { payload: utf8ToBytes(message) });
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic: ORDER_TOPIC });
+    await nodeRef.current.lightPush.send(encoder, {
+      payload: client.utf8ToBytes(message),
+    });
   }, []);
 
   const subscribeSystem = useCallback(async (cb: (msg: string) => void) => {
     if (!nodeRef.current) return () => {};
-    const decoder = createDecoder(SYSTEM_TOPIC);
+    const client = await getClient();
+    const decoder = client.createDecoder(SYSTEM_TOPIC);
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
         const signed = await verifyBeforeWrite(raw, schema);
         if (!signed) {
@@ -273,11 +276,12 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
 
   const subscribeOrders = useCallback(async (cb: (msg: string) => void) => {
     if (!nodeRef.current) return () => {};
-    const decoder = createDecoder(ORDER_TOPIC);
+    const client = await getClient();
+    const decoder = client.createDecoder(ORDER_TOPIC);
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
-        const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
         const signed = await verifyBeforeWrite(raw, schema);
         if (!signed) {

--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -2,7 +2,7 @@ import { startStream, types } from 'near-lake-framework';
 import dotenv from 'dotenv';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { Waku } from '@waku/sdk';
+import { getClient } from '../../../src/utils/transport';
 
 dotenv.config();
 
@@ -100,6 +100,7 @@ async function handleMessage(waku: Waku, streamerMessage: types.StreamerMessage)
 async function main() {
   const { height } = await loadState();
   const startHeight = Math.max(START_BLOCK, height);
+  const { Waku } = await getClient();
   const waku = await Waku.create({ bootstrap: { peers: WAKU_BOOTSTRAP } });
   await waku.waitForConnectedPeer();
 

--- a/packages/sdk-near/src/waku/index.ts
+++ b/packages/sdk-near/src/waku/index.ts
@@ -4,7 +4,7 @@
 // app source but is trimmed down for size and to avoid React dependencies.
 
 import type { LightNode } from '@waku/sdk';
-import { createLightNode, waitForRemotePeer, Protocols, createDecoder } from '@waku/sdk';
+import { getClient } from '../../../../src/utils/transport';
 import { Buffer } from 'buffer';
 import { topicFor } from '@blue-ocean/utils';
 
@@ -26,7 +26,9 @@ async function ensureNode(): Promise<LightNode | null> {
         .split(String.fromCharCode(44))
         .map((s) => s.trim())
       .filter(Boolean);
+    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
     node = await createLightNode({ libp2p: { bootstrap } } as any);
+    if (!node) return null;
     await node.start();
     // The Store protocol is required to query historical messages.
     await waitForRemotePeer(node, [Protocols.Store]);
@@ -44,6 +46,7 @@ async function ensureNode(): Promise<LightNode | null> {
 export async function hydrateMessages(topic: string): Promise<any[]> {
   const n = await ensureNode();
   if (!n) return messageCache.get(topic) || [];
+  const { createDecoder } = await getClient();
   const decoder = createDecoder(topic);
   const existing = messageCache.get(topic) || [];
   const seen = seenCache.get(topic) || new Set<string>();

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -1,12 +1,6 @@
 import { errorLog } from '@/utils/logger';
-import {
-  LightNode,
-  createLightNode,
-  waitForRemotePeer,
-  createEncoder,
-  Protocols,
-  utf8ToBytes,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { uuid } from '../utils/uuid';
 import { sha256 } from '@noble/hashes/sha256';
@@ -32,7 +26,9 @@ async function ensureNode(): Promise<LightNode | null> {
     let bootstrap = getWakuBootstrapNodes();
     if (bootstrap.length === 0) bootstrap = STABLE_BOOTSTRAP;
     if (bootstrap.length === 0) return null;
+    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
     node = await createLightNode({ libp2p: { bootstrap } } as any);
+    if (!node) return null;
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);
     return node;
@@ -51,7 +47,8 @@ export async function publish(
   const n = await ensureNode();
   if (!n) return;
   try {
-    const encoder = createEncoder({ contentTopic });
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic });
     const addr = chainAdapter.getAccountId();
     const event = {
       id: uuid(),
@@ -62,7 +59,7 @@ export async function publish(
       ...payload,
     };
     await n.lightPush.send(encoder, {
-      payload: utf8ToBytes(JSON.stringify(event)),
+      payload: client.utf8ToBytes(JSON.stringify(event)),
     });
   } catch (err) {
     errorLog('Failed to publish event', err);

--- a/services/eventLog.ts
+++ b/services/eventLog.ts
@@ -1,13 +1,7 @@
 // @ts-nocheck
 import { errorLog } from '@/utils/logger';
-import {
-  LightNode,
-  createLightNode,
-  waitForRemotePeer,
-  createEncoder,
-  Protocols,
-  utf8ToBytes,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { uuid } from '../utils/uuid';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
 import { OrderStatus } from '../types';
@@ -41,7 +35,9 @@ async function ensureNode(): Promise<LightNode | null> {
     }
     const bootstrap = getWakuBootstrapNodes();
     if (bootstrap.length === 0) return null;
+    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
     node = await createLightNode({ libp2p: { bootstrap } });
+    if (!node) return null;
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);
     return node;
@@ -59,9 +55,10 @@ export async function logOrderEvent(
   if (!n) return;
   try {
     const eventWithId: OrderEvent = { id: uuid(), ...event };
-    const encoder = createEncoder({ contentTopic: ORDER_TOPIC });
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic: ORDER_TOPIC });
     await n.lightPush.send(encoder, {
-      payload: utf8ToBytes(JSON.stringify(eventWithId)),
+      payload: client.utf8ToBytes(JSON.stringify(eventWithId)),
     });
   } catch (err) {
     errorLog('Failed to log order event', err);

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -2,16 +2,8 @@ import { debugLog, errorLog } from '@/utils/logger';
 import { assertNearChain } from './chain';
 import { getValue, setValue, listValues } from './nearKvStore';
 import config, { getWakuBootstrapNodes } from '../utils/appConfig';
-import {
-  LightNode,
-  Protocols,
-  createLightNode,
-  waitForRemotePeer,
-  createEncoder,
-  createDecoder,
-  utf8ToBytes,
-  bytesToUtf8,
-} from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import type { SettingsWriteEvent, WakuMessage } from '../types/waku';
 import { settingsWriteEventSchema, wakuMessageSchema } from '../schemas/waku';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
@@ -79,7 +71,9 @@ async function ensureNode(): Promise<LightNode | null> {
     if (bootstrap.length === 0) {
       return null;
     }
+    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
     node = await createLightNode({ libp2p: { bootstrap } as any });
+    if (!node) return null;
     await node.start();
     await waitForRemotePeer(node, [Protocols.Relay]);
     return node;
@@ -108,9 +102,10 @@ async function emit(event: SettingsWriteEvent) {
     const sig = await sign(msgBytes, priv);
     msg.signature = Buffer.from(sig).toString('hex');
 
-    const encoder = createEncoder({ contentTopic: '/blue-ocean/settings/1' });
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic: '/blue-ocean/settings/1' });
     await n.lightPush.send(encoder, {
-      payload: utf8ToBytes(JSON.stringify(msg)),
+      payload: client.utf8ToBytes(JSON.stringify(msg)),
     });
   } catch (err) {
     errorLog('Failed to broadcast settings.write', err);
@@ -122,11 +117,12 @@ export async function subscribeToSettingsWrites(
 ): Promise<() => void> {
   const n = await ensureNode();
   if (!n) return () => {};
-  const decoder = createDecoder('/blue-ocean/settings/1');
+  const client = await getClient();
+  const decoder = client.createDecoder('/blue-ocean/settings/1');
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
-      const raw = JSON.parse(bytesToUtf8(wakuMsg.payload));
+      const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
       const schema = wakuMessageSchema.extend({
         type: z.literal('settings.write'),
         payload: settingsWriteEventSchema,

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -1,4 +1,5 @@
-import { LightNode, createLightNode, waitForRemotePeer, Protocols } from '@waku/sdk';
+import type { LightNode } from '@waku/sdk';
+import { getClient } from '@/utils/transport';
 import { errorLog } from '@/utils/logger';
 
 const isProd = process.env.NODE_ENV === 'production';
@@ -75,7 +76,9 @@ export async function ensureNode(): Promise<LightNode | null> {
   }
   getPublisherKey();
   try {
+    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
     cachedNode = await createLightNode({ libp2p: { bootstrap } } as any);
+    if (!cachedNode) return null;
     await cachedNode.start();
     await waitForRemotePeer(cachedNode, [Protocols.Relay]);
     return cachedNode;

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -1,0 +1,25 @@
+// Minimal HTTP client placeholder for non-Waku transport
+export const Protocols = {} as any;
+export async function createLightNode(_: any): Promise<null> {
+  return null;
+}
+export async function waitForRemotePeer(_: any, __?: any): Promise<void> {}
+export function createEncoder(_: any): any {
+  return {};
+}
+export function createDecoder(_: any): any {
+  return {};
+}
+export function utf8ToBytes(str: string): Uint8Array {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(str);
+  }
+  // Node.js
+  return Buffer.from(str, 'utf8');
+}
+export function bytesToUtf8(bytes: Uint8Array): string {
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder().decode(bytes);
+  }
+  return Buffer.from(bytes).toString('utf8');
+}

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -1,0 +1,15 @@
+let client: Promise<any> | null = null;
+
+export async function getClient(): Promise<any> {
+  if (!client) {
+    const transport = (process.env.EXPO_PUBLIC_TRANSPORT || 'http').toLowerCase();
+    if (transport === 'waku') {
+      client = import('@waku/sdk');
+    } else {
+      client = import('./httpClient');
+    }
+  }
+  return client;
+}
+
+export default { getClient };

--- a/tests/notificationsAgent.test.ts
+++ b/tests/notificationsAgent.test.ts
@@ -17,17 +17,15 @@ const createLightNodeMock = jest.fn().mockResolvedValue({
 const createEncoderMock = jest.fn(({ contentTopic }: any) => ({ contentTopic }));
 const utf8ToBytesMock = jest.fn((str: string) => Buffer.from(str));
 
-jest.mock(
-  '@waku/sdk',
-  () => ({
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => ({
     createLightNode: createLightNodeMock as any,
     waitForRemotePeer: jest.fn().mockResolvedValue(undefined),
     createEncoder: createEncoderMock as any,
     Protocols: { Relay: 'relay' },
     utf8ToBytes: utf8ToBytesMock as any,
-  }),
-  { virtual: true },
-);
+  })),
+}));
 
 const notificationsAgent = require('../agents/notifications-agent').default;
 

--- a/tests/wakuErrorLogging.test.ts
+++ b/tests/wakuErrorLogging.test.ts
@@ -1,14 +1,13 @@
-jest.mock(
-  '@waku/sdk',
-  () => ({
-    createLightNode: jest.fn(async () => {
-      throw new Error('boom');
-    }),
+const createLightNode = jest.fn(async () => {
+  throw new Error('boom');
+});
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => ({
+    createLightNode,
     waitForRemotePeer: jest.fn(),
     Protocols: { Relay: 'relay' },
-  }),
-  { virtual: true },
-);
+  })),
+}));
 
 jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
 

--- a/tests/wakuHydration.test.ts
+++ b/tests/wakuHydration.test.ts
@@ -8,9 +8,8 @@ const queryGenerator = jest.fn(() => {
   })();
 });
 
-jest.mock(
-  '@waku/sdk',
-  () => ({
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => ({
     createLightNode: jest.fn(async () => ({
       start: jest.fn(),
       store: { queryGenerator },
@@ -18,9 +17,8 @@ jest.mock(
     waitForRemotePeer: jest.fn(),
     Protocols: { Store: 'store' },
     createDecoder: jest.fn(() => ({})),
-  }),
-  { virtual: true },
-);
+  })),
+}));
 
 import { hydrateMessages } from '../packages/sdk-near/src/waku';
 


### PR DESCRIPTION
## Summary
- add transport module to lazily load Waku or HTTP client based on EXPO_PUBLIC_TRANSPORT
- refactor Waku consumers to use getClient for dynamic imports
- run targeted Waku tests

## Testing
- `npx jest --runTestsByPath tests/wakuErrorLogging.test.ts tests/wakuHydration.test.ts tests/notificationsAgent.test.ts >/tmp/jest.log && tail -n 20 /tmp/jest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bddf7041c08326bfa7bd6ee36e371a