### PR TITLE
refactor: centralize env access

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,8 +7,9 @@ import { ctx } from './router-ctx.web';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { Spinner } from '@/ui';
 import AppProviders from '@/providers/AppProviders';
+import { isRouterEnabled } from '@/services/config';
 
-const USE_ROUTER = (process.env.EXPO_PUBLIC_USE_ROUTER ?? '1') === '1';
+const USE_ROUTER = isRouterEnabled();
 
 function RouterApp() {
   return <ExpoRoot context={ctx} />;

--- a/apps/web/app/_layout.tsx
+++ b/apps/web/app/_layout.tsx
@@ -3,9 +3,10 @@ import { View } from 'react-native';
 import { Stack } from 'expo-router';
 import '../services/chainGuard';
 import WalletButton from '../components/WalletButton';
+import { isWalletEnabled } from '@/services/config';
 
 export default function RootLayout() {
-  const walletEnabled = process.env.EXPO_PUBLIC_FEATURE_WALLET === '1';
+  const walletEnabled = isWalletEnabled();
 
   return (
     <View style={{ flex: 1 }}>

--- a/apps/web/services/chainGuard.ts
+++ b/apps/web/services/chainGuard.ts
@@ -2,12 +2,14 @@
 // - CHAIN must be 'near'
 
 
-const chain = process.env.EXPO_PUBLIC_CHAIN;
+import { getChain, isWalletEnabled } from '@/services/config';
+
+const chain = getChain();
 if (chain !== 'near') {
   throw new Error('CHAIN guard: EXPO_PUBLIC_CHAIN must be "near". Other chains are not supported.');
 }
 
-export const WALLET_ENABLED = process.env.EXPO_PUBLIC_FEATURE_WALLET === '1';
+export const WALLET_ENABLED = isWalletEnabled();
 
 export function assertStoreId(storeId?: string | null) {
   if (!storeId) throw new Error('storeId is required');

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -2,6 +2,12 @@ import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import config from '../utils/appConfig';
 import { fetchSettings } from '@/services/nearSettings';
+import {
+  getNetworkId,
+  getAdminWalletAddress,
+  getAdminWalletAddressMainnet,
+  getAdminWalletAddressTestnet,
+} from '@/services/config';
 
 export let TENANT = 'blue-ocean';
 
@@ -21,17 +27,15 @@ export interface TenantSettings {
 
 const initialAdmin =
   (() => {
-    const network =
-      (config.NEAR_NETWORK || process.env.NEAR_NETWORK || 'mainnet').toLowerCase();
-    const legacy =
-      config.ADMIN_WALLET_ADDRESS || process.env.ADMIN_WALLET_ADDRESS || '';
+    const network = (config.NEAR_NETWORK || getNetworkId()).toLowerCase();
+    const legacy = config.ADMIN_WALLET_ADDRESS || getAdminWalletAddress();
     const main =
       config.ADMIN_WALLET_ADDRESS_MAINNET ||
-      process.env.ADMIN_WALLET_ADDRESS_MAINNET ||
+      getAdminWalletAddressMainnet() ||
       legacy;
     const test =
       config.ADMIN_WALLET_ADDRESS_TESTNET ||
-      process.env.ADMIN_WALLET_ADDRESS_TESTNET ||
+      getAdminWalletAddressTestnet() ||
       legacy;
     return network === 'testnet' ? test : main;
   })() || '';

--- a/services/walletSelector.ts
+++ b/services/walletSelector.ts
@@ -4,45 +4,16 @@ import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
 import { Buffer } from 'buffer';
 import { useEffect, useState } from 'react';
-import { getContractId, getNetworkId } from '@/services/config';
+import {
+  getContractId,
+  getNetworkId,
+  getNearWalletUrl,
+  getNearHelperUrl,
+} from '@/services/config';
 
 // Exported for test overrides
 export let selector: WalletSelector | null = null;
 let initError: Error | null = null;
-
-function getWalletUrl(): string {
-  const override =
-    process.env.EXPO_PUBLIC_NEAR_WALLET_URL ||
-    process.env.NEAR_WALLET_URL;
-  if (override) {
-    const net = getNetworkId();
-    if (override.includes('testnet') !== (net === 'testnet')) {
-      console.error(`NEAR_WALLET_URL (${override}) does not match network ${net}`);
-    }
-    return override;
-  }
-  const net = getNetworkId();
-  return net === 'mainnet'
-    ? 'https://app.mynearwallet.com'
-    : 'https://testnet.mynearwallet.com';
-}
-
-function getHelperUrl(): string {
-  const override =
-    process.env.EXPO_PUBLIC_NEAR_HELPER_URL ||
-    process.env.NEAR_HELPER_URL;
-  if (override) {
-    const net = getNetworkId();
-    if (override.includes('testnet') !== (net === 'testnet')) {
-      console.error(`NEAR_HELPER_URL (${override}) does not match network ${net}`);
-    }
-    return override;
-  }
-  const net = getNetworkId();
-  return net === 'mainnet'
-    ? 'https://helper.mainnet.near.org'
-    : 'https://helper.testnet.near.org';
-}
 
 async function init() {
   if (selector || initError) {
@@ -54,8 +25,8 @@ async function init() {
     if (cid && (networkId === 'testnet') !== cid.endsWith('.testnet')) {
       console.error(`CONTRACT_ID (${cid}) does not match network ${networkId}`);
     }
-    const walletUrl = getWalletUrl();
-    const helperUrl = getHelperUrl();
+    const walletUrl = getNearWalletUrl();
+    const helperUrl = getNearHelperUrl();
     selector = await setupWalletSelector({
       network: {
         networkId,

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -37,4 +37,107 @@ export function getNetworkId(): string {
   return cid.endsWith('.testnet') ? 'testnet' : 'mainnet';
 }
 
+export function isRouterEnabled(): boolean {
+  return (
+    process.env.EXPO_PUBLIC_USE_ROUTER ??
+    process.env.USE_ROUTER ??
+    '1'
+  ) === '1';
+}
+
+export function isWalletEnabled(): boolean {
+  return (
+    process.env.EXPO_PUBLIC_FEATURE_WALLET === '1' ||
+    process.env.FEATURE_WALLET === '1'
+  );
+}
+
+export function getChain(): string {
+  return (
+    process.env.EXPO_PUBLIC_CHAIN ||
+    process.env.CHAIN ||
+    'near'
+  );
+}
+
+export function getTransport(): string {
+  return (
+    process.env.EXPO_PUBLIC_TRANSPORT ||
+    process.env.TRANSPORT ||
+    'http'
+  );
+}
+
+export function getNearWalletUrl(): string {
+  const override =
+    process.env.EXPO_PUBLIC_NEAR_WALLET_URL ||
+    process.env.NEAR_WALLET_URL;
+  if (override) {
+    const net = getNetworkId();
+    if (override.includes('testnet') !== (net === 'testnet')) {
+      console.error(`NEAR_WALLET_URL (${override}) does not match network ${net}`);
+    }
+    return override;
+  }
+  const net = getNetworkId();
+  return net === 'mainnet'
+    ? 'https://app.mynearwallet.com'
+    : 'https://testnet.mynearwallet.com';
+}
+
+export function getNearHelperUrl(): string {
+  const override =
+    process.env.EXPO_PUBLIC_NEAR_HELPER_URL ||
+    process.env.NEAR_HELPER_URL;
+  if (override) {
+    const net = getNetworkId();
+    if (override.includes('testnet') !== (net === 'testnet')) {
+      console.error(`NEAR_HELPER_URL (${override}) does not match network ${net}`);
+    }
+    return override;
+  }
+  const net = getNetworkId();
+  return net === 'mainnet'
+    ? 'https://helper.mainnet.near.org'
+    : 'https://helper.testnet.near.org';
+}
+
+export function isUiV2Enabled(): boolean {
+  return (
+    process.env.EXPO_PUBLIC_FEATURE_UI_V2 === '1' ||
+    process.env.FEATURE_UI_V2 === '1'
+  );
+}
+
+export function isDataV2Enabled(): boolean {
+  return (
+    process.env.EXPO_PUBLIC_FEATURE_DATA_V2 === '1' ||
+    process.env.FEATURE_DATA_V2 === '1'
+  );
+}
+
+export function getAdminWalletAddress(): string {
+  return (
+    process.env.EXPO_PUBLIC_ADMIN_WALLET_ADDRESS ||
+    process.env.ADMIN_WALLET_ADDRESS ||
+    ''
+  );
+}
+
+export function getAdminWalletAddressMainnet(): string {
+  return (
+    process.env.EXPO_PUBLIC_ADMIN_WALLET_ADDRESS_MAINNET ||
+    process.env.ADMIN_WALLET_ADDRESS_MAINNET ||
+    getAdminWalletAddress()
+  );
+}
+
+export function getAdminWalletAddressTestnet(): string {
+  return (
+    process.env.EXPO_PUBLIC_ADMIN_WALLET_ADDRESS_TESTNET ||
+    process.env.ADMIN_WALLET_ADDRESS_TESTNET ||
+    getAdminWalletAddress()
+  );
+}
+
 export default requireEnv;

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -1,8 +1,10 @@
+import { getTransport } from '@/services/config';
+
 let client: Promise<any> | null = null;
 
 export async function getClient(): Promise<any> {
   if (!client) {
-    const transport = (process.env.EXPO_PUBLIC_TRANSPORT || 'http').toLowerCase();
+    const transport = getTransport().toLowerCase();
     if (transport === 'waku') {
       client = import('@waku/sdk');
     } else {

--- a/utils/flags.ts
+++ b/utils/flags.ts
@@ -1,6 +1,8 @@
+import { isUiV2Enabled, isDataV2Enabled } from '@/services/config';
+
 export const flags = {
-  UI_V2: (process.env.EXPO_PUBLIC_FEATURE_UI_V2 ?? '0') === '1',
-  DATA_V2: (process.env.EXPO_PUBLIC_FEATURE_DATA_V2 ?? '0') === '1',
+  UI_V2: isUiV2Enabled(),
+  DATA_V2: isDataV2Enabled(),
 };
 
 export default flags;


### PR DESCRIPTION
## Summary
- centralize env lookups using dedicated getters
- expose wallet and helper URL getters with public/private fallbacks
- use config-based feature flags across client code

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c23f314b048326bf67f63231a3d7d7