### PR TITLE
scope queries by tenant

### DIFF
--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -16,45 +16,45 @@ class CategoriesAgent {
     await ensureNearWallet('Please connect your NEAR wallet to manage categories.');
   }
 
-  async add(item: Category): Promise<void> {
+  async add(storeId: string, item: Category): Promise<void> {
     await this.ensureWallet();
     const normalized = normalizeMessage<Category>('Category', item);
-    await setCategory(normalized);
+    await setCategory(storeId, normalized);
   }
 
-  async update(item: Category): Promise<void> {
+  async update(storeId: string, item: Category): Promise<void> {
     await this.ensureWallet();
     const normalized = normalizeMessage<Category>('Category', item);
-    await setCategory(normalized);
+    await setCategory(storeId, normalized);
   }
 
-  async remove(id: string): Promise<void> {
+  async remove(storeId: string, id: string): Promise<void> {
     await this.ensureWallet();
-    await removeCategory(id);
+    await removeCategory(storeId, id);
   }
 
   /**
    * Returns a defensive copy of a category by id.
    */
-  async selectCategory(id: string): Promise<Category | null> {
-    const cat = await getCategory(id);
+  async selectCategory(storeId: string, id: string): Promise<Category | null> {
+    const cat = await getCategory(storeId, id);
     return cat ? JSON.parse(JSON.stringify(cat)) : null;
   }
 
   /**
    * Returns defensive copies of all categories.
    */
-  async getCategories(): Promise<Category[]> {
-    const list = await listCategories();
+  async getCategories(storeId: string): Promise<Category[]> {
+    const list = await listCategories(storeId);
     return list.map((c) => JSON.parse(JSON.stringify(c)));
   }
 }
 
 const categoriesAgent = new CategoriesAgent();
 
-export const getCategories = (): Promise<Category[]> =>
-  categoriesAgent.getCategories();
-export const selectCategory = (id: string): Promise<Category | null> =>
-  categoriesAgent.selectCategory(id);
+export const getCategories = (storeId: string): Promise<Category[]> =>
+  categoriesAgent.getCategories(storeId);
+export const selectCategory = (storeId: string, id: string): Promise<Category | null> =>
+  categoriesAgent.selectCategory(storeId, id);
 
 export default categoriesAgent;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -80,7 +80,7 @@ function HomeScreenContent() {
     );
   }
 
-  const home = useHome();
+  const home = useHome(tenantId);
   const { refreshing, refresh, error } = home;
   const {
     productFormVisible,

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -18,7 +18,7 @@ export default function StoreDashboardScreen() {
   const [productCount, setProductCount] = useState(0);
   const [authorized, setAuthorized] = useState(false);
   const { data: store } = useStore(storeId);
-  const { data: products = [] } = useProducts(storeId || '');
+  const { data: products = [] } = useProducts(storeId ?? null);
 
   useEffect(() => {
     if (!storeId || !store) return;

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -32,7 +32,7 @@ export default function StoreProductsScreen() {
     data: initialProducts = [],
     isLoading,
     refetch,
-  } = useProducts(storeId || '');
+  } = useProducts(storeId ?? null);
   const [products, setProducts] = useState<Product[]>(initialProducts);
   const [formVisible, setFormVisible] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);

--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -2,13 +2,23 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { Product, Category } from '@/types';
 import { useProducts } from '@/services/useProducts';
 import { useCategories } from '@/services/useCategories';
-import { requireEnv } from '@/services/config';
 import { errorLog, debugLog } from '@/utils/logger';
 
-export function useHome() {
-  const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');
-  const productsQuery = useProducts(defaultStore);
-  const categoriesQuery = useCategories();
+export function useHome(tenantId: string | null) {
+  if (!tenantId) {
+    return {
+      products: [] as Product[],
+      categories: [] as Category[],
+      loading: false,
+      refreshing: false,
+      error: null as Error | null,
+      refresh: async () => {},
+      upsertProduct: (_p: Product, _isNew: boolean) => {},
+      removeProduct: (_id: string) => {},
+    };
+  }
+  const productsQuery = useProducts(tenantId);
+  const categoriesQuery = useCategories(tenantId);
 
   const [products, setProducts] = useState<Product[]>(productsQuery.data ?? []);
   const [categories, setCategories] = useState<Category[]>(categoriesQuery.data ?? []);

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -36,6 +36,7 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
 import { useCategories } from '@/services';
+import { useTenant } from '@/contexts/TenantContext';
 import { useAppRouter } from '@/services';
 import { Spinner } from '@/ui/primitives';
 
@@ -66,7 +67,8 @@ export default function ProductFormModal({
   const [videoError, setVideoError] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [videoPreview, setVideoPreview] = useState<string | null>(null);
-  const { data: categories = [] } = useCategories();
+  const { tenantId } = useTenant();
+  const { data: categories = [] } = useCategories(tenantId);
   const pinata = PinataService.getInstance();
 
   const toHttpUrl = (uri: string) =>

--- a/src/features/products/services/nearCategories.ts
+++ b/src/features/products/services/nearCategories.ts
@@ -7,25 +7,32 @@ import {
 import { Category } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { canonicalJson } from '@/utils/serialization';
+import { requireStoreId } from '@blue-ocean/utils';
 
 assertNearChain();
 
 const ADDRESS = 'categories';
 
-export async function getCategory(id: string): Promise<Category | null> {
-  const res = await getValue(ADDRESS, id);
+export async function getCategory(storeId: string, id: string): Promise<Category | null> {
+  const sid = requireStoreId(storeId);
+  const res = await getValue(ADDRESS, `${sid}:${id}`);
   return res ? (JSON.parse(res) as Category) : null;
 }
 
-export async function setCategory(category: Category) {
-  await setValue(ADDRESS, category.id, canonicalJson(category));
+export async function setCategory(storeId: string, category: Category) {
+  const sid = requireStoreId(storeId);
+  await setValue(ADDRESS, `${sid}:${category.id}`, canonicalJson(category));
 }
 
-export async function removeCategory(id: string) {
-  await removeValue(ADDRESS, id);
+export async function removeCategory(storeId: string, id: string) {
+  const sid = requireStoreId(storeId);
+  await removeValue(ADDRESS, `${sid}:${id}`);
 }
 
-export async function listCategories(): Promise<Category[]> {
+export async function listCategories(storeId: string): Promise<Category[]> {
+  const sid = requireStoreId(storeId);
   const items = await listValues(ADDRESS);
-  return items.map((i) => JSON.parse(i.value) as Category);
+  return items
+    .filter((i) => i.key.startsWith(`${sid}:`))
+    .map((i) => JSON.parse(i.value) as Category);
 }

--- a/src/services/useCategories.ts
+++ b/src/services/useCategories.ts
@@ -1,18 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Category } from '@/types';
+import invariant from '@/utils/invariant';
 
-let listCategories: (() => Promise<Category[]>) | undefined;
+let listCategories: ((storeId: string) => Promise<Category[]>) | undefined;
 if (chain === 'near') {
   ({ listCategories } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategories() {
+export function useCategories(tenantId: string | null) {
+  invariant(tenantId, 'tenantId required');
   return useQuery({
-    queryKey: ['categories'],
-    queryFn: () => (listCategories ? listCategories() : Promise.resolve([])),
+    queryKey: ['categories', tenantId],
+    queryFn: () =>
+      listCategories ? listCategories(tenantId) : Promise.resolve([]),
     select: (data) => data ?? [],
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    enabled: !!tenantId,
   });
 }

--- a/src/services/useCategory.ts
+++ b/src/services/useCategory.ts
@@ -1,20 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Category, Subcategory } from '@/types';
+import invariant from '@/utils/invariant';
 
-let setCategory: ((category: Category) => Promise<void>) | undefined;
+let setCategory: ((storeId: string, category: Category) => Promise<void>) | undefined;
 if (chain === 'near') {
   ({ setCategory } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategory(category: Category | null) {
+export function useCategory(category: Category | null, tenantId: string | null) {
+  invariant(tenantId, 'tenantId required');
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (updated: Category) =>
-      setCategory ? setCategory(updated) : Promise.resolve(),
+      setCategory ? setCategory(tenantId, updated) : Promise.resolve(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['categories', tenantId] });
     },
   });
 

--- a/src/services/useCategoryDetail.ts
+++ b/src/services/useCategoryDetail.ts
@@ -1,30 +1,35 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import type { Category, Subcategory } from '@/types';
+import invariant from '@/utils/invariant';
 
-let getCategory: ((id: string) => Promise<Category | null>) | undefined;
-let setCategory: ((category: Category) => Promise<void>) | undefined;
+let getCategory: ((storeId: string, id: string) => Promise<Category | null>) | undefined;
+let setCategory: ((storeId: string, category: Category) => Promise<void>) | undefined;
 if (chain === 'near') {
   ({ getCategory, setCategory } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategoryDetail(id?: string) {
+export function useCategoryDetail(id: string | undefined, tenantId: string | null) {
+  invariant(tenantId, 'tenantId required');
   const queryClient = useQueryClient();
 
   const { data: category = null, isLoading } = useQuery({
-    queryKey: ['category', id],
-    queryFn: () => (id && getCategory ? getCategory(id) : Promise.resolve(null)),
-    enabled: !!id,
+    queryKey: ['category', tenantId, id],
+    queryFn: () =>
+      id && tenantId && getCategory
+        ? getCategory(tenantId, id)
+        : Promise.resolve(null),
+    enabled: !!id && !!tenantId,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
 
   const mutation = useMutation({
     mutationFn: (updated: Category) =>
-      setCategory ? setCategory(updated) : Promise.resolve(),
+      setCategory ? setCategory(tenantId, updated) : Promise.resolve(),
     onSuccess: (_data, updated) => {
-      queryClient.invalidateQueries({ queryKey: ['category', updated.id] });
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['category', tenantId, updated.id] });
+      queryClient.invalidateQueries({ queryKey: ['categories', tenantId] });
     },
   });
 

--- a/src/services/useProducts.ts
+++ b/src/services/useProducts.ts
@@ -2,17 +2,19 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import DatabaseService from '@/services/database';
 import { productsAdapter } from '@/features/products/services';
 import { Product } from '@/types';
+import invariant from '@/utils/invariant';
 
-export function useProducts(storeId: string) {
+export function useProducts(tenantId: string | null) {
+  invariant(tenantId, 'tenantId required');
   return useQuery({
-    queryKey: ['products', storeId],
+    queryKey: ['products', tenantId],
     queryFn: async () => {
       const db = DatabaseService.getInstance();
       let data = await db.getProducts();
-      data = data.filter((p) => p.storeId === storeId);
+      data = data.filter((p) => p.storeId === tenantId);
       if (data.length === 0) {
         try {
-          data = await productsAdapter.listProducts(storeId);
+          data = await productsAdapter.listProducts(tenantId);
         } catch {}
       }
       return data;
@@ -20,24 +22,26 @@ export function useProducts(storeId: string) {
     select: (data) => data ?? [],
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    enabled: !!tenantId,
   });
 }
 
-export function useProductMutations(storeId: string) {
+export function useProductMutations(tenantId: string | null) {
+  invariant(tenantId, 'tenantId required');
   const queryClient = useQueryClient();
 
   const upsert = useMutation({
     mutationFn: (product: Product) =>
-      productsAdapter.setProduct(storeId, product),
+      productsAdapter.setProduct(tenantId, product),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['products', storeId] });
+      queryClient.invalidateQueries({ queryKey: ['products', tenantId] });
     },
   });
 
   const remove = useMutation({
-    mutationFn: (id: string) => productsAdapter.removeProduct(storeId, id),
+    mutationFn: (id: string) => productsAdapter.removeProduct(tenantId, id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['products', storeId] });
+      queryClient.invalidateQueries({ queryKey: ['products', tenantId] });
     },
   });
 

--- a/src/services/useSubcategories.ts
+++ b/src/services/useSubcategories.ts
@@ -2,8 +2,8 @@ import { useCategories } from './useCategories';
 import { useCategory } from './useCategory';
 import { Subcategory } from '@/types';
 
-export function useSubcategories(categoryId?: string) {
-  const { data: categories = [], isLoading: categoriesLoading } = useCategories();
+export function useSubcategories(categoryId: string | undefined, tenantId: string | null) {
+  const { data: categories = [], isLoading: categoriesLoading } = useCategories(tenantId);
   const category = categories.find((cat) => cat.id === categoryId) || null;
   const subcategories: Subcategory[] = category?.subcategories ?? [];
   const {
@@ -11,7 +11,7 @@ export function useSubcategories(categoryId?: string) {
     updateSubcategory,
     deleteSubcategory,
     isPending,
-  } = useCategory(category);
+  } = useCategory(category, tenantId);
 
   return {
     category,

--- a/utils/invariant.ts
+++ b/utils/invariant.ts
@@ -1,0 +1,5 @@
+export default function invariant(condition: any, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- scope home hook and product/category services by tenantId
- validate tenantId in product and category adapters
- add simple invariant helper

## Testing
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*
- `yarn typecheck` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18d03cf2883269d71dca1000692b9