### PR TITLE
Ensure ScrollArea fills viewport

### DIFF
--- a/src/ui/layout/ScrollArea.tsx
+++ b/src/ui/layout/ScrollArea.tsx
@@ -17,10 +17,11 @@ export default function ScrollArea({
 }: ScrollAreaProps) {
   return (
     <ScrollView
-      style={[backgroundColor ? { backgroundColor } : null, style]}
+      style={[backgroundColor ? { backgroundColor } : null, { flex: 1 }, style]}
       {...rest}
       contentContainerStyle={[
         padding ? { padding: spacing[padding] } : null,
+        { flexGrow: 1 },
         contentContainerStyle,
       ]}
     >


### PR DESCRIPTION
## Summary
- make ScrollArea expand to full size by default
- allow children to grow to viewport height via flexGrow

## Testing
- `yarn lint src/ui/layout/ScrollArea.tsx`
- `yarn typecheck` *(fails: Object literal may only specify known properties...)*
- `npx jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf85a64a6c8326b4c4c8d7b5568dea