### PR TITLE
feat: add observability tooling

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,23 @@
+# Observability
+
+Blue Ocean services emit structured logs and Prometheus metrics.
+
+## Logging
+
+Service modules use [pino](https://github.com/pinojs/pino) for structured logging. Logs include the service name and action for each call.
+
+## Metrics
+
+Metrics are exposed on `http://localhost:9464/metrics` by default. Set `METRICS_PORT` to change the port.
+
+Two metrics are exported:
+
+- `service_latency_seconds` – Histogram tracking service call latency.
+- `service_failures_total` – Counter of failed service calls.
+
+Prometheus alert thresholds are provided in [`scripts/monitoring/alerts.yml`](../scripts/monitoring/alerts.yml) for latency and failure rates.
+
+## Retry Middleware
+
+Network calls to Waku and NEAR RPC use a retry-with-exponential-backoff helper defined in [`utils/retry.ts`](../utils/retry.ts).
+

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "near-api-js": "2.1.4",
     "near-lake-framework": "^2.0.0",
     "pg": "^8.11.3",
+    "pino": "^9.3.1",
+    "prom-client": "^15.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.6",

--- a/scripts/monitoring/alerts.yml
+++ b/scripts/monitoring/alerts.yml
@@ -1,0 +1,19 @@
+groups:
+  - name: service-alerts
+    rules:
+      - alert: HighServiceLatency
+        expr: histogram_quantile(0.95, sum(rate(service_latency_seconds_bucket[5m])) by (le,service)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High service latency
+          description: 95th percentile latency over 1s for 5m.
+      - alert: HighServiceFailureRate
+        expr: sum(rate(service_failures_total[5m])) by (service) / sum(rate(service_latency_seconds_count[5m])) by (service) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: High service failure rate
+          description: More than 5% of service calls failing over 5m.

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -2,6 +2,8 @@ import { errorLog } from '@/utils/logger';
 import { chainAdapter } from '@/services/chain';
 import { fetchSettings } from './nearSettings';
 import { assertNearChain } from './chain';
+import { logger, serviceFailures, serviceLatency } from '@/utils/observability';
+import { retryWithBackoff } from '@/utils/retry';
 
 assertNearChain();
 
@@ -18,12 +20,13 @@ export async function getOrderPaymentFactoryAddress(): Promise<string> {
 }
 
 async function sendNear(message: string): Promise<string> {
-  return chainAdapter.signMessage?.(message) || '';
+  return retryWithBackoff(async () => chainAdapter.signMessage?.(message) || '');
 }
 
 export async function deployOrderPayment(
   amount: number,
 ): Promise<{ contractAddress: string; txHash: string }> {
+  const end = serviceLatency.startTimer({ service: 'near.deployOrderPayment' });
   try {
     const factoryAddress = await getOrderPaymentFactoryAddress();
     const settings = await fetchSettings();
@@ -32,28 +35,47 @@ export async function deployOrderPayment(
     const txHash = await sendNear(
       `Pay:${amount}:${feeAddress}:${feeBps}`,
     );
+    logger.info({ service: 'near.deployOrderPayment', txHash }, 'Order payment deployed');
     return { contractAddress: factoryAddress, txHash };
   } catch (e) {
+    serviceFailures.inc({ service: 'near.deployOrderPayment' });
     errorLog('Failed to deploy order payment', e);
+    logger.error({ err: e }, 'Failed to deploy order payment');
     throw e;
+  } finally {
+    end();
   }
 }
 
 export async function releasePayment(contractAddress: string): Promise<string> {
+  const end = serviceLatency.startTimer({ service: 'near.releasePayment' });
   try {
-    return await sendNear(`Release:${contractAddress}`);
+    const tx = await sendNear(`Release:${contractAddress}`);
+    logger.info({ service: 'near.releasePayment', contractAddress }, 'Payment released');
+    return tx;
   } catch (e) {
+    serviceFailures.inc({ service: 'near.releasePayment' });
     errorLog('Failed to release payment', e);
+    logger.error({ err: e }, 'Failed to release payment');
     throw e;
+  } finally {
+    end();
   }
 }
 
 export async function refundPayment(contractAddress: string): Promise<string> {
+  const end = serviceLatency.startTimer({ service: 'near.refundPayment' });
   try {
-    return await sendNear(`Refund:${contractAddress}`);
+    const tx = await sendNear(`Refund:${contractAddress}`);
+    logger.info({ service: 'near.refundPayment', contractAddress }, 'Payment refunded');
+    return tx;
   } catch (e) {
+    serviceFailures.inc({ service: 'near.refundPayment' });
     errorLog('Failed to refund payment', e);
+    logger.error({ err: e }, 'Failed to refund payment');
     throw e;
+  } finally {
+    end();
   }
 }
 
@@ -61,13 +83,20 @@ export async function adminResolve(
   contractAddress: string,
   toSeller: boolean,
 ): Promise<string> {
+  const end = serviceLatency.startTimer({ service: 'near.adminResolve' });
   try {
-    return await sendNear(
+    const tx = await sendNear(
       `AdminResolve:${contractAddress}:${toSeller ? 1 : 0}`,
     );
+    logger.info({ service: 'near.adminResolve', contractAddress }, 'Dispute resolved');
+    return tx;
   } catch (e) {
+    serviceFailures.inc({ service: 'near.adminResolve' });
     errorLog('Failed to resolve dispute', e);
+    logger.error({ err: e }, 'Failed to resolve dispute');
     throw e;
+  } finally {
+    end();
   }
 }
 

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -1,6 +1,8 @@
 import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import { errorLog } from '@/utils/logger';
+import { logger, serviceFailures, serviceLatency } from '@/utils/observability';
+import { retryWithBackoff } from '@/utils/retry';
 
 const isProd = process.env.NODE_ENV === 'production';
 const strict = (process.env.WAKU_STRICT ?? (isProd ? '1' : '0')) === '1';
@@ -69,50 +71,82 @@ export async function ensureNode(): Promise<LightNode | null> {
   if (disabled) return null;
   if (cachedNode) return cachedNode;
   const bootstrap = getBootstraps();
-  if (strict && bootstrap.length === 0) {
-    const err: any = new Error('WAKU_BOOTSTRAP_UNCONFIGURED');
-    err.code = 'WAKU_BOOTSTRAP_UNCONFIGURED';
-    err.source = 'notifications-agent';
-    throw err;
-  }
-  getPublisherKey();
+  const end = serviceLatency.startTimer({ service: 'waku.ensureNode' });
   try {
-    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-    cachedNode = await createLightNode({ libp2p: { bootstrap } } as any);
-    if (!cachedNode) return null;
-    await cachedNode.start();
-    await waitForRemotePeer(cachedNode, [Protocols.Relay]);
+    const startNode = async () => {
+      if (strict && bootstrap.length === 0) {
+        const err: any = new Error('WAKU_BOOTSTRAP_UNCONFIGURED');
+        err.code = 'WAKU_BOOTSTRAP_UNCONFIGURED';
+        err.source = 'notifications-agent';
+        throw err;
+      }
+      getPublisherKey();
+      const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
+      const node = await createLightNode({ libp2p: { bootstrap } } as any);
+      if (!node) return null;
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Relay]);
+      return node;
+    };
+    cachedNode = await retryWithBackoff(startNode);
+    logger.info({ service: 'waku.ensureNode' }, 'Waku node started');
     return cachedNode;
   } catch (err) {
+    serviceFailures.inc({ service: 'waku.ensureNode' });
     errorLog('Failed to start Waku node', err instanceof Error ? err.message : err);
     if (err instanceof Error && err.stack) {
       errorLog(err.stack);
     }
+    logger.error({ err }, 'Failed to start Waku node');
     cachedNode = null;
     return null;
+  } finally {
+    end();
   }
 }
 
 async function sendAck(topic: string, id: string): Promise<void> {
   const node = await ensureNode();
   if (!node) return;
-  const client = await getClient();
-  const encoder = client.createEncoder({ contentTopic: `${topic}/ack` });
-  await node.lightPush.send(encoder, {
-    payload: client.utf8ToBytes(JSON.stringify({ id })),
-  });
+  const end = serviceLatency.startTimer({ service: 'waku.ack' });
+  try {
+    const client = await getClient();
+    const encoder = client.createEncoder({ contentTopic: `${topic}/ack` });
+    await retryWithBackoff(() =>
+      node.lightPush.send(encoder, {
+        payload: client.utf8ToBytes(JSON.stringify({ id })),
+      }),
+    );
+  } catch (err) {
+    serviceFailures.inc({ service: 'waku.ack' });
+    logger.error({ err, topic }, 'Failed to send Waku ack');
+  } finally {
+    end();
+  }
 }
 
 export async function publish(topic: string, message: any): Promise<string> {
   const node = await ensureNode();
   if (!node) throw new Error('Waku disabled');
-  const client = await getClient();
-  const id = message?.id || Date.now().toString();
-  const encoder = client.createEncoder({ contentTopic: topic });
-  await node.lightPush.send(encoder, {
-    payload: client.utf8ToBytes(JSON.stringify({ ...message, id })),
-  });
-  return id;
+  const end = serviceLatency.startTimer({ service: 'waku.publish' });
+  try {
+    const client = await getClient();
+    const id = message?.id || Date.now().toString();
+    const encoder = client.createEncoder({ contentTopic: topic });
+    await retryWithBackoff(() =>
+      node.lightPush.send(encoder, {
+        payload: client.utf8ToBytes(JSON.stringify({ ...message, id })),
+      }),
+    );
+    logger.info({ service: 'waku.publish', topic, id }, 'Published message');
+    return id;
+  } catch (err) {
+    serviceFailures.inc({ service: 'waku.publish' });
+    logger.error({ err, topic }, 'Failed to publish');
+    throw err;
+  } finally {
+    end();
+  }
 }
 
 export async function subscribeWithAck(

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -1,0 +1,37 @@
+import pino from 'pino';
+import { collectDefaultMetrics, Counter, Histogram, register } from 'prom-client';
+import http from 'http';
+
+export const logger = pino();
+
+collectDefaultMetrics();
+
+export const serviceLatency = new Histogram({
+  name: 'service_latency_seconds',
+  help: 'Service call latency in seconds',
+  labelNames: ['service'],
+});
+
+export const serviceFailures = new Counter({
+  name: 'service_failures_total',
+  help: 'Total number of service call failures',
+  labelNames: ['service'],
+});
+
+let metricsStarted = false;
+export function startMetricsServer(port = Number(process.env.METRICS_PORT || 9464)) {
+  if (metricsStarted || typeof window !== 'undefined') return;
+  const server = http.createServer(async (req, res) => {
+    if (req.url === '/metrics') {
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+  server.listen(port);
+  metricsStarted = true;
+}
+
+startMetricsServer();

--- a/utils/retry.ts
+++ b/utils/retry.ts
@@ -1,0 +1,19 @@
+import { setTimeout as sleep } from 'timers/promises';
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delayMs = 500,
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt++;
+      if (attempt > retries) throw err;
+      const wait = delayMs * 2 ** (attempt - 1);
+      await sleep(wait);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- instrument services with pino logging and Prometheus metrics
- add retry with exponential backoff for network calls
- document observability and alert thresholds

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: 'suspense' does not exist...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b522e0248326bc9704932edffe29