### PR TITLE
refactor: centralize near config and provider order

### DIFF
--- a/services/walletSelector.ts
+++ b/services/walletSelector.ts
@@ -4,12 +4,7 @@ import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
 import { Buffer } from 'buffer';
 import { useEffect, useState } from 'react';
-import {
-  getContractId,
-  getNetworkId,
-  getNearWalletUrl,
-  getNearHelperUrl,
-} from '@/services/config';
+import { nearConfig } from '@/services/config';
 
 // Exported for test overrides
 export let selector: WalletSelector | null = null;
@@ -20,19 +15,14 @@ async function init() {
     return { selector: selector || undefined, error: initError } as const;
   }
   try {
-    const networkId = getNetworkId();
-    const cid = getContractId();
-    if (cid && (networkId === 'testnet') !== cid.endsWith('.testnet')) {
-      console.error(`CONTRACT_ID (${cid}) does not match network ${networkId}`);
+    const { networkId, contractId, walletUrl, rpcUrl, helperUrl } = nearConfig();
+    if (contractId && (networkId === 'testnet') !== contractId.endsWith('.testnet')) {
+      console.error(`CONTRACT_ID (${contractId}) does not match network ${networkId}`);
     }
-    const walletUrl = getNearWalletUrl();
-    const helperUrl = getNearHelperUrl();
     selector = await setupWalletSelector({
       network: {
         networkId,
-        nodeUrl: networkId === 'mainnet'
-          ? 'https://rpc.mainnet.near.org'
-          : 'https://rpc.testnet.near.org',
+        nodeUrl: rpcUrl,
         walletUrl,
         helperUrl,
       },
@@ -48,14 +38,12 @@ async function signIn(): Promise<void> {
   const { selector, error } = await init();
   if (!selector) throw (error || new Error('Wallet initialization failed'));
   const wallet = await selector.wallet('near-wallet');
-  const contractId = getContractId();
-  const baseUrl = typeof window !== 'undefined'
-    ? window.location.origin
-    : undefined;
+  const { contractId, redirectUrl } = nearConfig();
+  if (!contractId) throw new Error('CONTRACT_ID required');
   await wallet.signIn({
     contractId,
     methodNames: [],
-    ...(baseUrl ? { successUrl: baseUrl, failureUrl: baseUrl } : {}),
+    ...(redirectUrl ? { successUrl: redirectUrl, failureUrl: redirectUrl } : {}),
   });
 }
 

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -26,13 +26,13 @@ export const queryClient =
  * Composes the core providers used across the app.
  *
  * Provider order is important:
- * 1. `AppInfoProvider` – supplies branding and app configuration to theming.
- * 2. `ConfigProvider` – exposes static runtime configuration.
- * 3. `ErrorBoundary` – captures errors from all descendants.
- * 4. `ThemeProvider` – applies theming before any UI renders.
- * 5. `LanguageProvider` – sets up i18n and text direction.
- * 6. `CheckedQueryClientProvider` – enforces a single React Query client.
- * 7. `WalletProvider` – supplies wallet context for network layers.
+ * 1. `ThemeProvider` – applies theming before any UI renders.
+ * 2. `LanguageProvider` – sets up i18n and text direction.
+ * 3. `CheckedQueryClientProvider` – enforces a single React Query client.
+ * 4. `WalletProvider` – supplies wallet context for network layers.
+ * 5. `AppInfoProvider` – supplies branding and app configuration.
+ * 6. `ConfigProvider` – exposes static runtime configuration.
+ * 7. `ErrorBoundary` – captures errors from all descendants.
  * 8. `WakuProvider` – depends on the wallet and query client.
  * 9. `AuthProvider` – manages authentication state.
  * 10. `AuthModalProvider` – handles auth modal display.
@@ -42,13 +42,13 @@ export const queryClient =
 export default function AppProviders({ children }: React.PropsWithChildren) {
   const toast = useToast();
   return (
-    <AppInfoProvider>
-      <ConfigProvider>
-        <ErrorBoundary onError={(e) => toast.showError(e.message)}>
-          <ThemeProvider>
-            <LanguageProvider>
-              <CheckedQueryClientProvider client={queryClient}>
-                <WalletProvider>
+    <ThemeProvider>
+      <LanguageProvider>
+        <CheckedQueryClientProvider client={queryClient}>
+          <WalletProvider>
+            <AppInfoProvider>
+              <ConfigProvider>
+                <ErrorBoundary onError={(e) => toast.showError(e.message)}>
                   <WakuProvider>
                     <AuthProvider>
                       <AuthModalProvider>
@@ -58,12 +58,12 @@ export default function AppProviders({ children }: React.PropsWithChildren) {
                       </AuthModalProvider>
                     </AuthProvider>
                   </WakuProvider>
-                </WalletProvider>
-              </CheckedQueryClientProvider>
-            </LanguageProvider>
-          </ThemeProvider>
-        </ErrorBoundary>
-      </ConfigProvider>
-    </AppInfoProvider>
+                </ErrorBoundary>
+              </ConfigProvider>
+            </AppInfoProvider>
+          </WalletProvider>
+        </CheckedQueryClientProvider>
+      </LanguageProvider>
+    </ThemeProvider>
   );
 }

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -4,19 +4,24 @@
 
 ## Order
 
-1. **ErrorBoundary** – captures errors from all descendants.
-2. **ThemeProvider** – applies theming before any UI renders.
-3. **LanguageProvider** – sets up i18n and text direction.
-4. **CheckedQueryClientProvider** – enforces a single React Query client.
-5. **WalletProvider** – supplies wallet context for network layers.
-6. **WakuProvider** – depends on the wallet and query client.
+1. **ThemeProvider** – applies theming before any UI renders.
+2. **LanguageProvider** – sets up i18n and text direction.
+3. **CheckedQueryClientProvider** – enforces a single React Query client.
+4. **WalletProvider** – supplies wallet context for network layers.
+5. **AppInfoProvider** – supplies branding and app configuration.
+6. **ConfigProvider** – exposes static runtime configuration.
+7. **ErrorBoundary** – captures errors from all descendants.
+8. **WakuProvider** – depends on the wallet and query client.
+9. **AuthProvider** – manages authentication state.
+10. **AuthModalProvider** – handles auth modal display.
+11. **CurrencyProvider** – stores selected currency.
+12. **NotificationProvider** – listens for notifications and displays popups.
 
 ## Invariants
 
-- `ErrorBoundary` must wrap everything to surface runtime errors.
 - `ThemeProvider` and `LanguageProvider` must appear before any component that uses theming or i18n.
 - `CheckedQueryClientProvider` must wrap providers that rely on React Query, including the `WalletProvider`.
 - `WalletProvider` supplies wallet state for network layers and comes before providers that require it, such as `WakuProvider`.
-- `WakuProvider` depends on both the wallet and query client and therefore must be last.
+- `ErrorBoundary` wraps the remaining providers to surface runtime errors.
 
 See [AppProviders.tsx](./AppProviders.tsx) for the authoritative inline comment.

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -9,6 +9,65 @@ export function requireEnv(key: string, fallback?: string): string {
   return value;
 }
 
+export interface NearConfig {
+  networkId: string;
+  contractId: string;
+  walletUrl: string;
+  rpcUrl: string;
+  helperUrl: string;
+  redirectUrl: string;
+}
+
+export function nearConfig(): NearConfig {
+  const networkId =
+    process.env.EXPO_PUBLIC_NETWORK ||
+    process.env.EXPO_PUBLIC_NETWORK_ID ||
+    process.env.EXPO_PUBLIC_NEAR_NETWORK_ID ||
+    process.env.NEAR_NETWORK_ID ||
+    process.env.NETWORK_ID ||
+    'testnet';
+
+  const contractId =
+    process.env.EXPO_PUBLIC_CONTRACT_ID ||
+    process.env.CONTRACT_ID ||
+    '';
+
+  const walletUrl =
+    process.env.EXPO_PUBLIC_NEAR_WALLET_URL ||
+    process.env.NEAR_WALLET_URL ||
+    (networkId === 'mainnet'
+      ? 'https://app.mynearwallet.com'
+      : 'https://testnet.mynearwallet.com');
+
+  const rpcUrl =
+    process.env.EXPO_PUBLIC_NEAR_RPC_URL ||
+    process.env.NEAR_RPC_URL ||
+    (networkId === 'mainnet'
+      ? 'https://rpc.mainnet.near.org'
+      : 'https://rpc.testnet.near.org');
+
+  const helperUrl =
+    process.env.EXPO_PUBLIC_NEAR_HELPER_URL ||
+    process.env.NEAR_HELPER_URL ||
+    (networkId === 'mainnet'
+      ? 'https://helper.mainnet.near.org'
+      : 'https://helper.testnet.near.org');
+
+  const redirectUrl =
+    process.env.EXPO_PUBLIC_NEAR_WALLET_REDIRECT_URL ||
+    process.env.NEAR_WALLET_REDIRECT_URL ||
+    (typeof window !== 'undefined' ? window.location.origin : '');
+
+  return {
+    networkId,
+    contractId,
+    walletUrl,
+    rpcUrl,
+    helperUrl,
+    redirectUrl,
+  };
+}
+
 export function getShopTenantId(): string {
   return (
     process.env.EXPO_PUBLIC_SHOP_TENANT_ID ||


### PR DESCRIPTION
## Summary
- add consolidated `nearConfig` with public-then-private env fallbacks
- reorder core providers to Theme → Language → Query → Wallet → app
- use `nearConfig` in wallet selector to configure network and contract

## Testing
- `npx eslint src/services/config.ts services/walletSelector.ts src/providers/AppProviders.tsx src/providers/README.md`
- `yarn typecheck` (fails: Type '"start"' is not assignable...)
- `npx jest` (fails: TypeError: Cannot read properties of undefined (reading 'sourceFile'))

------
https://chatgpt.com/codex/tasks/task_e_68c2a6f1cefc83269e95a0f6ab10aefa