### PR TITLE
Guard nearKvStore path checks against missing path.isAbsolute

### DIFF
--- a/services/nearKvStore.ts
+++ b/services/nearKvStore.ts
@@ -28,7 +28,11 @@ const localDir =
 const memStore = new Map<string, Map<string, string>>();
 
 function validateSegment(seg: string) {
-  if (seg.includes('..') || seg.includes('/') || seg.includes('\\') || path.isAbsolute(seg)) {
+  const isAbs =
+    typeof path.isAbsolute === 'function'
+      ? path.isAbsolute(seg)
+      : /^(?:[\\/]|[A-Za-z]:)/.test(seg);
+  if (seg.includes('..') || seg.includes('/') || seg.includes('\\') || isAbs) {
     throw new Error('Invalid path segment');
   }
 }

--- a/tests/nearKvPersistence.test.ts
+++ b/tests/nearKvPersistence.test.ts
@@ -58,3 +58,19 @@ function runScript(code: string): string {
   });
 });
 
+describe('path_segment_validation', () => {
+  it('rejects absolute paths in Node environment', () => {
+    const out = runScript(
+      "const kv=require('./services/nearKvStore'); (async()=>{try{await kv.setValue('addr','/foo','bar'); console.log('ok');}catch{console.log('err');}})();",
+    );
+    expect(out).toBe('err');
+  });
+
+  it('rejects absolute paths without path.isAbsolute', () => {
+    const out = runScript(
+      "const path=require('path'); const kv=require('./services/nearKvStore'); path.isAbsolute=undefined; (async()=>{try{await kv.setValue('addr','/foo','bar'); console.log('ok');}catch{console.log('err');}})();",
+    );
+    expect(out).toBe('err');
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle absence of `path.isAbsolute` in nearKvStore with regex fallback
- test absolute path rejection in Node and shimmed environments

## Testing
- `npx jest tests/nearKvPersistence.test.ts --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68c0b253dcb083269ebdb2da89acc527