### PR TITLE
feat(home): hide product discovery on network

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -15,6 +15,7 @@ import { useHomeModals } from '@/features/home/hooks/useHomeModals';
 import { useHomeData } from '@/features/home/hooks/useHomeData';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
+import { useTenant } from '@/contexts/TenantContext';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
@@ -30,11 +31,55 @@ import SortModal from '@/features/home/components/SortModal';
 import { ScrollArea, Container, Stack } from '@/ui/layout';
 import { spacing, typography, radius, shadows } from '@/ui/tokens';
 import HeroCallout from '@/features/home/components/HeroCallout';
+import PromoCard from '@/features/home/components/PromoCard';
 import ErrorBoundary from 'src/shared/ErrorBoundary';
 import HomeError from '@/features/home/screens/HomeError';
 
 
 function HomeScreenContent() {
+  const { storeId: tenantId } = useTenant();
+  const isNetwork = !tenantId;
+  const { t } = useLanguage();
+  const { colors: themeColors } = useTheme();
+
+  if (isNetwork) {
+    return (
+      <ScrollArea
+        testID="home-root"
+        backgroundColor={themeColors.canvas}
+        showsVerticalScrollIndicator={false}
+      >
+        <HeroCallout />
+        <ScrollArea
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.networkCards}
+        >
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            title={t('home.createStore')}
+          />
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            title={t('home.becomeDriver')}
+          />
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            title={t('home.businessLogin')}
+          />
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            title={t('home.docs')}
+          />
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            title={t('home.apiDocs')}
+          />
+        </ScrollArea>
+      </ScrollArea>
+    );
+  }
+
   const home = useHome();
   const { refreshing, refresh, error } = home;
   const {
@@ -48,8 +93,6 @@ function HomeScreenContent() {
     closeInfoModal,
   } = useHomeModals(error);
   const { isStoreOwner } = useAuth();
-  const { t } = useLanguage();
-  const { colors: themeColors } = useTheme();
   const { products, categories, upsertProduct, removeProduct, loading: productsLoading } = home;
 
   const { fallbackCategories } = useHomeData();
@@ -327,6 +370,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 1,
+  },
+  networkCards: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.spacer16,
+    gap: spacing.spacer16,
+    marginBottom: spacing.spacer24,
   },
 });
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -106,7 +106,10 @@
     "highRating": "High Rating",
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
     "createStore": "Create a Store",
-    "becomeDriver": "Become a Driver"
+    "becomeDriver": "Become a Driver",
+    "businessLogin": "Business Login",
+    "docs": "Docs",
+    "apiDocs": "API Docs"
   },
   "categories": {
     "all": "All",

--- a/translations/he.json
+++ b/translations/he.json
@@ -106,7 +106,10 @@
     "highRating": "דירוג גבוה",
     "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש.",
     "createStore": "צור חנות",
-    "becomeDriver": "הפוך לשליח"
+    "becomeDriver": "הפוך לשליח",
+    "businessLogin": "כניסת עסקים",
+    "docs": "תיעוד",
+    "apiDocs": "ממשק API"
   },
   "categories": {
     "all": "הכל",


### PR DESCRIPTION
## Summary
- use tenant context to hide categories and products on network domain
- add network promo cards for store creation, driver signup, business login, docs & API
- provide i18n strings for promo cards

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: @waku/core@0.0.38 requires node >=22)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*


------
https://chatgpt.com/codex/tasks/task_e_68c18aaacce483268fb271677fa7d940