### PR TITLE
fix: conditionally disable shimmer placeholder on web

### DIFF
--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Image as ExpoImage, ImageProps } from 'expo-image';
+import { Platform } from 'react-native';
 
 const fallback = require('../assets/images/icon.png');
 // Valid blurhash placeholder used while the image loads
@@ -8,6 +9,9 @@ const shimmer = String.fromCharCode(
   76, 75, 79, 50, 63, 85, 37, 50, 84, 119, 61, 119, 93, 126, 82, 66,
   86, 90, 82, 105, 125, 59, 82, 80, 120, 117, 119, 72
 );
+
+const webPlaceholder =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
 interface SmartImageProps extends Omit<ImageProps, 'source' | 'width' | 'height'> {
   uri: string;
@@ -35,7 +39,7 @@ export default function SmartImage({
       style={style}
       contentFit={contentFit}
       cachePolicy={cachePolicy}
-      placeholder={shimmer}
+      placeholder={Platform.OS === 'web' ? webPlaceholder : shimmer}
       transition={300}
       onError={() => setSource(fallback)}
     />


### PR DESCRIPTION
## Summary
- import `Platform` and add base64 web placeholder in `SmartImage`
- disable shimmer placeholder on web to prevent `URI malformed` logs

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be286495288326acd47dd0fa9dc7f2