### PR TITLE
Add encrypted cache and block checkpointing

### DIFF
--- a/indexers/lake/src/checkpoint.ts
+++ b/indexers/lake/src/checkpoint.ts
@@ -1,0 +1,24 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const STATE_PATH = process.env.STATE_PATH || '.state/lake.json';
+
+async function ensureDir(filePath: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+export async function loadCheckpoint(): Promise<number> {
+  try {
+    const buf = await fs.readFile(STATE_PATH, 'utf8');
+    const { height } = JSON.parse(buf) as { height: number };
+    return typeof height === 'number' ? height : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function saveCheckpoint(height: number): Promise<void> {
+  await ensureDir(STATE_PATH);
+  await fs.writeFile(STATE_PATH, JSON.stringify({ height }), 'utf8');
+}
+

--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -2,14 +2,15 @@ import { startStream, types } from 'near-lake-framework';
 import dotenv from 'dotenv';
 import { promises as fs } from 'fs';
 import path from 'path';
+import type { Waku } from '@waku/sdk';
 import { getClient } from '../../../src/utils/transport';
+import { loadCheckpoint, saveCheckpoint } from './checkpoint';
 
 dotenv.config();
 
 const CONTRACT_ID = process.env.CONTRACT_ID as string;
 const LAKE_BUCKET = process.env.LAKE_BUCKET as string;
 const START_BLOCK = parseInt(process.env.START_BLOCK || '0', 10);
-const STATE_PATH = process.env.STATE_PATH || '.state/lake.json';
 const DEDUPE_PATH = process.env.DEDUPE_PATH || '.state/dedupe.json';
 const WAKU_BOOTSTRAP = (process.env.WAKU_BOOTSTRAP || '').split(',').filter(Boolean);
 const NETWORK = process.env.NETWORK || 'testnet';
@@ -35,10 +36,8 @@ async function writeJson(file: string, data: any) {
   await fs.writeFile(file, JSON.stringify(data), 'utf8');
 }
 
-async function loadState() {
-  const state = await readJson<{ height: number }>(STATE_PATH, { height: 0 });
+async function loadDedupe() {
   dedupeMem = await readJson<DedupStore>(DEDUPE_PATH, {});
-  return state;
 }
 
 function dedupeKey(tx: string, logIndex: number) {
@@ -93,12 +92,13 @@ async function handleMessage(waku: Waku, streamerMessage: types.StreamerMessage)
       }
     }
   }
-  await writeJson(STATE_PATH, { height: blockHeight });
+  await saveCheckpoint(blockHeight + 1);
   await writeJson(DEDUPE_PATH, dedupeMem);
 }
 
 async function main() {
-  const { height } = await loadState();
+  await loadDedupe();
+  const height = await loadCheckpoint();
   const startHeight = Math.max(START_BLOCK, height);
   const { Waku } = await getClient();
   const waku = await Waku.create({ bootstrap: { peers: WAKU_BOOTSTRAP } });

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,6 +55,7 @@ module.exports = {
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',
+    '<rootDir>/tests/indexers/**/*.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/services/cache/index.ts
+++ b/services/cache/index.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const CACHE_DIR = process.env.CACHE_DIR || path.join(process.cwd(), '.cache');
+const SECRET = process.env.CACHE_SECRET || 'blue-ocean';
+const KEY = crypto.createHash('sha256').update(SECRET).digest();
+
+function filePath(key: string): string {
+  return path.join(CACHE_DIR, `${key}.bin`);
+}
+
+async function ensureDir(dir: string) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+export async function saveSnapshot(key: string, data: unknown): Promise<string> {
+  const json = Buffer.from(JSON.stringify(data));
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', KEY, iv);
+  const enc = Buffer.concat([cipher.update(json), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const out = Buffer.concat([iv, tag, enc]);
+  await ensureDir(CACHE_DIR);
+  await fs.writeFile(filePath(key), out);
+  return crypto.createHash('sha256').update(json).digest('hex');
+}
+
+export async function loadSnapshot<T>(key: string, expectedHash: string): Promise<T | null> {
+  try {
+    const buf = await fs.readFile(filePath(key));
+    const iv = buf.subarray(0, 12);
+    const tag = buf.subarray(12, 28);
+    const enc = buf.subarray(28);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', KEY, iv);
+    decipher.setAuthTag(tag);
+    const json = Buffer.concat([decipher.update(enc), decipher.final()]);
+    const hash = crypto.createHash('sha256').update(json).digest('hex');
+    if (hash !== expectedHash) return null;
+    return JSON.parse(json.toString('utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function getValidatedSnapshot<T>(
+  key: string,
+  fetchHash: () => Promise<string>,
+): Promise<T | null> {
+  const expected = await fetchHash();
+  return loadSnapshot<T>(key, expected);
+}
+

--- a/tests/indexers/crashRecovery.test.ts
+++ b/tests/indexers/crashRecovery.test.ts
@@ -1,0 +1,26 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { loadCheckpoint, saveCheckpoint } from '../../indexers/lake/src/checkpoint';
+
+describe('indexer checkpoint crash recovery', () => {
+  const stateFile = path.join(__dirname, 'tmp-state.json');
+
+  beforeEach(async () => {
+    process.env.STATE_PATH = stateFile;
+    await fs.rm(stateFile, { force: true });
+  });
+
+  it('starts from zero when no checkpoint exists', async () => {
+    const height = await loadCheckpoint();
+    expect(height).toBe(0);
+  });
+
+  it('resumes from last saved height', async () => {
+    await saveCheckpoint(50);
+    const saved = await loadCheckpoint();
+    expect(saved).toBe(50);
+    // simulate another processed block
+    await saveCheckpoint(saved + 1);
+    expect(await loadCheckpoint()).toBe(51);
+  });
+});


### PR DESCRIPTION
## Summary
- checkpoint NEAR indexer heights to resume after restart
- add AES-encrypted snapshot cache with hash validation
- test indexer crash recovery and include new tests in Jest config

## Testing
- `yarn lint indexers/lake/src services/cache tests/indexers`
- `yarn typecheck` *(fails: Property 'variant' does not exist on type...)*
- `npx jest tests/indexers/crashRecovery.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0af8b15f08326b555e65efc41ec87