### PR TITLE
refactor: import service latency metric in waku service

### DIFF
--- a/services/waku.ts
+++ b/services/waku.ts
@@ -6,10 +6,9 @@ import { canonicalJson } from '@/utils/serialization';
 import { retryWithBackoff } from '@/utils/retry';
 import { enqueue, flush } from '@/utils/wakuStore';
 import { encrypt, decrypt } from '@/utils/wakuCrypto';
+import { serviceLatency, serviceFailures } from '@/utils/observability';
 
 declare const logger: any;
-declare const serviceLatency: any;
-declare const serviceFailures: any;
 
 const isProd = process.env.NODE_ENV === 'production';
 const strict = (config.WAKU_STRICT || (isProd ? '1' : '0')) === '1';

--- a/tests/__mocks__/utils/observability.ts
+++ b/tests/__mocks__/utils/observability.ts
@@ -1,0 +1,5 @@
+const serviceLatency = { startTimer: () => () => {} };
+const serviceFailures = { inc: jest.fn() };
+const logger = { info: jest.fn(), error: jest.fn() };
+const startMetricsServer = jest.fn();
+module.exports = { serviceLatency, serviceFailures, logger, startMetricsServer };

--- a/tests/waku/offlineReplay.test.ts
+++ b/tests/waku/offlineReplay.test.ts
@@ -8,10 +8,9 @@ jest.mock('@/utils/transport', () => ({
     createDecoder: () => ({}),
   })),
 }));
+jest.mock('@/utils/observability', () => require('@/tests/__mocks__/utils/observability'));
 
 ;(global as any).logger = { info: jest.fn(), error: jest.fn() };
-(global as any).serviceLatency = { startTimer: () => () => {} };
-(global as any).serviceFailures = { inc: jest.fn() };
 import { publish } from '@/services/waku';
 import { snapshot, flush } from '@/utils/wakuStore';
 

--- a/tests/waku/reconnect.test.ts
+++ b/tests/waku/reconnect.test.ts
@@ -13,10 +13,9 @@ const client = {
 jest.mock('@/utils/transport', () => ({
   getClient: jest.fn(async () => client),
 }));
+jest.mock('@/utils/observability', () => require('@/tests/__mocks__/utils/observability'));
 
 (global as any).logger = { info: jest.fn(), error: jest.fn() };
-(global as any).serviceLatency = { startTimer: () => () => {} };
-(global as any).serviceFailures = { inc: jest.fn() };
 import { ensureNode } from '@/services/waku';
 import { getClient } from '@/utils/transport';
 

--- a/tests/wakuErrorLogging.test.ts
+++ b/tests/wakuErrorLogging.test.ts
@@ -10,7 +10,9 @@ jest.mock('@/utils/transport', () => ({
 }));
 
 jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
+jest.mock('@/utils/observability', () => require('@/tests/__mocks__/utils/observability'));
 
+;(global as any).logger = { info: jest.fn(), error: jest.fn() };
 import { ensureNode } from '@/services/waku';
 import { errorLog } from '@/utils/logger';
 


### PR DESCRIPTION
## Summary
- import service latency and failure metrics from `utils/observability`
- provide mock observability module for tests and update waku tests

## Testing
- `npx jest tests/waku tests/wakuErrorLogging.test.ts --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0c92e2ecc8326a9c8b458e11a60ef