### PR TITLE
refactor: drop unused ProductGrid categories prop

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -230,7 +230,6 @@ function HomeScreenContent() {
           <Suspense fallback={<Spinner />}>
             <ProductGrid
               products={filteredProducts}
-              categories={categoriesToShow}
               isStoreOwner={isStoreOwner}
               onEdit={openProductForm}
               getItemWidth={getProductItemWidth}

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { View, StyleSheet, FlatList } from 'react-native';
 import { ProductCard, ProductCardSkeleton } from '@/features/products';
-import { Product, Category } from '@/types';
+import { Product } from '@/types';
 import { useLanguage } from '@/ui/ThemeProvider';
 import EmptyState from '@/shared/ui/EmptyState';
 import { Filter, Plus } from 'lucide-react-native';
@@ -9,7 +9,6 @@ import { spacing } from '@/shared/ui/tokens';
 
 interface ProductGridProps {
   products: Product[];
-  categories: Category[];
   isStoreOwner: boolean;
   onEdit: (product: Product) => void;
   getItemWidth: () => string;
@@ -31,7 +30,6 @@ const ProductRow = React.memo(({ item }: { item: Product }) => (
 
 function ProductGrid({
   products,
-  categories,
   isStoreOwner,
   onEdit,
   getItemWidth,
@@ -107,7 +105,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   productWrapper: {
-    marginBottom: 16,
+    marginBottom: spacing.spacer16,
   },
 });
 

--- a/src/features/home/screens/HomeProducts.tsx
+++ b/src/features/home/screens/HomeProducts.tsx
@@ -6,12 +6,11 @@ import { Container, Stack } from '@/ui/layout';
 import { Spinner } from '@/ui/primitives';
 import ProductGrid from '@/features/home/components/ProductGrid';
 import HomeServices from '@/features/home/components/HomeServices';
-import { Product, Category } from '@/types';
+import { Product } from '@/types';
 import { styles } from './HomeProducts.styles';
 
 type Props = {
   products: Product[];
-  categories: Category[];
   searchQuery: string;
   isStoreOwner: boolean;
   loading: boolean;
@@ -23,7 +22,6 @@ type Props = {
 
 export default function HomeProducts({
   products,
-  categories,
   searchQuery,
   isStoreOwner,
   loading,
@@ -100,7 +98,6 @@ export default function HomeProducts({
         <Suspense fallback={<Spinner />}>
           <ProductGrid
             products={products}
-            categories={categories}
             isStoreOwner={isStoreOwner}
             onEdit={onEditProduct}
             getItemWidth={getProductItemWidth}

--- a/tests/memoization.test.tsx
+++ b/tests/memoization.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import ProductGrid from '@features/home/components/ProductGrid';
-import { Product, Category } from '@/types';
+import { Product } from '@/types';
 
 jest.mock('@/ui/ThemeProvider', () => ({
   useLanguage: () => ({ t: (s: string) => s }),
@@ -42,10 +42,8 @@ describe('memoization', () => {
       storeId: 's',
       stock: 1,
     };
-    const categories: Category[] = [];
     const props = {
       products: [product],
-      categories,
       isStoreOwner: false,
       onEdit: () => {},
       getItemWidth: () => '50%',


### PR DESCRIPTION
## Summary
- remove unused `categories` prop from `ProductGrid` and all call sites
- use `spacing.spacer16` for grid item spacing

## Testing
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient' and other errors)*
- `yarn jest tests/memoization.test.tsx` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c17ce91b6c8326b7bb1959ae89181c