### PR TITLE
feat: add s3 persistence and relayer security

### DIFF
--- a/indexers/lake/src/checkpoint.ts
+++ b/indexers/lake/src/checkpoint.ts
@@ -1,5 +1,45 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
+
+let S3Client: typeof import('minio').Client | null = null;
+let s3: import('minio').Client | null = null;
+const s3Bucket = process.env.STATE_S3_BUCKET;
+const s3Region = process.env.STATE_S3_REGION || 'eu-central-1';
+
+async function ensureS3() {
+  if (s3 || !s3Bucket) return;
+  const endpoint = process.env.STATE_S3_ENDPOINT;
+  const opts: any = { region: s3Region, s3ForcePathStyle: true };
+  if (endpoint) {
+    const url = new URL(endpoint);
+    opts.endPoint = url.hostname;
+    if (url.port) opts.port = parseInt(url.port, 10);
+    opts.useSSL = url.protocol === 'https:';
+  } else {
+    opts.endPoint = `s3.${s3Region}.amazonaws.com`;
+    opts.useSSL = true;
+  }
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    opts.accessKey = process.env.AWS_ACCESS_KEY_ID;
+    opts.secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+  }
+  if (!S3Client) {
+    const { Client } = require('minio');
+    S3Client = Client;
+  }
+  s3 = new S3Client!(opts);
+}
+
+async function streamToString(stream: Readable | Uint8Array | string): Promise<string> {
+  if (typeof stream === 'string') return stream;
+  if (stream instanceof Uint8Array) return Buffer.from(stream).toString('utf8');
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
 
 function statePath() {
   return process.env.STATE_PATH || path.join(process.cwd(), '.state/lake.json');
@@ -10,6 +50,17 @@ async function ensureDir(filePath: string) {
 }
 
 export async function loadCheckpoint(file: string = statePath()): Promise<number> {
+  if (s3Bucket) {
+    await ensureS3();
+    try {
+      const stream = await s3!.getObject(s3Bucket, 'checkpoint.json');
+      const buf = await streamToString(stream as Readable);
+      const { height } = JSON.parse(buf) as { height: number };
+      return typeof height === 'number' ? height : 0;
+    } catch {
+      return 0;
+    }
+  }
   try {
     const buf = await fs.readFile(file, 'utf8');
     const { height } = JSON.parse(buf) as { height: number };
@@ -20,6 +71,11 @@ export async function loadCheckpoint(file: string = statePath()): Promise<number
 }
 
 export async function saveCheckpoint(height: number, file: string = statePath()): Promise<void> {
+  if (s3Bucket) {
+    await ensureS3();
+    await s3!.putObject(s3Bucket, 'checkpoint.json', JSON.stringify({ height }));
+    return;
+  }
   await ensureDir(file);
   await fs.writeFile(file, JSON.stringify({ height }), 'utf8');
 }

--- a/indexers/lake/src/main.ts
+++ b/indexers/lake/src/main.ts
@@ -17,6 +17,7 @@ const NETWORK = process.env.NETWORK || 'testnet';
 
 type DedupStore = { [key: string]: number };
 let dedupeMem: DedupStore = {};
+let lastHeight = 0;
 
 async function ensureDir(filePath: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
@@ -55,6 +56,11 @@ function topicFor(storeId: string, type: 'listings' | 'orders') {
 
 async function handleMessage(waku: Waku, streamerMessage: types.StreamerMessage) {
   const blockHeight = streamerMessage.block.header.height;
+  if (blockHeight <= lastHeight) {
+    // Possible reorg, reset dedupe cache
+    dedupeMem = {};
+  }
+  lastHeight = blockHeight;
   for (const shard of streamerMessage.shards) {
     for (const reo of shard.receiptExecutionOutcomes) {
       if (reo.receipt?.receiverId !== CONTRACT_ID) continue;
@@ -100,6 +106,7 @@ async function main() {
   await loadDedupe();
   const height = await loadCheckpoint();
   const startHeight = Math.max(START_BLOCK, height);
+  lastHeight = startHeight;
   const { Waku } = await getClient();
   const waku = await Waku.create({ bootstrap: { peers: WAKU_BOOTSTRAP } });
   await waku.waitForConnectedPeer();

--- a/relayer/src/server.ts
+++ b/relayer/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { z } from 'zod';
 import { connect, keyStores, utils } from 'near-api-js';
 import dotenv from 'dotenv';
+import { Buffer } from 'buffer';
 
 dotenv.config();
 
@@ -27,6 +28,8 @@ const rateLimitRps = Math.max(1, parseInt(RATE_LIMIT_RPS || '10', 10));
 const Body = z.object({
   action: z.enum(['add_listing', 'buy_listing']),
   args: z.record(z.any()),
+  publicKey: z.string(),
+  signature: z.string(),
 });
 
 // Minimal in-memory rate limiter
@@ -95,11 +98,16 @@ app.post('/meta-tx', async (req, res) => {
   metrics.total++;
   const parsed = Body.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  const { action, args } = parsed.data as any;
+  const { action, args, publicKey, signature } = parsed.data as any;
   try {
     // Guardrails
     requireStoreId(args);
     assertDepositCaps(action, args);
+    // Verify signature
+    const msg = new TextEncoder().encode(JSON.stringify({ action, args }));
+    const pk = utils.PublicKey.fromString(publicKey);
+    const sig = Buffer.from(signature, 'base64');
+    if (!pk.verify(msg, sig)) throw new Error('invalid signature');
     // Allowlist enforced by zod enum
     const tx = await callFunction(action, args);
     metrics.ok++;

--- a/services/storage/index.ts
+++ b/services/storage/index.ts
@@ -1,0 +1,107 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { Readable } from 'stream';
+
+let S3Client: typeof import('minio').Client | null = null;
+let s3: import('minio').Client | null = null;
+const bucket = process.env.STORAGE_BUCKET;
+const region = process.env.STORAGE_REGION || 'eu-central-1';
+const secret = process.env.STORAGE_SECRET || 'blue-ocean-storage';
+const dir = process.env.STORAGE_DIR || path.join(process.cwd(), '.storage');
+
+const KEY = crypto.createHash('sha256').update(secret).digest();
+
+async function ensureS3() {
+  if (s3 || !bucket) return;
+  const endpoint = process.env.STORAGE_ENDPOINT;
+  const opts: any = { region, s3ForcePathStyle: true };
+  if (endpoint) {
+    const url = new URL(endpoint);
+    opts.endPoint = url.hostname;
+    if (url.port) opts.port = parseInt(url.port, 10);
+    opts.useSSL = url.protocol === 'https:';
+  } else {
+    opts.endPoint = `s3.${region}.amazonaws.com`;
+    opts.useSSL = true;
+  }
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    opts.accessKey = process.env.AWS_ACCESS_KEY_ID;
+    opts.secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+  }
+  if (!S3Client) {
+    const { Client } = require('minio');
+    S3Client = Client;
+  }
+  s3 = new S3Client!(opts);
+}
+
+function encrypt(data: string): Buffer {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', KEY, iv);
+  const enc = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, enc]);
+}
+
+function decrypt(buf: Buffer): string {
+  const iv = buf.subarray(0, 12);
+  const tag = buf.subarray(12, 28);
+  const enc = buf.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', KEY, iv);
+  decipher.setAuthTag(tag);
+  const out = Buffer.concat([decipher.update(enc), decipher.final()]);
+  return out.toString('utf8');
+}
+
+async function streamToBuffer(stream: Readable | Buffer | string): Promise<Buffer> {
+  if (Buffer.isBuffer(stream)) return stream;
+  if (typeof stream === 'string') return Buffer.from(stream);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function setItem(key: string, value: string): Promise<void> {
+  await ensureS3();
+  const enc = encrypt(value);
+  if (s3 && bucket) {
+    await s3.putObject(bucket, key, enc);
+    return;
+  }
+  const file = path.join(dir, key);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, enc);
+}
+
+export async function getItem(key: string): Promise<string | null> {
+  await ensureS3();
+  if (s3 && bucket) {
+    try {
+      const stream = await s3.getObject(bucket, key);
+      const buf = await streamToBuffer(stream as Readable);
+      return decrypt(buf);
+    } catch {
+      return null;
+    }
+  }
+  const file = path.join(dir, key);
+  try {
+    const buf = await fs.readFile(file);
+    return decrypt(buf);
+  } catch {
+    return null;
+  }
+}
+
+export async function removeItem(key: string): Promise<void> {
+  await ensureS3();
+  if (s3 && bucket) {
+    await s3.removeObject(bucket, key).catch(() => {});
+    return;
+  }
+  const file = path.join(dir, key);
+  await fs.rm(file, { force: true }).catch(() => {});
+}

--- a/tests/indexers/crashRecovery.test.ts
+++ b/tests/indexers/crashRecovery.test.ts
@@ -1,6 +1,26 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import { loadCheckpoint, saveCheckpoint } from '../../indexers/lake/src/checkpoint';
+
+jest.mock('minio', () => {
+  const store = new Map<string, Buffer>();
+  class Client {
+    async putObject(bucket: string, key: string, value: Buffer | string) {
+      const buf = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      store.set(`${bucket}/${key}`, buf);
+    }
+    async getObject(bucket: string, key: string) {
+      const val = store.get(`${bucket}/${key}`);
+      if (!val) throw new Error('not found');
+      return Readable.from(val);
+    }
+    async removeObject(bucket: string, key: string) {
+      store.delete(`${bucket}/${key}`);
+    }
+  }
+  return { Client };
+});
 
 describe('indexer checkpoint crash recovery', () => {
   const stateFile = path.join(__dirname, 'tmp-state.json');
@@ -22,5 +42,16 @@ describe('indexer checkpoint crash recovery', () => {
     // simulate another processed block
     await saveCheckpoint(saved + 1);
     expect(await loadCheckpoint()).toBe(51);
+  });
+
+  it('replays from S3 after crash', async () => {
+    process.env.STATE_S3_BUCKET = 'test-bucket';
+    delete process.env.STATE_PATH;
+    const cp1 = require('../../indexers/lake/src/checkpoint');
+    await cp1.saveCheckpoint(99);
+    delete require.cache[require.resolve('../../indexers/lake/src/checkpoint')];
+    const cp2 = require('../../indexers/lake/src/checkpoint');
+    expect(await cp2.loadCheckpoint()).toBe(99);
+    delete process.env.STATE_S3_BUCKET;
   });
 });


### PR DESCRIPTION
## Summary
- add encrypted S3-backed storage service
- persist indexer checkpoints to S3 with reorg handling
- verify relayer calls via signature
- test indexer crash recovery with mocked S3

## Testing
- `npx jest tests/indexers/crashRecovery.test.ts --coverage=false`
- `npx tsc services/storage/index.ts indexers/lake/src/checkpoint.ts indexers/lake/src/main.ts relayer/src/server.ts --noEmit` *(fails: Duplicate identifier 'AbortController')*


------
https://chatgpt.com/codex/tasks/task_e_68c0b7db90448326abdfefb56b51dd12