### PR TITLE
fix: enable static class blocks in babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,8 @@ module.exports = function (api) {
   return {
     presets: ["babel-preset-expo"],
     // SDK 50+: expo-router/babel is built into the preset; don't add it here.
-    plugins: [],
+    // Enable support for static class blocks in dependencies like @smithy/core
+    // by transforming them during compilation.
+    plugins: ["@babel/plugin-transform-class-static-block"],
   };
 };

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "@babel/core": "^7.27.7",
     "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+    "@babel/plugin-transform-class-static-block": "^7.27.1",
     "@expo/cli": "^0.22.26",
     "@faker-js/faker": "^8.4.0",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- add `@babel/plugin-transform-class-static-block` to babel config so bundler can compile dependencies using static class blocks
- include the plugin as a dev dependency

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Cannot find a declaration file for module 'metro-runtime/src/modules/HMRClient', Object is possibly 'null', Cannot find name 'Category', and many others)*

------
https://chatgpt.com/codex/tasks/task_e_68bde52997708326aede591451206279