### PR TITLE
feat: add home redirect

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/(tabs)" />;
+}

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -3,8 +3,10 @@ import { useAppRouter } from '@/services';
 
 export default function LandingRedirect() {
   const { replace } = useAppRouter();
+
   useEffect(() => {
     replace('/');
   }, [replace]);
+
   return null;
 }


### PR DESCRIPTION
## Summary
- add index route redirecting to tabbed home screen
- restore landing redirect to root app layout

## Testing
- `npm run lint` *(fails: 1 error, 35 warnings)*
- `npm run typecheck` *(fails: TS2769, TS2305, TS2739, TS2741, TS2339, TS7053)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd2395c8326a3647179ba310771