### PR TITLE
Isolate category query by tenant

### DIFF
--- a/src/features/home/hooks/useHome.ts
+++ b/src/features/home/hooks/useHome.ts
@@ -8,7 +8,7 @@ import { errorLog, debugLog } from '@/utils/logger';
 export function useHome() {
   const defaultStore = requireEnv('EXPO_PUBLIC_DEFAULT_STORE', 'default');
   const productsQuery = useProducts(defaultStore);
-  const categoriesQuery = useCategories();
+  const categoriesQuery = useCategories(defaultStore);
 
   const [products, setProducts] = useState<Product[]>(productsQuery.data ?? []);
   const [categories, setCategories] = useState<Category[]>(categoriesQuery.data ?? []);

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -22,6 +22,7 @@ import PinataService from '@/services/pinata';
 import ipfsService from '@/services/ipfsService';
 import chain, { chainAdapter } from '@/services/chain';
 import { useWallet } from '@/contexts/WalletProvider';
+import { useTenant } from '@/contexts/TenantContext';
 
 let setProductBatch:
   | ((items: ProductIndexItem[]) => Promise<void>)
@@ -59,6 +60,7 @@ export default function ProductFormModal({
   const { currencySymbol } = useCurrency();
   const { address } = useWallet();
   const { push } = useAppRouter();
+  const { tenantId } = useTenant();
   const [editingProduct, setEditingProduct] = useState<Partial<Product>>({});
   const [imageUrls, setImageUrls] = useState('');
   const [videoUrls, setVideoUrls] = useState('');
@@ -66,7 +68,7 @@ export default function ProductFormModal({
   const [videoError, setVideoError] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [videoPreview, setVideoPreview] = useState<string | null>(null);
-  const { data: categories = [] } = useCategories();
+  const { data: categories = [] } = useCategories(tenantId ?? undefined);
   const pinata = PinataService.getInstance();
 
   const toHttpUrl = (uri: string) =>

--- a/src/services/useCategories.ts
+++ b/src/services/useCategories.ts
@@ -7,9 +7,9 @@ if (chain === 'near') {
   ({ listCategories } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategories() {
+export function useCategories(tenantId?: string) {
   return useQuery({
-    queryKey: ['categories'],
+    queryKey: ['categories', tenantId],
     queryFn: () => (listCategories ? listCategories() : Promise.resolve([])),
     select: (data) => data ?? [],
     staleTime: 5 * 60 * 1000,

--- a/src/services/useCategory.ts
+++ b/src/services/useCategory.ts
@@ -7,14 +7,14 @@ if (chain === 'near') {
   ({ setCategory } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategory(category: Category | null) {
+export function useCategory(category: Category | null, tenantId?: string) {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (updated: Category) =>
       setCategory ? setCategory(updated) : Promise.resolve(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['categories', tenantId] });
     },
   });
 

--- a/src/services/useCategoryDetail.ts
+++ b/src/services/useCategoryDetail.ts
@@ -8,7 +8,7 @@ if (chain === 'near') {
   ({ getCategory, setCategory } = require('@/features/products/services/nearCategories'));
 }
 
-export function useCategoryDetail(id?: string) {
+export function useCategoryDetail(id?: string, tenantId?: string) {
   const queryClient = useQueryClient();
 
   const { data: category = null, isLoading } = useQuery({
@@ -24,7 +24,7 @@ export function useCategoryDetail(id?: string) {
       setCategory ? setCategory(updated) : Promise.resolve(),
     onSuccess: (_data, updated) => {
       queryClient.invalidateQueries({ queryKey: ['category', updated.id] });
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['categories', tenantId] });
     },
   });
 

--- a/src/services/useSubcategories.ts
+++ b/src/services/useSubcategories.ts
@@ -2,8 +2,8 @@ import { useCategories } from './useCategories';
 import { useCategory } from './useCategory';
 import { Subcategory } from '@/types';
 
-export function useSubcategories(categoryId?: string) {
-  const { data: categories = [], isLoading: categoriesLoading } = useCategories();
+export function useSubcategories(categoryId?: string, tenantId?: string) {
+  const { data: categories = [], isLoading: categoriesLoading } = useCategories(tenantId);
   const category = categories.find((cat) => cat.id === categoryId) || null;
   const subcategories: Subcategory[] = category?.subcategories ?? [];
   const {
@@ -11,7 +11,7 @@ export function useSubcategories(categoryId?: string) {
     updateSubcategory,
     deleteSubcategory,
     isPending,
-  } = useCategory(category);
+  } = useCategory(category, tenantId);
 
   return {
     category,


### PR DESCRIPTION
## Summary
- scope category query cache by tenant
- ensure category mutations invalidate tenant-specific caches
- pass tenant IDs through category hooks and components

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1ba51e483269e644a10f45f985f