### PR TITLE
fix skeleton shimmer for web platform

### DIFF
--- a/src/ui/primitives/Skeleton.tsx
+++ b/src/ui/primitives/Skeleton.tsx
@@ -1,11 +1,11 @@
 import React, { useRef, useEffect } from 'react';
-import { View, Animated, StyleProp, ViewStyle } from 'react-native';
+import { View, Animated, StyleProp, ViewStyle, Platform, DimensionValue } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../ThemeProvider';
 
 interface SkeletonProps {
-  width?: number | string;
-  height?: number | string;
+  width?: DimensionValue;
+  height?: DimensionValue;
   style?: StyleProp<ViewStyle>;
   borderRadius?: number;
 }
@@ -24,7 +24,7 @@ export default function Skeleton({
       Animated.timing(shimmer, {
         toValue: 1,
         duration: 1000,
-        useNativeDriver: true,
+        useNativeDriver: Platform.OS !== 'web',
       }),
     );
     animation.start();


### PR DESCRIPTION
## Summary
- avoid useNativeDriver on web in Skeleton to prevent warnings
- type Skeleton width/height as DimensionValue

## Testing
- `yarn lint src/ui/primitives/Skeleton.tsx`
- `yarn typecheck` *(fails: Property 'icon' is missing, etc.)*
- `yarn dev`
- `yarn dev:web`


------
https://chatgpt.com/codex/tasks/task_e_68bdfba9615083268909cfdb36fd55ee