### PR TITLE
Enable driver application flow from home

### DIFF
--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -1,23 +1,29 @@
 import React from 'react';
-import { StyleSheet, Alert } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { Card, Text, Button } from '@/ui';
 import { Stack } from '@/ui/layout';
 import { spacing, radius } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
+import { useWallet } from '@/contexts/WalletProvider';
 
 export default function HomeOptions() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const appRouter = useAppRouter();
+  const { address: walletAddress, connect } = useWallet();
 
   const handleCreateStore = () => {
     appRouter.push(routes.createStore());
   };
 
-  const handleBecomeDriver = () => {
-    Alert.alert(t('profile.comingSoon', 'Coming Soon'));
+  const handleBecomeDriver = async () => {
+    if (!walletAddress) {
+      await connect();
+      return;
+    }
+    appRouter.push(routes.driver());
   };
 
   return (
@@ -43,7 +49,7 @@ export default function HomeOptions() {
           <Button
             title={t('home.becomeDriver', 'Become a Driver')}
             onPress={handleBecomeDriver}
-            accessibilityRole="button"
+            accessibilityRole="link"
             testID="become-driver-button"
           />
         </Stack>

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -5,6 +5,7 @@ export const routes = {
   }),
   store: (id: string | number) => `/store/${id}`,
   createStore: () => '/stores/create',
+  driver: () => '/driver',
 };
 
 export type Routes = typeof routes;


### PR DESCRIPTION
## Summary
- route "Become a Driver" CTA to driver flow after wallet check
- expose `/driver` helper in routes

## Testing
- `npx eslint src/features/home/components/HomeOptions.tsx utils/routes.ts`
- `npx jest` *(fails: TypeError: Cannot read properties of undefined (reading 'sourceFile'))*

------
https://chatgpt.com/codex/tasks/task_e_68c1f66de5d083269bc2caa305f427fe