### PR TITLE
fix: prioritize public Waku bootstrap env

### DIFF
--- a/packages/sdk-near/src/config.ts
+++ b/packages/sdk-near/src/config.ts
@@ -9,3 +9,18 @@ const config: Record<string, string> = {
 
 export default config;
 
+export function getNetworkId(): string {
+  const explicit =
+    process.env.EXPO_PUBLIC_NETWORK ||
+    process.env.EXPO_PUBLIC_NETWORK_ID ||
+    process.env.EXPO_PUBLIC_NEAR_NETWORK_ID ||
+    process.env.NEAR_NETWORK_ID ||
+    process.env.NETWORK_ID;
+  if (explicit) return explicit;
+  const cid =
+    process.env.EXPO_PUBLIC_CONTRACT_ID ||
+    process.env.CONTRACT_ID ||
+    '';
+  return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
+}
+

--- a/packages/sdk-near/src/waku/index.ts
+++ b/packages/sdk-near/src/waku/index.ts
@@ -6,6 +6,7 @@
 import type { LightNode } from '@waku/sdk';
 import { Buffer } from 'buffer';
 import { topicFor } from '@blue-ocean/utils';
+import { getNetworkId } from '../config';
 
 // In-memory cache of messages keyed by topic. Each topic also tracks a set of
 // previously seen payloads to avoid duplications when `hydrateMessages` is called
@@ -18,8 +19,8 @@ async function ensureNode(): Promise<LightNode | null> {
   if (node) return node;
   try {
     const bootstrap = (
-      process.env.WAKU_BOOTSTRAP ||
       process.env.EXPO_PUBLIC_WAKU_BOOTSTRAP ||
+      process.env.WAKU_BOOTSTRAP ||
       ''
       )
         .split(String.fromCharCode(44))
@@ -73,7 +74,7 @@ export async function hydrateMessages(topic: string): Promise<any[]> {
 // as Listing objects.
 export async function getListingsFromWaku(storeId: string) {
   try {
-    const network = process.env.EXPO_PUBLIC_NETWORK || 'testnet';
+    const network = getNetworkId();
     const topic = topicFor(network, storeId, 'listings');
     const msgs = await hydrateMessages(topic);
     return msgs.map((m) => ({


### PR DESCRIPTION
## Summary
- ensure sdk-near uses EXPO_PUBLIC_WAKU_BOOTSTRAP before private var
- unify network selection through shared getNetworkId helper

## Testing
- `npx eslint packages/sdk-near/src/waku/index.ts packages/sdk-near/src/config.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx tsc -p packages/sdk-near/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest'; tsconfig base missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c23aa24d288326b02c604a80d226c4