### PR TITLE
feat: expose env getters for client

### DIFF
--- a/services/wallet/keyRotation.ts
+++ b/services/wallet/keyRotation.ts
@@ -1,5 +1,5 @@
 import { connect, keyStores, KeyPair } from 'near-api-js';
-import { requireEnv } from '@/services/config';
+import { getNetworkId } from '@/services/config';
 
 /**
  * Rotate the access key for an account. Generates a new key pair,
@@ -9,7 +9,7 @@ export async function rotateKey(
   accountId: string,
   oldPublicKey: string,
 ): Promise<KeyPair> {
-  const network = requireEnv('EXPO_PUBLIC_NETWORK', 'testnet');
+  const network = getNetworkId();
   const nodeUrl =
     network === 'mainnet'
       ? 'https://rpc.mainnet.near.org'

--- a/services/walletSelector.ts
+++ b/services/walletSelector.ts
@@ -4,7 +4,7 @@ import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
 import { Buffer } from 'buffer';
 import { useEffect, useState } from 'react';
-import { requireEnv } from '@/services/config';
+import { requireEnv, getContractId, getNetworkId } from '@/services/config';
 
 // Exported for test overrides
 export let selector: WalletSelector | null = null;
@@ -16,17 +16,12 @@ async function init() {
   }
   try {
     const resolveNetwork = () => {
-      const explicit = requireEnv('NEAR_NETWORK_ID', '');
-      const cid = requireEnv('CONTRACT_ID', '');
-      if (explicit === 'mainnet' || explicit === 'testnet') {
-        if (cid && (explicit === 'testnet') !== cid.endsWith('.testnet')) {
-          console.error(`CONTRACT_ID (${cid}) does not match NEAR_NETWORK_ID ${explicit}`);
-        }
-        return explicit;
+      const net = getNetworkId();
+      const cid = getContractId();
+      if (cid && (net === 'testnet') !== cid.endsWith('.testnet')) {
+        console.error(`CONTRACT_ID (${cid}) does not match network ${net}`);
       }
-      if (explicit) console.error(`Invalid NEAR_NETWORK_ID: ${explicit}`);
-      if (!cid) console.error('Missing CONTRACT_ID to infer network');
-      return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
+      return net;
     };
 
     const getWalletUrl = () => {
@@ -81,12 +76,7 @@ async function signIn(): Promise<void> {
   const { selector, error } = await init();
   if (!selector) throw (error || new Error('Wallet initialization failed'));
   const wallet = await selector.wallet('near-wallet');
-  const contractId = requireEnv('CONTRACT_ID', '');
-  if (!contractId) {
-    const msg = 'Missing CONTRACT_ID for wallet sign-in';
-    console.error(msg);
-    throw new Error(msg);
-  }
+  const contractId = getContractId();
   const baseUrl = typeof window !== 'undefined'
     ? window.location.origin
     : undefined;

--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -11,10 +11,10 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Button, Heading, Text } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
 import { spacing, typography } from '@/ui/tokens';
-import { requireEnv } from '@/services/config';
+import { getShopTenantId } from '@/services/config';
 import PromoCard from './PromoCard';
 
-const SHOP_TENANT_ID = requireEnv('SHOP_TENANT_ID');
+const SHOP_TENANT_ID = getShopTenantId();
 
 export default function HeroCallout() {
   const { t } = useLanguage();

--- a/src/services/chain/near.ts
+++ b/src/services/chain/near.ts
@@ -1,15 +1,12 @@
 import { init, signIn, signMessage, useAccount, useAccountId, getAccountId, getPublicKey, getSelector } from '@/services/walletSelector';
 import { payPrivately as nearPayPrivately } from '@blue-ocean/sdk-near';
 import { listOrdersBySeller as nearListOrdersBySeller } from '@/services/nearOrders';
-import { requireEnv } from '@/services/config';
+import { getNetworkId } from '@/services/config';
 import type { ChainAdapter } from './ChainAdapter';
 import { canonicalJson } from '@/utils/serialization';
 
 function resolveNetwork(): 'mainnet' | 'testnet' {
-  const explicit = requireEnv('EXPO_PUBLIC_NETWORK', '');
-  if (explicit === 'mainnet' || explicit === 'testnet') return explicit;
-  const cid = requireEnv('EXPO_PUBLIC_CONTRACT_ID', '');
-  return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
+  return getNetworkId() as 'mainnet' | 'testnet';
 }
 
 async function getBalance(address: string): Promise<string> {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -9,4 +9,32 @@ export function requireEnv(key: string, fallback?: string): string {
   return value;
 }
 
+export function getShopTenantId(): string {
+  return (
+    process.env.EXPO_PUBLIC_SHOP_TENANT_ID ||
+    process.env.SHOP_TENANT_ID ||
+    requireEnv('SHOP_TENANT_ID')
+  );
+}
+
+export function getContractId(): string {
+  return (
+    process.env.EXPO_PUBLIC_CONTRACT_ID ||
+    process.env.CONTRACT_ID ||
+    requireEnv('CONTRACT_ID')
+  );
+}
+
+export function getNetworkId(): string {
+  const explicit =
+    process.env.EXPO_PUBLIC_NETWORK ||
+    process.env.EXPO_PUBLIC_NETWORK_ID ||
+    process.env.EXPO_PUBLIC_NEAR_NETWORK_ID ||
+    process.env.NEAR_NETWORK_ID ||
+    process.env.NETWORK_ID;
+  if (explicit) return explicit;
+  const cid = getContractId();
+  return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
+}
+
 export default requireEnv;


### PR DESCRIPTION
## Summary
- add client-safe getters for shop tenant, contract, and network ids
- use new getters instead of requireEnv in web-facing components and wallet helpers

## Testing
- `yarn lint src/services/config.ts src/features/home/components/HeroCallout.tsx services/walletSelector.ts src/services/chain/near.ts services/wallet/keyRotation.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: @waku/core@0.0.38 requires node >=22)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c2267f3eac83269b0f37b9052be2b2