### PR TITLE
Reframe platform positioning in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Blue Ocean
 
-Blue Ocean is a decentralized e‑commerce demo built with React Native and the Expo Router.
-Autonomous agents communicate over the Waku peer‑to‑peer network, keep their state in
-memory, and hydrate from message history on boot. Configuration such as debug logging or
-Waku bootstrap peers can be customized through `EXPO_PUBLIC_*` environment variables, but
-defaults are provided for a zero‑config experience. All data is replicated via Waku topics
-and NEAR smart contracts; the app does not use a local SQLite database. When configured,
-the key‑value store writes to an S3‑compatible bucket using the lightweight `minio` client.
+Blue Ocean is an underground gadgets platform for web3, privacy, and security services. It lets communities spin up stores to trade devices and accessories without centralized oversight.
+Autonomous agents communicate over the Waku peer‑to‑peer network, keep their state in memory, and hydrate from message history on boot. Configuration such as debug logging or Waku bootstrap peers can be customized through `EXPO_PUBLIC_*` environment variables, but defaults are provided for a zero‑config experience. All data is replicated via Waku topics and NEAR smart contracts; the app does not use a local SQLite database. When configured, the key‑value store writes to an S3‑compatible bucket using the lightweight `minio` client.
+
+Upcoming roles include a driver network and other specialized agents that extend supply‑chain coverage. These additions align with Blue Ocean’s strategic goals for 2025 to grow into a resilient, privacy‑preserving marketplace.
 
 See [docs/architecture.md](docs/architecture.md) for a high-level architecture overview and [docs/routes.md](docs/routes.md) for route and role details.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+Blue Ocean is an underground gadgets platform for web3, privacy, and security services. This document describes the agents and data flows that make store creation and other capabilities possible.
+
 ## Service Boundaries
 - **settings-agent** – subscribes to `/blue-ocean/{tenantId}/settings/1`, validates admin senders, and updates in-memory config.
 - **users-agent** – listens on `/blue-ocean/{tenantId}/users/1` to register users and roles, rejecting unauthenticated or duplicate roles.


### PR DESCRIPTION
## Summary
- Recast intro to position Blue Ocean as an underground gadgets platform with store creation and 2025 ambitions
- Align architecture overview with the new messaging

## Testing
- `yarn lint README.md docs/architecture.md`
- `yarn typecheck` *(fails: Type 'string' is not assignable to type 'DimensionValue | undefined' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb15798883268d18a8dbccd7ce00