### PR TITLE
Use blurhash string for SmartImage placeholder

### DIFF
--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -4,12 +4,10 @@ import { Image as ExpoImage, ImageProps } from 'expo-image';
 const fallback = require('../assets/images/icon.png');
 // Valid blurhash placeholder used while the image loads
 // Original hash: LKO2?U%2Tw=w]~RBVZRi};RPxuwH
-const shimmer = {
-  blurhash: String.fromCharCode(
-    76, 75, 79, 50, 63, 85, 37, 50, 84, 119, 61, 119, 93, 126, 82, 66,
-    86, 90, 82, 105, 125, 59, 82, 80, 120, 117, 119, 72
-  ),
-};
+const shimmer = String.fromCharCode(
+  76, 75, 79, 50, 63, 85, 37, 50, 84, 119, 61, 119, 93, 126, 82, 66,
+  86, 90, 82, 105, 125, 59, 82, 80, 120, 117, 119, 72
+);
 
 interface SmartImageProps extends Omit<ImageProps, 'source' | 'width' | 'height'> {
   uri: string;
@@ -24,7 +22,6 @@ export default function SmartImage({
   style,
   contentFit = 'cover',
   cachePolicy = 'memory-disk',
-  placeholder = shimmer,
   ...props
 }: SmartImageProps) {
   const [source, setSource] = useState<{ uri: string } | number>({ uri });
@@ -38,7 +35,7 @@ export default function SmartImage({
       style={style}
       contentFit={contentFit}
       cachePolicy={cachePolicy}
-      placeholder={placeholder}
+      placeholder={shimmer}
       transition={300}
       onError={() => setSource(fallback)}
     />


### PR DESCRIPTION
## Summary
- replace shimmer object with a blurhash string and use it as ExpoImage placeholder

## Testing
- `yarn lint components/SmartImage.tsx`
- `yarn typecheck` *(fails: Property 'icon' is missing in type, Property 'contains' does not exist on type 'View', Element implicitly has an 'any' type because...)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfba39e748326b9c874014a89cbe3