### PR TITLE
feat: enhance waku messaging reliability

### DIFF
--- a/contexts/WakuContext.tsx
+++ b/contexts/WakuContext.tsx
@@ -9,7 +9,8 @@ import React, {
 } from 'react';
 import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
-import { encryptMessage, decryptMessage } from '@/utils/chatCrypto';
+import { encryptMessage, decryptMessage, encryptTopic } from '@/utils/chatCrypto';
+import { enqueue, flush } from '@/utils/wakuStore';
 import DatabaseService from '@/services/database';
 import { ChatMessage } from '@/types';
 import { getWakuBootstrapNodes } from '@/utils/appConfig';
@@ -60,8 +61,9 @@ const defaultValue: WakuContextValue = {
 
 const WakuContext = createContext<WakuContextValue>(defaultValue);
 
-function chatTopic(roomId: string) {
-  return `/blue-ocean/chat/1/${roomId}`;
+async function chatTopic(roomId: string, peerPublicKey: string) {
+  const enc = await encryptTopic(roomId, peerPublicKey);
+  return `/blue-ocean/chat/1/${enc}`;
 }
 
 const SYSTEM_TOPIC = '/blue-ocean/notifications/1';
@@ -89,6 +91,11 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);
       nodeRef.current = node;
       setStatus('connected');
+      const client = await getClient();
+      void flush(async (topic, payload) => {
+        const encoder = client.createEncoder({ contentTopic: topic });
+        await node.lightPush.send(encoder, { payload });
+      });
     } catch (err) {
       errorLog('Failed to start Waku node', err);
       nodeRef.current = undefined;
@@ -125,13 +132,14 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       message: msg.message,
     };
     await db.sendChatMessage(roomId, { ...full, message: encrypted });
-
+    const client = await getClient();
+    const topic = await chatTopic(roomId, peerPublicKey);
+    const payload = client.utf8ToBytes(encrypted);
     if (nodeRef.current) {
-      const client = await getClient();
-      const encoder = client.createEncoder({ contentTopic: chatTopic(roomId) });
-      await nodeRef.current.lightPush.send(encoder, {
-        payload: client.utf8ToBytes(encrypted),
-      });
+      const encoder = client.createEncoder({ contentTopic: topic });
+      await nodeRef.current.lightPush.send(encoder, { payload });
+    } else {
+      enqueue(topic, payload);
     }
     return full;
   }, []);
@@ -143,7 +151,8 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
   ): Promise<() => void> => {
     if (!nodeRef.current) return () => {};
     const client = await getClient();
-    const decoder = client.createDecoder(chatTopic(roomId));
+    const topic = await chatTopic(roomId, peerPublicKey);
+    const decoder = client.createDecoder(topic);
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
@@ -188,7 +197,8 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
   ): Promise<number> => {
     if (!nodeRef.current) return 0;
     const client = await getClient();
-    const decoder = client.createDecoder(chatTopic(roomId));
+    const topic = await chatTopic(roomId, peerPublicKey);
+    const decoder = client.createDecoder(topic);
     const options: any = { decoder };
     if (after || before) {
       options.timeFilter = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,6 +55,7 @@ module.exports = {
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',
+    '<rootDir>/tests/waku/*.test.ts',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@near-wallet-selector/core": "8.9.3",
     "@near-wallet-selector/near-wallet": "8.9.3",
     "@near-wallet-selector/wallet-utils": "^8.9.1",
+    "@noble/ciphers": "^1.3.0",
     "@noble/ed25519": "^2.1.1",
     "@noble/hashes": "1.8.0",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -30,6 +30,7 @@ const DEFAULT_BOOTSTRAPS: string[] = [
 ];
 
 let cachedNode: LightNode | null = null;
+const receivedIds = new Set<string>();
 
 function getPublisherKey(): string {
   if (PUB) return PUB;
@@ -90,4 +91,58 @@ export async function ensureNode(): Promise<LightNode | null> {
     cachedNode = null;
     return null;
   }
+}
+
+async function sendAck(topic: string, id: string): Promise<void> {
+  const node = await ensureNode();
+  if (!node) return;
+  const client = await getClient();
+  const encoder = client.createEncoder({ contentTopic: `${topic}/ack` });
+  await node.lightPush.send(encoder, {
+    payload: client.utf8ToBytes(JSON.stringify({ id })),
+  });
+}
+
+export async function publish(topic: string, message: any): Promise<string> {
+  const node = await ensureNode();
+  if (!node) throw new Error('Waku disabled');
+  const client = await getClient();
+  const id = message?.id || Date.now().toString();
+  const encoder = client.createEncoder({ contentTopic: topic });
+  await node.lightPush.send(encoder, {
+    payload: client.utf8ToBytes(JSON.stringify({ ...message, id })),
+  });
+  return id;
+}
+
+export async function subscribeWithAck(
+  topic: string,
+  cb: (msg: any) => void,
+): Promise<() => void> {
+  const node = await ensureNode();
+  if (!node) return () => {};
+  const client = await getClient();
+  const decoder = client.createDecoder(topic);
+  const handler = async (wakuMsg: any) => {
+    if (!wakuMsg.payload) return;
+    try {
+      const msg = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
+      if (msg.id && receivedIds.has(msg.id)) return;
+      if (msg.id) receivedIds.add(msg.id);
+      cb(msg);
+      if (msg.id) await sendAck(topic, msg.id);
+    } catch {
+      /* ignore */
+    }
+  };
+  const maybeUnsub = (node.relay as any).addObserver(handler, [decoder]) as
+    | (() => void)
+    | void;
+  return () => {
+    if (typeof maybeUnsub === 'function') {
+      maybeUnsub();
+    } else {
+      (node.relay as any)?.deleteObserver?.(handler);
+    }
+  };
 }

--- a/tests/waku/load.test.ts
+++ b/tests/waku/load.test.ts
@@ -1,0 +1,16 @@
+import { enqueue, flush, snapshot } from '@/utils/wakuStore';
+
+const send = jest.fn(async (_topic: string, _payload: Uint8Array) => {
+  // no-op
+});
+
+describe('waku replay queue load', () => {
+  it('flushes high volume of messages', async () => {
+    for (let i = 0; i < 500; i++) {
+      enqueue('topic', new Uint8Array([i % 255]));
+    }
+    await flush(send);
+    expect(send).toHaveBeenCalledTimes(500);
+    expect(snapshot()).toHaveLength(0);
+  });
+});

--- a/utils/chatCrypto.ts
+++ b/utils/chatCrypto.ts
@@ -1,5 +1,12 @@
 import { getEd25519KeyPair } from '@/services/localIdentity';
-import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from './encryption';
+import {
+  deriveSharedKey,
+  aesEncrypt,
+  aesDecrypt,
+  deriveChatSalt,
+  deriveSharedKeyRaw,
+} from './encryption';
+import { xchacha20 } from '@noble/ciphers/chacha';
 
 // roomKeys stores derived AES keys per chat room. To keep memory usage bounded
 // we maintain a simple LRU cache with a fixed size.
@@ -69,4 +76,36 @@ export async function decryptMessage(
 ): Promise<string> {
   const key = await getRoomKey(roomId, peerPublicKey);
   return aesDecrypt(msg, key);
+}
+
+/**
+ * Encrypt the room topic using an xChaCha20 key derived from the participants' keys.
+ * The result is a hex string suitable for inclusion in a Waku topic.
+ */
+export async function encryptTopic(
+  roomId: string,
+  peerPublicKey: string,
+): Promise<string> {
+  const { privateKey: myPrivEd, publicKey: myPub } = await getEd25519KeyPair();
+  const myPubHex = Buffer.from(myPub).toString('hex');
+  const salt = deriveChatSalt(myPubHex, peerPublicKey);
+  const key = await deriveSharedKeyRaw(myPrivEd, peerPublicKey, 'topic', salt);
+  const nonce = new Uint8Array(24); // deterministic
+  const enc = xchacha20(key, nonce, new TextEncoder().encode(roomId));
+  return Buffer.from(enc).toString('hex');
+}
+
+/** Decrypt an encrypted topic back to the original room id. */
+export async function decryptTopic(
+  encrypted: string,
+  peerPublicKey: string,
+): Promise<string> {
+  const { privateKey: myPrivEd, publicKey: myPub } = await getEd25519KeyPair();
+  const myPubHex = Buffer.from(myPub).toString('hex');
+  const salt = deriveChatSalt(myPubHex, peerPublicKey);
+  const key = await deriveSharedKeyRaw(myPrivEd, peerPublicKey, 'topic', salt);
+  const nonce = new Uint8Array(24);
+  const data = Uint8Array.from(Buffer.from(encrypted, 'hex'));
+  const dec = xchacha20(key, nonce, data);
+  return new TextDecoder().decode(dec);
 }

--- a/utils/encryption.ts
+++ b/utils/encryption.ts
@@ -30,6 +30,23 @@ export async function deriveSharedKey(
 }
 
 /**
+ * Derive a shared 32-byte key for non-WebCrypto algorithms like xChaCha20.
+ * Returns raw key bytes instead of importing as a CryptoKey.
+ */
+export async function deriveSharedKeyRaw(
+  myPrivateEd25519: Uint8Array,
+  peerPublicEd25519Hex: string,
+  info: string,
+  salt: Uint8Array,
+): Promise<Uint8Array> {
+  const myX = ed2curve.convertSecretKey(myPrivateEd25519);
+  const peerX = ed2curve.convertPublicKey(Buffer.from(peerPublicEd25519Hex, 'hex'));
+  if (!myX || !peerX) throw new Error('key conversion failed');
+  const shared = nacl.scalarMult(myX, peerX);
+  return hkdf(sha256, shared, salt, info, 32);
+}
+
+/**
  * Derive a deterministic salt from two public ed25519 keys.
  * The keys are sorted to ensure consistent salt regardless of caller order.
  */

--- a/utils/wakuStore.ts
+++ b/utils/wakuStore.ts
@@ -1,0 +1,37 @@
+import { uuid } from './uuid';
+
+interface QueuedMessage {
+  id: string;
+  topic: string;
+  payload: Uint8Array;
+}
+
+const queue: QueuedMessage[] = [];
+
+/** Enqueue a message for later replay. Returns the generated message id. */
+export function enqueue(topic: string, payload: Uint8Array): string {
+  const id = uuid();
+  queue.push({ id, topic, payload });
+  return id;
+}
+
+/** Flush queued messages using the provided send function. */
+export async function flush(
+  send: (topic: string, payload: Uint8Array) => Promise<void>,
+): Promise<void> {
+  while (queue.length > 0) {
+    const msg = queue[0];
+    try {
+      await send(msg.topic, msg.payload);
+      queue.shift();
+    } catch {
+      // exit early; remaining messages stay queued
+      break;
+    }
+  }
+}
+
+/** Returns a snapshot of the current queue for debugging/testing. */
+export function snapshot(): QueuedMessage[] {
+  return [...queue];
+}


### PR DESCRIPTION
## Summary
- add message ID tracking and ACK support to waku service
- encrypt chat topics using xChaCha20 keys derived from participant public keys
- queue unsent messages and replay on reconnect
- include high-volume replay queue load test

## Testing
- `npx jest --runInBand tests/wakuErrorLogging.test.ts`
- `npx jest --runInBand tests/waku/load.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0af9db1cc832699d04b5ec1723f36