### PR TITLE
refactor: centralize promo card styling

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { View, StyleSheet, useWindowDimensions, Platform } from 'react-native';
-import { useTheme } from '@/ui/ThemeProvider';
-import { useLanguage } from '@/ui/ThemeProvider';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Button, Heading, Text } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
-import { spacing, radius, typography, shadows } from '@/ui/tokens';
+import { spacing, typography } from '@/ui/tokens';
+import PromoCard from './PromoCard';
 
 export default function HeroCallout() {
   const { t } = useLanguage();
@@ -13,12 +13,9 @@ export default function HeroCallout() {
   const isWide = width >= 768;
 
   return (
-    <View
-      style={[
-        styles.wrapper,
-        { backgroundColor: colors.surface.primary },
-        Platform.select(shadows.md),
-      ]}
+    <PromoCard
+      backgroundColor={colors.surface.primary}
+      style={{ marginHorizontal: spacing.spacer16, marginBottom: spacing.spacer16 }}
     >
       <Stack
         direction={isWide ? 'horizontal' : 'vertical'}
@@ -36,17 +33,11 @@ export default function HeroCallout() {
         </View>
         <Button title={t('home.heroAction')} />
       </Stack>
-    </View>
+    </PromoCard>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
-    marginHorizontal: spacing.spacer16,
-    marginBottom: spacing.spacer24,
-    padding: spacing.spacer24,
-    borderRadius: radius.lg,
-  },
   textContainer: {
     flex: 1,
   },

--- a/src/features/home/components/HomeServices.tsx
+++ b/src/features/home/components/HomeServices.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { StyleSheet, Alert } from 'react-native';
 import { Stack } from '@/ui/layout';
-import { Card, Text } from '@/ui';
-import { spacing, radius } from '@/ui/tokens';
+import { spacing } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { Store, Truck } from 'lucide-react-native';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
+import ServiceCard from './ServiceCard';
 
 export default function HomeServices() {
   const { t } = useLanguage();
@@ -23,36 +23,20 @@ export default function HomeServices() {
 
   return (
     <Stack direction="horizontal" gap="spacer16" style={styles.container}>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleCreateStore}
-          accessibilityRole="link"
-          testID="create-store-link"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Store size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.createStore')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleBecomeDriver}
-          accessibilityRole="button"
-          testID="become-driver-button"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Truck size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.becomeDriver')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
+      <ServiceCard
+        icon={<Store size={32} color={colors.gold} />}
+        title={t('home.createStore')}
+        onPress={handleCreateStore}
+        accessibilityRole="link"
+        testID="create-store-link"
+      />
+      <ServiceCard
+        icon={<Truck size={32} color={colors.gold} />}
+        title={t('home.becomeDriver')}
+        onPress={handleBecomeDriver}
+        accessibilityRole="button"
+        testID="become-driver-button"
+      />
     </Stack>
   );
 }
@@ -61,21 +45,6 @@ const styles = StyleSheet.create({
   container: {
     marginHorizontal: spacing.spacer16,
     marginBottom: spacing.spacer16,
-  },
-  card: {
-    flex: 1,
-    borderRadius: radius.lg,
-  },
-  touch: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  content: {
-    alignItems: 'center',
-  },
-  title: {
-    fontWeight: '600',
   },
 });
 

--- a/src/features/home/components/PromoCard.tsx
+++ b/src/features/home/components/PromoCard.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  AccessibilityRole,
+  Platform,
+  StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+import { useTheme } from '@/ui/ThemeProvider';
+import { Card, Text } from '@/ui';
+import { Stack } from '@/ui/layout';
+import { spacing, radius, shadows } from '@/ui/tokens';
+
+interface PromoCardProps {
+  backgroundColor: string;
+  icon?: React.ReactNode;
+  title?: string;
+  subtitle?: string;
+  onPress?: () => void;
+  accessibilityRole?: AccessibilityRole;
+  testID?: string;
+  children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export default function PromoCard({
+  backgroundColor,
+  icon,
+  title,
+  subtitle,
+  onPress,
+  accessibilityRole,
+  testID,
+  children,
+  style,
+}: PromoCardProps) {
+  const { colors } = useTheme();
+
+  const content = (
+    <Stack gap="spacer8" align="center">
+      {icon}
+      {title && (
+        <Text style={[styles.title, { color: colors.text.primary }]}>
+          {title}
+        </Text>
+      )}
+      {subtitle && (
+        <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+          {subtitle}
+        </Text>
+      )}
+      {children}
+    </Stack>
+  );
+
+  return (
+    <Card style={[styles.card, { backgroundColor }, style]}>
+      {onPress ? (
+        <TouchableOpacity
+          style={styles.touch}
+          onPress={onPress}
+          accessibilityRole={accessibilityRole}
+          testID={testID}
+        >
+          {content}
+        </TouchableOpacity>
+      ) : (
+        content
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: spacing.spacer16,
+    borderRadius: radius.lg,
+    ...Platform.select(shadows.md),
+  },
+  touch: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+  },
+});
+

--- a/src/features/home/components/ServiceCard.tsx
+++ b/src/features/home/components/ServiceCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AccessibilityRole } from 'react-native';
+import { useTheme } from '@/ui/ThemeProvider';
+import PromoCard from './PromoCard';
+
+interface ServiceCardProps {
+  icon: React.ReactNode;
+  title: string;
+  onPress: () => void;
+  backgroundColor?: string;
+  testID?: string;
+  accessibilityRole?: AccessibilityRole;
+}
+
+export default function ServiceCard({
+  icon,
+  title,
+  onPress,
+  backgroundColor,
+  testID,
+  accessibilityRole,
+}: ServiceCardProps) {
+  const { colors } = useTheme();
+
+  return (
+    <PromoCard
+      backgroundColor={backgroundColor ?? colors.surface.primary}
+      icon={icon}
+      title={title}
+      onPress={onPress}
+      testID={testID}
+      accessibilityRole={accessibilityRole}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `PromoCard` component with consistent spacing, radius, and shadow
- replace ad-hoc home service cards and hero callout with `PromoCard`

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: No lockfile found)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c16dca0be08326a26ad478fc486604