### PR TITLE
docs: streamline routing references

### DIFF
--- a/docs/app-structure.md
+++ b/docs/app-structure.md
@@ -1,35 +1,19 @@
-# BlueOcean v2 App Structure
+# App Structure
 
-This document captures the high-level directory tree for the BlueOcean v2 Expo application. Update it whenever the project structure changes so that it remains current.
+Blue Ocean uses Expo Router with a single root layout and a minimal set of routes.
 
 ```text
 blue-ocean/
-├─ app/                          App shell and routes
-│  ├─ _layout.tsx                Root layout → TabsLayout
-│  ├─ +html.tsx                  Web HTML shell
-│  ├─ +not-found.tsx             404 boundary
-│  ├─ index.tsx                  Home tab screen
-│  ├─ stores.tsx                 Stores tab screen
-│  ├─ cart.tsx                   Cart tab screen
-│  ├─ orders.tsx                 Orders tab screen
-│  ├─ profile.tsx                Profile tab screen
-│  ├─ categories.tsx
-│  ├─ category/
-│  ├─ product/
-│  ├─ reviews/
-│  ├─ user/
-│  └─ …
-├─ src/layout/                   Shared layouts
-│  ├─ TabsLayout.tsx             Renders global header & tabs
-│  └─ SidebarTabBar.tsx
-├─ components/GlobalHeader.tsx   Top header used in TabsLayout
-├─ public/                       Static web assets
-└─ …
+├─ app/
+│  ├─ _layout.tsx        Root layout -> RootLayout
+│  ├─ index.tsx          Home screen ("/")
+│  └─ store/
+│     └─ [storeId]/
+│        └─ index.tsx    Store detail screen ("/store/:id")
+├─ src/layout/
+│  └─ RootLayout.tsx     Application shell and navigation
 ```
 
-## Major Sections
-
-- **Root Layout & Tabs** – [`app/_layout.tsx`](../app/_layout.tsx) re-exports [`TabsLayout`](../src/layout/TabsLayout.tsx), which renders the global header and bottom tab bar.
-- **Domain Routes** – [`app/category`](../app/category), [`app/product`](../app/product), [`app/orders`](../app/orders), [`app/reviews`](../app/reviews), [`app/user`](../app/user)
+Additional UI flows (cart, orders, profile, etc.) are implemented as modals or other components instead of file-based routes.
 
 *Keep this file in sync with the repository’s evolving structure.*

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,23 +1,13 @@
 # Navigation
 
-Blue Ocean relies on [Expo Router](https://expo.github.io/router/) and a tab layout to move between screens.
-On phones the tabs appear along the bottom, while tablets and larger viewports show the same items in a fixed sidebar on the left.
-The diagram below outlines the primary user flow.
+Blue Ocean uses Expo Router with a custom `RootLayout` (`src/layout/RootLayout.tsx`) that provides the application shell, global header, and navigation menu.
 
 ```mermaid
 flowchart LR
-    Tabs --> Home
-    Tabs --> Stores
-    Tabs --> Cart
-    Tabs --> Orders
-    Tabs --> Profile
-    Home -->|select category| Category
-    Category --> Product
-    Product --> Cart
+    Home["/"] --> Store["/store/:id"]
 ```
 
-- **Tabs** – implemented in `src/layout/TabsLayout.tsx`, renders the bottom navigation bar or left sidebar based on screen size.
-- **Avatar Menu** – the profile avatar opens authentication actions.
-- **Category** – routes like `/category/[id]` show filtered product views.
+- **`/`** – home screen.
+- **`/store/:id`** – store detail screen.
 
-This high‑level map helps visualize how users move through the application.
+Additional flows such as cart and profile appear as modals or component-driven overlays instead of dedicated routes.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,59 +1,10 @@
 # Routes
 
-Documentation of file-based routes and required roles.
+All routes render within the shared `RootLayout` (`src/layout/RootLayout.tsx`). The router currently defines two paths:
 
-## Public
+| Path | Description | Role requirement |
+|------|-------------|------------------|
+| `/` | Home screen | none |
+| `/store/:id` | Store detail | none |
 
-| Path | Role requirement |
-|------|------------------|
-| `/` | none |
-| `/stores` | none |
-| `/categories` | none |
-| `/category/[id]` | none |
-| `/product/[id]` | none |
-
-## Authenticated
-
-| Path | Role requirement |
-|------|------------------|
-| `/cart` | login to checkout |
-| `/orders` | view personal orders (login required) |
-| `/profile` | manage account settings (login required) |
-
-## Store Owner
-
-| Path | Role requirement |
-|------|------------------|
-| `/store/[storeId]/admin/*` | owner of `[storeId]` |
-
-## Admin
-
-| Path | Role requirement |
-|------|------------------|
-| `/admin/*` | admin |
-
-## Driver
-
-| Path | Role requirement |
-|------|------------------|
-| `/driver-dashboard` | driver or admin |
-
-### RBAC Summary
-- **Public** routes are accessible without authentication.
-- **Authenticated** routes require a logged in user.
-- **Store Owner** routes require ownership of the target store.
-- **Admin** routes are restricted to platform administrators.
-- **Driver** screens require the driver role or admin privileges.
-
-### API Namespace Summary
-| Namespace | Topic |
-|-----------|-------|
-| `settings` | `/blue-ocean/settings/1` |
-| `users` | `/blue-ocean/users/1` |
-| `products` | `/blue-ocean/products/1` |
-| `stores` | `/blue-ocean/stores/1` |
-| `orders` | `/blue-ocean/orders/1` |
-| `notifications` | `/blue-ocean/notifications/1` |
-| `reviews` | `/blue-ocean/reviews/1` |
-| `analytics` | `/blue-ocean/analytics/1` |
-| `chat` | `/blue-ocean/chat/1/<roomId>` |
+Additional flows such as cart, orders, and profile are handled via modals or standalone components rather than file-based routes.


### PR DESCRIPTION
## Summary
- document only `/` and `/store/:id` routes
- refresh navigation docs for `RootLayout`
- note that additional flows use modals/components

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn lint`
- `yarn typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb2358f90832697ed3cd881fc4783