### PR TITLE
test: mock flash list for jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '^expo-asset$': '<rootDir>/tests/__mocks__/expo-asset.js',
     '^expo-secure-store$': '<rootDir>/tests/__mocks__/expo-secure-store.js',
     '^react-native$': '<rootDir>/tests/__mocks__/react-native.js',
+    '^@shopify/flash-list$': '<rootDir>/tests/__mocks__/@shopify/flash-list.js',
     '^@app/(.*)$': '<rootDir>/app/$1',
     '^@features/(.*)$': '<rootDir>/src/features/$1',
     '^@shared/(.*)$': '<rootDir>/src/shared/$1',

--- a/tests/__mocks__/@shopify/flash-list.js
+++ b/tests/__mocks__/@shopify/flash-list.js
@@ -1,0 +1,6 @@
+const React = require('react');
+const { FlatList } = require('react-native');
+
+const FlashList = React.forwardRef((props, ref) => React.createElement(FlatList, { ...props, ref }));
+
+module.exports = { FlashList, default: FlashList };


### PR DESCRIPTION
## Summary
- add mock FlashList component wrapping React Native FlatList
- map `@shopify/flash-list` to the mock in Jest config

## Testing
- `npx jest` *(fails: Jest encountered an unexpected token in TSX files)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb9301c5c8326a94312ff35dee760