### PR TITLE
feat: add wallet status chip

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -6,7 +6,7 @@ import {
   TextInput,
   Platform,
 } from 'react-native';
-import { Text } from '@/ui';
+import { Text, Chip } from '@/ui';
 import SmartImage from './SmartImage';
 import { Search, Bell, Globe } from 'lucide-react-native';
 import { useAppRouter } from '@/services';
@@ -18,6 +18,7 @@ import CommandPalette from './CommandPalette';
 import { spacing, radius, typography } from '@/ui/tokens';
 import { usePathname } from 'expo-router';
 import { useNotificationState } from './NotificationContext';
+import { useWallet } from '@/contexts/WalletProvider';
 
 interface GlobalHeaderProps {
   showSearch?: boolean;
@@ -29,6 +30,7 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const { appName, logoCid } = useAppInfo();
   const { push } = useAppRouter();
   const { unreadCount, refreshNotifications } = useNotificationState();
+  const { address, connect, disconnect } = useWallet();
   const pathname = usePathname();
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -54,6 +56,15 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const handleSearchSubmit = () => {
     setSearchOpen(false);
     if (pathname !== '/' && pathname !== '/index') push('/');
+  };
+
+  const walletLabel = address || t('wallet.connect', 'Connect Wallet');
+  const handleWalletPress = async () => {
+    if (address) {
+      await disconnect();
+    } else {
+      await connect();
+    }
   };
 
   return (
@@ -193,6 +204,13 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
         >
           <Globe size={24} color={colors.text.primary} />
         </Pressable>
+
+        <Chip
+          label={walletLabel}
+          onPress={handleWalletPress}
+          style={{ flexShrink: 1 }}
+          textStyle={{ textAlign: isRTL ? 'right' : 'left' }}
+        />
 
         <UserAvatar />
       </View>

--- a/tests/navigationLoop.test.tsx
+++ b/tests/navigationLoop.test.tsx
@@ -29,12 +29,17 @@ jest.mock('@/components/NotificationContext', () => ({
   useNotificationState: () => ({ unreadCount: 0, refreshNotifications: jest.fn() }),
 }));
 
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: null, connect: jest.fn(), disconnect: jest.fn() }),
+}));
+
 jest.mock('@/ui', () => {
   const React = require('react');
   const { Pressable, Text } = require('react-native');
   return {
     Text,
     Button: ({ onPress, children }: any) => React.createElement(Pressable, { onPress }, children),
+    Chip: ({ label, onPress }: any) => React.createElement(Pressable, { onPress }, label),
   };
 });
 


### PR DESCRIPTION
## Summary
- show wallet connection status chip in global header
- mock wallet hook in navigation loop test

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn add -D @typescript-eslint/parser` *(fails: @waku/core requires node >=22)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npx jest` *(fails: needs to install jest package)*

------
https://chatgpt.com/codex/tasks/task_e_68c215968aa88326bec7e69a3be1f3a1