### PR TITLE
feat: monitor near lake errors

### DIFF
--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -109,7 +109,12 @@ async function main() {
     s3RegionName: 'eu-central-1',
     startBlockHeight: startHeight,
   };
-  await startStream(lakeConfig, (msg) => handleMessage(waku, msg));
+  try {
+    await startStream(lakeConfig, (msg) => handleMessage(waku, msg));
+  } catch (err) {
+    console.error('NEAR Lake stream failed', err);
+    throw err;
+  }
 }
 
 main().catch((err) => {

--- a/services/nearLake.ts
+++ b/services/nearLake.ts
@@ -1,10 +1,14 @@
+import { EventEmitter } from 'events';
 import { startStream, types } from 'near-lake-framework';
 
 export interface LakeInitConfig {
   s3BucketName: string;
   s3RegionName: string;
   startBlockHeight: bigint;
+  onError?: (err: unknown) => void;
 }
+
+const lakeMonitor = new EventEmitter();
 
 /**
  * Initialize NEAR Lake stream.
@@ -17,8 +21,22 @@ export function initLake(config: LakeInitConfig): void {
     startBlockHeight: Number(config.startBlockHeight),
   };
 
-  // Fire and forget; failures are ignored to keep tests offline-friendly.
-  startStream(lakeConfig, async () => {}).catch(() => {});
+  (async () => {
+    try {
+      await startStream(lakeConfig, async () => {});
+    } catch (err) {
+      console.error('NEAR Lake stream failed', err);
+      lakeMonitor.emit('error', err);
+      config.onError?.(err);
+    }
+  })();
+}
+
+export function onLakeError(cb: (err: unknown) => void) {
+  lakeMonitor.on('error', cb);
+  return () => lakeMonitor.off('error', cb);
 }
 
 export default initLake;
+
+export { lakeMonitor };


### PR DESCRIPTION
## Summary
- wrap NEAR Lake stream startup in try/catch and forward errors to a new lakeMonitor event emitter
- add onLakeError helper so UIs can react to stream failures
- guard indexer stream with try/catch to surface errors

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Property 'variant' does not exist on type 'IntrinsicAttributes & TextFieldProps' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0acde9e888326a78b8bf79f71575d