### PR TITLE
docs: clarify shimmer placeholder usage

### DIFF
--- a/components/SmartImage.tsx
+++ b/components/SmartImage.tsx
@@ -3,8 +3,7 @@ import { Image as ExpoImage, ImageProps } from 'expo-image';
 import { Platform } from 'react-native';
 
 const fallback = require('../assets/images/icon.png');
-// Valid blurhash placeholder used while the image loads
-// Original hash: LKO2?U%2Tw=w]~RBVZRi};RPxuwH
+// blurhash placeholder used while the image loads
 const shimmer = 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH';
 
 interface SmartImageProps extends Omit<ImageProps, 'source' | 'width' | 'height'> {


### PR DESCRIPTION
## Summary
- clarify comment for SmartImage shimmer blurhash placeholder
- keep web placeholder disabled to avoid decode errors

## Testing
- `npx eslint components/SmartImage.tsx`
- `yarn typecheck` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bef313f0f88326a290e3df9055a069