### PR TITLE
feat: add command palette and global search

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, StyleSheet, TextInput, Pressable } from 'react-native';
+import { Text, Portal, Overlay } from '@/ui';
+import { useTheme } from '@/ui/ThemeProvider';
+import { useLanguage } from '@/ui/ThemeProvider';
+import { useAppInfo } from '../contexts/AppInfoContext';
+import { useAppRouter } from '@/services';
+import { useProducts } from '@/services/useProducts';
+import { spacing, radius, typography } from '@/ui/tokens';
+import { useOrders } from '@/services/useOrders';
+
+interface CommandPaletteProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+interface PaletteItem {
+  label: string;
+  action: () => void;
+  section: string;
+}
+
+export default function CommandPalette({ visible, onClose }: CommandPaletteProps) {
+  const { colors } = useTheme();
+  const { t, isRTL } = useLanguage();
+  const { tenantId } = useAppInfo();
+  const { push } = useAppRouter();
+  const { data: products = [] } = useProducts(tenantId);
+  const { data: orders = [] } = useOrders(tenantId);
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(query), 200);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  const sections = useMemo(() => {
+    const q = debounced.toLowerCase();
+    const nav: PaletteItem[] = [
+      { label: t('navigation.home'), action: () => push('/') , section: t('commandPalette.navigate', 'Navigate') },
+    ].filter((i) => i.label.toLowerCase().includes(q));
+    const prod: PaletteItem[] = products
+      .filter((p) => p.name.toLowerCase().includes(q))
+      .map((p) => ({
+        label: p.name,
+        action: () => push(`/store/${p.storeId}`),
+        section: t('commandPalette.products', 'Products'),
+      }));
+    const ord: PaletteItem[] = orders
+      .filter((o) => o.id.toLowerCase().includes(q))
+      .map((o) => ({
+        label: o.id,
+        action: () => push(`/orders/${o.id}`),
+        section: t('commandPalette.orders', 'Orders'),
+      }));
+    const actions: PaletteItem[] = [
+      { label: t('notifications.notifications'), action: () => push('/notifications'), section: t('commandPalette.actions', 'Actions') },
+    ].filter((i) => i.label.toLowerCase().includes(q));
+    const flat = [...nav, ...prod, ...ord, ...actions];
+    const grouped: Record<string, PaletteItem[]> = {};
+    flat.forEach((item) => {
+      if (!grouped[item.section]) grouped[item.section] = [];
+      grouped[item.section].push(item);
+    });
+    return { flat, grouped };
+  }, [debounced, products, orders, push, t]);
+
+  useEffect(() => setActive(0), [sections]);
+
+  const handleKeyDown = (e: any) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((i) => Math.min(i + 1, sections.flat.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      sections.flat[active]?.action();
+      onClose();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Portal>
+      <Overlay style={[styles.overlay, { backgroundColor: colors.canvas }]} />
+      <View style={[styles.center, { pointerEvents: 'box-none' }]}>
+        <View style={[styles.container, { backgroundColor: colors.surface.elevated }]}>
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            autoFocus
+            onKeyDown={handleKeyDown}
+            placeholder={t('home.searchPlaceholder')}
+            placeholderTextColor={colors.text.tertiary}
+            style={[
+              styles.input,
+              { color: colors.text.primary, textAlign: isRTL ? 'right' : 'left' },
+            ]}
+          />
+          <View style={styles.results}>
+            {Object.entries(sections.grouped).map(([title, items]) => (
+              <View key={title} style={styles.section}>
+                <Text style={[styles.sectionTitle, { color: colors.text.secondary }]}>
+                  {title}
+                </Text>
+                {items.map((item, idx) => {
+                  const index = sections.flat.indexOf(item);
+                  const selected = index === active;
+                  return (
+                    <Pressable
+                      key={item.label}
+                      onPress={() => {
+                        item.action();
+                        onClose();
+                      }}
+                      style={[
+                        styles.item,
+                        selected && { backgroundColor: colors.surface.primary },
+                      ]}
+                    >
+                      <Text style={[styles.itemText, { color: colors.text.primary }]}>
+                        {item.label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ))}
+          </View>
+        </View>
+      </View>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    opacity: 0.5,
+  },
+  center: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.spacer20,
+  },
+  container: {
+    width: '100%',
+    maxWidth: 480,
+    borderRadius: radius.xl,
+    padding: spacing.spacer16,
+  },
+  input: {
+    ...typography.md,
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.spacer8,
+    marginBottom: spacing.spacer12,
+  },
+  results: {
+    maxHeight: 300,
+  },
+  section: {
+    marginBottom: spacing.spacer12,
+  },
+  sectionTitle: {
+    ...typography.sm,
+    marginBottom: spacing.spacer4,
+  },
+  item: {
+    paddingVertical: spacing.spacer8,
+    paddingHorizontal: spacing.spacer8,
+    borderRadius: radius.sm,
+  },
+  itemText: {
+    ...typography.md,
+  },
+});

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   StyleSheet,
@@ -14,15 +14,16 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useAppInfo } from '../contexts/AppInfoContext';
 import UserAvatar from './UserAvatar';
+import CommandPalette from './CommandPalette';
 import { spacing, radius, typography } from '@/ui/tokens';
 import { usePathname } from 'expo-router';
 import { useNotificationState } from './NotificationContext';
 
-interface TopBarProps {
+interface GlobalHeaderProps {
   showSearch?: boolean;
 }
 
-export default function TopBar({ showSearch = true }: TopBarProps) {
+export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const { t, isRTL, currentLanguage, setLanguage } = useLanguage();
   const { colors } = useTheme();
   const { appName, logoCid } = useAppInfo();
@@ -31,6 +32,19 @@ export default function TopBar({ showSearch = true }: TopBarProps) {
   const pathname = usePathname();
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setPaletteOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   const toggleLanguage = async () => {
     const next = currentLanguage === 'he' ? 'en' : 'he';
@@ -182,6 +196,10 @@ export default function TopBar({ showSearch = true }: TopBarProps) {
 
         <UserAvatar />
       </View>
+      <CommandPalette
+        visible={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+      />
     </View>
   );
 }

--- a/docs/near-dev-packet.md
+++ b/docs/near-dev-packet.md
@@ -452,7 +452,7 @@ BlueOcean
 │  └─ /admin/settings             (Flags, Feature toggles)
 │
 ├─ UI Components (reusable)
-│  ├─ Navigation: TopBar, SideBar, Breadcrumbs, TenantSwitcher
+│  ├─ Navigation: GlobalHeader, SideBar, Breadcrumbs, TenantSwitcher
 │  ├─ Wallet: NEARConnectButton, AccountBadge
 │  ├─ Catalog: ProductCard, ProductGrid, VariantSelector
 │  ├─ Cart: CartDrawer, LineItem, QuantityPicker

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import TopBar from '@/components/TopBar';
+import GlobalHeader from '@/components/GlobalHeader';
 
 export default function HomeHeader() {
-  return <TopBar showSearch={false} />;
+  return <GlobalHeader showSearch={false} />;
 }
 

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -3,7 +3,7 @@ import { View, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { Slot, usePathname } from 'expo-router';
-import TopBar from '@/components/TopBar';
+import GlobalHeader from '@/components/GlobalHeader';
 import { FloatingCartWidget } from '@/features/cart';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -39,7 +39,7 @@ export default function RootLayout() {
     <ErrorBoundary>
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
         <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
-        <TopBar showSearch={showSearch} />
+        <GlobalHeader showSearch={showSearch} />
         <View style={{ flex: 1, flexDirection: isRTL ? 'row-reverse' : 'row' }}>
           {isLargeScreen && <SidebarTabBar items={navItems} isSidebar />}
           <View style={{ flex: 1 }}>

--- a/src/services/useOrders.ts
+++ b/src/services/useOrders.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import ordersAgent from '@/agents/orders-agent';
+import { Order } from '@/types';
+
+export function useOrders(tenantId: string | null) {
+  return useQuery({
+    queryKey: ['orders', tenantId],
+    queryFn: async () => {
+      if (!tenantId) return [] as Order[];
+      const all = await ordersAgent.getAll();
+      return all.filter((o) => o.items?.[0]?.product?.storeId === tenantId);
+    },
+    select: (data) => data ?? [],
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    enabled: !!tenantId,
+  });
+}

--- a/tests/navigationLoop.test.tsx
+++ b/tests/navigationLoop.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import TopBar from '@/components/TopBar';
+import GlobalHeader from '@/components/GlobalHeader';
 import { Pressable } from 'react-native';
 
 const mockPush = jest.fn();
@@ -45,7 +45,7 @@ describe('navigation loop prevention', () => {
 
   it('does not push to current path', () => {
     mockUsePathname.mockReturnValue('/');
-    const tree = renderer.create(React.createElement(TopBar));
+    const tree = renderer.create(React.createElement(GlobalHeader));
     const pressables = tree.root.findAllByType(Pressable);
     pressables[0].props.onPress();
     expect(mockPush).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- rename TopBar to GlobalHeader and add Command+K / Ctrl+K keyboard shortcut
- implement CommandPalette modal with global navigation, product, order, and action search
- add `useOrders` hook and update imports and tests

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68c1de6bb2c88326b83988e53036ff30