### PR TITLE
Add CID validation, secure uploads and redundant pinning

### DIFF
--- a/scripts/pin.js
+++ b/scripts/pin.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Redundant IPFS pinning utility. Pins provided files to all configured
+ * gateways so content remains available even if one service goes down.
+ */
+
+const fs = require('fs');
+const FormData = require('form-data');
+
+const gateways = [];
+
+if (process.env.EXPO_PUBLIC_PINATA_JWT || process.env.PINATA_JWT) {
+  gateways.push({
+    name: 'pinata',
+    url: 'https://api.pinata.cloud/pinning/pinFileToIPFS',
+    headers: {
+      Authorization: `Bearer ${process.env.EXPO_PUBLIC_PINATA_JWT || process.env.PINATA_JWT}`,
+    },
+  });
+}
+
+if (process.env.WEB3_STORAGE_TOKEN) {
+  gateways.push({
+    name: 'web3.storage',
+    url: 'https://api.web3.storage/upload',
+    headers: {
+      Authorization: `Bearer ${process.env.WEB3_STORAGE_TOKEN}`,
+    },
+  });
+}
+
+if (gateways.length === 0) {
+  console.error('No IPFS gateway tokens configured');
+  process.exit(1);
+}
+
+async function pinToGateway(gateway, filePath) {
+  const data = new FormData();
+  data.append('file', fs.createReadStream(filePath));
+  const res = await fetch(gateway.url, {
+    method: 'POST',
+    body: data,
+    headers: { ...gateway.headers, ...data.getHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to pin via ${gateway.name}: ${res.status}`);
+  }
+  const json = await res.json();
+  return json.IpfsHash || json.cid || json.Hash;
+}
+
+async function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('Usage: node scripts/pin.js <file> [file...]');
+    process.exit(1);
+  }
+  for (const file of files) {
+    const results = await Promise.all(
+      gateways.map(async (g) => ({ gateway: g.name, cid: await pinToGateway(g, file) }))
+    );
+    console.log(`${file}: ${results.map((r) => `${r.gateway}:${r.cid}`).join(' | ')}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/media.ts
+++ b/services/media.ts
@@ -42,6 +42,26 @@ class MediaService {
   }
 
   /**
+   * Validate a CID against Pinata's API.
+   */
+  async validateCid(cid: string): Promise<boolean> {
+    const svc = PinataService.getInstance();
+    return await svc.validateCid(cid);
+  }
+
+  /**
+   * Resolve a CID or ipfs:// URI to a gateway URL after validation.
+   * Returns null if the CID fails validation.
+   */
+  async resolveUri(uri: string): Promise<string | null> {
+    const svc = PinataService.getInstance();
+    if (!svc.isCidOrUrl(uri)) return uri;
+    const cleaned = uri.replace(/^ipfs:\/\//, '');
+    const ok = await this.validateCid(cleaned);
+    return ok ? `https://gateway.pinata.cloud/ipfs/${cleaned}` : null;
+  }
+
+  /**
    * Upload multiple media files
    */
   async uploadMultipleFiles(files: { uri: string, name: string }[]): Promise<string[]> {

--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -1,6 +1,10 @@
 import { debugLog } from '@/utils/logger';
 import isCidOrUrl from '@/utils/isCidOrUrl';
 import config from '@/utils/appConfig';
+import { aesEncrypt } from '@/utils/encryption';
+import { getPrivateKey } from './localIdentity';
+import { sha256 } from '@noble/hashes/sha256';
+import { Buffer } from 'buffer';
 
 /**
  * Minimal Pinata helper. Supports uploads using either a JWT or
@@ -58,6 +62,7 @@ class PinataService {
       const fs = await import('fs/promises');
       const path = uri.startsWith('file://') ? uri.replace('file://', '') : uri;
       const buffer = await fs.readFile(path);
+      await this.secureDelete(path);
       form.append('file', new Blob([buffer]), name);
     } else {
       form.append('file', { uri, name, type: 'application/octet-stream' } as any);
@@ -86,6 +91,73 @@ class PinataService {
     const json = await res.json();
     onProgress?.(100);
     return json.IpfsHash as string;
+  }
+
+  private async getEncryptionKey(): Promise<CryptoKey> {
+    const priv = await getPrivateKey();
+    const material = sha256(Buffer.from(priv));
+    return crypto.subtle.importKey(
+      'raw',
+      material,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt'],
+    );
+  }
+
+  private async secureDelete(path: string): Promise<void> {
+    const fs = await import('fs/promises');
+    try {
+      const data = await fs.readFile(path);
+      const key = await this.getEncryptionKey();
+      const enc = await aesEncrypt(Buffer.from(data).toString('base64'), key);
+      await fs.writeFile(path, enc);
+    } catch {}
+    try {
+      await fs.unlink(path);
+    } catch {}
+  }
+
+  /**
+   * Validate that a given CID is pinned on Pinata.
+   * Returns true when the CID exists in the authenticated account.
+   */
+  public async validateCid(cid: string): Promise<boolean> {
+    const cleaned = cid.replace(/^ipfs:\/\//, '').trim();
+    if (!this.isCidOrUrl(cleaned)) return false;
+
+    if (!(await this.isPinataConfigured())) {
+      // Without credentials we cannot query Pinata; assume valid
+      return true;
+    }
+
+    const jwt =
+      config.EXPO_PUBLIC_PINATA_JWT || process.env.EXPO_PUBLIC_PINATA_JWT;
+    const apiKey =
+      config.EXPO_PUBLIC_PINATA_API_KEY || process.env.EXPO_PUBLIC_PINATA_API_KEY;
+    const secret =
+      config.EXPO_PUBLIC_PINATA_SECRET_API_KEY ||
+      process.env.EXPO_PUBLIC_PINATA_SECRET_API_KEY;
+
+    const headers: Record<string, string> = {};
+    if (jwt) {
+      headers.Authorization = `Bearer ${jwt}`;
+    } else if (apiKey && secret) {
+      headers.pinata_api_key = apiKey;
+      headers.pinata_secret_api_key = secret;
+    }
+
+    try {
+      const res = await fetch(
+        `https://api.pinata.cloud/data/pinList?hashContains=${cleaned}`,
+        { headers },
+      );
+      if (!res.ok) return false;
+      const json = await res.json();
+      return (json.count || 0) > 0;
+    } catch {
+      return false;
+    }
   }
 
   public async isPinataConfigured(): Promise<boolean> {

--- a/tests/media/hashIntegrity.test.ts
+++ b/tests/media/hashIntegrity.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import PinataService from '@/services/pinata';
+import { insertConfig } from '../testUtils';
+
+describe('temporary upload encryption', () => {
+  beforeEach(() => {
+    insertConfig({ EXPO_PUBLIC_PINATA_JWT: 'jwt-token' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('encrypts and deletes temp file', async () => {
+    const tmp = path.join(__dirname, 'tmp.txt');
+    fs.writeFileSync(tmp, 'hello');
+
+    const fsPromises = require('fs/promises');
+    const writeSpy = jest.spyOn(fsPromises, 'writeFile');
+    const unlinkSpy = jest
+      .spyOn(fsPromises, 'unlink')
+      .mockImplementation(async () => {});
+
+    jest
+      .spyOn(global as any, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ IpfsHash: 'cid123' }) } as any);
+
+    const svc = PinataService.getInstance();
+    await svc.uploadFile(tmp, 'tmp.txt');
+
+    expect(writeSpy).toHaveBeenCalled();
+    expect(unlinkSpy).toHaveBeenCalled();
+    const written = writeSpy.mock.calls[0][1];
+    expect(written).not.toBe('hello');
+    fs.unlinkSync(tmp);
+  });
+});

--- a/tests/media/validation.test.ts
+++ b/tests/media/validation.test.ts
@@ -1,0 +1,32 @@
+import MediaService from '@/services/media';
+import { insertConfig } from '../testUtils';
+
+describe('MediaService CID validation', () => {
+  beforeEach(() => {
+    insertConfig({ EXPO_PUBLIC_PINATA_JWT: 'jwt-token' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('confirms pinned CID', async () => {
+    const svc = MediaService.getInstance();
+    const mock = jest
+      .spyOn(global as any, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ count: 1 }) } as any);
+    await expect(svc.validateCid('cid123')).resolves.toBe(true);
+    expect(mock).toHaveBeenCalledWith(
+      expect.stringContaining('hashContains=cid123'),
+      expect.any(Object)
+    );
+  });
+
+  it('rejects missing CID', async () => {
+    const svc = MediaService.getInstance();
+    jest
+      .spyOn(global as any, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ count: 0 }) } as any);
+    await expect(svc.validateCid('cid999')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- validate CIDs before use in MediaService
- encrypt and securely remove temporary uploads in PinataService
- add redundant IPFS pinning script and smoke tests

## Testing
- `npx eslint services/media.ts services/pinata.ts scripts/pin.js tests/media/validation.test.ts tests/media/hashIntegrity.test.ts`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Duplicate identifier 'AbortSignal', etc.)*
- `npx jest --runTestsByPath tests/media/validation.test.ts tests/media/hashIntegrity.test.ts tests/pinataService.test.ts` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b13195a88326bc2d23ff55bd4fb6