### PR TITLE
fix missing translations and undefined home screen vars

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -51,6 +51,34 @@ function HomeScreenContent() {
   const { t } = useLanguage();
   const { colors: themeColors } = useTheme();
   const home = useHome(tenantId);
+  const router = useAppRouter();
+  const { width: windowWidth } = useWindowDimensions();
+
+  const actionsLoading = false;
+  const networkActions = [
+    {
+      key: 'create-store',
+      label: t('home.createStore'),
+      onPress: () => router.push(routes.createStore()),
+    },
+    {
+      key: 'become-driver',
+      label: t('home.becomeDriver'),
+      onPress: () => router.push('/driver'),
+    },
+    {
+      key: 'business-login',
+      label: t('home.businessLogin'),
+      onPress: () => router.push('/login'),
+    },
+    {
+      key: 'docs-api',
+      label: t('home.docsApi'),
+      onPress: () => router.push('/docs'),
+    },
+  ];
+
+  const networkItemWidth = getNetworkCardWidth(windowWidth);
 
   if (isNetwork) {
     return (
@@ -111,17 +139,17 @@ function HomeScreenContent() {
   const { fallbackCategories } = useHomeData();
   const categoriesToShow = categories.length ? categories : fallbackCategories;
 
-  const { filteredProducts, searchQuery, selectedCategory, setSelectedCategory, minPrice, setMinPrice, maxPrice, setMaxPrice, sortBy, setSortBy, showSortModal, setShowSortModal } = useHomeFilters(products);
-  const [showCategorySelector, setShowCategorySelector] = useState(false);
+    const { filteredProducts, searchQuery, selectedCategory, setSelectedCategory, minPrice, setMinPrice, maxPrice, setMaxPrice, sortBy, setSortBy, showSortModal, setShowSortModal } = useHomeFilters(products);
+    const [showCategorySelector, setShowCategorySelector] = useState(false);
 
-  const getProductItemWidth = () => {
-    if (windowWidth >= 1024) {
-      return '23.5%';
-    } else if (windowWidth >= 768) {
-      return '32%';
-    }
-    return '48%';
-  };
+    const getProductItemWidth = () => {
+      if (windowWidth >= 1024) {
+        return '23.5%';
+      } else if (windowWidth >= 768) {
+        return '32%';
+      }
+      return '48%';
+    };
 
   const getSortLabel = () => {
     switch (sortBy) {

--- a/translations/en.json
+++ b/translations/en.json
@@ -26,7 +26,8 @@
     "reload": "Reload",
     "comingSoon": "Coming Soon",
     "goHome": "Go Home",
-    "route": "Route:"
+    "route": "Route:",
+    "language": "Language"
   },
   "app": {
     "routerDisabled": "Router disabled"
@@ -40,6 +41,12 @@
     "notifications": "Notifications",
     "reviews": "Reviews",
     "profile": "Profile"
+  },
+  "commandPalette": {
+    "navigate": "Navigate",
+    "actions": "Actions",
+    "products": "Products",
+    "orders": "Orders"
   },
   "auth": {
     "login": "Login",

--- a/translations/he.json
+++ b/translations/he.json
@@ -26,7 +26,8 @@
     "reload": "טען מחדש",
     "comingSoon": "בקרוב",
     "goHome": "חזור לבית",
-    "route": "נתיב:"
+    "route": "נתיב:",
+    "language": "שפה"
   },
   "app": {
     "routerDisabled": "הנתב מושבת"
@@ -40,6 +41,12 @@
     "notifications": "התראות",
     "reviews": "ביקורות",
     "profile": "פרופיל"
+  },
+  "commandPalette": {
+    "navigate": "ניווט",
+    "actions": "פעולות",
+    "products": "מוצרים",
+    "orders": "הזמנות"
   },
   "auth": {
     "login": "התחבר",


### PR DESCRIPTION
## Summary
- add translation entries for `common.language` and command palette labels
- define network actions and loading state in `HomeScreenContent` to prevent runtime errors

## Testing
- ⚠️ `node scripts/check-i18n.js` *(node: command not found)*
- ⚠️ `yarn lint` *(yarn: command not found)*
- ⚠️ `yarn typecheck` *(yarn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1429eb48326aa0d1f8e3f8aced9