### PR TITLE
refactor home services typography

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -27,10 +27,12 @@ export default function HeroCallout() {
         style={{ justifyContent: 'space-between' }}
       >
         <View style={styles.textContainer}>
-          <Heading size="xl" style={{ color: colors.text.primary }}>
+          <Heading size="lg" style={{ color: colors.text.primary }}>
             {t('home.heroTitle')}
           </Heading>
-          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+          <Text
+            style={[typography.sm, { color: colors.text.secondary, marginTop: spacing.spacer8 }]}
+          >
             {t('home.heroSubtitle')}
           </Text>
         </View>
@@ -49,10 +51,6 @@ const styles = StyleSheet.create({
   },
   textContainer: {
     flex: 1,
-  },
-  subtitle: {
-    ...typography.md,
-    marginTop: spacing.spacer8,
   },
 });
 

--- a/src/features/home/components/HomeServices.tsx
+++ b/src/features/home/components/HomeServices.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { StyleSheet, Alert } from 'react-native';
 import { Stack } from '@/ui/layout';
-import { Card, Text } from '@/ui';
-import { spacing, radius } from '@/ui/tokens';
+import { spacing } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { Store, Truck } from 'lucide-react-native';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
+import ServiceCard from './ServiceCard';
 
 export default function HomeServices() {
   const { t } = useLanguage();
@@ -23,36 +23,20 @@ export default function HomeServices() {
 
   return (
     <Stack direction="horizontal" gap="spacer16" style={styles.container}>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleCreateStore}
-          accessibilityRole="link"
-          testID="create-store-link"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Store size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.createStore')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleBecomeDriver}
-          accessibilityRole="button"
-          testID="become-driver-button"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Truck size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.becomeDriver')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
+      <ServiceCard
+        icon={<Store size={32} color={colors.gold} />}
+        title={t('home.createStore')}
+        onPress={handleCreateStore}
+        accessibilityRole="link"
+        testID="create-store-link"
+      />
+      <ServiceCard
+        icon={<Truck size={32} color={colors.gold} />}
+        title={t('home.becomeDriver')}
+        onPress={handleBecomeDriver}
+        accessibilityRole="button"
+        testID="become-driver-button"
+      />
     </Stack>
   );
 }
@@ -61,21 +45,6 @@ const styles = StyleSheet.create({
   container: {
     marginHorizontal: spacing.spacer16,
     marginBottom: spacing.spacer16,
-  },
-  card: {
-    flex: 1,
-    borderRadius: radius.lg,
-  },
-  touch: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  content: {
-    alignItems: 'center',
-  },
-  title: {
-    fontWeight: '600',
   },
 });
 

--- a/src/features/home/components/ServiceCard.tsx
+++ b/src/features/home/components/ServiceCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { Card, Text } from '@/ui';
+import { Stack } from '@/ui/layout';
+import { radius, typography } from '@/ui/tokens';
+import { useTheme } from '@/ui/ThemeProvider';
+
+interface ServiceCardProps {
+  title: string;
+  icon: React.ReactNode;
+  onPress: () => void;
+  accessibilityRole?: 'button' | 'link';
+  testID?: string;
+}
+
+export default function ServiceCard({
+  title,
+  icon,
+  onPress,
+  accessibilityRole = 'button',
+  testID,
+}: ServiceCardProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Card style={[styles.card, { backgroundColor: colors.surface.secondary }]}>
+      <TouchableOpacity
+        style={styles.touch}
+        onPress={onPress}
+        accessibilityRole={accessibilityRole}
+        testID={testID}
+      >
+        <Stack gap="spacer8" style={styles.content}>
+          {icon}
+          <Text style={[typography.sm, { color: colors.text.primary }]}>{title}</Text>
+        </Stack>
+      </TouchableOpacity>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    borderRadius: radius.lg,
+  },
+  touch: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    alignItems: 'center',
+  },
+});
+


### PR DESCRIPTION
## Summary
- replace inline service cards with reusable ServiceCard component using surface.secondary background
- update hero callout and service titles to use typography tokens

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c16dd1db7083268783974bbdbd3fdb