### PR TITLE
Protect marketplace listing auth and deposits

### DIFF
--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -1,8 +1,8 @@
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::UnorderedMap;
 use near_sdk::json_types::U128;
-use near_sdk::{env, near_bindgen, AccountId, PanicOnDefault, BorshStorageKey};
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{env, near_bindgen, AccountId, BorshStorageKey, PanicOnDefault, Promise};
 
 /// A marketplace listing.
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
@@ -39,37 +39,61 @@ impl Marketplace {
     }
 
     /// Add a listing for a given contract and token id.
-    pub fn add_listing(&mut self, contract_id: String, token_id: String, seller: AccountId, price: U128) {
-        let listing = Listing { seller: seller.clone(), price };
+    pub fn add_listing(
+        &mut self,
+        contract_id: String,
+        token_id: String,
+        seller: AccountId,
+        price: U128,
+    ) {
+        assert_eq!(
+            env::predecessor_account_id(),
+            seller,
+            "seller must be predecessor"
+        );
+        let listing = Listing {
+            seller: seller.clone(),
+            price,
+        };
         let key = (contract_id.clone(), token_id.clone());
         self.listings.insert(&key, &listing);
-        env::log_str(&near_sdk::serde_json::json!({
-            "event": "add_listing",
-            "contract_id": contract_id,
-            "token_id": token_id,
-            "seller": seller,
-            "price": listing.price
-        }).to_string());
+        env::log_str(
+            &near_sdk::serde_json::json!({
+                "event": "add_listing",
+                "contract_id": contract_id,
+                "token_id": token_id,
+                "seller": seller,
+                "price": listing.price
+            })
+            .to_string(),
+        );
     }
 
-    /// Buy a listing. Removes the listing and logs the purchase event.
-    pub fn buy_listing(&mut self, contract_id: String, token_id: String, buyer: AccountId, amount: U128) {
+    /// Buy a listing. Removes the listing, transfers funds and logs the purchase event.
+    pub fn buy_listing(&mut self, contract_id: String, token_id: String) {
+        let buyer = env::predecessor_account_id();
+        let deposit = env::attached_deposit();
         let key = (contract_id.clone(), token_id.clone());
         let listing = self.listings.remove(&key).expect("listing not found");
-        assert!(amount.0 >= listing.price.0, "insufficient payment");
+        assert!(deposit >= listing.price.0, "insufficient deposit");
         let fee = listing.price.0 * self.fee_bps as u128 / 10_000u128;
         let seller_amount = listing.price.0 - fee;
-        env::log_str(&near_sdk::serde_json::json!({
-            "event": "buy_listing",
-            "contract_id": contract_id,
-            "token_id": token_id,
-            "buyer": buyer,
-            "seller": listing.seller,
-            "price": listing.price,
-            "fee": U128(fee),
-            "seller_amount": U128(seller_amount),
-            "treasury": self.treasury
-        }).to_string());
+        Promise::new(listing.seller.clone()).transfer(seller_amount);
+        Promise::new(self.treasury.clone()).transfer(fee);
+        env::log_str(
+            &near_sdk::serde_json::json!({
+                "event": "buy_listing",
+                "contract_id": contract_id,
+                "token_id": token_id,
+                "buyer": buyer,
+                "seller": listing.seller,
+                "price": listing.price,
+                "fee": U128(fee),
+                "seller_amount": U128(seller_amount),
+                "treasury": self.treasury
+            })
+            .to_string(),
+        );
     }
 
     /// Retrieve a single listing.
@@ -80,5 +104,58 @@ impl Marketplace {
     /// Retrieve all listings.
     pub fn get_listings(&self) -> Vec<((String, String), Listing)> {
         self.listings.iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_sdk::{test_utils::VMContextBuilder, testing_env};
+
+    fn init() -> Marketplace {
+        Marketplace::init(0, AccountId::new_unchecked("treasury.near".to_string()))
+    }
+
+    #[test]
+    fn unauthorized_add_listing_fails() {
+        let mut context = VMContextBuilder::new();
+        context.predecessor_account_id(AccountId::new_unchecked("alice.near".to_string()));
+        testing_env!(context.build());
+        let mut contract = init();
+        let result = std::panic::catch_unwind(move || {
+            contract.add_listing(
+                "nft.near".to_string(),
+                "1".to_string(),
+                AccountId::new_unchecked("bob.near".to_string()),
+                U128(10),
+            );
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn buy_listing_insufficient_deposit_fails() {
+        // seller adds a listing
+        let mut context = VMContextBuilder::new();
+        context.predecessor_account_id(AccountId::new_unchecked("seller.near".to_string()));
+        testing_env!(context.build());
+        let mut contract = init();
+        contract.add_listing(
+            "nft.near".to_string(),
+            "1".to_string(),
+            AccountId::new_unchecked("seller.near".to_string()),
+            U128(100),
+        );
+
+        // buyer attempts to buy with insufficient deposit
+        let mut context = VMContextBuilder::new();
+        context
+            .predecessor_account_id(AccountId::new_unchecked("buyer.near".to_string()))
+            .attached_deposit(50);
+        testing_env!(context.build());
+        let result = std::panic::catch_unwind(move || {
+            contract.buy_listing("nft.near".to_string(), "1".to_string());
+        });
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Ensure only the seller account can create a listing
- Validate deposit and transfer funds to seller and treasury when buying a listing
- Add tests covering unauthorized listing creation and purchases with insufficient deposits

## Testing
- `cargo test` *(fails: failed to select a version for the requirement `parity-secp256k1 = "^0.7"`; version 0.7.0 is yanked)*

------
https://chatgpt.com/codex/tasks/task_e_68c0acdf987483268e0c45c4bf5882cb