### PR TITLE
fix: address ts compile errors

### DIFF
--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -55,21 +55,22 @@ export const shadows = {
 };
 
 const dark = {
-  canvas: darkColors.canvas,
-  surface: darkColors.surface.primary,
+  ...darkColors,
   primary: darkColors.interactive.primary,
   muted: darkColors.text.secondary,
+  // Flatten commonly used color tokens for easy access
+  canvas: darkColors.canvas,
+  surface: darkColors.surface.primary,
   border: darkColors.border.secondary,
-  ...darkColors,
 };
 
 const light = {
-  canvas: LightColors.canvas,
-  surface: LightColors.surface.primary,
+  ...LightColors,
   primary: LightColors.interactive.primary,
   muted: LightColors.text.secondary,
+  canvas: LightColors.canvas,
+  surface: LightColors.surface.primary,
   border: LightColors.border.secondary,
-  ...LightColors,
 };
 
 export const colors = dark;

--- a/services/media.ts
+++ b/services/media.ts
@@ -90,7 +90,7 @@ class MediaService {
       u8arr[n] = bstr.charCodeAt(n);
     }
     
-    return new Blob([u8arr], { type: mime });
+    return new Blob([u8arr.buffer], { type: mime });
   }
 
   /**

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -3,6 +3,8 @@ import { chainAdapter } from '@/services/chain';
 import { fetchSettings } from './nearSettings';
 import { assertNearChain } from './chain';
 import config from '@/config';
+import { retryWithBackoff } from '@/utils/retry';
+import { logger, serviceLatency, serviceFailures } from '@/utils/observability';
 
 assertNearChain();
 

--- a/services/pinata.ts
+++ b/services/pinata.ts
@@ -59,7 +59,7 @@ class PinataService {
       const path = uri.startsWith('file://') ? uri.replace('file://', '') : uri;
       const buffer = await fs.readFile(path);
       await this.secureDelete(path);
-      form.append('file', new Blob([buffer]), name);
+      (form as any).append('file', new Blob([buffer.buffer]), name);
     } else {
       form.append('file', { uri, name, type: 'application/octet-stream' } as any);
     }

--- a/src/ui/primitives/Menu.tsx
+++ b/src/ui/primitives/Menu.tsx
@@ -33,7 +33,8 @@ export default function Menu({ trigger, open, onOpenChange, items }: MenuProps) 
     };
 
     const handleFocus = (e: FocusEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+      const element = menuRef.current as any;
+      if (element && !element.contains(e.target as Node)) {
         onOpenChange(false);
       }
     };

--- a/src/ui/primitives/TextField.tsx
+++ b/src/ui/primitives/TextField.tsx
@@ -9,9 +9,10 @@ interface TextFieldProps {
   placeholder?: string;
   style?: StyleProp<TextStyle>;
   secureTextEntry?: boolean;
+  keyboardType?: string;
 }
 
-export default function TextField({ value, onChangeText, placeholder, style, secureTextEntry }: TextFieldProps) {
+export default function TextField({ value, onChangeText, placeholder, style, secureTextEntry, keyboardType }: TextFieldProps) {
   const { colors } = useTheme();
   return (
     <TextInput
@@ -20,6 +21,7 @@ export default function TextField({ value, onChangeText, placeholder, style, sec
       placeholder={placeholder}
       placeholderTextColor={colors.text.tertiary}
       secureTextEntry={secureTextEntry}
+      keyboardType={keyboardType as any}
       style={[
         {
           backgroundColor: colors.surface.primary,


### PR DESCRIPTION
## Summary
- avoid color token property duplicates
- support keyboardType prop in TextField
- cast web-only menu ref for contains checks
- fix Blob handling for media and pinata services
- wire observability utils into nearContract

## Testing
- `yarn lint`
- `CI=true yarn jest tests/priceRange.test.tsx` *(fails: process exited without output)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ce19a070832695e488582e961ecd