### PR TITLE
fix: redirect root to landing

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { Redirect } from 'expo-router';
 
+// Redirect the root path to the landing page so `/` always resolves.
 export default function Index() {
-  return <Redirect href="/landing" />;
-
+  return <Redirect href='/landing' />;
 }

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,6 +1,1 @@
-import { Redirect } from 'expo-router';
-
-export default function Landing() {
-  return <Redirect href='/(tabs)' />;
-}
-
+export { default } from './storefront';


### PR DESCRIPTION
## Summary
- ensure `/` resolves by redirecting to a landing screen
- expose landing route by re-exporting `storefront` index

## Testing
- `yarn lint app/index.tsx app/landing.tsx`
- `yarn typecheck` *(fails: Module '../ui/ThemeProvider' has no exported member 't', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bef31282348326b67d085182c6eabd