### PR TITLE
feat: use FlashList for product grids

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.614.0",
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/runtime": "^7.27.6",
     "@blue-ocean/sdk-near": "file:packages/sdk-near",
     "@blue-ocean/utils": "file:packages/utils",
-    "@aws-sdk/client-s3": "^3.614.0",
     "@expo/metro-runtime": "~3.1.3",
     "@expo/vector-icons": "^14.1.0",
     "@expo/webpack-config": "^19.0.1",
@@ -34,6 +34,7 @@
     "@react-navigation/bottom-tabs": "~6.5.7",
     "@react-navigation/native": "~6.1.6",
     "@react-navigation/native-stack": "~6.9.12",
+    "@shopify/flash-list": "^2.0.3",
     "@tanstack/react-query": "^5.85.6",
     "@waku/core": "0.0.33",
     "@waku/sdk": "0.0.33",
@@ -100,8 +101,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.27.7",
-    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@babel/plugin-transform-class-static-block": "^7.27.1",
+    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@expo/cli": "^0.22.26",
     "@faker-js/faker": "^8.4.0",
     "@types/jest": "^30.0.0",

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { View, StyleSheet, FlatList } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { ProductCard, ProductCardSkeleton } from '@/features/products';
 import { Product, Category } from '@/types';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -87,10 +88,11 @@ function ProductGrid({
   }
 
   return (
-    <FlatList
+    <FlashList
       data={products}
       keyExtractor={keyExtractor}
       numColumns={2}
+      estimatedItemSize={300}
       columnWrapperStyle={columnWrapperStyle}
       contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}

--- a/src/features/products/components/ProductGrid.tsx
+++ b/src/features/products/components/ProductGrid.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { FlatList, View, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import EmptyState from '@/shared/ui/EmptyState';
 import ProductCard from '../ProductCard';
 import { Product } from '@/types';
@@ -55,10 +56,11 @@ function ProductGrid({ products }: { products: Product[] }) {
   }
 
   return (
-    <FlatList
+    <FlashList
       data={products}
       keyExtractor={keyExtractor}
       numColumns={2}
+      estimatedItemSize={300}
       columnWrapperStyle={columnWrapperStyle}
       contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}


### PR DESCRIPTION
## Summary
- add @shopify/flash-list dependency
- switch product grids to FlashList with virtualization tuning

## Testing
- `yarn lint`
- `yarn typecheck` (fails: Argument of type '{}' is not assignable...)
- `npx jest` (fails: TypeError: Cannot read properties of undefined (reading 'sourceFile'))
- `node - <<'NODE' ...` (fails: SyntaxError: Unexpected token 'typeof')


------
https://chatgpt.com/codex/tasks/task_e_68bfb394b7488326962b81516550a931