### PR TITLE
feat: verify admin signatures against settings

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -5,6 +5,8 @@ import {
   setSetting,
   getAdmins as fetchAdmins,
   setAdmins as storeAdmins,
+  getAdminPublicKeys as fetchAdminPublicKeys,
+  setAdminPublicKeys as storeAdminPublicKeys,
   subscribeToSettingsWrites,
 } from '@/services/nearSettings';
 import ensureNearWallet from '../utils/ensureNearWallet';
@@ -29,6 +31,8 @@ class SettingsAgent {
   private static instance: SettingsAgent;
   private admins: string[] = [];
   private adminsFetchedAt = 0;
+  private adminPublicKeys: string[] = [];
+  private adminPublicKeysFetchedAt = 0;
   private static ADMIN_CACHE_TTL = 60_000; // 1 minute
 
   private constructor() {
@@ -36,6 +40,10 @@ class SettingsAgent {
       if (evt.key === 'admins') {
         this.admins = [];
         this.adminsFetchedAt = 0;
+      }
+      if (evt.key === 'adminPublicKeys') {
+        this.adminPublicKeys = [];
+        this.adminPublicKeysFetchedAt = 0;
       }
     });
   }
@@ -81,6 +89,26 @@ class SettingsAgent {
     await storeAdmins(normalized, actor);
     this.admins = normalized;
     this.adminsFetchedAt = Date.now();
+  }
+
+  async getAdminPublicKeys(): Promise<string[]> {
+    const now = Date.now();
+    if (
+      this.adminPublicKeys.length === 0 ||
+      now - this.adminPublicKeysFetchedAt > SettingsAgent.ADMIN_CACHE_TTL
+    ) {
+      this.adminPublicKeys = await fetchAdminPublicKeys();
+      this.adminPublicKeysFetchedAt = now;
+    }
+    return this.adminPublicKeys;
+  }
+
+  async setAdminPublicKeys(keys: string[]): Promise<void> {
+    await this.ensureWallet();
+    const actor = nearAuth.getAccountId()!;
+    await storeAdminPublicKeys(keys, actor);
+    this.adminPublicKeys = keys;
+    this.adminPublicKeysFetchedAt = Date.now();
   }
 
   async getRpcUrls(): Promise<{ rpcUrl: string; rpcFallbackUrls: string[] }> {

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -34,7 +34,9 @@ const ADMIN_ADDRESS =
     : ADMIN_MAIN || (process.env.NODE_ENV === 'test' ? TEST_ADMIN : '');
 
 function assertAdmin(actor: string): void {
-  if (!ADMIN_ADDRESS) return;
+  if (!ADMIN_ADDRESS) {
+    throw new Error('Admin wallet address required');
+  }
   if (actor !== ADMIN_ADDRESS) {
     throw new Error('Admin wallet address required');
   }
@@ -49,6 +51,7 @@ export interface NearSettings {
   feeAddress?: string;
   feeBps?: number;
   admins: string[];
+  adminPublicKeys: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
   wakuBootstrap?: string[];
@@ -127,7 +130,8 @@ export async function subscribeToSettingsWrites(
         type: z.literal('settings.write'),
         payload: settingsWriteEventSchema,
       });
-      const signed = await verifyBeforeWrite(raw, schema);
+      const adminKeys = await getAdminPublicKeys();
+      const signed = await verifyBeforeWrite(raw, schema, adminKeys);
       if (!signed) return;
       cb(signed.payload);
     } catch (err) {
@@ -197,6 +201,9 @@ export async function fetchSettings(): Promise<NearSettings> {
     feeAddress: map['feeAddress'] ?? '',
     feeBps,
     admins: map['admins'] ? JSON.parse(map['admins']) : [],
+    adminPublicKeys: map['adminPublicKeys']
+      ? JSON.parse(map['adminPublicKeys'])
+      : [],
     rpcUrl: map['rpcUrl'] ?? '',
     rpcFallbackUrls: map['rpcFallbackUrls']
       ? JSON.parse(map['rpcFallbackUrls'])
@@ -229,6 +236,22 @@ export async function getAdmins(): Promise<string[]> {
 
 export async function setAdmins(admins: string[], actor: string): Promise<void> {
   await setSetting('admins', JSON.stringify(admins), actor);
+}
+
+export async function getAdminPublicKeys(): Promise<string[]> {
+  const raw = await getSetting('adminPublicKeys');
+  try {
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function setAdminPublicKeys(
+  keys: string[],
+  actor: string,
+): Promise<void> {
+  await setSetting('adminPublicKeys', JSON.stringify(keys), actor);
 }
 
 export async function getPaymentFactoryAddress(): Promise<string> {

--- a/tests/verifyBeforeWrite.test.ts
+++ b/tests/verifyBeforeWrite.test.ts
@@ -1,0 +1,32 @@
+import { getPublicKey, sign, utils } from '@noble/ed25519';
+import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
+import { wakuMessageSchema } from '../schemas/waku';
+import { z } from 'zod';
+import type { WakuMessage } from '../types/waku';
+
+describe('verifyBeforeWrite', () => {
+  it('respects allowed public keys', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const pubHex = Buffer.from(pub).toString('hex');
+
+    const msg: WakuMessage<string> = {
+      type: 'test',
+      payload: 'hi',
+      sender: { publicKey: pubHex },
+      signature: '',
+    };
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+    );
+    const sig = await sign(bytes, priv);
+    msg.signature = Buffer.from(sig).toString('hex');
+
+    const schema = wakuMessageSchema.extend({ type: z.literal('test'), payload: z.string() });
+
+    await expect(verifyBeforeWrite(msg, schema, [pubHex])).resolves.not.toBeNull();
+    await expect(
+      verifyBeforeWrite(msg, schema, ['deadbeef']),
+    ).resolves.toBeNull();
+  });
+});

--- a/utils/verifyBeforeWrite.ts
+++ b/utils/verifyBeforeWrite.ts
@@ -6,6 +6,7 @@ import { verifyMessageSignature } from './verifyMessageSignature';
 export async function verifyBeforeWrite<T>(
   data: unknown,
   schema: z.ZodType<WakuMessage<T>>,
+  allowedPublicKeys?: string[],
 ): Promise<WakuMessage<T> | null> {
   const res = schema.safeParse(data);
   if (!res.success) {
@@ -16,6 +17,10 @@ export async function verifyBeforeWrite<T>(
   const ok = await verifyMessageSignature(msg, msg.sender.publicKey);
   if (!ok) {
     errorLog('Invalid message signature', msg);
+    return null;
+  }
+  if (allowedPublicKeys && !allowedPublicKeys.includes(msg.sender.publicKey)) {
+    errorLog('Unauthorized sender', msg.sender.publicKey);
     return null;
   }
   return msg;


### PR DESCRIPTION
## Summary
- require ADMIN_ADDRESS and validate admin writes against persisted keys
- allow verifyBeforeWrite to restrict senders with allowed public keys
- expose admin public key management in SettingsAgent

## Testing
- `npx jest` *(fails: Jest encountered unexpected token and other errors)*
- `yarn lint`
- `yarn typecheck` *(fails: TS2322, TS2769, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7b4dce48326bc6e820ed09786e0