### PR TITLE
refactor: adjust theme tokens and tests

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -56,10 +56,11 @@ class ProductsAgent {
       const bootstrap = getWakuBootstrapNodes();
       if (bootstrap.length === 0) return null;
       const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-      this.node = await createLightNode({ libp2p: { bootstrap } as any });
-      await this.node.start();
-      await waitForRemotePeer(this.node, [Protocols.Relay]);
-      return this.node;
+      const node = await createLightNode({ libp2p: { bootstrap } as any });
+      await node.start();
+      await waitForRemotePeer(node, [Protocols.Relay]);
+      this.node = node;
+      return node;
     } catch (err) {
       errorLog('Failed to start Waku node', err);
       this.node = null;

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -60,8 +60,6 @@ const dark = {
   muted: darkColors.text.secondary,
   // Flatten commonly used color tokens for easy access
   canvas: darkColors.canvas,
-  surface: darkColors.surface.primary,
-  border: darkColors.border.secondary,
 };
 
 const light = {
@@ -69,8 +67,6 @@ const light = {
   primary: LightColors.interactive.primary,
   muted: LightColors.text.secondary,
   canvas: LightColors.canvas,
-  surface: LightColors.surface.primary,
-  border: LightColors.border.secondary,
 };
 
 export const colors = dark;

--- a/packages/utils/src/env.js
+++ b/packages/utils/src/env.js
@@ -1,0 +1,1 @@
+module.exports = require('./env.ts');

--- a/packages/utils/src/fees.js
+++ b/packages/utils/src/fees.js
@@ -1,0 +1,1 @@
+module.exports = require('./fees.ts');

--- a/packages/utils/src/near.js
+++ b/packages/utils/src/near.js
@@ -1,0 +1,1 @@
+module.exports = require('./near.ts');

--- a/packages/utils/src/store.js
+++ b/packages/utils/src/store.js
@@ -1,0 +1,1 @@
+module.exports = require('./store.ts');

--- a/packages/utils/src/topics.js
+++ b/packages/utils/src/topics.js
@@ -1,0 +1,1 @@
+module.exports = require('./topics.ts');

--- a/schemas/waku/message.ts
+++ b/schemas/waku/message.ts
@@ -20,7 +20,7 @@ export function parseWakuMessage<T>(
 ): WakuMessage<T> | null {
   const schema = wakuMessageSchema.extend({ payload: payloadSchema });
   const res = schema.safeParse(data);
-  return res.success ? res.data : null;
+  return res.success ? (res.data as WakuMessage<T>) : null;
 }
 
 export function isWakuMessage<T>(

--- a/src/features/home/components/PriceRange.tsx
+++ b/src/features/home/components/PriceRange.tsx
@@ -24,16 +24,14 @@ export default function PriceRange({
         onChangeText={setMinPrice}
         placeholder={t('priceRange.min')}
         keyboardType="numeric"
-        style={[styles.priceInput, { marginEnd: spacing.spacer8 }]}
-        textAlign="right"
+        style={[styles.priceInput, { marginEnd: spacing.spacer8, textAlign: 'right' }]}
       />
       <TextField
         value={maxPrice}
         onChangeText={setMaxPrice}
         placeholder={t('priceRange.max')}
         keyboardType="numeric"
-        style={styles.priceInput}
-        textAlign="right"
+        style={[styles.priceInput, { textAlign: 'right' }]}
       />
     </View>
   );

--- a/tests/indexers/crashRecovery.test.ts
+++ b/tests/indexers/crashRecovery.test.ts
@@ -1,10 +1,10 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { Readable } from 'stream';
 import { loadCheckpoint, saveCheckpoint } from '../../indexers/lake/src/checkpoint';
 
 jest.mock('minio', () => {
   const store = new Map<string, Buffer>();
+  const { Readable } = require('stream');
   class Client {
     async putObject(bucket: string, key: string, value: Buffer | string) {
       const buf = Buffer.isBuffer(value) ? value : Buffer.from(value);

--- a/tests/navigationLoop.test.tsx
+++ b/tests/navigationLoop.test.tsx
@@ -3,15 +3,15 @@ import renderer from 'react-test-renderer';
 import GlobalHeader from '@/components/GlobalHeader';
 import { Pressable } from 'react-native';
 
-const pushMock = jest.fn();
-const usePathnameMock = jest.fn();
+const mockPush = jest.fn();
+const mockUsePathname = jest.fn();
 
 jest.mock('@/services', () => ({
-  useAppRouter: () => ({ push: pushMock })
+  useAppRouter: () => ({ push: mockPush })
 }));
 
 jest.mock('expo-router', () => ({
-  usePathname: () => usePathnameMock()
+  usePathname: () => mockUsePathname()
 }));
 
 jest.mock('@/contexts/AppInfoContext', () => ({
@@ -45,15 +45,15 @@ jest.mock('@/ui', () => {
 
 describe('navigation loop prevention', () => {
   beforeEach(() => {
-    pushMock.mockClear();
+    mockPush.mockClear();
   });
 
   it('does not push to current path', () => {
-    usePathnameMock.mockReturnValue('/');
+    mockUsePathname.mockReturnValue('/');
     const tree = renderer.create(React.createElement(GlobalHeader));
     const pressables = tree.root.findAllByType(Pressable);
     pressables[0].props.onPress();
-    expect(pushMock).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
 });

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -36,10 +36,13 @@ jest.mock('@/features/products/services/nearProducts', () => ({ listProducts: je
 
 jest.mock('@/features/auth/AuthContext', () => ({ useAuth: jest.fn() }));
 
-jest.mock('@/features/stores/components/OrderRevenueMetrics', () => ({
-  __esModule: true,
-  default: () => React.createElement('OrderRevenueMetrics', null, 'metrics'),
-}));
+jest.mock('@/features/stores/components/OrderRevenueMetrics', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('OrderRevenueMetrics', null, 'metrics'),
+  };
+});
 
 describe('StoreDashboardScreen', () => {
   const { useLocalSearchParams } = require('expo-router');

--- a/tests/waku/reconnect.test.ts
+++ b/tests/waku/reconnect.test.ts
@@ -1,7 +1,7 @@
 jest.mock('@/config', () => ({ default: {} }));
 jest.mock('@/utils/logger', () => ({ errorLog: jest.fn() }));
 
-const client = {
+const mockClient = {
   waitForRemotePeer: jest.fn(async () => {}),
   Protocols: { Relay: 'relay', Store: 'store' },
   utf8ToBytes: (s: string) => new TextEncoder().encode(s),
@@ -11,7 +11,7 @@ const client = {
 };
 
 jest.mock('@/utils/transport', () => ({
-  getClient: jest.fn(async () => client),
+  getClient: jest.fn(async () => mockClient),
 }));
 jest.mock('@/utils/observability', () => require('@/tests/__mocks__/utils/observability'));
 
@@ -40,8 +40,8 @@ describe('waku auto reconnect', () => {
       .mockResolvedValueOnce(node1)
       .mockRejectedValueOnce(new Error('fail'))
       .mockResolvedValueOnce(node2);
-    (getClient as jest.Mock).mockResolvedValueOnce({ ...client, createLightNode })
-      .mockResolvedValue({ ...client, createLightNode });
+    (getClient as jest.Mock).mockResolvedValueOnce({ ...mockClient, createLightNode })
+      .mockResolvedValue({ ...mockClient, createLightNode });
     await ensureNode();
     expect(createLightNode).toHaveBeenCalledTimes(1);
     node1.libp2p.dispatchEvent(new Event('peer:disconnect'));

--- a/tests/wakuErrorLogging.test.ts
+++ b/tests/wakuErrorLogging.test.ts
@@ -1,9 +1,9 @@
-const createLightNode = jest.fn(async () => {
+const mockCreateLightNode = jest.fn(async () => {
   throw new Error('boom');
 });
 jest.mock('@/utils/transport', () => ({
   getClient: jest.fn(async () => ({
-    createLightNode,
+    createLightNode: mockCreateLightNode,
     waitForRemotePeer: jest.fn(),
     Protocols: { Relay: 'relay' },
   })),

--- a/tests/wakuHydration.test.ts
+++ b/tests/wakuHydration.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 
-const queryGenerator = jest.fn(() => {
+const mockQueryGenerator = jest.fn(() => {
   return (async function* () {
     const payload1 = Buffer.from(JSON.stringify({ itemId: 1, seller: 'alice', priceYocto: '5' }));
     const payload2 = Buffer.from(JSON.stringify({ itemId: 2, seller: 'bob', priceYocto: '7' }));
@@ -12,7 +12,7 @@ jest.mock('@/utils/transport', () => ({
   getClient: jest.fn(async () => ({
     createLightNode: jest.fn(async () => ({
       start: jest.fn(),
-      store: { queryGenerator },
+      store: { queryGenerator: mockQueryGenerator },
     })),
     waitForRemotePeer: jest.fn(),
     Protocols: { Store: 'store' },
@@ -30,6 +30,6 @@ describe('hydrate_messages', () => {
     expect(first).toHaveLength(2);
     const second = await hydrateMessages(TOPIC);
     expect(second).toHaveLength(2);
-    expect(queryGenerator).toHaveBeenCalledTimes(2);
+    expect(mockQueryGenerator).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- keep border and surface objects intact in theme tokens
- ensure Waku message parser and product agent handle types safely
- add runtime stubs and test fixes for utils and mocks

## Testing
- `yarn jest` *(fails: TypeError in lucide-react-native Mixin; TS errors in SettingsAgent whenReady; missing TS config for utils; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fdfa0a7c83269bd734f3d2cdf893