### PR TITLE
Use native driver conditionally for animations

### DIFF
--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -10,6 +10,7 @@ import {
   Animated,
   Easing,
   Alert,
+  Platform,
 } from 'react-native';
 import SmartImage from './SmartImage';
 import { X, CircleCheck as CheckCircle, Circle, Package, Truck, MapPin, Star, Phone, MessageCircle, Copy } from 'lucide-react-native';
@@ -61,7 +62,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
         toValue: stepIndex / (statusOrder.length - 1),
         duration: 1000,
         easing: Easing.out(Easing.ease),
-        useNativeDriver: false,
+        useNativeDriver: Platform.OS !== 'web',
       }).start();
       
       // Set estimated delivery time

--- a/src/features/cart/components/FloatingCartWidget.tsx
+++ b/src/features/cart/components/FloatingCartWidget.tsx
@@ -7,6 +7,7 @@ import {
   Animated,
   ScrollView,
   I18nManager,
+  Platform,
 } from 'react-native';
 import SmartImage from '@/components/SmartImage';
 import { ShoppingCart, X, Plus, Minus } from 'lucide-react-native';
@@ -45,7 +46,7 @@ export default function FloatingCartWidget() {
       Animated.timing(animatedOpacity, {
         toValue: visible ? 1 : 0,
         duration: 300,
-        useNativeDriver: false,
+        useNativeDriver: Platform.OS !== 'web',
       }).start(() => {
         if (!visible) setIsExpanded(false);
       });
@@ -63,7 +64,7 @@ export default function FloatingCartWidget() {
             )
           : spacing.spacer20 * 3,
         duration: 300,
-        useNativeDriver: false,
+        useNativeDriver: Platform.OS !== 'web',
       }).start();
     },
     [animatedHeight]


### PR DESCRIPTION
## Summary
- import Platform and set `useNativeDriver: Platform.OS !== 'web'` in OrderTrackingModal
- apply the same `useNativeDriver` logic in FloatingCartWidget to prevent web warnings

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Module '../ui/ThemeProvider' has no exported member 't', along with other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd53d9c8326ace0350d91437093