### PR TITLE
feat: support network tenant mode

### DIFF
--- a/apps/web/contexts/TenantContext.tsx
+++ b/apps/web/contexts/TenantContext.tsx
@@ -3,12 +3,22 @@ import { stripTabsPrefix } from '@/services/navigation';
 
 export function useTenant() {
   if (typeof window !== 'undefined') {
+    const hostParts = window.location.hostname.split('.');
+    if (hostParts.length > 0) {
+      const sub = hostParts[0];
+      if (sub && sub !== 'www' && sub !== 'localhost') {
+        return { tenantId: decodeURIComponent(sub), isNetwork: false } as const;
+      }
+    }
+
     const path = stripTabsPrefix(window.location.pathname) ?? window.location.pathname;
     const m = path.match(/^\/store\/([^/]+)/);
-    if (!m) throw new Error('storeId missing');
-    return { storeId: decodeURIComponent(m[1]) } as const;
+    if (m) {
+      return { tenantId: decodeURIComponent(m[1]), isNetwork: false } as const;
+    }
+    return { tenantId: null, isNetwork: true } as const;
   }
-  return { storeId: '' } as const;
+  return { tenantId: null, isNetwork: true } as const;
 }
 
 export default useTenant;

--- a/contexts/TenantContext.tsx
+++ b/contexts/TenantContext.tsx
@@ -4,37 +4,60 @@ import { stripTabsPrefix } from '@/services/navigation';
 import { loadTenantSettings } from '@/constants/tenant';
 
 interface TenantContextType {
-  storeId: string | null;
-  setStoreId: (id: string | null) => void;
+  tenantId: string | null;
+  setTenantId: (id: string | null) => void;
+  isNetwork: boolean;
 }
 
 const TenantContext = createContext<TenantContextType>({
-  storeId: null,
-  setStoreId: () => {},
+  tenantId: null,
+  setTenantId: () => {},
+  isNetwork: true,
 });
 
-export const useTenant = () => useContext(TenantContext);
+export function useTenant() {
+  const { tenantId, isNetwork } = useContext(TenantContext);
+  return { tenantId, isNetwork } as const;
+}
 
 interface Props {
   children: React.ReactNode;
 }
 
 export function TenantProvider({ children }: Props) {
-  const [storeId, setStoreId] = useState<string | null>(null);
+  const [tenantId, setTenantId] = useState<string | null>(null);
   const pathname = usePathname();
 
   useEffect(() => {
-    const path = stripTabsPrefix(pathname) ?? pathname;
-    const match = path.match(/^\/store\/([^\/]+)/);
-    setStoreId(match ? match[1] : null);
+    let id: string | null = null;
+
+    if (typeof window !== 'undefined') {
+      const host = window.location.hostname.split('.');
+      if (host.length > 0) {
+        const sub = host[0];
+        if (sub && sub !== 'www' && sub !== 'localhost') {
+          id = decodeURIComponent(sub);
+        }
+      }
+    }
+
+    if (!id) {
+      const path = stripTabsPrefix(pathname) ?? pathname;
+      const match = path.match(/^\/store\/([^\/]+)/);
+      id = match ? decodeURIComponent(match[1]) : null;
+    }
+
+    setTenantId(id);
   }, [pathname]);
 
   useEffect(() => {
     loadTenantSettings();
-  }, [storeId]);
+  }, [tenantId]);
+
+  const isNetwork = !tenantId;
 
   return (
-    <TenantContext.Provider value={{ storeId, setStoreId }}>
+    <TenantContext.Provider value={{ tenantId, setTenantId, isNetwork }}>
       {children}
     </TenantContext.Provider>
   );

--- a/docs/near-dev-packet.md
+++ b/docs/near-dev-packet.md
@@ -393,7 +393,7 @@ BlueOcean
 ├─ App Shell
 │  ├─ Global Layout (Header, Footer, Toasts, Modals, Theme)
 │  ├─ WalletConnect (NEAR Wallet Selector)
-│  ├─ TenantContext (storeId, slug, config)
+│  ├─ TenantContext (tenantId, network mode, config)
 │  ├─ AuthContext (accountId, roles, session)
 │  ├─ FeatureFlags (CHAIN='near', WALLET_ENABLED, DEBUG_LOGS)
 │  └─ Polyfills (web/native) + HMR
@@ -465,7 +465,7 @@ BlueOcean
 │  └─ Feedback: Toast, Modal, Spinner, EmptyState
 │
 ├─ Hooks & State
-│  ├─ useTenant()           (storeId + slug logic)
+│  ├─ useTenant()           (tenantId + network mode logic)
 │  ├─ useWallet()           (NEAR wallet state + connect)
 │  ├─ useRelayer()          (Meta-tx status)
 │  ├─ useCart()             (price calc + items)


### PR DESCRIPTION
## Summary
- extend tenant context to expose `tenantId` and `isNetwork` derived from hostname or path
- support network mode for web tenant hook
- document network-aware tenant usage

## Testing
- `npx eslint contexts/TenantContext.tsx apps/web/contexts/TenantContext.tsx docs/near-dev-packet.md`
- `npx tsc --noEmit contexts/TenantContext.tsx apps/web/contexts/TenantContext.tsx` *(fails: conflicting WebSocket types in react-native)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c18702970483268071c497551c3fdf