### PR TITLE
feat: add vault env loader and wallet context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,20 @@ jobs:
       - run: yarn typecheck
       - run: yarn config:check
       - run: yarn build:web
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Clippy
+        working-directory: contracts/marketplace
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Cargo audit
+        working-directory: contracts/marketplace
+        run: cargo audit

--- a/apps/web/app/_layout.tsx
+++ b/apps/web/app/_layout.tsx
@@ -1,20 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { Stack } from 'expo-router';
-import { chainAdapter } from '@/services/chain';
 import '../services/chainGuard';
 import WalletButton from '../components/WalletButton';
 
 export default function RootLayout() {
   const walletEnabled = process.env.EXPO_PUBLIC_FEATURE_WALLET === '1';
-
-  useEffect(() => {
-    if (walletEnabled) {
-      chainAdapter.init().catch((e) => {
-        console.error('Wallet init failed', e);
-      });
-    }
-  }, []);
 
   return (
     <View style={{ flex: 1 }}>

--- a/apps/web/components/WalletButton.tsx
+++ b/apps/web/components/WalletButton.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 
 export default function WalletButton() {
-  const [acct, setAcct] = React.useState<string | null>(null);
-  React.useEffect(() => {
-    try {
-      setAcct(chainAdapter.getAccountId());
-    } catch {}
-  }, []);
+  const { address: acct, connect } = useWallet();
   return (
     <button
       style={{
@@ -19,8 +14,7 @@ export default function WalletButton() {
       }}
       onClick={async () => {
         try {
-          await chainAdapter.openModal();
-          setAcct(chainAdapter.getAccountId());
+          await connect();
         } catch {}
       }}
     >

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,6 +1,8 @@
 import { config as loadEnv } from 'dotenv';
 import { z } from 'zod';
+import { loadVaultEnv } from './vault';
 
+loadVaultEnv();
 loadEnv();
 
 const envSchema = z.object({

--- a/config/vault.ts
+++ b/config/vault.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+import { config as load } from 'dotenv';
+
+export function loadVaultEnv(): void {
+  const vaultPath = process.env.VAULT_ENV || path.join(process.cwd(), '.env.vault');
+  if (fs.existsSync(vaultPath)) {
+    load({ path: vaultPath });
+  }
+}
+
+export default loadVaultEnv;

--- a/contexts/WalletProvider.tsx
+++ b/contexts/WalletProvider.tsx
@@ -28,6 +28,11 @@ export function WalletProvider({ children }: Props) {
   const address = chainAdapter.useAccount();
 
   const connect = useCallback(async () => {
+    const { error } = await chainAdapter.init();
+    if (error) {
+      console.error('Wallet initialization failed:', error);
+      return;
+    }
     await chainAdapter.openModal();
   }, []);
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -17,6 +17,10 @@ Two metrics are exported:
 
 Prometheus alert thresholds are provided in [`scripts/monitoring/alerts.yml`](../scripts/monitoring/alerts.yml) for latency and failure rates.
 
+## Service Hooks
+
+Use `withMonitoring` from [`services/monitoring.ts`](../services/monitoring.ts) to wrap asynchronous service calls. The helper records latency, increments the failure counter on errors and emits structured logs via the shared logger.
+
 ## Retry Middleware
 
 Network calls to Waku and NEAR RPC use a retry-with-exponential-backoff helper defined in [`utils/retry.ts`](../utils/retry.ts).

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -1,4 +1,5 @@
 import { errorLog } from '@/utils/logger';
+import { withMonitoring } from './monitoring';
 import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import { getWakuBootstrapNodes } from '../utils/appConfig';
@@ -46,26 +47,28 @@ export async function publish(
   type: string,
   payload: Record<string, unknown> = {},
 ): Promise<void> {
-  const n = await ensureNode();
-  if (!n) return;
-  try {
-    const client = await getClient();
-    const encoder = client.createEncoder({ contentTopic });
-    const addr = chainAdapter.getAccountId();
-    const event = {
-      id: uuid(),
-      timestamp: Date.now(),
-      actor: addr ? Buffer.from(sha256(Buffer.from(addr))).toString('hex') : undefined,
-      sessionId,
-      type,
-      ...payload,
-    };
-    await n.lightPush.send(encoder, {
-      payload: client.utf8ToBytes(canonicalJson(event)),
-    });
-  } catch (err) {
-    errorLog('Failed to publish event', err);
-  }
+  await withMonitoring('eventBus.publish', async () => {
+    const n = await ensureNode();
+    if (!n) return;
+    try {
+      const client = await getClient();
+      const encoder = client.createEncoder({ contentTopic });
+      const addr = chainAdapter.getAccountId();
+      const event = {
+        id: uuid(),
+        timestamp: Date.now(),
+        actor: addr ? Buffer.from(sha256(Buffer.from(addr))).toString('hex') : undefined,
+        sessionId,
+        type,
+        ...payload,
+      };
+      await n.lightPush.send(encoder, {
+        payload: client.utf8ToBytes(canonicalJson(event)),
+      });
+    } catch (err) {
+      errorLog('Failed to publish event', err);
+    }
+  });
 }
 
 export async function track(

--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -1,0 +1,32 @@
+import pino from 'pino';
+import { Counter, Histogram, Registry } from 'prom-client';
+
+export const registry = new Registry();
+export const logger = pino();
+
+export const latencyHistogram = new Histogram({
+  name: 'service_latency_seconds',
+  help: 'Service call latency',
+  labelNames: ['service'],
+  registers: [registry],
+});
+
+export const failureCounter = new Counter({
+  name: 'service_failures_total',
+  help: 'Service call failures',
+  labelNames: ['service'],
+  registers: [registry],
+});
+
+export async function withMonitoring<T>(service: string, fn: () => Promise<T>): Promise<T> {
+  const end = latencyHistogram.startTimer({ service });
+  try {
+    return await fn();
+  } catch (err) {
+    failureCounter.inc({ service });
+    logger.error({ service, err }, 'service failure');
+    throw err;
+  } finally {
+    end();
+  }
+}

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -3,7 +3,7 @@ import { Alert } from 'react-native';
 import { Spinner } from '@/ui';
 import { User } from '@/types';
 import { errorLog } from '@/utils/logger';
-import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 import usersAgent from '@/agents/users-agent';
 import { getEd25519KeyPair } from '@/services/localIdentity';
 import { t } from '@/i18n';
@@ -45,7 +45,7 @@ export const useAuth = () => useContext(AuthContext);
 interface AuthProviderProps { children: ReactNode }
 
 export function AuthProvider({ children }: AuthProviderProps) {
-  const address = chainAdapter.useAccount();
+  const { address, connect, disconnect } = useWallet();
   const [user, setUser] = useState<User | null>(null);
   const [initialized, setInitialized] = useState(false);
 
@@ -103,17 +103,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   useEffect(() => {
-    chainAdapter
-      .init()
-      .catch(() => null)
-      .finally(() => {
-        checkAuthState().finally(() => setInitialized(true));
-      });
+    checkAuthState().finally(() => setInitialized(true));
   }, [address]);
 
   const login = async () => {
     try {
-      await chainAdapter.openModal();
+      await connect();
     } catch (err: unknown) {
       errorLog(
         t('auth.walletConnectionFailed', 'Wallet connection failed'),
@@ -133,9 +128,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const logout = async () => {
     try {
-      const selector = chainAdapter.getSelector();
-      const wallet = await selector?.wallet();
-      await wallet?.signOut();
+      await disconnect();
     } catch (err) {
       errorLog(t('auth.logoutFailed', 'Logout failed'), err);
     }

--- a/src/features/auth/components/WalletConnectButton.tsx
+++ b/src/features/auth/components/WalletConnectButton.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Text, Button } from '@/ui';
-import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 
 interface WalletConnectButtonProps {
   onConnect?: () => void;
 }
 
 export default function WalletConnectButton({ onConnect }: WalletConnectButtonProps) {
-  const account = chainAdapter.useAccount();
+  const { address: account, connect } = useWallet();
 
   useEffect(() => {
     if (account) {
@@ -17,12 +17,7 @@ export default function WalletConnectButton({ onConnect }: WalletConnectButtonPr
   }, [account, onConnect]);
 
   const handleConnect = async () => {
-    const { error } = await chainAdapter.init();
-    if (error) {
-      console.error('Wallet initialization failed:', error);
-      return;
-    }
-    chainAdapter.openModal();
+    await connect();
   };
 
   return (

--- a/src/features/payments/components/MoonPayButton.tsx
+++ b/src/features/payments/components/MoonPayButton.tsx
@@ -2,7 +2,7 @@ import { errorLog } from '@/utils/logger';
 import React, { useState } from 'react';
 import { Button } from '@/ui';
 import { useAppInfo } from '@/contexts/AppInfoContext';
-import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 import MoonPayModal from './MoonPayModal';
 
 interface MoonPayButtonProps {
@@ -11,7 +11,7 @@ interface MoonPayButtonProps {
 
 export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
   const { fiatKey } = useAppInfo();
-  const walletAddress = chainAdapter.useAccount();
+  const { address: walletAddress, connect } = useWallet();
   const [visible, setVisible] = useState(false);
   const [amountNEAR, setAmountNEAR] = useState<number | undefined>(undefined);
 
@@ -19,7 +19,7 @@ export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
 
   const handlePress = async () => {
     if (!walletAddress) {
-      await chainAdapter.openModal();
+      await connect();
       return;
     }
     try {

--- a/src/features/payments/components/PayPrivatelyButton.tsx
+++ b/src/features/payments/components/PayPrivatelyButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/ui';
 import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 
 interface PayPrivatelyButtonProps {
   listingId: number;
@@ -9,12 +10,12 @@ interface PayPrivatelyButtonProps {
 }
 
 export default function PayPrivatelyButton({ listingId, amountYocto, onComplete }: PayPrivatelyButtonProps) {
-  const accountId = chainAdapter.useAccount();
+  const { address: accountId, connect } = useWallet();
   const [loading, setLoading] = useState(false);
 
   const handlePress = async () => {
     if (!accountId) {
-      await chainAdapter.openModal();
+      await connect();
       return;
     }
     try {

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -21,6 +21,7 @@ import DatabaseService from '@/services/database';
 import PinataService from '@/services/pinata';
 import ipfsService from '@/services/ipfsService';
 import chain, { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 
 let setProductBatch:
   | ((items: ProductIndexItem[]) => Promise<void>)
@@ -56,7 +57,7 @@ export default function ProductFormModal({
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { currencySymbol } = useCurrency();
-  const address = chainAdapter.useAccountId();
+  const { address } = useWallet();
   const { push } = useAppRouter();
   const [editingProduct, setEditingProduct] = useState<Partial<Product>>({});
   const [imageUrls, setImageUrls] = useState('');

--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useLanguage } from '@/ui/ThemeProvider';
 import storesAgent from '@/agents/stores-agent';
 import { chainAdapter } from '@/services/chain';
+import { useWallet } from '@/contexts/WalletProvider';
 import { errorLog } from '@/utils/logger';
 
 const StoreCreation: React.FC = () => {
@@ -21,11 +22,12 @@ const StoreCreation: React.FC = () => {
   const { t } = useLanguage();
   const { replace } = useAppRouter();
 
+  const { address: owner, connect } = useWallet();
+
   const mintStore = async () => {
     if (!name) return;
-    const owner = chainAdapter.getAccountId();
     if (!owner) {
-      await chainAdapter.openModal();
+      await connect();
       return;
     }
     try {

--- a/tests/config/vaultLoader.test.ts
+++ b/tests/config/vaultLoader.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('vault env loader', () => {
+  const vaultFile = path.join(process.cwd(), 'temp.env.vault');
+
+  afterEach(() => {
+    delete process.env.VAULT_ENV;
+    delete process.env.SECRET_TOKEN;
+    if (fs.existsSync(vaultFile)) fs.unlinkSync(vaultFile);
+  });
+
+  it('loads variables from vault file', () => {
+    fs.writeFileSync(vaultFile, 'SECRET_TOKEN=abc123');
+    process.env.VAULT_ENV = vaultFile;
+    jest.resetModules();
+    const cfg = require('@/config').default;
+    expect(cfg.SECRET_TOKEN).toBe('abc123');
+  });
+});

--- a/tests/moonPayButton.test.ts
+++ b/tests/moonPayButton.test.ts
@@ -16,6 +16,10 @@ jest.mock('@/features/auth/services/nearAuth', () => ({
   useAccountId: jest.fn(() => 'addr'),
 }));
 
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: 'addr', connect: jest.fn() }),
+}));
+
 const modalMock = jest.fn(({ visible, amountNEAR, amountUSD }: any) =>
   visible ? React.createElement('MoonPayModal', { amountNEAR, amountUSD }) : null,
 );

--- a/tests/payPrivatelyButton.test.tsx
+++ b/tests/payPrivatelyButton.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import PayPrivatelyButton from '@/features/payments/components/PayPrivatelyButton';
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    payPrivately: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mockConnect = jest.fn();
+const mockUseWallet = jest.fn(() => ({ address: null, connect: mockConnect }));
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: mockUseWallet,
+}));
+
+describe('PayPrivatelyButton', () => {
+  it('prompts connect when no account', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(
+        <PayPrivatelyButton listingId={1} amountYocto="10" />,
+      );
+    });
+    const btn = root!.root.findByProps({ testID: 'pay-privately-button' });
+    await act(async () => {
+      await btn.props.onPress();
+    });
+    expect(mockConnect).toHaveBeenCalled();
+  });
+
+  it('calls payPrivately when account exists', async () => {
+    const { chainAdapter } = require('@/services/chain');
+    mockUseWallet.mockReturnValue({ address: 'alice.testnet', connect: jest.fn() });
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(
+        <PayPrivatelyButton listingId={2} amountYocto="20" />,
+      );
+    });
+    const btn = root!.root.findByProps({ testID: 'pay-privately-button' });
+    await act(async () => {
+      await btn.props.onPress();
+    });
+    expect(chainAdapter.payPrivately).toHaveBeenCalledWith({
+      id: 2,
+      buyer: 'alice.testnet',
+      amountYocto: '20',
+    });
+  });
+});

--- a/tests/services/monitoring.test.ts
+++ b/tests/services/monitoring.test.ts
@@ -1,0 +1,16 @@
+import { failureCounter, latencyHistogram, withMonitoring } from '@/services/monitoring';
+
+describe('monitoring hooks', () => {
+  it('records latency and failures', async () => {
+    const startCount = failureCounter.hashMap['service:test']?.value || 0;
+    await expect(
+      withMonitoring('service:test', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    const endCount = failureCounter.hashMap['service:test']?.value || 0;
+    expect(endCount).toBe(startCount + 1);
+    const metric = latencyHistogram.hashMap['service:test'];
+    expect(metric).toBeDefined();
+  });
+});

--- a/tests/wallet/connectButton.test.tsx
+++ b/tests/wallet/connectButton.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import WalletConnectButton from '@/features/auth/components/WalletConnectButton';
+
+const mockConnect = jest.fn();
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: null, connect: mockConnect }),
+}));
+
+describe('WalletConnectButton', () => {
+  it('invokes connect on press', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<WalletConnectButton />);
+    });
+    const btn = root!.root.findByType('Button');
+    await act(async () => {
+      await btn.props.onPress();
+    });
+    expect(mockConnect).toHaveBeenCalled();
+  });
+});

--- a/tests/wallet/provider.test.ts
+++ b/tests/wallet/provider.test.ts
@@ -4,6 +4,7 @@ import { WalletProvider, useWallet } from '@/contexts/WalletProvider';
 
 jest.mock('@/services/chain', () => ({
   chainAdapter: {
+    init: jest.fn().mockResolvedValue({ error: null }),
     useAccount: () => 'alice.testnet',
     openModal: jest.fn().mockResolvedValue(undefined),
     signMessage: jest.fn().mockResolvedValue('signed'),


### PR DESCRIPTION
## Summary
- load secrets from vault-backed `.env` file
- centralize wallet actions via `WalletProvider`
- add monitoring hooks and contract linting in CI

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Cannot find module 'pino' or its types, etc)*
- `cargo clippy --all-targets -- -D warnings` *(fails: parity-secp256k1 yanked)*
- `npx jest --config jest.config.js tests/config/vaultLoader.test.ts tests/services/monitoring.test.ts` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_68c0bc0c1f7c83269be195f5baea4efa