### PR TITLE
Use canonical serialization for message signing

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -17,6 +17,7 @@ import { verifyBeforeWrite } from '@/utils/verifyBeforeWrite';
 import { productUpdatedSchema } from '../schemas/waku/product.updated';
 import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
 import { sign } from '@noble/ed25519';
+import { canonicalJson } from '@/utils/canonicalJson';
 import type { WakuMessage } from '@/types/waku';
 import { errorLog } from '@/utils/logger';
 import { buildTopic } from '@/utils/wakuTopics';
@@ -143,7 +144,11 @@ class ProductsAgent {
         signature: '',
       };
       const msgBytes = new TextEncoder().encode(
-        JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+        canonicalJson({
+          type: msg.type,
+          payload: msg.payload,
+          sender: msg.sender,
+        }),
       );
       const sig = await sign(msgBytes, priv);
       msg.signature = Buffer.from(sig).toString('hex');

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "axios": "^1.6.2",
     "bcryptjs": "^2.4.3",
     "buffer": "^6.0.3",
+    "canonicalize": "^2.1.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "ed2curve": "^0.3.0",
@@ -100,8 +101,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.27.7",
-    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@babel/plugin-transform-class-static-block": "^7.27.1",
+    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@expo/cli": "^0.22.26",
     "@faker-js/faker": "^8.4.0",
     "@types/jest": "^30.0.0",

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -9,6 +9,7 @@ import { settingsWriteEventSchema, wakuMessageSchema } from '../schemas/waku';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { z } from 'zod';
 import { sign } from '@noble/ed25519';
+import { canonicalJson } from '@/utils/canonicalJson';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
 
 assertNearChain();
@@ -100,7 +101,11 @@ async function emit(event: SettingsWriteEvent) {
       signature: '',
     };
     const msgBytes = new TextEncoder().encode(
-      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+      canonicalJson({
+        type: msg.type,
+        payload: msg.payload,
+        sender: msg.sender,
+      }),
     );
     const sig = await sign(msgBytes, priv);
     msg.signature = Buffer.from(sig).toString('hex');

--- a/tests/verifyBeforeWrite.test.ts
+++ b/tests/verifyBeforeWrite.test.ts
@@ -2,6 +2,7 @@ import { getPublicKey, sign, utils } from '@noble/ed25519';
 import { verifyBeforeWrite } from '../utils/verifyBeforeWrite';
 import { wakuMessageSchema } from '../schemas/waku';
 import { z } from 'zod';
+import { canonicalJson } from '../utils/canonicalJson';
 import type { WakuMessage } from '../types/waku';
 
 describe('verifyBeforeWrite', () => {
@@ -17,7 +18,7 @@ describe('verifyBeforeWrite', () => {
       signature: '',
     };
     const bytes = new TextEncoder().encode(
-      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+      canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
     );
     const sig = await sign(bytes, priv);
     msg.signature = Buffer.from(sig).toString('hex');

--- a/tests/verifyMessageSignature.test.ts
+++ b/tests/verifyMessageSignature.test.ts
@@ -1,5 +1,6 @@
 import { getPublicKey, sign, utils } from '@noble/ed25519';
 import { verifyMessageSignature } from '../utils/verifyMessageSignature';
+import { canonicalJson } from '../utils/canonicalJson';
 import type { WakuMessage } from '../types/waku';
 
 describe('verifyMessageSignature', () => {
@@ -15,7 +16,7 @@ describe('verifyMessageSignature', () => {
       signature: '',
     };
     const bytes = new TextEncoder().encode(
-      JSON.stringify({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+      canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
     );
     const sig = await sign(bytes, priv);
     msg.signature = Buffer.from(sig).toString('hex');

--- a/utils/canonicalJson.ts
+++ b/utils/canonicalJson.ts
@@ -1,0 +1,7 @@
+import canonicalize from 'canonicalize';
+
+export function canonicalJson(value: unknown): string {
+  // canonicalize returns undefined for unsupported inputs
+  const result = canonicalize(value);
+  return result ?? '';
+}

--- a/utils/verifyMessageSignature.ts
+++ b/utils/verifyMessageSignature.ts
@@ -1,5 +1,6 @@
 import { verify } from '@noble/ed25519';
 import type { WakuMessage } from '../types/waku';
+import { canonicalJson } from './canonicalJson';
 
 export async function verifyMessageSignature<T>(
   message: WakuMessage<T>,
@@ -7,7 +8,7 @@ export async function verifyMessageSignature<T>(
 ): Promise<boolean> {
   try {
     const msgBytes = new TextEncoder().encode(
-      JSON.stringify({
+      canonicalJson({
         type: message.type,
         payload: message.payload,
         sender: message.sender,


### PR DESCRIPTION
## Summary
- add canonical JSON helper using `canonicalize`
- sign and verify messages using canonical serialization for deterministic keys
- update tests to use canonical signing

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Property 'variant' does not exist...)*
- `npx jest --runTestsByPath tests/verifyMessageSignature.test.ts tests/verifyBeforeWrite.test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa796b38832681f62151e0ca8202