### PR TITLE
fix(sdk-near): include config and serialization modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/runtime": "^7.27.6",
-    "@blue-ocean/sdk-near": "file:packages/sdk-near",
+    "@blue-ocean/sdk-near": "link:packages/sdk-near",
     "@blue-ocean/utils": "file:packages/utils",
     "@expo/metro-runtime": "~3.1.3",
     "@expo/vector-icons": "^14.1.0",

--- a/packages/sdk-near/dist/config.d.ts
+++ b/packages/sdk-near/dist/config.d.ts
@@ -1,0 +1,2 @@
+declare const config: Record<string, string>;
+export default config;

--- a/packages/sdk-near/dist/config.js
+++ b/packages/sdk-near/dist/config.js
@@ -1,0 +1,8 @@
+// Minimal configuration loader for the SDK. Reads required
+// environment variables and exposes them as a simple object.
+const config = {
+    EXPO_PUBLIC_RELAYER_URL: process.env.EXPO_PUBLIC_RELAYER_URL || '',
+    EXPO_PUBLIC_INDEXER_URL: process.env.EXPO_PUBLIC_INDEXER_URL || '',
+    EXPO_PUBLIC_TRANSPORT: process.env.EXPO_PUBLIC_TRANSPORT || '',
+};
+export default config;

--- a/packages/sdk-near/dist/index.d.ts
+++ b/packages/sdk-near/dist/index.d.ts
@@ -1,0 +1,36 @@
+/** Represents a listing returned from the indexer. */
+export interface Listing {
+    id: number;
+    seller: string;
+    price: number;
+}
+/** Arguments required to add a new listing via the relayer. */
+export interface AddListingArgs {
+    storeId: string;
+    itemId: number;
+    priceYocto: string;
+    metadata: string;
+}
+/** Arguments required to purchase a listing via the relayer. */
+export interface BuyListingArgs {
+    storeId: string;
+    itemId: number;
+    amountYocto: string;
+}
+export declare function getListings(storeId: string): Promise<Listing[]>;
+/** Submit a request to add a new listing through the relayer. */
+export declare function addListing(args: AddListingArgs): Promise<any>;
+/** Submit a purchase request for a listing through the relayer. */
+export declare function buyListing(args: BuyListingArgs): Promise<any>;
+/**
+ * Pay for a listing while attempting to preserve privacy.
+ * TODO: integrate with mixer for on-chain privacy once available.
+ */
+export declare function payPrivately(args: BuyListingArgs): Promise<any>;
+declare const _default: {
+    getListings: typeof getListings;
+    addListing: typeof addListing;
+    buyListing: typeof buyListing;
+    payPrivately: typeof payPrivately;
+};
+export default _default;

--- a/packages/sdk-near/dist/index.js
+++ b/packages/sdk-near/dist/index.js
@@ -1,0 +1,82 @@
+// SDK functions for interacting with the Blue Ocean NEAR marketplace
+// Uses relayer and indexer services defined by EXPO_PUBLIC_* env variables.
+function requireEnv(name) {
+    const value = config[name];
+    if (!value) {
+        throw new Error(`${name} is not configured`);
+    }
+    return value;
+}
+/** Fetch all listings from the indexer service. */
+import { requireStoreId } from '@blue-ocean/utils';
+import { canonicalJson } from './utils/serialization';
+import config from './config';
+export async function getListings(storeId) {
+    const sid = requireStoreId(storeId);
+    const transport = config.EXPO_PUBLIC_TRANSPORT || 'http';
+    if (transport === 'waku') {
+        // dynamic import to keep SDK usable without Waku
+        const mod = await import('./waku/index').catch(() => null);
+        if (mod?.getListingsFromWaku)
+            return mod.getListingsFromWaku(sid);
+    }
+    const indexerUrl = requireEnv('EXPO_PUBLIC_INDEXER_URL');
+    const res = await fetch(`${indexerUrl}/listings?storeId=${encodeURIComponent(sid)}`);
+    if (!res.ok) {
+        throw new Error(`Failed to fetch listings: ${res.status} ${res.statusText}`);
+    }
+    const json = await res.json();
+    if (!Array.isArray(json)) {
+        throw new Error('Invalid listings response');
+    }
+    return json;
+}
+/** Submit a request to add a new listing through the relayer. */
+export async function addListing(args) {
+    const sid = requireStoreId(args.storeId);
+    const relayerUrl = requireEnv('EXPO_PUBLIC_RELAYER_URL');
+    const res = await fetch(`${relayerUrl}/meta-tx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: canonicalJson({
+            storeId: sid,
+            action: 'add_listing',
+            args: { id: args.itemId, seller: '', price: 0, metadata: args.metadata, priceYocto: args.priceYocto },
+        }),
+    });
+    if (!res.ok) {
+        throw new Error(`Failed to add listing: ${res.status} ${res.statusText}`);
+    }
+    const json = await res.json();
+    if (json.error) {
+        throw new Error(json.error.message || 'Relayer error');
+    }
+    return json;
+}
+/** Submit a purchase request for a listing through the relayer. */
+export async function buyListing(args) {
+    const sid = requireStoreId(args.storeId);
+    const relayerUrl = requireEnv('EXPO_PUBLIC_RELAYER_URL');
+    const res = await fetch(`${relayerUrl}/meta-tx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: canonicalJson({ storeId: sid, action: 'buy_listing', args }),
+    });
+    if (!res.ok) {
+        throw new Error(`Failed to buy listing: ${res.status} ${res.statusText}`);
+    }
+    const json = await res.json();
+    if (json.error) {
+        throw new Error(json.error.message || 'Relayer error');
+    }
+    return json;
+}
+/**
+ * Pay for a listing while attempting to preserve privacy.
+ * TODO: integrate with mixer for on-chain privacy once available.
+ */
+export async function payPrivately(args) {
+    // For MVP, private payment falls back to the same relayer path.
+    return buyListing(args);
+}
+export default { getListings, addListing, buyListing, payPrivately };

--- a/packages/sdk-near/dist/utils/serialization.d.ts
+++ b/packages/sdk-near/dist/utils/serialization.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Serialize a value using canonical JSON encoding so that
+ * equivalent objects produce the same string representation.
+ */
+export declare function serializeCanonical(value: unknown): string;
+export declare const canonicalJson: typeof serializeCanonical;
+export default serializeCanonical;

--- a/packages/sdk-near/dist/utils/serialization.js
+++ b/packages/sdk-near/dist/utils/serialization.js
@@ -1,0 +1,11 @@
+import canonicalize from 'canonicalize';
+/**
+ * Serialize a value using canonical JSON encoding so that
+ * equivalent objects produce the same string representation.
+ */
+export function serializeCanonical(value) {
+    const result = canonicalize(value);
+    return result ?? '';
+}
+export const canonicalJson = serializeCanonical;
+export default serializeCanonical;

--- a/packages/sdk-near/dist/waku/index.d.ts
+++ b/packages/sdk-near/dist/waku/index.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Fetch and cache all historical messages for a given topic.
+ * Subsequent calls only append new unseen messages, preventing duplicates.
+ */
+export declare function hydrateMessages(topic: string): Promise<any[]>;
+export declare function getListingsFromWaku(storeId: string): Promise<any[]>;
+declare const _default: {
+    getListingsFromWaku: typeof getListingsFromWaku;
+    hydrateMessages: typeof hydrateMessages;
+};
+export default _default;

--- a/packages/sdk-near/dist/waku/index.js
+++ b/packages/sdk-near/dist/waku/index.js
@@ -1,0 +1,89 @@
+// Basic helpers for reading data from the Waku store. These functions intentionally
+// avoid depending on the rest of the application so that the SDK can be used on
+// its own. The logic here mirrors the higher level Waku utilities found in the
+// app source but is trimmed down for size and to avoid React dependencies.
+import { Buffer } from 'buffer';
+import { topicFor } from '@blue-ocean/utils';
+// In-memory cache of messages keyed by topic. Each topic also tracks a set of
+// previously seen payloads to avoid duplications when `hydrateMessages` is called
+// multiple times.
+const messageCache = new Map();
+const seenCache = new Map();
+let node = null;
+async function ensureNode() {
+    if (node)
+        return node;
+    try {
+        const bootstrap = (process.env.WAKU_BOOTSTRAP ||
+            process.env.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
+            '')
+            .split(String.fromCharCode(44))
+            .map((s) => s.trim())
+            .filter(Boolean);
+        const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
+        node = await createLightNode({ libp2p: { bootstrap } });
+        if (!node)
+            return null;
+        await node.start();
+        // The Store protocol is required to query historical messages.
+        await waitForRemotePeer(node, [Protocols.Store]);
+        return node;
+    }
+    catch {
+        node = null;
+        return null;
+    }
+}
+/**
+ * Fetch and cache all historical messages for a given topic.
+ * Subsequent calls only append new unseen messages, preventing duplicates.
+ */
+export async function hydrateMessages(topic) {
+    const n = await ensureNode();
+    if (!n)
+        return messageCache.get(topic) || [];
+    const { createDecoder } = await import('@waku/sdk');
+    const decoder = createDecoder(topic);
+    const existing = messageCache.get(topic) || [];
+    const seen = seenCache.get(topic) || new Set();
+    for await (const batch of n.store.queryGenerator({ decoder })) {
+        for (const msg of (batch.messages || [])) {
+            if (!msg.payload)
+                continue;
+            const key = Buffer.from(msg.payload).toString('hex');
+            if (seen.has(key))
+                continue;
+            seen.add(key);
+            try {
+                const parsed = JSON.parse(Buffer.from(msg.payload).toString('utf8'));
+                existing.push(parsed);
+            }
+            catch {
+                // ignore unparsable messages
+            }
+        }
+    }
+    seenCache.set(topic, seen);
+    messageCache.set(topic, existing);
+    return existing;
+}
+// Convenience function used by the SDK's `getListings` method. It hydrates the
+// listings topic for the given store and returns the cached messages formatted
+// as Listing objects.
+export async function getListingsFromWaku(storeId) {
+    try {
+        const network = process.env.EXPO_PUBLIC_NETWORK || 'testnet';
+        const topic = topicFor(network, storeId, 'listings');
+        const msgs = await hydrateMessages(topic);
+        return msgs.map((m) => ({
+            id: Number(m.itemId ?? 0),
+            seller: m.seller || '',
+            price: Number(m.priceYocto ?? 0),
+        }));
+    }
+    catch (e) {
+        console.warn('sdk-near', 'waku', 'get_listings_failed', e);
+        return [];
+    }
+}
+export default { getListingsFromWaku, hydrateMessages };

--- a/packages/sdk-near/package.json
+++ b/packages/sdk-near/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@blue-ocean/sdk-near",
-  "version": "0.1.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "version": "0.1.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "buffer": "^6.0.3",
-    "@blue-ocean/utils": "file:../utils"
+    "@blue-ocean/utils": "file:../utils",
+    "canonicalize": "^2.1.0"
   }
 }

--- a/packages/sdk-near/src/config.ts
+++ b/packages/sdk-near/src/config.ts
@@ -1,5 +1,11 @@
-export const relayerUrl = process.env.EXPO_PUBLIC_RELAYER_URL || '';
-export const indexerUrl = process.env.EXPO_PUBLIC_INDEXER_URL || '';
-export const contractId = process.env.EXPO_PUBLIC_CONTRACT_ID || '';
+// Minimal configuration loader for the SDK. Reads required
+// environment variables and exposes them as a simple object.
 
-export default { relayerUrl, indexerUrl, contractId };
+const config: Record<string, string> = {
+  EXPO_PUBLIC_RELAYER_URL: process.env.EXPO_PUBLIC_RELAYER_URL || '',
+  EXPO_PUBLIC_INDEXER_URL: process.env.EXPO_PUBLIC_INDEXER_URL || '',
+  EXPO_PUBLIC_TRANSPORT: process.env.EXPO_PUBLIC_TRANSPORT || '',
+};
+
+export default config;
+

--- a/packages/sdk-near/src/index.ts
+++ b/packages/sdk-near/src/index.ts
@@ -35,8 +35,8 @@ function requireEnv(
 
 /** Fetch all listings from the indexer service. */
 import { requireStoreId } from '@blue-ocean/utils';
-import { canonicalJson } from '../../utils/serialization';
-import config from '../../config';
+import { canonicalJson } from './utils/serialization';
+import config from './config';
 
 export async function getListings(storeId: string): Promise<Listing[]> {
   const sid = requireStoreId(storeId);

--- a/packages/sdk-near/src/utils/serialization.ts
+++ b/packages/sdk-near/src/utils/serialization.ts
@@ -1,0 +1,15 @@
+import canonicalize from 'canonicalize';
+
+/**
+ * Serialize a value using canonical JSON encoding so that
+ * equivalent objects produce the same string representation.
+ */
+export function serializeCanonical(value: unknown): string {
+  const result = canonicalize(value);
+  return result ?? '';
+}
+
+export const canonicalJson = serializeCanonical;
+
+export default serializeCanonical;
+

--- a/packages/sdk-near/src/waku/index.ts
+++ b/packages/sdk-near/src/waku/index.ts
@@ -4,7 +4,6 @@
 // app source but is trimmed down for size and to avoid React dependencies.
 
 import type { LightNode } from '@waku/sdk';
-import { getClient } from '../../../../src/utils/transport';
 import { Buffer } from 'buffer';
 import { topicFor } from '@blue-ocean/utils';
 
@@ -26,7 +25,7 @@ async function ensureNode(): Promise<LightNode | null> {
         .split(String.fromCharCode(44))
         .map((s) => s.trim())
       .filter(Boolean);
-    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
+    const { createLightNode, waitForRemotePeer, Protocols } = await import('@waku/sdk');
     node = await createLightNode({ libp2p: { bootstrap } } as any);
     if (!node) return null;
     await node.start();
@@ -46,7 +45,7 @@ async function ensureNode(): Promise<LightNode | null> {
 export async function hydrateMessages(topic: string): Promise<any[]> {
   const n = await ensureNode();
   if (!n) return messageCache.get(topic) || [];
-  const { createDecoder } = await getClient();
+  const { createDecoder } = await import('@waku/sdk');
   const decoder = createDecoder(topic);
   const existing = messageCache.get(topic) || [];
   const seen = seenCache.get(topic) || new Set<string>();

--- a/packages/sdk-near/tsconfig.json
+++ b/packages/sdk-near/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}
+


### PR DESCRIPTION
## Summary
- add local config and canonical serialization helpers to `@blue-ocean/sdk-near`
- build sdk-near with compiled output and link it in workspace

## Testing
- `yarn install --ignore-engines`
- `yarn jest` *(fails: Cannot read properties of undefined (reading 'sourceFile'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0c933a72c832683a4e636e152038d