### PR TITLE
feat: enable waku history and reconnect

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -58,6 +58,7 @@ module.exports = {
     '<rootDir>/tests/wakuErrorLogging.test.ts',
     '<rootDir>/tests/wakuHydration.test.ts',
     '<rootDir>/tests/nearAdapter.test.ts',
+    '<rootDir>/tests/waku/**/*.test.ts',
     '<rootDir>/tests/i18n-offline.test.ts',
     '<rootDir>/tests/smoke.test.ts',
     '<rootDir>/tests/navigation.test.ts',

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -3,6 +3,13 @@ import { getClient } from '@/utils/transport';
 import { errorLog } from '@/utils/logger';
 import config from '@/config';
 import { canonicalJson } from '@/utils/serialization';
+import { retryWithBackoff } from '@/utils/retry';
+import { enqueue, flush } from '@/utils/wakuStore';
+import { encrypt, decrypt } from '@/utils/wakuCrypto';
+
+declare const logger: any;
+declare const serviceLatency: any;
+declare const serviceFailures: any;
 
 const isProd = process.env.NODE_ENV === 'production';
 const strict = (config.WAKU_STRICT || (isProd ? '1' : '0')) === '1';
@@ -22,7 +29,7 @@ const BOOT = (
   config.WAKU_BOOTSTRAP ||
   config.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
   ''
-) 
+)
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
@@ -33,6 +40,7 @@ const DEFAULT_BOOTSTRAPS: string[] = [
 
 let cachedNode: LightNode | null = null;
 const receivedIds = new Set<string>();
+let reconnectAttempt = 0;
 
 function getPublisherKey(): string {
   if (PUB) return PUB;
@@ -67,27 +75,52 @@ function getBootstraps(): string[] {
   return BOOT;
 }
 
+async function startNode(): Promise<LightNode | null> {
+  const bootstrap = getBootstraps();
+  if (strict && bootstrap.length === 0) {
+    const err: any = new Error('WAKU_BOOTSTRAP_UNCONFIGURED');
+    err.code = 'WAKU_BOOTSTRAP_UNCONFIGURED';
+    err.source = 'notifications-agent';
+    throw err;
+  }
+  getPublisherKey();
+  const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
+  const node = await createLightNode({ libp2p: { bootstrap } } as any);
+  if (!node) return null;
+  node.libp2p.addEventListener('peer:disconnect', () => {
+    cachedNode = null;
+    scheduleReconnect();
+  });
+  await node.start();
+  await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);
+  const client = await getClient();
+  await flush(async (topic, payload) => {
+    const encoder = client.createEncoder({ contentTopic: topic });
+    await node.lightPush.send(encoder, { payload });
+  });
+  reconnectAttempt = 0;
+  return node;
+}
+
+function scheduleReconnect(attempt = 0): void {
+  reconnectAttempt = attempt;
+  const delay = Math.min(30000, 1000 * 2 ** attempt);
+  setTimeout(async () => {
+    try {
+      cachedNode = await startNode();
+      if (!cachedNode) throw new Error('no node');
+    } catch {
+      cachedNode = null;
+      scheduleReconnect(attempt + 1);
+    }
+  }, delay);
+}
+
 export async function ensureNode(): Promise<LightNode | null> {
   if (disabled) return null;
   if (cachedNode) return cachedNode;
-  const bootstrap = getBootstraps();
   const end = serviceLatency.startTimer({ service: 'waku.ensureNode' });
   try {
-    const startNode = async () => {
-      if (strict && bootstrap.length === 0) {
-        const err: any = new Error('WAKU_BOOTSTRAP_UNCONFIGURED');
-        err.code = 'WAKU_BOOTSTRAP_UNCONFIGURED';
-        err.source = 'notifications-agent';
-        throw err;
-      }
-      getPublisherKey();
-      const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-      const node = await createLightNode({ libp2p: { bootstrap } } as any);
-      if (!node) return null;
-      await node.start();
-      await waitForRemotePeer(node, [Protocols.Relay]);
-      return node;
-    };
     cachedNode = await retryWithBackoff(startNode);
     logger.info({ service: 'waku.ensureNode' }, 'Waku node started');
     return cachedNode;
@@ -113,20 +146,22 @@ async function sendAck(topic: string, id: string): Promise<void> {
   await node.lightPush.send(encoder, {
     payload: client.utf8ToBytes(canonicalJson({ id })),
   });
-
 }
 
 export async function publish(topic: string, message: any): Promise<string> {
-  const node = await ensureNode();
-  if (!node) throw new Error('Waku disabled');
   const client = await getClient();
   const id = message?.id || Date.now().toString();
-  const encoder = client.createEncoder({ contentTopic: topic });
-  await node.lightPush.send(encoder, {
-    payload: client.utf8ToBytes(canonicalJson({ ...message, id })),
-  });
+  const payload = client.utf8ToBytes(canonicalJson({ ...message, id }));
+  const encPayload = encrypt(topic, payload);
+  try {
+    const node = await ensureNode();
+    if (!node) throw new Error('Waku disabled');
+    const encoder = client.createEncoder({ contentTopic: topic });
+    await node.lightPush.send(encoder, { payload: encPayload });
+  } catch {
+    enqueue(topic, encPayload);
+  }
   return id;
-
 }
 
 export async function subscribeWithAck(
@@ -140,7 +175,8 @@ export async function subscribeWithAck(
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
-      const msg = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
+      const dec = decrypt(topic, wakuMsg.payload);
+      const msg = JSON.parse(client.bytesToUtf8(dec));
       if (msg.id && receivedIds.has(msg.id)) return;
       if (msg.id) receivedIds.add(msg.id);
       cb(msg);
@@ -160,3 +196,34 @@ export async function subscribeWithAck(
     }
   };
 }
+
+export async function fetchHistory(
+  topic: string,
+  cb: (msg: any) => void,
+): Promise<void> {
+  const node = await ensureNode();
+  if (!node) return;
+  const client = await getClient();
+  const decoder = client.createDecoder(topic);
+  let cursor: any = undefined;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const res = await (node.store as any).queryHistory(decoder, { cursor });
+    const messages = res.messages || [];
+    for (const wakuMsg of messages) {
+      if (!wakuMsg.payload) continue;
+      try {
+        const dec = decrypt(topic, wakuMsg.payload);
+        const msg = JSON.parse(client.bytesToUtf8(dec));
+        cb(msg);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (!res.next) break;
+    cursor = res.next;
+  }
+}
+
+// Expose internals for testing
+export const __test__ = { startNode, scheduleReconnect };

--- a/tests/waku/offlineReplay.test.ts
+++ b/tests/waku/offlineReplay.test.ts
@@ -1,0 +1,27 @@
+jest.mock('@/config', () => ({ default: { EXPO_PUBLIC_WAKU_DISABLE: '1' } }));
+jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => ({
+    utf8ToBytes: (s: string) => new TextEncoder().encode(s),
+    bytesToUtf8: (b: Uint8Array) => new TextDecoder().decode(b),
+    createEncoder: () => ({}),
+    createDecoder: () => ({}),
+  })),
+}));
+
+;(global as any).logger = { info: jest.fn(), error: jest.fn() };
+(global as any).serviceLatency = { startTimer: () => () => {} };
+(global as any).serviceFailures = { inc: jest.fn() };
+import { publish } from '@/services/waku';
+import { snapshot, flush } from '@/utils/wakuStore';
+
+describe('waku offline replay', () => {
+  it('queues messages when offline and flushes on reconnect', async () => {
+    await publish('/test', { hello: 'world' });
+    expect(snapshot()).toHaveLength(1);
+    const send = jest.fn(async (_t: string, _p: Uint8Array) => {});
+    await flush(send);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(snapshot()).toHaveLength(0);
+  });
+});

--- a/tests/waku/reconnect.test.ts
+++ b/tests/waku/reconnect.test.ts
@@ -1,0 +1,55 @@
+jest.mock('@/config', () => ({ default: {} }));
+jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
+
+const client = {
+  waitForRemotePeer: jest.fn(async () => {}),
+  Protocols: { Relay: 'relay', Store: 'store' },
+  utf8ToBytes: (s: string) => new TextEncoder().encode(s),
+  bytesToUtf8: (b: Uint8Array) => new TextDecoder().decode(b),
+  createEncoder: () => ({}),
+  createDecoder: () => ({}),
+};
+
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => client),
+}));
+
+(global as any).logger = { info: jest.fn(), error: jest.fn() };
+(global as any).serviceLatency = { startTimer: () => () => {} };
+(global as any).serviceFailures = { inc: jest.fn() };
+import { ensureNode } from '@/services/waku';
+import { getClient } from '@/utils/transport';
+
+function createFakeNode() {
+  const libp2p = new EventTarget();
+  return {
+    start: jest.fn(),
+    libp2p,
+    lightPush: { send: jest.fn() },
+    relay: { addObserver: jest.fn(), deleteObserver: jest.fn() },
+    store: { queryHistory: jest.fn().mockResolvedValue({ messages: [], next: null }) },
+  } as any;
+}
+
+describe('waku auto reconnect', () => {
+  it('retries connection with exponential backoff', async () => {
+    jest.useFakeTimers();
+    const node1 = createFakeNode();
+    const node2 = createFakeNode();
+    const createLightNode = jest
+      .fn()
+      .mockResolvedValueOnce(node1)
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(node2);
+    (getClient as jest.Mock).mockResolvedValueOnce({ ...client, createLightNode })
+      .mockResolvedValue({ ...client, createLightNode });
+    await ensureNode();
+    expect(createLightNode).toHaveBeenCalledTimes(1);
+    node1.libp2p.dispatchEvent(new Event('peer:disconnect'));
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(createLightNode).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(createLightNode).toHaveBeenCalledTimes(3);
+    jest.useRealTimers();
+  });
+});

--- a/utils/wakuCrypto.ts
+++ b/utils/wakuCrypto.ts
@@ -1,0 +1,44 @@
+import { xchacha20 } from '@noble/ciphers/chacha';
+import { blake2b } from '@noble/hashes/blake2b';
+import { randomBytes } from '@noble/hashes/utils';
+
+// Derive a stable symmetric key for each topic using a Noise-style hash of the topic
+// and a random root secret. This avoids storing raw topic names on the wire.
+const rootSecret = randomBytes(32);
+const topicKeys = new Map<string, Uint8Array>();
+
+function topicKey(topic: string): Uint8Array {
+  if (!topicKeys.has(topic)) {
+    const enc = new TextEncoder().encode(topic);
+    // Combine root secret with topic name and hash to 32 bytes key.
+    const key = blake2b(Uint8Array.from([...rootSecret, ...enc]), { dkLen: 32 });
+    topicKeys.set(topic, key);
+  }
+  return topicKeys.get(topic)!;
+}
+
+/**
+ * Encrypt a payload for the given topic using xChaCha20.
+ * The returned Uint8Array contains nonce || ciphertext.
+ */
+export function encrypt(topic: string, payload: Uint8Array): Uint8Array {
+  const key = topicKey(topic);
+  const nonce = randomBytes(24);
+  const enc = xchacha20(key, nonce, payload);
+  const out = new Uint8Array(nonce.length + enc.length);
+  out.set(nonce, 0);
+  out.set(enc, nonce.length);
+  return out;
+}
+
+/**
+ * Decrypt a payload previously encrypted with {@link encrypt}.
+ */
+export function decrypt(topic: string, payload: Uint8Array): Uint8Array {
+  const key = topicKey(topic);
+  const nonce = payload.slice(0, 24);
+  const data = payload.slice(24);
+  return xchacha20(key, nonce, data);
+}
+
+export default { encrypt, decrypt };


### PR DESCRIPTION
## Summary
- integrate Waku store node with reconnection and history fetching
- add per-topic xChaCha20 message encryption helpers
- cover offline replay and reconnection with new tests

## Testing
- `npx jest tests/waku/offlineReplay.test.ts tests/waku/reconnect.test.ts tests/waku/load.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c0baa4342c83269c7f3fec3564e075