### PR TITLE
fix: remove duplicate tenantId declaration

### DIFF
--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -37,7 +37,6 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import PricingTierFormModal from "./PricingTierFormModal";
 import SubcategoryPicker from './SubcategoryPicker';
 import { useCategories } from '@/services';
-import { useTenant } from '@/contexts/TenantContext';
 import { useAppRouter } from '@/services';
 import { Spinner } from '@/ui/primitives';
 
@@ -69,7 +68,6 @@ export default function ProductFormModal({
   const [videoError, setVideoError] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [videoPreview, setVideoPreview] = useState<string | null>(null);
-  const { tenantId } = useTenant();
   const { data: categories = [] } = useCategories(tenantId);
   const pinata = PinataService.getInstance();
 


### PR DESCRIPTION
## Summary
- avoid redeclaring tenantId in ProductFormModal

## Testing
- `yarn lint src/features/products/components/ProductFormModal.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install --frozen-lockfile` *(fails: @waku/core requires node >=22)*
- `yarn typecheck` *(fails: missing type definitions)*


------
https://chatgpt.com/codex/tasks/task_e_68c1dedde8bc8326a81f67e7df82e2e6