### PR TITLE
fix: guard server-only modules in browser

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -3,7 +3,13 @@ import { z } from 'zod';
 import { loadVaultEnv } from './vault';
 
 loadVaultEnv();
-loadEnv();
+
+// `dotenv` uses `process.cwd` to locate files, which is missing in browser
+// environments (e.g. Expo web). Calling it would throw `process.cwd is not a
+// function`, so only invoke when running in Node.js where the function exists.
+if (typeof process !== 'undefined' && typeof process.cwd === 'function') {
+  loadEnv();
+}
 
 const envSchema = z.object({
   EXPO_PUBLIC_TRANSPORT: z.string().optional().default(''),

--- a/config/vault.ts
+++ b/config/vault.ts
@@ -3,6 +3,14 @@ import path from 'path';
 import { config as load } from 'dotenv';
 
 export function loadVaultEnv(): void {
+  // `process.cwd` is only available in Node.js environments. When running in
+  // browsers (e.g. Expo Web) `process` is polyfilled without `cwd`, which was
+  // causing a runtime TypeError. Bail out early when `process.cwd` is missing
+  // so that client bundles don't attempt to access the filesystem.
+  if (typeof process === 'undefined' || typeof process.cwd !== 'function') {
+    return;
+  }
+
   const vaultPath = process.env.VAULT_ENV || path.join(process.cwd(), '.env.vault');
   if (fs.existsSync(vaultPath)) {
     load({ path: vaultPath });

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -1,27 +1,38 @@
 import pino from 'pino';
 import { collectDefaultMetrics, Counter, Histogram, register } from 'prom-client';
-import http from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 
 export const logger = pino();
 
-collectDefaultMetrics();
+if (typeof process?.cwd === 'function') {
+  collectDefaultMetrics();
+}
 
-export const serviceLatency = new Histogram({
-  name: 'service_latency_seconds',
-  help: 'Service call latency in seconds',
-  labelNames: ['service'],
-});
+export const serviceLatency =
+  typeof process?.cwd === 'function'
+    ? new Histogram({
+        name: 'service_latency_seconds',
+        help: 'Service call latency in seconds',
+        labelNames: ['service'],
+      })
+    : { startTimer: () => () => {} };
 
-export const serviceFailures = new Counter({
-  name: 'service_failures_total',
-  help: 'Total number of service call failures',
-  labelNames: ['service'],
-});
+export const serviceFailures =
+  typeof process?.cwd === 'function'
+    ? new Counter({
+        name: 'service_failures_total',
+        help: 'Total number of service call failures',
+        labelNames: ['service'],
+      })
+    : { inc: () => {} };
 
 let metricsStarted = false;
-export function startMetricsServer(port = Number(process.env.METRICS_PORT || 9464)) {
+export function startMetricsServer(
+  port = Number(process.env.METRICS_PORT || 9464)
+) {
   if (metricsStarted || typeof window !== 'undefined') return;
-  const server = http.createServer(async (req, res) => {
+  const http = require('http');
+  const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.url === '/metrics') {
       res.setHeader('Content-Type', register.contentType);
       res.end(await register.metrics());
@@ -34,4 +45,6 @@ export function startMetricsServer(port = Number(process.env.METRICS_PORT || 946
   metricsStarted = true;
 }
 
-startMetricsServer();
+if (typeof process?.cwd === 'function') {
+  startMetricsServer();
+}


### PR DESCRIPTION
## Summary
- skip loading dotenv in browser environments by checking for `process.cwd`
- ensure dotenv vault loading also exits early when filesystem access is unavailable
- avoid `prom-client` metrics in browsers by providing no-op stubs and guarding metric server startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Property 'primary' does not exist on type 'string', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d314f7fc83269f952447af262026