### PR TITLE
refactor: remove storefront references

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -7,7 +7,7 @@ import StoreTabs from '@/features/stores/components/store/StoreTabs';
 import { ProductGrid } from '@/features/products';
 import { useStoreData } from '@/services/useStoreData';
 
-export default function StorefrontStoreScreen() {
+export default function StoreScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
   const { store, products, score } = useStoreData(storeId);

--- a/docs/near-dev-packet.md
+++ b/docs/near-dev-packet.md
@@ -449,7 +449,7 @@ BlueOcean
 │  └─ Polyfills (web/native) + HMR
 │
 ├─ Public
-│  ├─ /                          (Landing / marketing)
+│  ├─ /                          (marketing)
 │  ├─ /store/[storeId]
 │  │  ├─ /home                  (Hero, featured, promos)
 │  │  ├─ /catalog

--- a/tests/reputation.test.tsx
+++ b/tests/reputation.test.tsx
@@ -72,7 +72,7 @@ jest.mock('@/ui/primitives', () => ({ Spinner: () => null }));
 jest.mock('@/features/products', () => ({ ProductCard: () => null }));
 
 import storesAgent from '@/agents/stores-agent';
-import StorefrontStoreScreen from '@app/store/[storeId]';
+import StoreScreen from '@app/store/[storeId]';
 import AdminDashboardScreen from '@app/admin/dashboard';
 
 describe('store reputation', () => {
@@ -92,7 +92,7 @@ describe('store reputation', () => {
 
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StorefrontStoreScreen />);
+      root = renderer.create(<StoreScreen />);
     });
     expect(JSON.stringify(root!.toJSON())).toContain('4.5');
 

--- a/tests/storeScreen.test.tsx
+++ b/tests/storeScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import StorefrontStoreScreen from '@app/store/[storeId]';
+import StoreScreen from '@app/store/[storeId]';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ storeId: 's1' }),
@@ -60,11 +60,11 @@ jest.mock('@/features/products', () => ({
   ProductCard: ({ product }: any) => React.createElement('ProductCard', null, product.name),
 }));
 
-describe('StorefrontStoreScreen', () => {
+describe('StoreScreen', () => {
   it('shows store catalog with reviews', async () => {
     let root: renderer.ReactTestRenderer;
     await act(async () => {
-      root = renderer.create(<StorefrontStoreScreen />);
+      root = renderer.create(<StoreScreen />);
     });
     await act(async () => {});
     const str = JSON.stringify(root!.toJSON());


### PR DESCRIPTION
## Summary
- remove leftover Storefront screen references
- update tests after dropping Storefront naming
- clean docs reference to landing page

## Testing
- `npm run lint`
- `npx jest` *(fails: SyntaxError: Unexpected token '<' and other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf535f89c48326a25171a4814d2759