### PR TITLE
Add home screen render test for fallback data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -48,6 +48,7 @@ module.exports = {
     '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
     '<rootDir>/tests/signupLogic.test.ts',
     '<rootDir>/tests/nearKvPersistence.test.ts',
+    '<rootDir>/tests/homeScreenRender.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/tests/homeScreenRender.test.tsx
+++ b/tests/homeScreenRender.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import HomeScreen from '@app/index';
+
+jest.mock('@/services', () => ({
+  useAppRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/index',
+  router: { replace: jest.fn() },
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return {
+    SafeAreaView: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@features/auth/AuthContext', () => ({
+  useAuth: () => ({ isStoreOwner: false }),
+}));
+
+jest.mock('@/ui/ThemeProvider', () => {
+  const colors = {
+    background: '#fff',
+    canvas: '#fff',
+    text: { primary: '#000', secondary: '#333', tertiary: '#666', inverse: '#fff' },
+    border: { primary: '#000', secondary: '#ccc' },
+    gold: '#FFD700',
+    surface: { primary: '#fff', elevated: '#eee' },
+    interactive: { secondary: '#eee', disabled: '#999' },
+  };
+  return {
+    useLanguage: () => ({ t: (s: string) => s }),
+    useTheme: () => ({
+      colors,
+      getColor: (path: string) => path.split('.').reduce((acc: any, key) => (acc ? acc[key] : undefined), colors),
+    }),
+  };
+});
+
+jest.mock('@/components/BannerFormModal', () => () => null);
+jest.mock('@features/cart', () => ({ CartModal: () => null }));
+jest.mock('@features/products', () => ({
+  ProductFormModal: () => null,
+  ProductCard: () => null,
+  ProductCardSkeleton: () => null,
+}));
+jest.mock('@/components/InfoModal', () => () => null);
+jest.mock('@/components/SmartImage', () => () => null);
+
+jest.mock('@/features/home/hooks/useHome', () => ({
+  useHome: () => ({
+    products: [],
+    categories: [],
+    loading: false,
+    refreshing: false,
+    error: null,
+    refresh: jest.fn(),
+    upsertProduct: jest.fn(),
+    removeProduct: jest.fn(),
+  }),
+}));
+
+jest.mock('@/features/home/hooks/useHomeBanners', () => ({
+  useHomeBanners: () => ({
+    heroBanners: [],
+    loading: false,
+    refreshing: false,
+    error: null,
+    refresh: jest.fn(),
+    upsertBanner: jest.fn(),
+    removeBanner: jest.fn(),
+  }),
+}));
+
+jest.mock('@/features/home/hooks/useHomeFilters', () => ({
+  useHomeFilters: () => ({
+    filteredProducts: [],
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    selectedCategory: null,
+    setSelectedCategory: jest.fn(),
+    minPrice: '',
+    setMinPrice: jest.fn(),
+    maxPrice: '',
+    setMaxPrice: jest.fn(),
+    sortBy: 'newest',
+    setSortBy: jest.fn(),
+    showSortModal: false,
+    setShowSortModal: jest.fn(),
+  }),
+}));
+
+describe('HomeScreen render', () => {
+  it('uses fallback data when hooks return empty', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<HomeScreen />);
+    });
+    await act(async () => {});
+    const tree = root!.toJSON();
+    const str = JSON.stringify(tree);
+    expect(str).toContain('categories.electronics');
+    expect(str).toContain('Min');
+    expect(str).toContain('home.fallbackBanner1Title');
+    expect(str).toContain('home.noProducts');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add homeScreenRender test verifying fallback category chips, price range, banners, and product grid empty state
- include new test in jest config

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest tests/homeScreenRender.test.tsx` *(fails: ReferenceError: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bf625f469c8326930a8ca270bf61a4