### PR TITLE
refactor: schedule banner rotation after scroll

### DIFF
--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -47,22 +47,41 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
   const { push } = useAppRouter();
   const bannerScrollRef = useRef<FlatList<HeroBanner>>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const rotationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rotateRef = useRef<() => void>();
 
   useEffect(() => {
-    if (heroBanners.length > 1) {
-      const bannerInterval = setInterval(() => {
-        setCurrentIndex((prevIndex) => {
-          const nextIndex = (prevIndex + 1) % heroBanners.length;
-          bannerScrollRef.current?.scrollToOffset({
-            offset: nextIndex * (width - 32),
-            animated: true,
-          });
-          return nextIndex;
+    rotateRef.current = () => {
+      setCurrentIndex((prevIndex) => {
+        const nextIndex = (prevIndex + 1) % heroBanners.length;
+        bannerScrollRef.current?.scrollToOffset({
+          offset: nextIndex * (width - 32),
+          animated: true,
         });
+        return nextIndex;
+      });
+    };
+  }, [heroBanners.length]);
+
+  const scheduleNextRotation = useCallback(() => {
+    if (heroBanners.length > 1) {
+      if (rotationTimeoutRef.current) {
+        clearTimeout(rotationTimeoutRef.current);
+      }
+      rotationTimeoutRef.current = setTimeout(() => {
+        rotateRef.current?.();
       }, 5000);
-      return () => clearInterval(bannerInterval);
     }
   }, [heroBanners.length]);
+
+  useEffect(() => {
+    scheduleNextRotation();
+    return () => {
+      if (rotationTimeoutRef.current) {
+        clearTimeout(rotationTimeoutRef.current);
+      }
+    };
+  }, [scheduleNextRotation]);
   const renderBanner = useCallback(
     ({ item }: { item: HeroBanner }) => (
       <View style={styles.heroBanner}>
@@ -140,8 +159,9 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       const newIndex = Math.round(event.nativeEvent.contentOffset.x / (width - 32));
       setCurrentIndex(newIndex);
+      scheduleNextRotation();
     },
-    []
+    [scheduleNextRotation]
   );
 
   if (loading) {


### PR DESCRIPTION
## Summary
- replace setInterval with timeout-based rotation in `BannerArea`
- reset banner rotation once scrolling completes

## Testing
- `yarn lint src/features/home/components/BannerArea.tsx`
- `yarn typecheck` *(fails: Object literal may only specify known properties, and 'suspense' does not exist in type 'UseQueryOptions'...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ea34e4c8326974a38624e4e25bb