### PR TITLE
Ensure light theme text contrasts canvas

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -52,6 +52,7 @@ module.exports = {
     '<rootDir>/tests/homeScreenRender.test.tsx',
     '<rootDir>/tests/homeFallbackVisibility.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
+    '<rootDir>/tests/themeContrast.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/src/ui/ThemeProvider.tsx
+++ b/src/ui/ThemeProvider.tsx
@@ -88,23 +88,34 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   const applyTheme = (mode: ThemeMode, color: string) => {
     const base = mode === 'light' ? lightTokens : darkTokens;
-    setCurrentTokens(prev => ({
-      ...prev,
-      ...base,
-      colors: {
-        ...prev.colors,
-        ...base.colors,
-        gold: color,
-        interactive: {
-          ...base.colors.interactive,
-          ...prev.colors.interactive,
-          primary: color,
-          primaryHover: color,
+    setCurrentTokens(prev => {
+      const nextTokens = {
+        ...prev,
+        ...base,
+        colors: {
+          ...prev.colors,
+          ...base.colors,
+          gold: color,
+          interactive: {
+            ...base.colors.interactive,
+            ...prev.colors.interactive,
+            primary: color,
+            primaryHover: color,
+          },
+          tabBar: { ...base.colors.tabBar, ...prev.colors.tabBar, active: color },
+          border: { ...base.colors.border, ...prev.colors.border, focus: color },
         },
-        tabBar: { ...base.colors.tabBar, ...prev.colors.tabBar, active: color },
-        border: { ...base.colors.border, ...prev.colors.border, focus: color },
-      },
-    }));
+      };
+
+      if (nextTokens.colors.text.primary === nextTokens.colors.canvas) {
+        nextTokens.colors.text = {
+          ...nextTokens.colors.text,
+          primary: '#1A1A1A',
+        };
+      }
+
+      return nextTokens;
+    });
   };
 
   const setTheme = useCallback(

--- a/tests/themeContrast.test.tsx
+++ b/tests/themeContrast.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { ThemeProvider, useTheme } from '@/ui/ThemeProvider';
+
+describe('theme contrast', () => {
+  it('uses distinct text and canvas colors in light mode', async () => {
+    let colorsRef: any;
+    let setThemeRef: any;
+
+    const Capture = () => {
+      const { colors, setTheme } = useTheme();
+      colorsRef = colors;
+      setThemeRef = setTheme;
+      return null;
+    };
+
+    renderer.create(React.createElement(ThemeProvider, null, React.createElement(Capture)));
+
+    await act(async () => {
+      await setThemeRef('light');
+    });
+
+    expect(colorsRef.text.primary).not.toBe(colorsRef.canvas);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent text color from matching canvas, defaulting to `#1A1A1A` if necessary
- test light theme to ensure `text.primary` differs from `canvas`

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/themeContrast.test.tsx` *(fails: SyntaxError: Unexpected token '<')*

------
https://chatgpt.com/codex/tasks/task_e_68bfa0c3ea048326b184548d3d0bb7d3