### PR TITLE
Avoid event argument in Add Product press handler

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -292,7 +292,7 @@ function HomeScreenContent() {
                       borderColor: themeColors.gold,
                     },
                   ]}
-                    onPress={openProductForm}
+                    onPress={() => openProductForm()}
                 >
                   <Plus size={16} color={themeColors.gold} />
                 </TouchableOpacity>


### PR DESCRIPTION
## Summary
- avoid passing press event to `openProductForm`

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient', many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9b977848326ad8a15278f175d9e