### PR TITLE
Track last home errors and retest modal

### DIFF
--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -1,9 +1,9 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Product, Category } from '@/types';
 import { useProducts } from '@/services/useProducts';
 import { useCategories } from '@/services/useCategories';
 import { requireEnv } from '@/services/config';
-import { errorLog } from '@/utils/logger';
+import { errorLog, debugLog } from '@/utils/logger';
 
 export function useHome() {
   const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');
@@ -12,9 +12,8 @@ export function useHome() {
 
   const [products, setProducts] = useState<Product[]>(productsQuery.data ?? []);
   const [categories, setCategories] = useState<Category[]>(categoriesQuery.data ?? []);
-  const [error, setError] = useState<Error | null>(
-    (productsQuery.error || categoriesQuery.error) as Error | null,
-  );
+  const [error, setError] = useState<Error | null>(null);
+  const lastErrorRef = useRef<Error | null>(null);
 
   useEffect(() => {
     if (productsQuery.data) {
@@ -31,7 +30,11 @@ export function useHome() {
   useEffect(() => {
     if (productsQuery.error || categoriesQuery.error) {
       const err = (productsQuery.error || categoriesQuery.error) as Error;
-      setError(err);
+      if (lastErrorRef.current !== err) {
+        lastErrorRef.current = err;
+        setError(err);
+      }
+      debugLog('useHome initial load failed', err);
       errorLog('useHome initial load failed', err);
     }
   }, [productsQuery.error, categoriesQuery.error]);
@@ -43,13 +46,24 @@ export function useHome() {
         categoriesQuery.refetch(),
       ]);
       const err = (productsRes.error || categoriesRes.error) as Error | null;
-      setError(err);
       if (err) {
+        if (lastErrorRef.current !== err) {
+          lastErrorRef.current = err;
+          setError(err);
+        }
+        debugLog('useHome refresh failed', err);
         errorLog('useHome refresh failed', err);
+      } else {
+        lastErrorRef.current = null;
+        setError(null);
       }
     } catch (err) {
       const error = err as Error;
-      setError(error);
+      if (lastErrorRef.current !== error) {
+        lastErrorRef.current = error;
+        setError(error);
+      }
+      debugLog('useHome refresh failed', error);
       errorLog('useHome refresh failed', error);
     }
   }, [productsQuery, categoriesQuery]);

--- a/src/features/home/hooks/useHomeBanners.ts
+++ b/src/features/home/hooks/useHomeBanners.ts
@@ -1,8 +1,8 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import { HeroBanner } from '@/types';
-import { errorLog } from '@/utils/logger';
+import { errorLog, debugLog } from '@/utils/logger';
 
 export function useHomeBanners() {
   const { data, refetch, isLoading, error: queryError } = useQuery({
@@ -12,6 +12,7 @@ export function useHomeBanners() {
         const db = DatabaseService.getInstance();
         return await db.getHeroBanners();
       } catch (err) {
+        debugLog('useHomeBanners query failed', err);
         errorLog('useHomeBanners query failed', err);
         throw err;
       }
@@ -26,11 +27,16 @@ export function useHomeBanners() {
     }
   }, [data]);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<Error | null>(queryError ?? null);
+  const [error, setError] = useState<Error | null>(null);
+  const lastErrorRef = useRef<Error | null>(null);
 
   useEffect(() => {
     if (queryError) {
-      setError(queryError as Error);
+      if (lastErrorRef.current !== queryError) {
+        lastErrorRef.current = queryError as Error;
+        setError(queryError as Error);
+      }
+      debugLog('useHomeBanners initial load failed', queryError);
       errorLog('useHomeBanners initial load failed', queryError);
     }
   }, [queryError]);
@@ -42,15 +48,26 @@ export function useHomeBanners() {
       if (res.data) {
         setHeroBanners(res.data);
       }
-      if (res.error) {
-        errorLog('useHomeBanners refresh failed', res.error);
-        setError(res.error as Error);
+      const err = res.error as Error | null;
+      if (err) {
+        if (lastErrorRef.current !== err) {
+          lastErrorRef.current = err;
+          setError(err);
+        }
+        debugLog('useHomeBanners refresh failed', err);
+        errorLog('useHomeBanners refresh failed', err);
       } else {
+        lastErrorRef.current = null;
         setError(null);
       }
     } catch (err) {
-      errorLog('useHomeBanners refresh failed', err);
-      setError(err as Error);
+      const error = err as Error;
+      if (lastErrorRef.current !== error) {
+        lastErrorRef.current = error;
+        setError(error);
+      }
+      debugLog('useHomeBanners refresh failed', error);
+      errorLog('useHomeBanners refresh failed', error);
     } finally {
       setRefreshing(false);
     }

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -3,6 +3,8 @@ import renderer from 'react-test-renderer';
 import { Text } from 'react-native';
 import HomeScreen from '@app/index';
 
+const InfoModalMock: jest.Mock = jest.fn();
+
 jest.mock('@/services', () => ({
   useAppRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
 }));
@@ -24,10 +26,14 @@ jest.mock('@/ui/ThemeProvider', () => ({
   useLanguage: () => ({ t: (s: string) => s }),
   useTheme: () => ({ colors: { background: '#fff', text: { primary: '#000', secondary: '#333' } } }),
 }));
+let homeHeaderThrows = true;
 jest.mock('@features/home/components/HomeHeader', () => {
   const React = require('react');
   return () => {
-    throw new Error('boom');
+    if (homeHeaderThrows) {
+      throw new Error('boom');
+    }
+    return null;
   };
 });
 jest.mock('@features/home/components/CategoryChips', () => () => null);
@@ -38,23 +44,37 @@ jest.mock('@/components/BannerFormModal', () => () => null);
 jest.mock('@features/cart', () => ({ CartModal: () => null }));
 jest.mock('@features/products', () => ({ ProductFormModal: () => null }));
 jest.mock('@/components/SmartImage', () => () => null);
-jest.mock('@/components/InfoModal', () => () => null);
+jest.mock('@/components/InfoModal', () => (props: any) => {
+  InfoModalMock(props);
+  return null;
+});
 jest.mock('@/services/database', () => ({}));
 jest.mock('@/services/chain', () => 'near');
 jest.mock('@features/products/services/nearCategories', () => ({
   listCategories: jest.fn().mockResolvedValue([]),
 }));
-jest.mock('@features/home/hooks/useHome', () => ({
-  useHome: () => ({
-    products: [],
-    categories: [],
-    refreshing: false,
-    refresh: jest.fn(),
-    upsertProduct: jest.fn(),
-    removeProduct: jest.fn(),
-    error: null,
-  }),
-}));
+let homeErrorList: (Error | null)[] = [null];
+jest.mock('@features/home/hooks/useHome', () => {
+  const React = require('react');
+  return {
+    useHome: () => {
+      const [index, setIndex] = React.useState(0);
+      const refresh = () => {
+        setIndex((i: number) => Math.min(i + 1, homeErrorList.length - 1));
+        return Promise.resolve();
+      };
+      return {
+        products: [],
+        categories: [],
+        refreshing: false,
+        refresh,
+        upsertProduct: jest.fn(),
+        removeProduct: jest.fn(),
+        error: homeErrorList[index],
+      };
+    },
+  };
+});
 jest.mock('@features/home/hooks/useHomeBanners', () => ({
   useHomeBanners: () => ({
     heroBanners: [],
@@ -85,6 +105,8 @@ jest.mock('@features/home/hooks/useHomeFilters', () => ({
 
 describe('HomeScreen error handling', () => {
   it('shows fallback and keeps app shell when child throws', () => {
+    homeHeaderThrows = true;
+    homeErrorList = [null];
     const App = () => (
       <>
         <HomeScreen />
@@ -97,5 +119,21 @@ describe('HomeScreen error handling', () => {
     expect(str).toContain('Something went wrong');
     expect(str).toContain('App shell');
     expect(str).toContain('Retry');
+  });
+
+  it('reopens InfoModal when a new error occurs', async () => {
+    homeHeaderThrows = false;
+    homeErrorList = [new Error('first'), new Error('second')];
+    InfoModalMock.mockClear();
+    renderer.create(<HomeScreen />);
+    const firstCall = InfoModalMock.mock.calls[0] as any[];
+    expect(firstCall[0].visible).toBe(true);
+    await renderer.act(async () => {
+      firstCall[0].onClose();
+    });
+    const visibilities = (InfoModalMock.mock.calls as any[]).map(
+      (c: any[]) => c[0].visible,
+    );
+    expect(visibilities).toEqual([true, false, true]);
   });
 });


### PR DESCRIPTION
## Summary
- store last errors in refs for home data and banners to re-trigger InfoModal on new failures
- log debug info for home hooks to expose errors during development
- add regression test to ensure InfoModal reopens on repeated errors

## Testing
- `npx jest --config jest.config.js --testMatch '**/homeErrorBoundary.test.tsx'` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa0c77a9c8326a223f072267bf30d