### PR TITLE
fix duplicate orders route

### DIFF
--- a/app/orders/index.tsx
+++ b/app/orders/index.tsx
@@ -9,14 +9,14 @@ import {
 import { useAppRouter } from '@/services';
 import { Package, ArrowLeft, ChevronLeft, ShoppingBag, Clock, Truck } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
-import { Order, CartItem } from '../types';
+import { Order, CartItem } from '../../types';
 import { useTheme } from '@/ui/ThemeProvider';
 import EmptyState from '@/shared/ui/EmptyState';
-import OrderTrackingModal from '../components/OrderTrackingModal';
+import OrderTrackingModal from '../../components/OrderTrackingModal';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import commonStyles from '@/constants/styles';
 import { useLanguage } from '@/ui/ThemeProvider';
-import { useCurrency } from '../contexts/CurrencyContext';
+import { useCurrency } from '../../contexts/CurrencyContext';
 import { useOrders } from '@/services';
 import { requireEnv } from '@/services/config';
 


### PR DESCRIPTION
## Summary
- move orders screen into `orders/index.tsx` under layout to resolve duplicate layout conflict

## Testing
- `npx eslint app/orders/index.tsx app/orders/_layout.tsx`
- `yarn typecheck` *(fails: Object literal may only specify known properties, and 'suspense' does not exist in type 'UseQueryOptions', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf58081b608326bd3c1b6ef3cb5689