### PR TITLE
Avoid redundant navigation pushes

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -34,6 +34,7 @@ import { spacing } from '@/shared/ui/tokens';
 import { ScrollArea, Container, Stack } from '@/ui/layout';
 import { routes } from '@/utils/routes';
 import ErrorBoundary from 'src/shared/ErrorBoundary';
+import { usePathname } from 'expo-router';
 
 
 function HomeScreenContent() {
@@ -59,6 +60,7 @@ function HomeScreenContent() {
   const { isStoreOwner } = useAuth();
   const { t } = useLanguage();
   const { colors: themeColors } = useTheme();
+  const pathname = usePathname();
 
   const {
     products,
@@ -153,10 +155,13 @@ function HomeScreenContent() {
   };
 
   const renderCategory = ({ item }: { item: Category }) => (
-    <TouchableOpacity
-      style={[styles.categoryCard]}
-      onPress={() => push(routes.category(item.id))}
-    >
+      <TouchableOpacity
+        style={[styles.categoryCard]}
+        onPress={() => {
+          const dest = routes.category(item.id);
+          if (pathname !== dest) push(dest);
+        }}
+      >
       <View
         style={[
           styles.categoryIcon,
@@ -173,16 +178,19 @@ function HomeScreenContent() {
       </Text>
       {isStoreOwner && (
         <View style={styles.categoryAdminActions}>
-          <TouchableOpacity
-            style={[
-              styles.categoryAdminButton,
-              {
-                backgroundColor: themeColors.background,
-                borderColor: themeColors.gold,
-              },
-            ]}
-            onPress={() => push(routes.category(item.id))}
-          >
+            <TouchableOpacity
+              style={[
+                styles.categoryAdminButton,
+                {
+                  backgroundColor: themeColors.background,
+                  borderColor: themeColors.gold,
+                },
+              ]}
+              onPress={() => {
+                const dest = routes.category(item.id);
+                if (pathname !== dest) push(dest);
+              }}
+            >
             <Pencil size={10} color={themeColors.gold} />
           </TouchableOpacity>
         </View>
@@ -252,7 +260,11 @@ function HomeScreenContent() {
             <Text style={[styles.sectionTitle, { color: themeColors.text.primary }]}>
               {t('home.categories')}
             </Text>
-            <TouchableOpacity onPress={() => push('/categories')}>
+              <TouchableOpacity
+                onPress={() => {
+                  if (pathname !== '/categories') push('/categories');
+                }}
+              >
               <Text style={[styles.seeAll, { color: themeColors.gold }]}>
                 {t('common.viewAll')}
               </Text>

--- a/app/orders/index.tsx
+++ b/app/orders/index.tsx
@@ -19,6 +19,7 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useCurrency } from '../../contexts/CurrencyContext';
 import { useOrders } from '@/services';
 import { requireEnv } from '@/services/config';
+import { usePathname } from 'expo-router';
 
 const OrderItem = React.memo(({ item }: { item: CartItem }) => {
   const { t } = useLanguage();
@@ -45,6 +46,7 @@ export default function OrdersScreen() {
   const { t, currentLanguage } = useLanguage();
   const { currencySymbol } = useCurrency();
   const { push, back } = useAppRouter();
+  const pathname = usePathname();
   const storeEnv = 'expo_public_default_store'.toUpperCase();
   const storeId = requireEnv(storeEnv, 'default');
   const { data: orders = [], refetch } = useOrders(storeId);
@@ -188,7 +190,9 @@ export default function OrdersScreen() {
         title={t('orders.emptyTitle') as string}
         message={t('orders.emptyMessage') as string}
         actionText={t('orders.shopNow') as string}
-        onAction={() => push('/')}
+        onAction={() => {
+          if (pathname !== '/') push('/');
+        }}
       />
     ) : (
       <EmptyState

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -11,6 +11,7 @@ import { useRoadmap } from '../contexts/RoadmapContext';
 import UserAvatar from './UserAvatar';
 import { WishlistModal, useWishlistCount } from '@/features/cart';
 import { spacing, radius, typography } from '@/ui/tokens';
+import { usePathname } from 'expo-router';
 
 interface GlobalHeaderProps {
   searchQuery?: string;
@@ -30,9 +31,12 @@ export default function GlobalHeader({
   const { push } = useAppRouter();
   const [showWishlistModal, setShowWishlistModal] = useState(false);
   const wishlistItemsCount = useWishlistCount();
+  const pathname = usePathname();
 
   const navigateToReviews = () => {
-    push('/reviews');
+    if (pathname !== '/reviews') {
+      push('/reviews');
+    }
   };
 
   return (
@@ -41,7 +45,9 @@ export default function GlobalHeader({
         <View style={styles.headerTop}>
           <Pressable
             style={styles.logo}
-            onPress={() => push('/')}
+            onPress={() => {
+              if (pathname !== '/') push('/');
+            }}
           >
             {logoCid ? (
               <SmartImage uri={logoCid} width={50} height={50} style={styles.logoImage} contentFit="contain" />

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -7,6 +7,7 @@ import { useAppRouter } from '@/services';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { Menu, Avatar, type MenuItem } from '@/ui';
+import { usePathname } from 'expo-router';
 
 export default function UserAvatar() {
   const { isLoggedIn, user, logout } = useAuth();
@@ -16,6 +17,7 @@ export default function UserAvatar() {
   const { push, replace } = useAppRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [logoutConfirmVisible, setLogoutConfirmVisible] = useState(false);
+  const pathname = usePathname();
 
   const getInitials = () => {
     if (!user?.displayName && !user?.username) return 'G';
@@ -37,7 +39,9 @@ export default function UserAvatar() {
 
   const handleProfile = () => {
     setMenuOpen(false);
-    push('/profile');
+    if (pathname !== '/profile') {
+      push('/profile');
+    }
   };
 
   const handleLogin = () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,7 @@ module.exports = {
     '<rootDir>/tests/signupLogic.test.ts',
     '<rootDir>/tests/nearKvPersistence.test.ts',
     '<rootDir>/tests/homeScreenRender.test.tsx',
+    '<rootDir>/tests/navigationLoop.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/src/features/home/components/BannerArea.tsx
+++ b/src/features/home/components/BannerArea.tsx
@@ -25,6 +25,7 @@ import EmptyState from '@/shared/ui/EmptyState';
 import { Spinner, Skeleton, Text, Heading, Button } from '@/ui';
 import { spacing, radius, typography } from '@/ui/tokens';
 import { routes } from '@/utils/routes';
+import { usePathname } from 'expo-router';
 
 
 const SmartImage = lazy(() => import('@/components/SmartImage'));
@@ -45,6 +46,7 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { push } = useAppRouter();
+  const pathname = usePathname();
   const bannerScrollRef = useRef<FlatList<HeroBanner>>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -68,7 +70,10 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
       <View style={styles.heroBanner}>
         <TouchableOpacity
           style={styles.bannerTouchable}
-          onPress={() => push(routes.category(item.category))}
+          onPress={() => {
+            const dest = routes.category(item.category);
+            if (pathname !== dest) push(dest);
+          }}
         >
           <Suspense fallback={<Spinner />}>
             <SmartImage
@@ -131,7 +136,7 @@ function BannerArea({ heroBanners, isStoreOwner, onAddBanner, onEditBanner, load
         )}
       </View>
     ),
-    [colors, isStoreOwner, onEditBanner, push, t]
+    [colors, isStoreOwner, onEditBanner, pathname, push, t]
   );
 
   const keyExtractor = useCallback((item: HeroBanner) => item.id, []);

--- a/src/features/home/components/CTABecomeSeller.tsx
+++ b/src/features/home/components/CTABecomeSeller.tsx
@@ -3,15 +3,17 @@ import { StyleSheet } from 'react-native';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import { Button } from '@/ui';
+import { usePathname } from 'expo-router';
 
 export default function CTABecomeSeller() {
   const { t } = useLanguage();
   const { push } = useAppRouter();
+  const pathname = usePathname();
 
   return (
     <Button
       title={t('home.becomeSeller')}
-      onPress={() => push('/stores/create')}
+      onPress={() => pathname !== '/stores/create' && push('/stores/create')}
       accessibilityRole="link"
       style={styles.button}
     />

--- a/tests/navigationLoop.test.tsx
+++ b/tests/navigationLoop.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import GlobalHeader from '@/components/GlobalHeader';
+import { Pressable } from 'react-native';
+
+const pushMock = jest.fn();
+const usePathnameMock = jest.fn();
+
+jest.mock('@/services', () => ({
+  useAppRouter: () => ({ push: pushMock })
+}));
+
+jest.mock('expo-router', () => ({
+  usePathname: () => usePathnameMock()
+}));
+
+jest.mock('@/contexts/AppInfoContext', () => ({
+  useAppInfo: () => ({ appName: 'Blue', logoCid: null })
+}));
+
+jest.mock('@/contexts/RoadmapContext', () => ({
+  useRoadmap: () => ({ progress: 0 })
+}));
+
+jest.mock('@/features/cart', () => ({
+  WishlistModal: () => null,
+  useWishlistCount: () => 0
+}));
+
+jest.mock('@/components/SmartImage', () => () => null);
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => ({ t: (s: string) => s }),
+  useTheme: () => ({ colors: { background: '#fff', surface: { primary: '#fff' }, text: { primary: '#000', inverse: '#fff' }, gold: '#FFD700', border: { primary: '#000' } } })
+}));
+
+jest.mock('@/ui', () => {
+  const React = require('react');
+  const { Pressable, Text } = require('react-native');
+  return {
+    Text,
+    Button: ({ onPress, children }: any) => React.createElement(Pressable, { onPress }, children),
+  };
+});
+
+describe('navigation loop prevention', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+  });
+
+  it('does not push to current path', () => {
+    usePathnameMock.mockReturnValue('/');
+    const tree = renderer.create(React.createElement(GlobalHeader));
+    const pressables = tree.root.findAllByType(Pressable);
+    pressables[0].props.onPress();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('avoids pushing reviews when already there', () => {
+    usePathnameMock.mockReturnValue('/reviews');
+    const tree = renderer.create(React.createElement(GlobalHeader));
+    const pressables = tree.root.findAllByType(Pressable);
+    pressables[1].props.onPress();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard navigation calls with pathname checks to prevent pushing the current route
- test GlobalHeader to ensure repeated `push` isn't triggered

## Testing
- `npx jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ea0b2f48326addda3d67c46c986