### PR TITLE
feat: add navigation config with role guards

### DIFF
--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -8,10 +8,51 @@ import { FloatingCartWidget } from '@/features/cart';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import ErrorBoundary from '@/shared/ErrorBoundary';
-import SidebarTabBar from '@/components/SidebarTabBar';
+import SidebarTabBar, { NavItem } from '@/components/SidebarTabBar';
+import { useAuth } from '@/features/auth/AuthContext';
+import { useTenant } from '@/contexts/TenantContext';
 
-const BASE_NAV_ITEMS = [
+interface NavItemConfig extends NavItem {
+  requiresAuth?: boolean;
+  requiresStoreOwner?: boolean;
+  requiresTenant?: boolean;
+}
+
+const NAV_ITEMS: readonly NavItemConfig[] = [
   { href: '/', title: 'navigation.home', icon: 'Home' },
+  { href: '/store', title: 'navigation.shopNow', icon: 'Store' },
+  {
+    href: '/messages',
+    title: 'navigation.messages',
+    icon: 'MessageCircle',
+    requiresAuth: true,
+  },
+  {
+    href: '/profile',
+    title: 'navigation.profile',
+    icon: 'User',
+    requiresAuth: true,
+  },
+  {
+    href: '/dashboard',
+    title: 'navigation.dashboard',
+    icon: 'LayoutDashboard',
+    requiresAuth: true,
+    requiresStoreOwner: true,
+    requiresTenant: true,
+  },
+  {
+    href: '/orders',
+    title: 'navigation.orders',
+    icon: 'Package',
+    requiresAuth: true,
+  },
+  {
+    href: '/settings',
+    title: 'navigation.settings',
+    icon: 'Settings',
+    requiresAuth: true,
+  },
 ] as const;
 
 const LARGE_SCREEN = 768;
@@ -21,19 +62,22 @@ export default function RootLayout() {
   const { isRTL } = useLanguage();
   const pathname = usePathname();
   const { width } = useWindowDimensions();
+  const { isLoggedIn, isStoreOwner } = useAuth();
+  const { tenantId } = useTenant();
   const isLargeScreen = width >= LARGE_SCREEN;
   const showSearch = pathname === '/' || pathname === '/index';
   const showCartWidget = showSearch;
 
-  const navItems = useMemo(() => {
-    if (pathname.startsWith('/store/')) {
-      return [
-        ...BASE_NAV_ITEMS,
-        { href: pathname, title: 'navigation.store', icon: 'Store' as const },
-      ];
-    }
-    return BASE_NAV_ITEMS;
-  }, [pathname]);
+  const navItems = useMemo(
+    () =>
+      NAV_ITEMS.filter((item) => {
+        if (item.requiresAuth && !isLoggedIn) return false;
+        if (item.requiresStoreOwner && !isStoreOwner) return false;
+        if (item.requiresTenant && !tenantId) return false;
+        return true;
+      }),
+    [isLoggedIn, isStoreOwner, tenantId],
+  );
 
   return (
     <ErrorBoundary>

--- a/translations/en.json
+++ b/translations/en.json
@@ -40,7 +40,11 @@
     "categories": "Categories",
     "notifications": "Notifications",
     "reviews": "Reviews",
-    "profile": "Profile"
+    "profile": "Profile",
+    "shopNow": "Shop Now",
+    "messages": "Messages",
+    "dashboard": "Dashboard",
+    "settings": "Settings"
   },
   "commandPalette": {
     "navigate": "Navigate",

--- a/translations/he.json
+++ b/translations/he.json
@@ -40,7 +40,11 @@
     "categories": "קטגוריות",
     "notifications": "התראות",
     "reviews": "ביקורות",
-    "profile": "פרופיל"
+    "profile": "פרופיל",
+    "shopNow": "קנה עכשיו",
+    "messages": "הודעות",
+    "dashboard": "לוח בקרה",
+    "settings": "הגדרות"
   },
   "commandPalette": {
     "navigate": "ניווט",


### PR DESCRIPTION
## Summary
- centralize sidebar navigation config with Home, Shop Now, Messages, Profile, Dashboard, Orders, and Settings
- filter navigation by auth and tenant, so only permitted links render
- localize new navigation entries

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest' et al.)*
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68c215a4af1c8326a4c1dd8b004dec54