### PR TITLE
feat: add home redirect

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/landing" />;
+}

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
-import { useAppRouter } from '@/services';
+import { View, Text } from 'react-native';
 
-export default function LandingRedirect() {
-  const { replace } = useAppRouter();
-  useEffect(() => {
-    replace('/');
-  }, [replace]);
-  return null;
+export default function Landing() {
+  return (
+    <View>
+      <Text>Welcome to Blue Ocean</Text>
+    </View>
+  );
 }


### PR DESCRIPTION
## Summary
- add index page redirecting to landing screen
- replace landing with simple placeholder content

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: TS2769 No overload matches this call, TS2305, TS2739, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd2395c8326a3647179ba310771