### PR TITLE
refactor: move query provider ahead of wallet provider

### DIFF
--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -31,8 +31,8 @@ export const queryClient =
  * 3. `ErrorBoundary` – captures errors from all descendants.
  * 4. `ThemeProvider` – applies theming before any UI renders.
  * 5. `LanguageProvider` – sets up i18n and text direction.
- * 6. `WalletProvider` – supplies wallet context for network layers.
- * 7. `CheckedQueryClientProvider` – enforces a single React Query client.
+ * 6. `CheckedQueryClientProvider` – enforces a single React Query client.
+ * 7. `WalletProvider` – supplies wallet context for network layers.
  * 8. `WakuProvider` – depends on the wallet and query client.
  * 9. `AuthProvider` – manages authentication state.
  * 10. `AuthModalProvider` – handles auth modal display.
@@ -47,8 +47,8 @@ export default function AppProviders({ children }: React.PropsWithChildren) {
         <ErrorBoundary onError={(e) => toast.showError(e.message)}>
           <ThemeProvider>
             <LanguageProvider>
-              <WalletProvider>
-                <CheckedQueryClientProvider client={queryClient}>
+              <CheckedQueryClientProvider client={queryClient}>
+                <WalletProvider>
                   <WakuProvider>
                     <AuthProvider>
                       <AuthModalProvider>
@@ -58,8 +58,8 @@ export default function AppProviders({ children }: React.PropsWithChildren) {
                       </AuthModalProvider>
                     </AuthProvider>
                   </WakuProvider>
-                </CheckedQueryClientProvider>
-              </WalletProvider>
+                </WalletProvider>
+              </CheckedQueryClientProvider>
             </LanguageProvider>
           </ThemeProvider>
         </ErrorBoundary>

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -7,16 +7,16 @@
 1. **ErrorBoundary** – captures errors from all descendants.
 2. **ThemeProvider** – applies theming before any UI renders.
 3. **LanguageProvider** – sets up i18n and text direction.
-4. **WalletProvider** – supplies wallet context for network layers.
-5. **CheckedQueryClientProvider** – enforces a single React Query client.
+4. **CheckedQueryClientProvider** – enforces a single React Query client.
+5. **WalletProvider** – supplies wallet context for network layers.
 6. **WakuProvider** – depends on the wallet and query client.
 
 ## Invariants
 
 - `ErrorBoundary` must wrap everything to surface runtime errors.
 - `ThemeProvider` and `LanguageProvider` must appear before any component that uses theming or i18n.
-- `WalletProvider` precedes providers that rely on wallet state, including React Query and Waku.
-- `CheckedQueryClientProvider` ensures only one `QueryClient` instance; `WakuProvider` relies on the client created here.
+- `CheckedQueryClientProvider` must wrap providers that rely on React Query, including the `WalletProvider`.
+- `WalletProvider` supplies wallet state for network layers and comes before providers that require it, such as `WakuProvider`.
 - `WakuProvider` depends on both the wallet and query client and therefore must be last.
 
 See [AppProviders.tsx](./AppProviders.tsx) for the authoritative inline comment.


### PR DESCRIPTION
## Summary
- ensure CheckedQueryClientProvider wraps WalletProvider and update provider order comments
- document new provider ordering in src/providers/README.md

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx -y jest` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*


------
https://chatgpt.com/codex/tasks/task_e_68c202e9a24c8326b6ac43283de1fcf0