### PR TITLE
fix: type useQuery for hero banners

### DIFF
--- a/src/features/home/hooks/useHomeBanners.ts
+++ b/src/features/home/hooks/useHomeBanners.ts
@@ -5,9 +5,9 @@ import { HeroBanner } from '@/types';
 import { errorLog, debugLog } from '@/utils/logger';
 
 export function useHomeBanners() {
-  const { data, refetch, isLoading, error: queryError } = useQuery({
+  const { data, refetch, isLoading, error: queryError } = useQuery<HeroBanner[]>({
     queryKey: ['homeBanners'],
-    queryFn: async () => {
+    queryFn: async (): Promise<HeroBanner[]> => {
       try {
         const db = DatabaseService.getInstance();
         return await db.getHeroBanners();
@@ -17,7 +17,6 @@ export function useHomeBanners() {
         throw err;
       }
     },
-    suspense: false,
   });
   const [heroBanners, setHeroBanners] = useState<HeroBanner[]>(data ?? []);
 


### PR DESCRIPTION
## Summary
- type home hero banners query so state setters always get `HeroBanner[]`

## Testing
- `yarn typecheck` *(fails: Property 'variant' does not exist, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bfb921aea883269d682bd9cc2a1dd8