### PR TITLE
Handle profile and reviews load errors

### DIFF
--- a/app/profile.tsx
+++ b/app/profile.tsx
@@ -35,6 +35,7 @@ import { useAuthModal } from '@/features/auth/AuthModalContext';
 import { useProfileData } from '@/services';
 import { routes } from '@/utils/routes';
 import { spacing } from '@/shared/ui/tokens';
+import EmptyState from '@/shared/ui/EmptyState';
 
 
 
@@ -53,7 +54,7 @@ export default function ProfileScreen() {
   const scrollViewRef = useRef<ScrollView>(null);
   const { openAuthModal } = useAuthModal();
   const { push, replace } = useAppRouter();
-  const { ordersCount, wishlistCount, reviewCount, storeId } = useProfileData(user);
+  const { ordersCount, wishlistCount, reviewCount, storeId, error } = useProfileData(user);
 
   // Modal states
   const [infoModal, setInfoModal] = useState({
@@ -247,7 +248,13 @@ export default function ProfileScreen() {
         {/* Admin Menu or Create Store CTA */}
         {isLoggedIn && (
           <View style={styles.section}>
-            {isStoreOwner && storeId ? (
+            {error ? (
+              <EmptyState
+                icon={AlertTriangle}
+                title={t('common.error')}
+                message={error.message}
+              />
+            ) : isStoreOwner && storeId ? (
               <>
                 <Text style={[styles.sectionTitle, { color: colors.text.primary }]}> 
                   {t('profile.management')}

--- a/app/reviews/index.tsx
+++ b/app/reviews/index.tsx
@@ -60,11 +60,19 @@ export default function ReviewsScreen() {
   };
 
   // Modal states
-  const [infoModal, setInfoModal] = useState({
+  const [infoModal, setInfoModal] = useState<{
+    visible: boolean;
+    title: string;
+    message: string;
+    type: 'success' | 'error' | 'info' | 'warning';
+    buttonText?: string;
+    onClose?: () => void;
+    autoClose?: boolean;
+  }>({
     visible: false,
     title: '',
     message: '',
-    type: 'info' as 'success' | 'error' | 'info' | 'warning'
+    type: 'info',
   });
 
   // Confirmation modal for delete
@@ -95,11 +103,15 @@ export default function ReviewsScreen() {
       }
     } catch (error) {
       errorLog('Error loading reviews:', error);
+      const message = error instanceof Error ? error.message : 'טעינת הביקורות נכשלה';
       setInfoModal({
         visible: true,
         title: 'שגיאה',
-        message: 'טעינת הביקורות נכשלה',
-        type: 'error'
+        message,
+        type: 'error',
+        buttonText: 'נסה שוב',
+        autoClose: false,
+        onClose: () => loadData(),
       });
     } finally {
       setLoading(false);
@@ -852,7 +864,13 @@ export default function ReviewsScreen() {
         title={infoModal.title}
         message={infoModal.message}
         type={infoModal.type}
-        onClose={() => setInfoModal({...infoModal, visible: false})}
+        buttonText={infoModal.buttonText}
+        autoClose={infoModal.autoClose}
+        onClose={() => {
+          const callback = infoModal.onClose;
+          setInfoModal(prev => ({ ...prev, visible: false }));
+          callback?.();
+        }}
       />
 
       {/* Delete Confirmation Modal */}

--- a/src/services/useProfileData.ts
+++ b/src/services/useProfileData.ts
@@ -16,6 +16,7 @@ export function useProfileData(user?: User | null) {
   const [wishlistCount, setWishlistCount] = useState(0);
   const [reviewCount, setReviewCount] = useState(0);
   const [storeId, setStoreId] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -46,14 +47,16 @@ export function useProfileData(user?: User | null) {
         const stores = await listStores();
         const store = stores.find((s: any) => s.owner === user.address);
         if (store) setStoreId(store.id);
+        setError(null);
       } catch (err) {
         errorLog('Failed to load store for user', err);
+        setError(err instanceof Error ? err : new Error('Failed to load store'));
       }
     };
     loadStore();
   }, [user?.address]);
 
-  return { ordersCount, wishlistCount, reviewCount, storeId };
+  return { ordersCount, wishlistCount, reviewCount, storeId, error };
 }
 
 export default useProfileData;


### PR DESCRIPTION
## Summary
- show InfoModal with error and retry when review loading fails
- surface store-loading errors in useProfileData
- display an EmptyState on profile page when store details fail to load

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: TS2769 No overload matches this call)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ea2460c8326bc74b8e77cc76f03