### PR TITLE
Add ServiceCard component with optional image and ripple feedback

### DIFF
--- a/src/features/home/components/HomeServices.tsx
+++ b/src/features/home/components/HomeServices.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { StyleSheet, Alert } from 'react-native';
 import { Stack } from '@/ui/layout';
-import { Card, Text } from '@/ui';
-import { spacing, radius } from '@/ui/tokens';
+import { spacing } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { Store, Truck } from 'lucide-react-native';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
+import ServiceCard from './ServiceCard';
 
 export default function HomeServices() {
   const { t } = useLanguage();
@@ -23,59 +23,28 @@ export default function HomeServices() {
 
   return (
     <Stack direction="horizontal" gap="spacer16" style={styles.container}>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleCreateStore}
-          accessibilityRole="link"
-          testID="create-store-link"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Store size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.createStore')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
-      <Card style={styles.card}>
-        <TouchableOpacity
-          style={styles.touch}
-          onPress={handleBecomeDriver}
-          accessibilityRole="button"
-          testID="become-driver-button"
-        >
-          <Stack gap="spacer8" style={styles.content}>
-            <Truck size={32} color={colors.gold} />
-            <Text style={[styles.title, { color: colors.text.primary }]}>
-              {t('home.becomeDriver')}
-            </Text>
-          </Stack>
-        </TouchableOpacity>
-      </Card>
+      <ServiceCard
+        title={t('home.createStore')}
+        icon={<Store size={32} color={colors.gold} />}
+        onPress={handleCreateStore}
+        accessibilityRole="link"
+        testID="create-store-link"
+      />
+      <ServiceCard
+        title={t('home.becomeDriver')}
+        icon={<Truck size={32} color={colors.gold} />}
+        onPress={handleBecomeDriver}
+        accessibilityRole="button"
+        testID="become-driver-button"
+      />
     </Stack>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    marginHorizontal: spacing.spacer16,
+    paddingHorizontal: spacing.spacer16,
     marginBottom: spacing.spacer16,
-  },
-  card: {
-    flex: 1,
-    borderRadius: radius.lg,
-  },
-  touch: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  content: {
-    alignItems: 'center',
-  },
-  title: {
-    fontWeight: '600',
   },
 });
 

--- a/src/features/home/components/ServiceCard.tsx
+++ b/src/features/home/components/ServiceCard.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Pressable, StyleSheet, AccessibilityRole, Image, ImageSourcePropType } from 'react-native';
+import { Card, Text } from '@/ui';
+import { Stack } from '@/ui/layout';
+import { useTheme } from '@/ui/ThemeProvider';
+import { radius } from '@/ui/tokens';
+
+interface ServiceCardProps {
+  title: string;
+  icon?: React.ReactNode;
+  image?: ImageSourcePropType;
+  onPress?: () => void;
+  accessibilityRole?: AccessibilityRole;
+  testID?: string;
+}
+
+export default function ServiceCard({
+  title,
+  icon,
+  image,
+  onPress,
+  accessibilityRole = 'button',
+  testID,
+}: ServiceCardProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Card style={styles.card}>
+      <Pressable
+        android_ripple={{ color: colors.interactive.secondary }}
+        style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+        onPress={onPress}
+        accessibilityRole={accessibilityRole}
+        testID={testID}
+      >
+        <Stack gap="spacer8" style={styles.content}>
+          {image ? <Image source={image} style={styles.image} /> : icon}
+          <Text style={[styles.title, { color: colors.text.primary }]}>{title}</Text>
+        </Stack>
+      </Pressable>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: 200,
+    borderRadius: radius.lg,
+  },
+  pressable: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    alignItems: 'center',
+  },
+  title: {
+    fontWeight: '600',
+  },
+  image: {
+    width: 64,
+    height: 64,
+    borderRadius: radius.md,
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add reusable `ServiceCard` with optional image, pressable ripple/opacity feedback, and fixed width
- refactor `HomeServices` to use `ServiceCard` and apply equal horizontal padding

## Testing
- `yarn lint src/features/home/components/ServiceCard.tsx src/features/home/components/HomeServices.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn add -D @typescript-eslint/parser` *(fails: @waku/sdk requires Node >=22)*
- `yarn typecheck` *(fails: Cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_68c16dd64ec48326b58f530d27de7a67