### PR TITLE
feat: add tenant hero card

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useState } from 'react';
 import {
   View,
   Text,
@@ -7,8 +7,6 @@ import {
   RefreshControl,
   useWindowDimensions,
   Platform,
-  Alert,
-  Linking,
 } from 'react-native';
 import { Plus, ArrowUpDown } from 'lucide-react-native';
 import { Product } from '@/types';
@@ -18,13 +16,15 @@ import { useHomeData } from '@/features/home/hooks/useHomeData';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useTenant } from '@/contexts/TenantContext';
-import { useWallet } from '@/contexts/WalletProvider';
+import { useAppInfo } from '@/contexts/AppInfoContext';
+import SmartImage from '@/components/SmartImage';
+import PromoCard from '@/features/home/components/PromoCard';
 import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
 import ProductGrid from '@/features/home/components/ProductGrid';
 import CategoryCard from '@/features/home/components/CategoryCard';
-import { Spinner, Heading, Card, Button, Skeleton } from '@/ui/primitives';
+import { Spinner, Heading } from '@/ui/primitives';
 import EmptyState from '@/shared/ui/EmptyState';
 import { CartModal } from '@/features/cart';
 import { ProductFormModal } from '@/features/products';
@@ -36,69 +36,14 @@ import { spacing, typography, radius, shadows } from '@/ui/tokens';
 import HeroCallout from '@/features/home/components/HeroCallout';
 import ErrorBoundary from 'src/shared/ErrorBoundary';
 import HomeError from '@/features/home/screens/HomeError';
-import { useAppRouter } from '@/services/useAppRouter';
-import { routes } from '@/utils/routes';
-
-const getNetworkCardWidth = (width: number) => {
-  if (width >= 1024) {
-    return '23.5%';
-  } else if (width >= 768) {
-    return '32%';
-  }
-  return '48%';
-};
 
 function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
   const { t } = useLanguage();
   const { colors: themeColors } = useTheme();
   const home = useHome(tenantId);
-  const router = useAppRouter();
+  const { appName, logoCid } = useAppInfo();
   const { width: windowWidth } = useWindowDimensions();
-  const { address, connect } = useWallet();
-
-  const actionsLoading = false;
-
-  const requireWallet = useCallback(
-    (action: () => void) => {
-      if (!address) {
-        void connect();
-        return;
-      }
-      action();
-    },
-    [address, connect],
-  );
-
-  const networkActions = [
-    {
-      key: 'create-store',
-      label: t('home.createStore'),
-      onPress: () => requireWallet(() => router.push(routes.createStore())),
-    },
-    {
-      key: 'become-driver',
-      label: t('home.becomeDriver'),
-      onPress: () => requireWallet(() => router.push('/driver')),
-    },
-    {
-      key: 'business-login',
-      label: t('home.businessLogin'),
-      onPress: () => requireWallet(() => router.push('/login')),
-    },
-    {
-      key: 'docs-api',
-      label: t('home.docsApi'),
-      onPress: () => {
-        const url = process.env.EXPO_PUBLIC_DOCS_URL;
-        if (url) {
-          void Linking.openURL(url);
-        }
-      },
-    },
-  ];
-
-  const networkItemWidth = getNetworkCardWidth(windowWidth);
 
   if (isNetwork) {
     return (
@@ -108,36 +53,6 @@ function HomeScreenContent() {
         showsVerticalScrollIndicator={false}
       >
         <HeroCallout />
-        {actionsLoading ? (
-          <View style={styles.networkGrid}>
-            {Array.from({ length: 4 }).map((_, idx) => (
-              <Card key={idx} style={[styles.networkCard, { width: networkItemWidth }]}> 
-                <Skeleton height={20} style={{ marginBottom: spacing.spacer8 }} />
-                <Skeleton height={40} borderRadius={radius.md} />
-              </Card>
-            ))}
-          </View>
-        ) : (
-          <View style={styles.networkGrid}>
-            {networkActions.map((action) => (
-              <Card key={action.key} style={[styles.networkCard, { width: networkItemWidth }]}> 
-                <Stack gap="spacer8">
-                  <Text style={[styles.networkTitle, { color: themeColors.text.primary }]}> 
-                    {action.label}
-                  </Text>
-                  <Button
-                    title={action.label}
-                    onPress={action.onPress}
-                    style={({ hovered, focused }) => [
-                      hovered && { backgroundColor: themeColors.interactive.primaryHover },
-                      focused && { borderColor: themeColors.border.focus, borderWidth: 1 },
-                    ]}
-                  />
-                </Stack>
-              </Card>
-            ))}
-          </View>
-        )}
       </ScrollArea>
     );
   }
@@ -224,6 +139,23 @@ function HomeScreenContent() {
         showsVerticalScrollIndicator={false}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
       >
+        {tenantId && (
+          <PromoCard
+            backgroundColor={themeColors.surface.primary}
+            icon={
+              logoCid ? (
+                <SmartImage
+                  uri={logoCid}
+                  width={60}
+                  height={60}
+                  contentFit="contain"
+                />
+              ) : undefined
+            }
+            title={appName}
+            style={{ marginHorizontal: spacing.spacer16, marginBottom: spacing.spacer16 }}
+          />
+        )}
         <CategoryChips
           tenantId={tenantId}
           categories={categoriesToShow}
@@ -431,20 +363,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 1,
-  },
-  networkGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.spacer16,
-    gap: spacing.spacer16,
-    marginBottom: spacing.spacer24,
-  },
-  networkCard: {
-    borderRadius: radius.lg,
-  },
-  networkTitle: {
-    fontWeight: '600',
   },
 });
 

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Text } from 'react-native';
-import HomeScreen from '@app/index';
-
 const InfoModalMock: jest.Mock = jest.fn();
 
 jest.mock('@/services', () => ({
@@ -29,17 +27,22 @@ jest.mock('@/ui/ThemeProvider', () => ({
   useLanguage: () => ({ t: (s: string) => s }),
   useTheme: () => ({ colors: { background: '#fff', text: { primary: '#000', secondary: '#333' } } }),
 }));
-let homeHeaderThrows = true;
-jest.mock('@features/home/components/HomeHeader', () => {
+jest.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ tenantId: 'tenant1', isNetwork: false }),
+}));
+jest.mock('@/contexts/AppInfoContext', () => ({
+  useAppInfo: () => ({ appName: 'Test', logoCid: null }),
+}));
+let categoryChipsThrows = true;
+jest.mock('@features/home/components/CategoryChips', () => {
   const React = require('react');
   return () => {
-    if (homeHeaderThrows) {
+    if (categoryChipsThrows) {
       throw new Error('boom');
     }
     return null;
   };
 });
-jest.mock('@features/home/components/CategoryChips', () => () => null);
 jest.mock('@features/home/components/ProductGrid', () => () => null);
 jest.mock('@ui/primitives', () => ({ Spinner: () => null }));
 jest.mock('@shared/ui/EmptyState', () => () => null);
@@ -106,9 +109,11 @@ jest.mock('@features/home/hooks/useHomeFilters', () => ({
   }),
 }));
 
+const HomeScreen = require('@app/index').default;
+
 describe('HomeScreen error handling', () => {
   it('shows fallback and keeps app shell when child throws', () => {
-    homeHeaderThrows = true;
+    categoryChipsThrows = true;
     homeErrorList = [null];
     const App = () => (
       <>
@@ -125,7 +130,7 @@ describe('HomeScreen error handling', () => {
   });
 
   it('reopens InfoModal when a new error occurs', async () => {
-    homeHeaderThrows = false;
+    categoryChipsThrows = false;
     homeErrorList = [new Error('first'), new Error('second')];
     InfoModalMock.mockClear();
     renderer.create(<HomeScreen />);

--- a/tests/homeFallbackVisibility.test.tsx
+++ b/tests/homeFallbackVisibility.test.tsx
@@ -12,6 +12,13 @@ jest.mock('@/ui/layout/ScrollArea', () => {
     ReactMock.createElement('ScrollArea', { style, contentContainerStyle, ...props }, children);
 });
 
+jest.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ tenantId: 'tenant1', isNetwork: false }),
+}));
+jest.mock('@/contexts/AppInfoContext', () => ({
+  useAppInfo: () => ({ appName: 'Test', logoCid: null }),
+}));
+
 const HomeScreen = require('@app/index').default;
 
 jest.mock('@/services', () => ({

--- a/tests/homeScreenRender.test.tsx
+++ b/tests/homeScreenRender.test.tsx
@@ -13,6 +13,10 @@ jest.mock('@/features/home/hooks/useHome', () => ({
   useHome: (tenantId: string) => mockUseHome(tenantId),
 }));
 
+jest.mock('@/contexts/AppInfoContext', () => ({
+  useAppInfo: () => ({ appName: 'Test', logoCid: null }),
+}));
+
 
 const mockCategoryChips = jest.fn(() => null);
 jest.mock('@/features/home/components/CategoryChips', () => ({
@@ -104,7 +108,7 @@ describe('HomeScreen render', () => {
     jest.clearAllMocks();
   });
 
-  it('renders network mode with hero cards only', async () => {
+  it('renders network mode with hero only', async () => {
     mockUseTenant.mockReturnValue({ tenantId: null, isNetwork: true });
 
     let root: renderer.ReactTestRenderer;
@@ -115,7 +119,7 @@ describe('HomeScreen render', () => {
 
     const tree = root!.toJSON();
     const str = JSON.stringify(tree);
-    expect(str).toContain('home.createStore');
+    expect(str).toContain('home.heroTitle');
     expect(mockCategoryChips).not.toHaveBeenCalled();
     expect(mockProductGrid).not.toHaveBeenCalled();
     expect(mockUseHome).toHaveBeenCalledWith(null);


### PR DESCRIPTION
## Summary
- show tenant promo hero before category chips with logo and name
- keep network root to only show main hero and "Shop now"
- update home screen tests for new hero

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser' and yarn install fails due to node engine requirements)*
- `npm run typecheck` *(fails: cannot find type definition files)*
- `npx jest tests/homeScreenRender.test.tsx tests/homeFallbackVisibility.test.tsx tests/homeErrorBoundary.test.tsx` *(fails: jest package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c215b2c28c8326876799c146544129