### PR TITLE
feat: add accessibility metadata to category touch targets

### DIFF
--- a/src/features/home/components/CategoryCard.tsx
+++ b/src/features/home/components/CategoryCard.tsx
@@ -22,6 +22,8 @@ export default function CategoryCard({ category, isStoreOwner, onPress, onEdit }
 
   return (
     <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={t(category.name)}
       style={[styles.categoryCard, { backgroundColor: themeColors.surface.primary }, shadowStyle]}
       onPress={onPress}
     >
@@ -42,6 +44,8 @@ export default function CategoryCard({ category, isStoreOwner, onPress, onEdit }
       {isStoreOwner && (
         <View style={styles.categoryAdminActions}>
           <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel={t('category.editCategory')}
             style={[
               styles.categoryAdminButton,
               {

--- a/src/features/home/components/CategoryChips.tsx
+++ b/src/features/home/components/CategoryChips.tsx
@@ -33,6 +33,8 @@ function CategoryChips({
         style={styles.categoriesScroll}
       >
         <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={t('categories.all')}
           style={[
             styles.categoryChip,
             {
@@ -56,6 +58,8 @@ function CategoryChips({
         </TouchableOpacity>
         {categories.map((cat) => (
           <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel={t(cat.name)}
             key={cat.id}
             style={[
               styles.categoryChip,


### PR DESCRIPTION
## Summary
- make category chips and cards accessible with role and labels

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c17edbcb80832684629956eb31ed80