### PR TITLE
fix: guard dotenv config for browser

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -3,7 +3,13 @@ import { z } from 'zod';
 import { loadVaultEnv } from './vault';
 
 loadVaultEnv();
-loadEnv();
+
+// `dotenv` uses `process.cwd` to locate files, which is missing in browser
+// environments (e.g. Expo web). Calling it would throw `process.cwd is not a
+// function`, so only invoke when running in Node.js where the function exists.
+if (typeof process !== 'undefined' && typeof process.cwd === 'function') {
+  loadEnv();
+}
 
 const envSchema = z.object({
   EXPO_PUBLIC_TRANSPORT: z.string().optional().default(''),

--- a/config/vault.ts
+++ b/config/vault.ts
@@ -3,6 +3,14 @@ import path from 'path';
 import { config as load } from 'dotenv';
 
 export function loadVaultEnv(): void {
+  // `process.cwd` is only available in Node.js environments. When running in
+  // browsers (e.g. Expo Web) `process` is polyfilled without `cwd`, which was
+  // causing a runtime TypeError. Bail out early when `process.cwd` is missing
+  // so that client bundles don't attempt to access the filesystem.
+  if (typeof process === 'undefined' || typeof process.cwd !== 'function') {
+    return;
+  }
+
   const vaultPath = process.env.VAULT_ENV || path.join(process.cwd(), '.env.vault');
   if (fs.existsSync(vaultPath)) {
     load({ path: vaultPath });


### PR DESCRIPTION
## Summary
- skip loading dotenv in browser environments by checking for `process.cwd`
- ensure dotenv vault loading also exits early when filesystem access is unavailable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: TS2339 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d314f7fc83269f952447af262026