### PR TITLE
fix: guard prom-client usage for browser builds

### DIFF
--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -1,5 +1,32 @@
 import pino from 'pino';
-import { Counter, Histogram, Registry } from 'prom-client';
+
+// prom-client relies on Node-specific APIs like process.uptime which are not
+// available in browser/React Native environments. Dynamically load it only when
+// those APIs exist and otherwise fall back to no-op implementations.
+let Counter: any;
+let Histogram: any;
+let Registry: any;
+
+if (
+  typeof process !== 'undefined' &&
+  typeof (process as any).uptime === 'function'
+) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const promClient = require('prom-client');
+  Counter = promClient.Counter;
+  Histogram = promClient.Histogram;
+  Registry = promClient.Registry;
+} else {
+  class NoopMetric {
+    startTimer() {
+      return () => {};
+    }
+    inc() {}
+  }
+  Counter = class extends NoopMetric {};
+  Histogram = class extends NoopMetric {};
+  Registry = class {};
+}
 
 export const registry = new Registry();
 export const logger = pino();
@@ -18,7 +45,10 @@ export const failureCounter = new Counter({
   registers: [registry],
 });
 
-export async function withMonitoring<T>(service: string, fn: () => Promise<T>): Promise<T> {
+export async function withMonitoring<T>(
+  service: string,
+  fn: () => Promise<T>,
+): Promise<T> {
   const end = latencyHistogram.startTimer({ service });
   try {
     return await fn();


### PR DESCRIPTION
## Summary
- dynamically require `prom-client` only when Node APIs like `process.uptime` exist
- provide no-op metric implementations when running in browsers/React Native

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Property 'secondary' does not exist on type 'string')*
- `npx jest` *(fails: The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fcff424c832687495b672b5e1eb2