### PR TITLE
feat: surface home refresh errors

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useCallback } from 'react';
 import {
   View,
   Text,
@@ -94,10 +94,10 @@ function HomeScreenContent() {
     setShowSortModal,
   } = useHomeFilters(products);
 
-  const handleReload = () => {
+  const handleReload = useCallback(() => {
     closeInfoModal();
     refresh();
-  };
+  }, [closeInfoModal, refresh]);
 
   if (error) {
     return (

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -38,11 +38,19 @@ export function useHome() {
 
   const refresh = useCallback(async () => {
     try {
-      await Promise.all([productsQuery.refetch(), categoriesQuery.refetch()]);
-      setError(null);
+      const [productsRes, categoriesRes] = await Promise.all([
+        productsQuery.refetch(),
+        categoriesQuery.refetch(),
+      ]);
+      const err = (productsRes.error || categoriesRes.error) as Error | null;
+      setError(err);
+      if (err) {
+        errorLog('useHome refresh failed', err);
+      }
     } catch (err) {
-      setError(err as Error);
-      errorLog('useHome refresh failed', err);
+      const error = err as Error;
+      setError(error);
+      errorLog('useHome refresh failed', error);
     }
   }, [productsQuery, categoriesQuery]);
 

--- a/src/features/home/hooks/useHomeBanners.ts
+++ b/src/features/home/hooks/useHomeBanners.ts
@@ -31,6 +31,7 @@ export function useHomeBanners() {
   useEffect(() => {
     if (queryError) {
       setError(queryError as Error);
+      errorLog('useHomeBanners initial load failed', queryError);
     }
   }, [queryError]);
 
@@ -41,7 +42,12 @@ export function useHomeBanners() {
       if (res.data) {
         setHeroBanners(res.data);
       }
-      setError(null);
+      if (res.error) {
+        errorLog('useHomeBanners refresh failed', res.error);
+        setError(res.error as Error);
+      } else {
+        setError(null);
+      }
     } catch (err) {
       errorLog('useHomeBanners refresh failed', err);
       setError(err as Error);

--- a/src/features/home/hooks/useHomeRefresh.ts
+++ b/src/features/home/hooks/useHomeRefresh.ts
@@ -10,7 +10,7 @@ export function useHomeRefresh(
   const refresh = useCallback(async () => {
     await Promise.all([data.refresh(), banners.refresh()]);
   }, [data, banners]);
-  const error = data.error || banners.error;
+  const error = data.error ?? banners.error;
   return { refreshing, refresh, error } as const;
 }
 


### PR DESCRIPTION
## Summary
- handle errors in home queries and refresh logic
- expose combined error from home data and banners
- show retryable empty state when home data fails

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Object literal may only specify known properties, and 'suspense' does not exist in type 'UseQueryOptions...')*


------
https://chatgpt.com/codex/tasks/task_e_68bf7d1b73b8832697ca2d058cfb9e5e