### PR TITLE
Use bottom tabs by default

### DIFF
--- a/src/layout/TabsLayout.tsx
+++ b/src/layout/TabsLayout.tsx
@@ -4,7 +4,7 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useState, useEffect, useMemo } from 'react';
 import { usePathname } from 'expo-router';
-import { Platform, useWindowDimensions, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { FloatingCartWidget } from '@/features/cart';
@@ -13,17 +13,14 @@ import { useAuth } from '@/features/auth/AuthContext';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 import { spacing, shadows, typography } from '@/shared/ui/tokens';
 import GlobalHeader from '@/components/GlobalHeader';
-import SidebarTabBar, { SIDEBAR_WIDTH } from './SidebarTabBar';
 
 export default function TabsLayout() {
   const { t } = useLanguage();
   const { theme, colors } = useTheme();
   const auth = useAuth();
   const pathname = usePathname();
-  const { width } = useWindowDimensions();
   const [showCartWidget, setShowCartWidget] = useState(false);
   const tabs = useMemo(() => getTabsForAuth(auth), [auth]);
-  const isLargeScreen = width >= 768;
 
   useEffect(() => {
     setShowCartWidget(pathname === '/' || pathname === '/index');
@@ -40,9 +37,7 @@ export default function TabsLayout() {
     paddingTop: spacing.spacer8,
     ...Platform.select(shadows.sm),
   } as const;
-  if (!isLargeScreen) {
-    warnIfTabBarHidden(tabBarStyle as any, TabsLayout.name);
-  }
+  warnIfTabBarHidden(tabBarStyle as any, TabsLayout.name);
 
   const screenOptions = {
     headerShown: false,
@@ -50,7 +45,7 @@ export default function TabsLayout() {
     tabBarShowLabel: true,
     tabBarActiveTintColor: colors.tabBar.active,
     tabBarInactiveTintColor: colors.tabBar.inactive,
-    tabBarStyle: isLargeScreen ? undefined : tabBarStyle,
+    tabBarStyle,
     tabBarLabelStyle: {
       fontSize: typography.xs.fontSize,
       fontWeight: '500',
@@ -63,11 +58,7 @@ export default function TabsLayout() {
         <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
         <GlobalHeader showSearch={pathname === '/' || pathname === '/index'} />
         <View style={{ flex: 1 }}>
-          <Tabs
-            screenOptions={screenOptions}
-            tabBar={(props) => (isLargeScreen ? <SidebarTabBar {...props} /> : undefined)}
-            sceneContainerStyle={isLargeScreen ? { marginLeft: SIDEBAR_WIDTH } : undefined}
-          >
+          <Tabs screenOptions={screenOptions}>
             {tabs.map((tab) => {
               const Icon = (Lucide as any)[tab.icon] as React.ComponentType<{ size: number; color: string }>;
               const title = mapTitle(t, tab.title);


### PR DESCRIPTION
## Summary
- Remove large-screen sidebar tab layout and rely on standard bottom Tabs bar
- Drop scene container margin and width check for default styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf3526375c8326af3a4625ecace0a5