### PR TITLE
docs: clarify FlashList usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ yarn lint && yarn typecheck
 Metro's web bundler requires `it-all` and `it-pipe` to be listed explicitly in
 `dependencies`; both packages are included in `package.json` for web builds.
 
+The app also uses the open-source [`@shopify/flash-list`](https://github.com/Shopify/flash-list) package solely for local list virtualization. It is independent of Shopify's platform and does not require a Shopify account or any access to Shopify APIs.
+
 When the app loads you'll see the global header and bottom tab bar (Home, Stores, Cart, Orders, Profile).
 
 ## Design Tokens


### PR DESCRIPTION
## Summary
- document that `@shopify/flash-list` is open source and only used for local list virtualization

## Testing
- `yarn lint README.md`
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient', plus numerous other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb92fa8fc8326aa0a40c9d21ad9cd