### PR TITLE
feat: enhance button accessibility and tooltips

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -60,6 +60,7 @@ export default function HeroCallout() {
           onPress={handlePress}
           accessibilityRole="link"
           onKeyDown={handleKeyDown}
+          tooltip={t('home.heroAction')}
         />
       </Stack>
     </PromoCard>

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   StyleSheet,
-  Pressable,
   Linking,
   type NativeSyntheticEvent,
   type KeyboardEvent,
@@ -76,20 +75,16 @@ export default function HomeOptions() {
           <Text style={[styles.title, { color: colors.text.primary }]}>
             {t('home.createStore', 'Create a Store')}
           </Text>
-          <Pressable
+          <Button
+            title={t('home.createStore', 'Create a Store')}
             onPress={handleCreateStore}
             onKeyDown={(e) => handleKeyDown(e, handleCreateStore)}
             accessibilityRole="link"
-            title={walletAddress ? undefined : walletTooltip}
+            tooltip={walletAddress ? undefined : walletTooltip}
+            disabled={!walletAddress}
             style={styles.fullWidth}
-          >
-            <Button
-              title={t('home.createStore', 'Create a Store')}
-              disabled={!walletAddress}
-              pointerEvents="none"
-              testID="create-store-link"
-            />
-          </Pressable>
+            testID="create-store-link"
+          />
         </Stack>
       </Card>
 
@@ -98,20 +93,16 @@ export default function HomeOptions() {
           <Text style={[styles.title, { color: colors.text.primary }]}>
             {t('home.becomeDriver', 'Become a Driver')}
           </Text>
-          <Pressable
+          <Button
+            title={t('home.becomeDriver', 'Become a Driver')}
             onPress={handleBecomeDriver}
             onKeyDown={(e) => handleKeyDown(e, handleBecomeDriver)}
             accessibilityRole="link"
-            title={walletAddress ? undefined : walletTooltip}
+            tooltip={walletAddress ? undefined : walletTooltip}
+            disabled={!walletAddress}
             style={styles.fullWidth}
-          >
-            <Button
-              title={t('home.becomeDriver', 'Become a Driver')}
-              disabled={!walletAddress}
-              pointerEvents="none"
-              testID="become-driver-button"
-            />
-          </Pressable>
+            testID="become-driver-button"
+          />
         </Stack>
       </Card>
 
@@ -120,20 +111,16 @@ export default function HomeOptions() {
           <Text style={[styles.title, { color: colors.text.primary }]}>
             {t('home.businessLogin', 'Business Login')}
           </Text>
-          <Pressable
+          <Button
+            title={t('home.businessLogin', 'Business Login')}
             onPress={handleBusinessLogin}
             onKeyDown={(e) => handleKeyDown(e, handleBusinessLogin)}
             accessibilityRole="link"
-            title={walletAddress ? undefined : walletTooltip}
+            tooltip={walletAddress ? undefined : walletTooltip}
+            disabled={!walletAddress}
             style={styles.fullWidth}
-          >
-            <Button
-              title={t('home.businessLogin', 'Business Login')}
-              disabled={!walletAddress}
-              pointerEvents="none"
-              testID="business-login-button"
-            />
-          </Pressable>
+            testID="business-login-button"
+          />
         </Stack>
       </Card>
 
@@ -142,19 +129,15 @@ export default function HomeOptions() {
           <Text style={[styles.title, { color: colors.text.primary }]}>
             {t('home.docsApi', 'Docs & API')}
           </Text>
-          <Pressable
+          <Button
+            title={t('home.docsApi', 'Docs & API')}
             onPress={handleDocs}
             onKeyDown={(e) => handleKeyDown(e, handleDocs)}
             accessibilityRole="link"
-            title={DOCS_URL}
+            tooltip={DOCS_URL}
             style={styles.fullWidth}
-          >
-            <Button
-              title={t('home.docsApi', 'Docs & API')}
-              pointerEvents="none"
-              testID="docs-api-button"
-            />
-          </Pressable>
+            testID="docs-api-button"
+          />
         </Stack>
       </Card>
     </Stack>

--- a/src/ui/primitives/Button.tsx
+++ b/src/ui/primitives/Button.tsx
@@ -8,6 +8,7 @@ import {
   PressableProps,
   PressableStateCallbackType,
   Animated,
+  Platform,
 } from 'react-native';
 import { useTheme } from '../ThemeProvider';
 import { spacing, radius, typography } from '../tokens';
@@ -19,6 +20,8 @@ interface ButtonProps extends PressableProps {
   textStyle?: StyleProp<TextStyle>;
   loading?: boolean;
   children?: React.ReactNode;
+  tooltip?: string;
+  onKeyDown?: (e: any) => void;
 }
 
 const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
@@ -30,6 +33,7 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
       textStyle,
       loading = false,
       children,
+      tooltip,
       ...rest
     },
     ref,
@@ -55,15 +59,20 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
     };
 
     const isDisabled = disabled || loading;
-    const combinedStyle =
-      typeof style === 'function'
-        ? (state: PressableStateCallbackType) => [
-            styles.button(colors),
-            state.pressed && styles.pressed,
-            isDisabled && styles.disabled,
-            style(state),
-          ]
-        : [styles.button(colors), isDisabled && styles.disabled, style];
+    const combinedStyle = (state: PressableStateCallbackType) => {
+      const base = [
+        styles.button(colors),
+        state.pressed && styles.pressed,
+        state.focused && styles.focused(colors),
+        isDisabled && styles.disabled,
+      ];
+      if (typeof style === 'function') {
+        base.push(style(state));
+      } else if (style) {
+        base.push(style as any);
+      }
+      return base;
+    };
 
     return (
       <Animated.View style={{ transform: [{ scale }] }}>
@@ -73,6 +82,7 @@ const Button = forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
           style={combinedStyle}
           onPressIn={handlePressIn}
           onPressOut={handlePressOut}
+          {...(Platform.OS === 'web' && tooltip ? { title: tooltip } : {})}
           {...rest}
         >
           {loading ? (
@@ -99,6 +109,8 @@ const styles = {
     paddingHorizontal: spacing.spacer16,
     borderRadius: radius.md,
     alignItems: 'center',
+    borderWidth: 2,
+    borderColor: 'transparent',
   }),
   label: (colors: any) => ({
     ...typography.md,
@@ -106,4 +118,7 @@ const styles = {
   }),
   disabled: { opacity: 0.5 },
   pressed: { opacity: 0.9 },
+  focused: (colors: any): ViewStyle => ({
+    borderColor: colors.border.focus,
+  }),
 };


### PR DESCRIPTION
## Summary
- add tooltip, focus, and keyboard support to Button primitive
- refactor home CTAs to use new tooltip and keydown props
- expose tooltip on hero callout button

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser'; attempted install but @waku/core requires node >=22)*
- `yarn typecheck` *(fails: Cannot find type definitions for jest, node, react and expo/tsconfig.base)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a6d26bfc832687405abec3cbff8b