### PR TITLE
fix: wire hero CTA to store

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -1,16 +1,38 @@
 import React from 'react';
-import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type KeyboardEvent,
+} from 'react-native';
+import { router } from 'expo-router';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Button, Heading, Text } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
 import { spacing, typography } from '@/ui/tokens';
+import { requireEnv } from '@/services/config';
 import PromoCard from './PromoCard';
+
+const SHOP_TENANT_ID = requireEnv('SHOP_TENANT_ID');
 
 export default function HeroCallout() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const { width } = useWindowDimensions();
   const isWide = width >= 768;
+
+  const handlePress = () => {
+    router.push(`/store/${SHOP_TENANT_ID}`);
+  };
+
+  const handleKeyDown = (e: NativeSyntheticEvent<KeyboardEvent>) => {
+    const key = e.nativeEvent.key;
+    if (key === 'Enter' || key === ' ') {
+      e.preventDefault();
+      handlePress();
+    }
+  };
 
   return (
     <PromoCard
@@ -33,7 +55,12 @@ export default function HeroCallout() {
             {t('home.heroSubtitle')}
           </Text>
         </View>
-        <Button title={t('home.heroAction')} />
+        <Button
+          title={t('home.heroAction')}
+          onPress={handlePress}
+          accessibilityRole="link"
+          onKeyDown={handleKeyDown}
+        />
       </Stack>
     </PromoCard>
   );


### PR DESCRIPTION
## Summary
- connect Hero CTA to tenant store via router
- add accessibility role and key handling for Hero CTA

## Testing
- `yarn lint src/features/home/components/HeroCallout.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: @waku/core@0.0.38 requires node >=22, got 20.19.4)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', 'react'; expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f62d558c83268b305813249f1f7e