### PR TITLE
Add sortProducts translation

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -98,6 +98,7 @@
     "fallbackBanner2Title": "No banners yet",
     "fallbackBanner2Subtitle": "Add banners to make your home page shine.",
     "addBanner": "Add Banner",
+    "sortProducts": "Sort products",
     "sortBy": "Sort by",
     "newest": "Newest",
     "priceLowHigh": "Price: Low to High",

--- a/translations/he.json
+++ b/translations/he.json
@@ -98,6 +98,7 @@
     "fallbackBanner2Title": "אין עדיין באנרים",
     "fallbackBanner2Subtitle": "הוסף באנרים כדי לשדרג את דף הבית",
     "addBanner": "הוסף באנר",
+    "sortProducts": "מיון מוצרים",
     "sortBy": "מיון לפי",
     "newest": "החדשים ביותר",
     "priceLowHigh": "מחיר: נמוך לגבוה",


### PR DESCRIPTION
## Summary
- add `home.sortProducts` key for English and Hebrew translations

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: variant not assignable, suspense option, etc.)*
- `npm test` *(fails: missing script 'test')*
- `npx jest` *(fails: multiple test suites could not run due to unexpected tokens and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b2540dc08326bf880b06e9d4bf61