### PR TITLE
Gate network CTAs by wallet state

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,6 +8,7 @@ import {
   useWindowDimensions,
   Platform,
   Alert,
+  Linking,
 } from 'react-native';
 import { Plus, ArrowUpDown } from 'lucide-react-native';
 import { Product } from '@/types';
@@ -17,6 +18,7 @@ import { useHomeData } from '@/features/home/hooks/useHomeData';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useTenant } from '@/contexts/TenantContext';
+import { useWallet } from '@/contexts/WalletProvider';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
@@ -53,28 +55,46 @@ function HomeScreenContent() {
   const home = useHome(tenantId);
   const router = useAppRouter();
   const { width: windowWidth } = useWindowDimensions();
+  const { address, connect } = useWallet();
 
   const actionsLoading = false;
+
+  const requireWallet = useCallback(
+    (action: () => void) => {
+      if (!address) {
+        void connect();
+        return;
+      }
+      action();
+    },
+    [address, connect],
+  );
+
   const networkActions = [
     {
       key: 'create-store',
       label: t('home.createStore'),
-      onPress: () => router.push(routes.createStore()),
+      onPress: () => requireWallet(() => router.push(routes.createStore())),
     },
     {
       key: 'become-driver',
       label: t('home.becomeDriver'),
-      onPress: () => router.push('/driver'),
+      onPress: () => requireWallet(() => router.push('/driver')),
     },
     {
       key: 'business-login',
       label: t('home.businessLogin'),
-      onPress: () => router.push('/login'),
+      onPress: () => requireWallet(() => router.push('/login')),
     },
     {
       key: 'docs-api',
       label: t('home.docsApi'),
-      onPress: () => router.push('/docs'),
+      onPress: () => {
+        const url = process.env.EXPO_PUBLIC_DOCS_URL;
+        if (url) {
+          void Linking.openURL(url);
+        }
+      },
     },
   ];
 

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -22,6 +22,9 @@ jest.mock('react-native-safe-area-context', () => {
 jest.mock('@features/auth/AuthContext', () => ({
   useAuth: () => ({ isStoreOwner: false }),
 }));
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: 'test', connect: jest.fn() }),
+}));
 jest.mock('@/ui/ThemeProvider', () => ({
   useLanguage: () => ({ t: (s: string) => s }),
   useTheme: () => ({ colors: { background: '#fff', text: { primary: '#000', secondary: '#333' } } }),

--- a/tests/homeFallbackVisibility.test.tsx
+++ b/tests/homeFallbackVisibility.test.tsx
@@ -30,6 +30,9 @@ jest.mock('react-native-safe-area-context', () => {
     SafeAreaView: ({ children }: any) => React.createElement(React.Fragment, null, children),
   };
 });
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: 'test', connect: jest.fn() }),
+}));
 
 jest.mock('@features/auth/AuthContext', () => ({
   useAuth: () => ({ isStoreOwner: false }),

--- a/tests/homeScreenRender.test.tsx
+++ b/tests/homeScreenRender.test.tsx
@@ -42,6 +42,9 @@ jest.mock('react-native-safe-area-context', () => {
     SafeAreaView: ({ children }: any) => React.createElement(React.Fragment, null, children),
   };
 });
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: 'test', connect: jest.fn() }),
+}));
 
 jest.mock('@features/auth/AuthContext', () => ({
   useAuth: () => ({ isStoreOwner: false }),


### PR DESCRIPTION
## Summary
- ensure network call-to-actions require wallet connection
- use env docs URL and open externally
- mock wallet context in home screen tests

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f63e7e18832692e666b424b9b211