### PR TITLE
Wrap HomeScreen with ErrorBoundary

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -33,6 +33,7 @@ import { useHomeFilters, SortOption } from '@/features/home/hooks/useHomeFilters
 import { spacing } from '@/shared/ui/tokens';
 import { ScrollArea, Container, Stack } from '@/ui/layout';
 import { routes } from '@/utils/routes';
+import ErrorBoundary from 'src/shared/ErrorBoundary';
 
 
 function HomeScreenContent() {
@@ -421,9 +422,11 @@ function HomeScreenContent() {
 
 export default function HomeScreen() {
   return (
-    <Suspense fallback={<Spinner />}>
-      <HomeScreenContent />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback={<Spinner />}>
+        <HomeScreenContent />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap HomeScreen in an ErrorBoundary to gracefully handle runtime errors

## Testing
- `yarn jest tests/homeErrorBoundary.test.tsx` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf625e7fe08326a0521ae2a3a19789