### PR TITLE
Scope home queries by tenant

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -177,6 +177,7 @@ function HomeScreenContent() {
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
       >
         <CategoryChips
+          tenantId={tenantId}
           categories={categoriesToShow}
           selectedCategory={selectedCategory}
           setSelectedCategory={setSelectedCategory}
@@ -283,6 +284,7 @@ function HomeScreenContent() {
 
           <Suspense fallback={<Spinner />}>
             <ProductGrid
+              tenantId={tenantId}
               products={filteredProducts}
               isStoreOwner={isStoreOwner}
               onEdit={openProductForm}

--- a/src/features/home/components/CategoryChips.tsx
+++ b/src/features/home/components/CategoryChips.tsx
@@ -6,12 +6,15 @@ import { Category } from '@/types';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 
 interface CategoryChipsProps {
+  tenantId?: string | null;
   categories: Category[];
   selectedCategory: string | null;
   setSelectedCategory: (id: string | null) => void;
 }
 
 function CategoryChips({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  tenantId,
   categories,
   selectedCategory,
   setSelectedCategory,

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -8,6 +8,7 @@ import { Filter, Plus } from 'lucide-react-native';
 import { spacing } from '@/shared/ui/tokens';
 
 interface ProductGridProps {
+  tenantId?: string | null;
   products: Product[];
   isStoreOwner: boolean;
   onEdit: (product: Product) => void;
@@ -29,6 +30,8 @@ const ProductRow = React.memo(({ item }: { item: Product }) => (
 ));
 
 function ProductGrid({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  tenantId,
   products,
   isStoreOwner,
   onEdit,

--- a/src/services/useCategories.ts
+++ b/src/services/useCategories.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Category } from '@/types';
+import invariant from '@/utils/invariant';
 
 let listCategories: ((storeId: string) => Promise<Category[]>) | undefined;
 if (chain === 'near') {
@@ -10,10 +11,11 @@ if (chain === 'near') {
 export function useCategories(tenantId: string | null) {
   return useQuery({
     queryKey: ['categories', tenantId],
-    queryFn: () =>
-      tenantId && listCategories
-        ? listCategories(tenantId)
-        : Promise.resolve([] as Category[]),
+    queryFn: () => {
+      invariant(tenantId, 'tenantId required');
+      if (!listCategories) return Promise.resolve([] as Category[]);
+      return listCategories(tenantId);
+    },
     select: (data) => data ?? [],
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,

--- a/src/services/useProducts.ts
+++ b/src/services/useProducts.ts
@@ -8,7 +8,7 @@ export function useProducts(tenantId: string | null) {
   return useQuery({
     queryKey: ['products', tenantId],
     queryFn: async () => {
-      if (!tenantId) return [] as Product[];
+      invariant(tenantId, 'tenantId required');
       const db = DatabaseService.getInstance();
       let data = await db.getProducts();
       data = data.filter((p) => p.storeId === tenantId);


### PR DESCRIPTION
## Summary
- pass tenantId to home CategoryChips and ProductGrid
- guard product and category queries against missing tenantId

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ddabee5c832680e78e3074e05392