### PR TITLE
feat: add reusable sidebar tab bar

### DIFF
--- a/components/SidebarTabBar.tsx
+++ b/components/SidebarTabBar.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Pressable, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Lucide from 'lucide-react-native';
+import { usePathname } from 'expo-router';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { useAppRouter } from '@/services';
+import { spacing, typography } from '@/shared/ui/tokens';
+
+export interface NavItem {
+  href: string;
+  title: string;
+  icon: string;
+}
+
+const SIDEBAR_WIDTH = 80;
+
+interface SidebarTabBarProps {
+  items: readonly NavItem[];
+  isSidebar?: boolean;
+}
+
+export const SidebarTabBar: React.FC<SidebarTabBarProps> = ({ items, isSidebar }) => {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const { push } = useAppRouter();
+  const pathname = usePathname();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={
+        isSidebar
+          ? {
+              width: SIDEBAR_WIDTH,
+              backgroundColor: colors.tabBar.background,
+              paddingTop: insets.top,
+              paddingBottom: insets.bottom,
+            }
+          : {
+              flexDirection: 'row',
+              backgroundColor: colors.tabBar.background,
+              paddingBottom: insets.bottom,
+              height: spacing.spacer24 * 3,
+            }
+      }
+    >
+      {items.map((item) => {
+        const Icon = (Lucide as any)[item.icon] as React.ComponentType<{ size: number; color: string }>;
+        const focused = pathname === item.href;
+        const color = focused ? colors.tabBar.active : colors.tabBar.inactive;
+        return (
+          <Pressable
+            key={item.href}
+            onPress={() => push(item.href)}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              flex: isSidebar ? undefined : 1,
+              paddingVertical: spacing.spacer16,
+            }}
+          >
+            {Icon && <Icon size={24} color={color} />}
+            <Text
+              style={{
+                color,
+                fontSize: typography.xs.fontSize,
+                fontWeight: '500',
+                marginTop: spacing.spacer4,
+              }}
+            >
+              {t(item.title)}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
+
+export default SidebarTabBar;
+

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo } from 'react';
-import { View, Pressable, Text, useWindowDimensions } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { View, useWindowDimensions } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
-import * as Lucide from 'lucide-react-native';
 import { Slot, usePathname } from 'expo-router';
 import GlobalHeader from '@/components/GlobalHeader';
 import { FloatingCartWidget } from '@/features/cart';
-import { useAppRouter } from '@/services';
-import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { useTheme } from '@/ui/ThemeProvider';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import { spacing, typography } from '@/shared/ui/tokens';
+import SidebarTabBar from '@/components/SidebarTabBar';
 
 const NAV_ITEMS = [
   { href: '/', title: 'navigation.home', icon: 'Home' },
@@ -19,15 +17,11 @@ const NAV_ITEMS = [
   { href: '/profile', title: 'navigation.profile', icon: 'User' },
 ] as const;
 
-const SIDEBAR_WIDTH = 80;
 const LARGE_SCREEN = 768;
 
 export default function RootLayout() {
-  const { t } = useLanguage();
   const { theme, colors } = useTheme();
-  const { push } = useAppRouter();
   const pathname = usePathname();
-  const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const isLargeScreen = width >= LARGE_SCREEN;
   const showSearch = pathname === '/' || pathname === '/index';
@@ -35,68 +29,18 @@ export default function RootLayout() {
 
   const navItems = useMemo(() => NAV_ITEMS, []);
 
-  const NavBar = (
-    <View
-      style={
-        isLargeScreen
-          ? {
-              width: SIDEBAR_WIDTH,
-              backgroundColor: colors.tabBar.background,
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-            }
-          : {
-              flexDirection: 'row',
-              backgroundColor: colors.tabBar.background,
-              paddingBottom: insets.bottom,
-              height: spacing.spacer24 * 3,
-            }
-      }
-    >
-      {navItems.map((item) => {
-        const Icon = (Lucide as any)[item.icon] as React.ComponentType<{ size: number; color: string }>;
-        const focused = pathname === item.href;
-        const color = focused ? colors.tabBar.active : colors.tabBar.inactive;
-        return (
-          <Pressable
-            key={item.href}
-            onPress={() => push(item.href)}
-            style={{
-              alignItems: 'center',
-              justifyContent: 'center',
-              flex: isLargeScreen ? undefined : 1,
-              paddingVertical: spacing.spacer16,
-            }}
-          >
-            {Icon && <Icon size={24} color={color} />}
-            <Text
-              style={{
-                color,
-                fontSize: typography.xs.fontSize,
-                fontWeight: '500',
-                marginTop: spacing.spacer4,
-              }}
-            >
-              {t(item.title)}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-
   return (
     <ErrorBoundary>
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
         <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
         <GlobalHeader showSearch={showSearch} />
         <View style={{ flex: 1, flexDirection: 'row' }}>
-          {isLargeScreen && NavBar}
+          {isLargeScreen && <SidebarTabBar items={navItems} isSidebar />}
           <View style={{ flex: 1 }}>
             <Slot />
           </View>
         </View>
-        {!isLargeScreen && NavBar}
+        {!isLargeScreen && <SidebarTabBar items={navItems} />}
         {showCartWidget && <FloatingCartWidget />}
       </SafeAreaView>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- extract sidebar tab bar component supporting sidebar and bottom tabs
- use SidebarTabBar in RootLayout instead of inline nav bar

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'HeroBanner[] | (() => HeroBanner[])')*


------
https://chatgpt.com/codex/tasks/task_e_68bfb23b4000832695466d652cf85839