### PR TITLE
Optimize homepage loading with lazy assets and caching

### DIFF
--- a/components/HomeCards.tsx
+++ b/components/HomeCards.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, FlatList, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
+import { Image } from 'expo-image';
+
+interface Card {
+  id: string;
+  title: string;
+  image: string;
+}
+
+export default function HomeCards() {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const { width } = useWindowDimensions();
+  const numColumns = width >= 1024 ? 3 : width >= 640 ? 2 : 1;
+
+  const loadCards = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(false);
+      const url = new URL('api/catalog.json', globalThis.location.origin);
+      const res = await fetch(url.toString());
+      const data = (await res.json()) as Card[];
+      setCards(data);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCards();
+  }, [loadCards]);
+
+  if (loading) {
+    return <Text accessibilityRole="text">Loading catalog...</Text>;
+  }
+
+  if (error) {
+    return (
+      <View>
+        <Text accessibilityRole="text">Failed to load catalog.</Text>
+        <Button title="Retry" onPress={loadCards} accessibilityRole="button" />
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={cards}
+      key={numColumns}
+      numColumns={numColumns}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => (
+        <View style={styles.card}>
+          <Image
+            source={{ uri: item.image }}
+            style={styles.image}
+            contentFit="cover"
+            transition={100}
+            cachePolicy="memory-disk"
+            accessibilityLabel={item.title}
+            alt={item.title}
+            priority="low"
+          />
+          <Text accessibilityRole="text" style={styles.title}>{item.title}</Text>
+        </View>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    margin: 8,
+  },
+  image: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 8,
+  },
+  title: {
+    marginTop: 4,
+    textAlign: 'center',
+  },
+});

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,44 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, Button, Text, View } from 'react-native';
+
+const HomeCards = React.lazy(() => import('../components/HomeCards'));
+
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View>
+          <Text>Something went wrong.</Text>
+          <Button title="Retry" onPress={() => this.setState({ hasError: false })} />
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default function IndexPage() {
+  React.useEffect(() => {
+    if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+      const swUrl = new URL('service-worker.js', window.location.origin);
+      navigator.serviceWorker.register(swUrl.toString()).catch(() => undefined);
+    }
+  }, []);
+
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<ActivityIndicator />}>
+        <HomeCards />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,42 @@
+const CACHE = 'static-v1';
+const IMG_CACHE = 'images-v1';
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (![CACHE, IMG_CACHE].includes(key)) {
+            return caches.delete(key);
+          }
+          return undefined;
+        }),
+      ),
+    ),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.destination === 'image') {
+    event.respondWith(
+      caches.open(IMG_CACHE).then((cache) =>
+        cache.match(request).then((resp) => {
+          if (resp) return resp;
+          return fetch(request).then((networkResp) => {
+            cache.put(request, networkResp.clone());
+            return networkResp;
+          });
+        }),
+      ),
+    );
+    return;
+  }
+  event.respondWith(
+    fetch(request).catch(() => caches.match(request)),
+  );
+});


### PR DESCRIPTION
## Summary
- Split homepage bundle and register service worker for asset caching
- Add responsive HomeCards component with lazy-loaded images and accessibility
- Include fallback UI and error boundaries for retryable sections

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Cannot find module 'pino' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bb5150688326aa2f5e6426b8b13c