### PR TITLE
fix: stabilize product form modal effect

### DIFF
--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -92,7 +92,7 @@ export default function ProductFormModal({
       initForm();
       loadPricingTiers();
     }
-  }, [visible, product, address]);
+  }, [visible, product?.id]);
 
   useEffect(() => {
     const category = categories.find(c => c.id === editingProduct.category);


### PR DESCRIPTION
## Summary
- prevent recursive updates in ProductFormModal by watching `visible` and `product?.id`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: TypeScript errors)*
- `npx jest --testMatch "**/productFormModal.test.tsx"` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b254f44c8326a03e617340dec4fb