### PR TITLE
feat: add default local near lake dir

### DIFF
--- a/services/nearKvStore.ts
+++ b/services/nearKvStore.ts
@@ -12,7 +12,7 @@ let lakeStarted = false;
 let s3: S3Client | null = null;
 const bucket = process.env.NEAR_LAKE_BUCKET;
 const region = process.env.NEAR_LAKE_REGION || 'eu-central-1';
-const localDir = process.env.NEAR_LAKE_DIR;
+const localDir = process.env.NEAR_LAKE_DIR || path.join(process.cwd(), '.near-lake');
 
 function ensureLake() {
   if (lakeStarted) return;
@@ -41,7 +41,6 @@ function objectKey(address: string, key: string): string {
 }
 
 function localFile(address: string, key: string): string {
-  if (!localDir) throw new Error('missing_lake_dir');
   return path.join(localDir, address, key);
 }
 
@@ -127,7 +126,7 @@ export async function listValues(
     }
     return out;
   }
-  const dir = path.join(localDir || '', address);
+  const dir = path.join(localDir, address);
   try {
     const files = await fs.readdir(dir);
     const entries = await Promise.all(


### PR DESCRIPTION
## Summary
- avoid `missing_lake_dir` errors by providing a default local path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: SyntaxError: Unexpected token '<')*
- `npm run lint`
- `npm run typecheck` *(fails: Property 'icon' is missing in type '{ id: string; name: string; }' but required in type 'Category'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bde837f4808326a4ea91a160251c71