### PR TITLE
Add category and banner translations

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -89,6 +89,10 @@
     "productsComingSoon": "Products coming soon",
     "noResults": "No results found",
     "tryDifferentSearch": "Try searching for something else",
+    "fallbackBanner1Title": "Create your first banner",
+    "fallbackBanner1Subtitle": "Banners help highlight promotions.",
+    "fallbackBanner2Title": "No banners yet",
+    "fallbackBanner2Subtitle": "Add banners to make your home page shine.",
     "addBanner": "Add Banner",
     "sortBy": "Sort by",
     "newest": "Newest",
@@ -99,7 +103,16 @@
     "becomeSeller": "Become a Seller"
   },
   "categories": {
-    "all": "All"
+    "all": "All",
+    "electronics": "Electronics",
+    "fashion": "Fashion",
+    "home": "Home",
+    "beauty": "Beauty",
+    "sports": "Sports",
+    "books": "Books"
+  },
+  "banner": {
+    "addBanner": "Add Banner"
   },
   "product": {
     "inStock": "In Stock ({count})",

--- a/translations/he.json
+++ b/translations/he.json
@@ -89,6 +89,10 @@
     "productsComingSoon": "מוצרים יתווספו בקרוב",
     "noResults": "לא נמצאו תוצאות",
     "tryDifferentSearch": "נסה לחפש משהו אחר",
+    "fallbackBanner1Title": "צור את הבאנר הראשון שלך",
+    "fallbackBanner1Subtitle": "באנרים עוזרים להדגיש מבצעים",
+    "fallbackBanner2Title": "אין עדיין באנרים",
+    "fallbackBanner2Subtitle": "הוסף באנרים כדי לשדרג את דף הבית",
     "addBanner": "הוסף באנר",
     "sortBy": "מיון לפי",
     "newest": "החדשים ביותר",
@@ -99,7 +103,16 @@
     "becomeSeller": "הפוך למוכר"
   },
   "categories": {
-    "all": "הכל"
+    "all": "הכל",
+    "electronics": "אלקטרוניקה",
+    "fashion": "אופנה",
+    "home": "בית",
+    "beauty": "יופי",
+    "sports": "ספורט",
+    "books": "ספרים"
+  },
+  "banner": {
+    "addBanner": "הוסף באנר"
   },
   "product": {
     "inStock": "במלאי ({count})",


### PR DESCRIPTION
## Summary
- localize fallback banner titles and subtitles
- expand category translations for electronics, fashion, home, beauty, sports, and books
- add banner namespace for shared addBanner text

## Testing
- `node scripts/check-i18n.js src/features/home/hooks/useHomeData.ts`
- `npx jest tests/homeFallbackVisibility.test.tsx tests/homeScreenRender.test.tsx` *(fails: handleCategoryPress is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bfacce3f708326a1bc355ec8bb3c3f