### PR TITLE
Handle home data query errors

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -9,7 +9,7 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { useAppRouter } from '@/services';
-import { Plus, X, ArrowUpDown, Pencil } from 'lucide-react-native';
+import { Plus, X, ArrowUpDown, Pencil, Info } from 'lucide-react-native';
 import { Product, HeroBanner, Category } from '@/types';
 import { useHome } from '@/features/home/hooks/useHome';
 import { useHomeBanners } from '@/features/home/hooks/useHomeBanners';
@@ -78,20 +78,62 @@ function HomeScreenContent() {
   const categoriesToShow = categories.length ? categories : fallbackCategories;
   const heroBannersToShow = heroBanners.length ? heroBanners : fallbackBanners;
 
-    const {
-      filteredProducts,
-      searchQuery,
-      selectedCategory,
-      setSelectedCategory,
-      minPrice,
-      setMinPrice,
-      maxPrice,
-      setMaxPrice,
-      sortBy,
-      setSortBy,
-      showSortModal,
-      setShowSortModal,
-    } = useHomeFilters(products);
+  const {
+    filteredProducts,
+    searchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    sortBy,
+    setSortBy,
+    showSortModal,
+    setShowSortModal,
+  } = useHomeFilters(products);
+
+  const handleReload = () => {
+    closeInfoModal();
+    refresh();
+  };
+
+  if (error) {
+    return (
+      <>
+        <ScrollArea
+          testID="home-root"
+          backgroundColor={themeColors.canvas}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={refresh} />
+          }
+        >
+          <EmptyState
+            icon={Info}
+            title={t('common.error')}
+            message={t('home.loadErrorMessage')}
+            actionText={t('common.reload')}
+            onAction={handleReload}
+          />
+        </ScrollArea>
+        <Suspense fallback={<Spinner />}>
+          <InfoModal
+            visible={infoModal.visible}
+            title={infoModal.title}
+            message={infoModal.message}
+            type={infoModal.type}
+            buttonText={infoModal.buttonText}
+            onClose={handleReload}
+            autoClose={false}
+          />
+        </Suspense>
+        <Suspense fallback={<Spinner />}>
+          <CartModal visible={showCartModal} onClose={closeCartModal} />
+        </Suspense>
+      </>
+    );
+  }
 
   const handleBannerSaved = (b: HeroBanner, isNew: boolean) => {
     upsertBanner(b, isNew);
@@ -173,11 +215,6 @@ function HomeScreenContent() {
       default:
         return t('home.newest');
     }
-  };
-
-  const handleReload = () => {
-    closeInfoModal();
-    refresh();
   };
 
   return (

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -3,6 +3,7 @@ import { Product, Category } from '@/types';
 import { useProducts } from '@/services/useProducts';
 import { useCategories } from '@/services/useCategories';
 import { requireEnv } from '@/services/config';
+import { errorLog } from '@/utils/logger';
 
 export function useHome() {
   const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');
@@ -11,6 +12,9 @@ export function useHome() {
 
   const [products, setProducts] = useState<Product[]>(productsQuery.data ?? []);
   const [categories, setCategories] = useState<Category[]>(categoriesQuery.data ?? []);
+  const [error, setError] = useState<Error | null>(
+    (productsQuery.error || categoriesQuery.error) as Error | null,
+  );
 
   useEffect(() => {
     if (productsQuery.data) {
@@ -24,8 +28,22 @@ export function useHome() {
     }
   }, [categoriesQuery.data]);
 
+  useEffect(() => {
+    if (productsQuery.error || categoriesQuery.error) {
+      const err = (productsQuery.error || categoriesQuery.error) as Error;
+      setError(err);
+      errorLog('useHome initial load failed', err);
+    }
+  }, [productsQuery.error, categoriesQuery.error]);
+
   const refresh = useCallback(async () => {
-    await Promise.all([productsQuery.refetch(), categoriesQuery.refetch()]);
+    try {
+      await Promise.all([productsQuery.refetch(), categoriesQuery.refetch()]);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+      errorLog('useHome refresh failed', err);
+    }
   }, [productsQuery, categoriesQuery]);
 
   const upsertProduct = useCallback((p: Product, isNew: boolean) => {
@@ -40,7 +58,6 @@ export function useHome() {
 
   const loading = productsQuery.isLoading || categoriesQuery.isLoading;
   const refreshing = productsQuery.isFetching || categoriesQuery.isFetching;
-  const error = productsQuery.error || categoriesQuery.error;
 
   return {
     products,

--- a/src/features/home/hooks/useHomeBanners.ts
+++ b/src/features/home/hooks/useHomeBanners.ts
@@ -2,13 +2,19 @@ import { useState, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import { HeroBanner } from '@/types';
+import { errorLog } from '@/utils/logger';
 
 export function useHomeBanners() {
-  const { data, refetch, isLoading } = useQuery({
+  const { data, refetch, isLoading, error: queryError } = useQuery({
     queryKey: ['homeBanners'],
     queryFn: async () => {
-      const db = DatabaseService.getInstance();
-      return db.getHeroBanners();
+      try {
+        const db = DatabaseService.getInstance();
+        return await db.getHeroBanners();
+      } catch (err) {
+        errorLog('useHomeBanners query failed', err);
+        throw err;
+      }
     },
     suspense: false,
   });
@@ -20,7 +26,13 @@ export function useHomeBanners() {
     }
   }, [data]);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const [error, setError] = useState<Error | null>(queryError ?? null);
+
+  useEffect(() => {
+    if (queryError) {
+      setError(queryError as Error);
+    }
+  }, [queryError]);
 
   const refresh = useCallback(async () => {
     try {
@@ -31,6 +43,7 @@ export function useHomeBanners() {
       }
       setError(null);
     } catch (err) {
+      errorLog('useHomeBanners refresh failed', err);
       setError(err as Error);
     } finally {
       setRefreshing(false);


### PR DESCRIPTION
## Summary
- log and surface errors in home data and banner hooks
- surface home refresh errors and show empty state
- show InfoModal when home screen data fails to load

## Testing
- `npm test` (missing script)
- `yarn lint`
- `yarn typecheck` (fails: Object literal may only specify known properties...)


------
https://chatgpt.com/codex/tasks/task_e_68bf625e7b5083269863b5c402705810