### PR TITLE
Add responsive sidebar navigation for large screens

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,6 +1,7 @@
 # Navigation
 
 Blue Ocean relies on [Expo Router](https://expo.github.io/router/) and a tab layout to move between screens.
+On phones the tabs appear along the bottom, while tablets and larger viewports show the same items in a fixed sidebar on the left.
 The diagram below outlines the primary user flow.
 
 ```mermaid
@@ -15,7 +16,7 @@ flowchart LR
     Product --> Cart
 ```
 
-- **Tabs** – implemented in `src/layout/TabsLayout.tsx`, renders the bottom navigation bar.
+- **Tabs** – implemented in `src/layout/TabsLayout.tsx`, renders the bottom navigation bar or left sidebar based on screen size.
 - **Avatar Menu** – the profile avatar opens authentication actions.
 - **Category** – routes like `/storefront/category/[id]` show filtered storefront views.
 

--- a/src/layout/SidebarTabBar.tsx
+++ b/src/layout/SidebarTabBar.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { View, Pressable, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Lucide from 'lucide-react-native';
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { getTabsForAuth } from '@/config/navigation';
+import { useAuth } from '@/features/auth/AuthContext';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { spacing, typography } from '@/shared/ui/tokens';
+
+const SIDEBAR_WIDTH = 80;
+
+export default function SidebarTabBar({ state, navigation }: BottomTabBarProps) {
+  const insets = useSafeAreaInsets();
+  const auth = useAuth();
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const tabs = React.useMemo(() => getTabsForAuth(auth), [auth]);
+
+  return (
+    <View
+      style={{
+        width: SIDEBAR_WIDTH,
+        backgroundColor: colors.tabBar.background,
+        paddingTop: insets.top,
+        paddingBottom: insets.bottom,
+      }}
+    >
+      {tabs.map((tab) => {
+        const routeIndex = state.routes.findIndex((r: any) => r.name === tab.name);
+        const focused = state.index === routeIndex;
+        const Icon = (Lucide as any)[tab.icon] as React.ComponentType<{ size: number; color: string }>;
+        const color = focused ? colors.tabBar.active : colors.tabBar.inactive;
+        const label = mapTitle(t, tab.title);
+
+        return (
+          <Pressable
+            key={tab.name}
+            onPress={() => navigation.navigate(tab.name)}
+            style={{
+              alignItems: 'center',
+              paddingVertical: spacing.spacer16,
+            }}
+          >
+            {Icon && <Icon size={24} color={color} />}
+            <Text
+              style={{
+                color,
+                fontSize: typography.xs.fontSize,
+                fontWeight: '500',
+                marginTop: spacing.spacer4,
+              }}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function mapTitle(t: (key: string) => string, raw: string) {
+  const map: Record<string, string> = {
+    Home: t('navigation.home'),
+    Stores: t('navigation.stores'),
+    Cart: t('navigation.cart'),
+    Orders: t('navigation.orders'),
+    Profile: t('navigation.profile'),
+    Categories: t('navigation.categories'),
+    Notifications: t('navigation.notifications'),
+    Reviews: t('navigation.reviews'),
+  };
+  return map[raw] ?? raw;
+}
+
+export { SIDEBAR_WIDTH };

--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -4,20 +4,23 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useState, useEffect, useMemo } from 'react';
 import { usePathname } from 'expo-router';
-import { Platform } from 'react-native';
+import { Platform, useWindowDimensions } from 'react-native';
 import { FloatingCartWidget } from '@/features/cart';
 import { getTabsForAuth } from '@/config/navigation';
 import { useAuth } from '@/features/auth/AuthContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { spacing, shadows, typography } from '@/shared/ui/tokens';
+import SidebarTabBar, { SIDEBAR_WIDTH } from './SidebarTabBar';
 
 export default function TabsLayout() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const auth = useAuth();
   const pathname = usePathname();
+  const { width } = useWindowDimensions();
   const [showCartWidget, setShowCartWidget] = useState(false);
   const tabs = useMemo(() => getTabsForAuth(auth), [auth]);
+  const isLargeScreen = width >= 768;
 
   useEffect(() => {
     setShowCartWidget(pathname === '/' || pathname === '/index');
@@ -34,7 +37,9 @@ export default function TabsLayout() {
     paddingTop: spacing.spacer8,
     ...Platform.select(shadows.sm),
   } as const;
-  warnIfTabBarHidden(tabBarStyle as any, TabsLayout.name);
+  if (!isLargeScreen) {
+    warnIfTabBarHidden(tabBarStyle as any, TabsLayout.name);
+  }
 
   const screenOptions = {
     headerShown: false,
@@ -42,7 +47,7 @@ export default function TabsLayout() {
     tabBarShowLabel: true,
     tabBarActiveTintColor: colors.tabBar.active,
     tabBarInactiveTintColor: colors.tabBar.inactive,
-    tabBarStyle,
+    tabBarStyle: isLargeScreen ? undefined : tabBarStyle,
     tabBarLabelStyle: {
       fontSize: typography.xs.fontSize,
       fontWeight: '500',
@@ -52,7 +57,11 @@ export default function TabsLayout() {
   return (
     <ErrorBoundary>
       <>
-        <Tabs screenOptions={screenOptions}>
+        <Tabs
+          screenOptions={screenOptions}
+          tabBar={(props) => (isLargeScreen ? <SidebarTabBar {...props} /> : undefined)}
+          sceneContainerStyle={isLargeScreen ? { marginLeft: SIDEBAR_WIDTH } : undefined}
+        >
           {tabs.map((tab) => {
             const Icon = (Lucide as any)[tab.icon] as React.ComponentType<{ size: number; color: string }>;
             const title = mapTitle(t, tab.title);


### PR DESCRIPTION
## Summary
- switch bottom tabs to left sidebar on screens >= 768px
- implement reusable SidebarTabBar with icons and labels
- document responsive navigation behavior

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: missing types and interface mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68bede02c5508326b7072677c0bb3d11