### PR TITLE
Warn on missing translations and default to English on load errors

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,11 +1,26 @@
 import enTranslations from '@/translations/en.json';
 
+// Current translation table. Defaults to English.
+let translations: Record<string, any> = enTranslations;
+
+/**
+ * Override the active translation dictionary.
+ */
+export const setTranslations = (dict: Record<string, any>) => {
+  translations = dict;
+};
+
+/**
+ * Translate a key using the active translation dictionary. If the key is not
+ * found, a console warning is emitted and the key itself is returned so
+ * developers can easily spot missing translations.
+ */
 export let t = (
   key: string,
   options?: Record<string, string | number> | string,
 ): string => {
   const keys = key.split('.');
-  let value: any = enTranslations;
+  let value: any = translations;
   for (const k of keys) {
     value = value?.[k];
   }
@@ -15,6 +30,7 @@ export let t = (
     }
     return value;
   }
+  console.warn(`Missing translation for key: ${key}`);
   return typeof options === 'string' ? options : key;
 };
 

--- a/src/ui/ThemeProvider.tsx
+++ b/src/ui/ThemeProvider.tsx
@@ -14,7 +14,7 @@ import { useAppInfo } from '@/contexts/AppInfoContext';
 import { configureRTL } from '@/utils/rtl';
 import enTranslations from '@/translations/en.json';
 import heTranslations from '@/translations/he.json';
-import { setT, t as defaultT } from '@/i18n';
+import { setT, t as defaultT, setTranslations as setGlobalTranslations } from '@/i18n';
 
 // -----------------
 // Theme context
@@ -169,7 +169,7 @@ const LANGUAGE_STORAGE_KEY = 'app_language';
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
   const [currentLanguage, setCurrentLanguage] = useState<Language>('he');
-  const [translations, setTranslations] = useState(heTranslations);
+  const [translations, setTranslationsState] = useState(heTranslations);
   const [isRTL, setIsRTL] = useState(true);
 
   useEffect(() => {
@@ -196,19 +196,24 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     try {
       setCurrentLanguage(language);
 
-      if (language === 'en') {
-        setTranslations(enTranslations);
-        setIsRTL(false);
-      } else {
-        setTranslations(heTranslations);
-        setIsRTL(true);
-      }
-      configureRTL(language === 'he');
+      // Attempt to clone the translation object; if the JSON is malformed this
+      // will throw and be caught below.
+      const raw = language === 'en' ? enTranslations : heTranslations;
+      const parsed = JSON.parse(JSON.stringify(raw));
 
+      setTranslationsState(parsed);
+      setGlobalTranslations(parsed);
+      const rtl = language === 'he';
+      setIsRTL(rtl);
+      configureRTL(rtl);
       await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, language);
     } catch (error) {
+      // Any IO or JSON parse errors default the app back to English so the UI
+      // remains usable.
       errorLog(error);
-      setTranslations(enTranslations);
+      const fallback = JSON.parse(JSON.stringify(enTranslations));
+      setTranslationsState(fallback);
+      setGlobalTranslations(fallback);
       setIsRTL(false);
       setCurrentLanguage('en');
       configureRTL(false);
@@ -254,6 +259,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       return value;
     }
 
+    console.warn(`Missing translation for key: ${key}`);
     return fallback || key;
   };
 

--- a/tests/missingTranslation.test.ts
+++ b/tests/missingTranslation.test.ts
@@ -1,0 +1,18 @@
+import { t, setTranslations } from '@/i18n';
+import enTranslations from '@/translations/en.json';
+
+describe('missing translation fallback', () => {
+  afterEach(() => {
+    // Restore English translations after each test to avoid side effects
+    setTranslations(enTranslations);
+  });
+
+  it('warns and returns the key when a translation is missing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    setTranslations({});
+    const result = t('categories.electronics');
+    expect(result).toBe('categories.electronics');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('categories.electronics'));
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add global `setTranslations` helper and log when translation keys are missing
- guard `setLanguage` against JSON/IO issues and fall back to English strings
- test missing translations return key and emit a warning

## Testing
- `npx jest --runTestsByPath tests/missingTranslation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfa0c5e1908326a267583fe25ac9cc