### PR TITLE
feat: enhance NEAR auth safety

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -69,6 +69,8 @@ module.exports = {
     '<rootDir>/tests/priceRange.test.tsx',
     '<rootDir>/tests/wallet/**/*.test.ts',
     '<rootDir>/tests/indexers/**/*.test.ts',
+    '<rootDir>/tests/auth/**/*.test.ts',
+    '<rootDir>/tests/auth/**/*.test.tsx',
   ],
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/setupEnv.ts'],

--- a/services/wallet/index.ts
+++ b/services/wallet/index.ts
@@ -1,1 +1,3 @@
 export { rotateKey } from './keyRotation';
+export { withAdminMFA } from './mfa';
+export { recoverKey } from './keyRecovery';

--- a/services/wallet/keyRecovery.ts
+++ b/services/wallet/keyRecovery.ts
@@ -1,0 +1,24 @@
+import { KeyPair } from 'near-api-js';
+
+interface RecoveryOptions {
+  backupKey?: string;
+  socialRecovery?: () => Promise<string>;
+}
+
+/**
+ * Recover a key either from a provided backup key string or via a
+ * social recovery function. Only one method is required. If both are
+ * supplied the backup key takes precedence.
+ */
+export async function recoverKey(options: RecoveryOptions): Promise<KeyPair> {
+  if (options.backupKey) {
+    return KeyPair.fromString(options.backupKey);
+  }
+  if (options.socialRecovery) {
+    const key = await options.socialRecovery();
+    return KeyPair.fromString(key);
+  }
+  throw new Error('No recovery method provided');
+}
+
+export default recoverKey;

--- a/services/wallet/keyRotation.ts
+++ b/services/wallet/keyRotation.ts
@@ -22,7 +22,7 @@ export async function rotateKey(
   });
   const account = await near.account(accountId);
   const newKeyPair = KeyPair.fromRandom('ed25519');
-  await account.addKey(newKeyPair.publicKey.toString());
+  await account.addKey(newKeyPair.getPublicKey().toString());
   if (oldPublicKey) {
     try {
       await account.deleteKey(oldPublicKey);

--- a/services/wallet/mfa.ts
+++ b/services/wallet/mfa.ts
@@ -1,0 +1,19 @@
+/**
+ * Optional multi-factor check wrapper for sensitive admin actions.
+ * If a verifier is provided, the action will only execute when the
+ * verifier resolves to `true`.
+ */
+export async function withAdminMFA<T>(
+  action: () => Promise<T>,
+  verify?: () => Promise<boolean>,
+): Promise<T> {
+  if (verify) {
+    const ok = await verify();
+    if (!ok) {
+      throw new Error('MFA verification failed');
+    }
+  }
+  return action();
+}
+
+export default withAdminMFA;

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -66,7 +66,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const chatPublicKey = Buffer.from(publicKey).toString('hex');
 
       if (profile) {
-        if (profile.chatPublicKey !== chatPublicKey) {
+        const roleChanged = user?.role !== profile.role;
+        if (profile.chatPublicKey !== chatPublicKey || roleChanged) {
           profile = { ...profile, chatPublicKey };
           await setChainUser(profile);
           await usersAgent.update(profile);

--- a/tests/auth/keyRecovery.test.ts
+++ b/tests/auth/keyRecovery.test.ts
@@ -1,0 +1,18 @@
+import { recoverKey } from '@/services/wallet';
+import { KeyPair } from 'near-api-js';
+
+describe('wallet key recovery', () => {
+  it('recovers key from backup string', async () => {
+    const original = KeyPair.fromRandom('ed25519');
+    const recovered = await recoverKey({ backupKey: original.toString() });
+    expect(recovered.toString()).toBe(original.toString());
+  });
+
+  it('recovers key using social recovery function', async () => {
+    const expected = KeyPair.fromRandom('ed25519');
+    const recovered = await recoverKey({
+      socialRecovery: async () => expected.toString(),
+    });
+    expect(recovered.toString()).toBe(expected.toString());
+  });
+});

--- a/tests/auth/sessionRoleRefresh.test.ts
+++ b/tests/auth/sessionRoleRefresh.test.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { AuthProvider, useAuth } from '@/features/auth/AuthContext';
+import * as nearUsers from '@/features/auth/services/nearUsers';
+import { chainAdapter } from '@/services/chain';
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    init: jest.fn(),
+    useAccount: jest.fn(),
+    openModal: jest.fn(),
+    getSelector: jest.fn(() => ({ wallet: async () => ({ signOut: jest.fn() }) })),
+  },
+}));
+
+const mockChain = chainAdapter as unknown as {
+  init: jest.Mock;
+  useAccount: jest.Mock;
+};
+
+function Capture() {
+  (Capture as any).ctx = useAuth();
+  return null;
+}
+
+describe('Auth role refresh on session start', () => {
+  it('invalidates stale roles when starting a new session', async () => {
+    mockChain.useAccount.mockReturnValue('alice.near');
+    mockChain.init.mockResolvedValue(undefined);
+
+    await nearUsers.setUser({
+      id: 'alice.near',
+      username: 'alice.near',
+      displayName: 'alice.near',
+      isAdmin: true,
+      address: 'alice.near',
+      role: 'admin',
+      chatPublicKey: '',
+    });
+
+    await act(async () => {
+      renderer.create(
+        React.createElement(AuthProvider, null, React.createElement(Capture, null)),
+      );
+    });
+
+    let ctx = (Capture as any).ctx;
+    expect(ctx.isAdmin).toBe(true);
+
+    await nearUsers.setUser({
+      id: 'alice.near',
+      username: 'alice.near',
+      displayName: 'alice.near',
+      isAdmin: false,
+      address: 'alice.near',
+      role: 'user',
+      chatPublicKey: ctx.user?.chatPublicKey || '',
+    });
+
+    await act(async () => {
+      renderer.create(
+        React.createElement(AuthProvider, null, React.createElement(Capture, null)),
+      );
+    });
+
+    ctx = (Capture as any).ctx;
+    expect(ctx.isAdmin).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional MFA wrapper and key-recovery helpers to wallet services
- refresh on-chain roles at session start and prune stale privileges
- cover key recovery and role refresh in auth tests

## Testing
- `npx jest tests/auth/keyRecovery.test.ts --runInBand --no-coverage`
- `npx jest tests/auth/sessionRoleRefresh.test.ts tests/auth/keyRecovery.test.ts --runInBand --no-coverage` *(fails: Unexpected token '<' in AuthContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b7cec96883269c39e82f07cc5284