### PR TITLE
Redirect root to landing

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return <Redirect href="/(tabs)" />;
+  return <Redirect href="/landing" />;
 
 }


### PR DESCRIPTION
## Summary
- point app root to landing page instead of tabs

## Testing
- `npm run lint` *(fails: 35 warnings)*
- `npm run typecheck` *(fails: type errors)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beeeece6e08326abb7f0a46eef93b0