### PR TITLE
Document NEAR Lake S3 configuration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -8,3 +8,8 @@ Use `requireEnv(key, fallback?)` from `src/services/config.ts` to read environme
 | `EXPO_PUBLIC_NETWORK` | NEAR network override (`mainnet` or `testnet`) | inferred from contract ID |
 | `EXPO_PUBLIC_CONTRACT_ID` | NEAR contract account | none |
 | `EXPO_PUBLIC_WALLET_URL` | Optional wallet URL | based on network |
+| `NEAR_LAKE_BUCKET` | S3 bucket for NEAR Lake state | none |
+| `NEAR_LAKE_REGION` | AWS region for the bucket | `eu-central-1` |
+| `NEAR_LAKE_ENDPOINT` | Override S3 endpoint used for NEAR Lake | none |
+| `AWS_ACCESS_KEY_ID` | Access key for custom S3 endpoints | none |
+| `AWS_SECRET_ACCESS_KEY` | Secret key for custom S3 endpoints | none |

--- a/services/nearKvStore.ts
+++ b/services/nearKvStore.ts
@@ -43,6 +43,11 @@ function ensureLake() {
         s3RegionName: region,
         startBlockHeight: BigInt(process.env.NEAR_LAKE_START_BLOCK || '0'),
       });
+      // The NEAR Lake bucket exposes a public, S3-compatible API, so this
+      // client works out of the box without AWS credentials. Use the
+      // `NEAR_LAKE_ENDPOINT` env var to point at a custom S3 endpoint and
+      // provide `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` if that endpoint
+      // requires authentication.
       s3 = new S3Client({
         region,
         endpoint: process.env.NEAR_LAKE_ENDPOINT,


### PR DESCRIPTION
## Summary
- clarify NEAR Lake S3 client setup and environment variables
- document NEAR Lake configuration keys and optional credentials

## Testing
- `yarn lint services/nearKvStore.ts docs/config.md`
- `yarn typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'HeroBanner[] | (() => HeroBanner[])')*
- `yarn jest tests/nearKvPersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bfb7bd07bc8326921d7cde48851d2a