### PR TITLE
feat: link home options to create store

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   RefreshControl,
   useWindowDimensions,
-  Modal,
 } from 'react-native';
 import { Plus, ArrowUpDown } from 'lucide-react-native';
 import { Product } from '@/types';
@@ -18,7 +17,6 @@ import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
-import StoreCreation from '@/features/stores/components/StoreCreation';
 import ProductGrid from '@/features/home/components/ProductGrid';
 import CategoryCard from '@/features/home/components/CategoryCard';
 import { Spinner } from '@/ui/primitives';
@@ -44,9 +42,6 @@ function HomeScreenContent() {
     closeProductForm,
     showCartModal,
     closeCartModal,
-    storeCreationVisible,
-    openStoreCreation,
-    closeStoreCreation,
     infoModal,
     closeInfoModal,
   } = useHomeModals(error);
@@ -135,7 +130,7 @@ function HomeScreenContent() {
           maxPrice={maxPrice}
           setMaxPrice={setMaxPrice}
         />
-        <HomeOptions onCreateStore={openStoreCreation} />
+          <HomeOptions />
 
         {/* Categories Section */}
         <Container style={styles.section}>
@@ -267,16 +262,6 @@ function HomeScreenContent() {
           visible={showCartModal}
           onClose={closeCartModal}
         />
-      </Suspense>
-
-      <Suspense fallback={<Spinner />}>
-        <Modal
-          visible={storeCreationVisible}
-          animationType="slide"
-          onRequestClose={closeStoreCreation}
-        >
-          <StoreCreation />
-        </Modal>
       </Suspense>
 
     </>

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -1,35 +1,51 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Alert } from 'react-native';
 import { Card, Text, Button } from '@/ui';
 import { Stack } from '@/ui/layout';
 import { spacing, radius } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
+import { useAppRouter } from '@/services/useAppRouter';
+import { routes } from '@/utils/routes';
 
-interface HomeOptionsProps {
-  onCreateStore?: () => void;
-  onBecomeDriver?: () => void;
-}
-
-export default function HomeOptions({ onCreateStore, onBecomeDriver }: HomeOptionsProps) {
+export default function HomeOptions() {
   const { t } = useLanguage();
   const { colors } = useTheme();
+  const appRouter = useAppRouter();
+
+  const handleCreateStore = () => {
+    appRouter.push(routes.createStore());
+  };
+
+  const handleBecomeDriver = () => {
+    Alert.alert(t('profile.comingSoon', 'Coming Soon'));
+  };
 
   return (
     <Stack gap="spacer16" style={styles.container}>
       <Card style={styles.card}>
         <Stack gap="spacer8">
-          <Text style={[styles.title, { color: colors.text.primary }]}>
+          <Text style={[styles.title, { color: colors.text.primary }]}> 
             {t('home.createStore', 'Create a Store')}
           </Text>
-          <Button title={t('home.createStore', 'Create a Store')} onPress={onCreateStore} />
+          <Button
+            title={t('home.createStore', 'Create a Store')}
+            onPress={handleCreateStore}
+            accessibilityRole="link"
+            testID="create-store-link"
+          />
         </Stack>
       </Card>
       <Card style={styles.card}>
         <Stack gap="spacer8">
-          <Text style={[styles.title, { color: colors.text.primary }]}>
+          <Text style={[styles.title, { color: colors.text.primary }]}> 
             {t('home.becomeDriver', 'Become a Driver')}
           </Text>
-          <Button title={t('home.becomeDriver', 'Become a Driver')} onPress={onBecomeDriver} />
+          <Button
+            title={t('home.becomeDriver', 'Become a Driver')}
+            onPress={handleBecomeDriver}
+            accessibilityRole="button"
+            testID="become-driver-button"
+          />
         </Stack>
       </Card>
     </Stack>

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -4,6 +4,7 @@ export const routes = {
     params,
   }),
   store: (id: string | number) => `/store/${id}`,
+  createStore: () => '/stores/create',
 };
 
 export type Routes = typeof routes;


### PR DESCRIPTION
## Summary
- navigate from HomeOptions to `/stores/create`
- alert users that driver onboarding is coming soon
- streamline Home screen by removing unused store creation modal

## Testing
- `npx eslint src/features/home/components/HomeOptions.tsx app/index.tsx && echo 'eslint:success'`
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient', plus other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb105548832681dd7f844b876cda