### PR TITLE
fix: avoid web decode error in SmartImage shimmer

### DIFF
--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -5,13 +5,7 @@ import { Platform } from 'react-native';
 const fallback = require('../assets/images/icon.png');
 // Valid blurhash placeholder used while the image loads
 // Original hash: LKO2?U%2Tw=w]~RBVZRi};RPxuwH
-const shimmer = String.fromCharCode(
-  76, 75, 79, 50, 63, 85, 37, 50, 84, 119, 61, 119, 93, 126, 82, 66,
-  86, 90, 82, 105, 125, 59, 82, 80, 120, 117, 119, 72
-);
-
-const webPlaceholder =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+const shimmer = 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH';
 
 interface SmartImageProps extends Omit<ImageProps, 'source' | 'width' | 'height'> {
   uri: string;
@@ -39,7 +33,7 @@ export default function SmartImage({
       style={style}
       contentFit={contentFit}
       cachePolicy={cachePolicy}
-      placeholder={Platform.OS === 'web' ? webPlaceholder : shimmer}
+      placeholder={Platform.OS === 'web' ? undefined : shimmer}
       transition={300}
       onError={() => setSource(fallback)}
     />


### PR DESCRIPTION
## Summary
- define shimmer blurhash constant as string
- disable placeholder on web to prevent decode errors and asset requests

## Testing
- `yarn lint components/SmartImage.tsx`
- `yarn typecheck` *(fails: Argument of type '{ ios: { elevation: number; }; android: { elevation: number; }; web: { boxShadow: string; }; }' is not assignable to parameter of type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd64bfc8326996819d760ab0d61