### PR TITLE
feat: add react and ts presets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,11 @@ module.exports = function (api) {
   process.env.EXPO_ROUTER_APP_ROOT = "./app";
 
   return {
-    presets: ["babel-preset-expo"],
+    presets: [
+      "babel-preset-expo",
+      "@babel/preset-react",
+      "@babel/preset-typescript",
+    ],
     // SDK 50+: expo-router/babel is built into the preset; don't add it here.
     // Enable support for static class blocks in dependencies like @smithy/core
     // by transforming them during compilation.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, babelConfig: true }],
     '^.+\\.js$': 'babel-jest',
   },
   transformIgnorePatterns: [


### PR DESCRIPTION
## Summary
- enable React and TypeScript presets in Babel config
- configure ts-jest to respect repo's Babel config

## Testing
- `npx jest --maxWorkers=2` *(fails: cannot find module, out-of-scope variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c92805708326a0a389963c079ee5