### PR TITLE
refactor: apply layout tokens and remove tab bar

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -5,6 +5,7 @@ import {
   Pressable,
   TextInput,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
 import { Text, Chip } from '@/ui';
 import SmartImage from './SmartImage';
@@ -32,6 +33,8 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const { unreadCount, refreshNotifications } = useNotificationState();
   const { address, connect, disconnect } = useWallet();
   const pathname = usePathname();
+  const { width } = useWindowDimensions();
+  const isMd = width >= 768;
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -74,6 +77,7 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
         {
           backgroundColor: colors.background,
           flexDirection: isRTL ? 'row-reverse' : 'row',
+          paddingHorizontal: isMd ? spacing.spacer24 : spacing.spacer16,
         },
       ]}
     >
@@ -208,7 +212,7 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
         <Chip
           label={walletLabel}
           onPress={handleWalletPress}
-          style={{ flexShrink: 1 }}
+          style={{ flexShrink: 1, height: spacing.spacer40, justifyContent: 'center' }}
           textStyle={{ textAlign: isRTL ? 'right' : 'left' }}
         />
 
@@ -224,10 +228,10 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
 
 const styles = StyleSheet.create({
   header: {
-    paddingHorizontal: spacing.spacer16,
-    paddingVertical: spacing.spacer16,
+    paddingVertical: spacing.spacer8,
     alignItems: 'center',
     justifyContent: 'space-between',
+    height: spacing.spacer16 * 4,
   },
   logo: {
     flexDirection: 'row',
@@ -250,6 +254,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.spacer12,
+    height: '100%',
   },
   iconButton: {
     position: 'relative',

--- a/src/features/home/components/CategoryCard.tsx
+++ b/src/features/home/components/CategoryCard.tsx
@@ -6,7 +6,7 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { spacing, radius, typography, shadows } from '@/shared/ui/tokens';
 import { Text } from '@/ui/primitives';
 
-const shadowStyle = Platform.select(shadows.sm);
+const shadowStyle = Platform.select(shadows.md);
 
         
 interface CategoryCardProps {
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     width: spacing.spacer40 * 2, // 80px width ensures even grid layout
     position: 'relative',
     padding: spacing.spacer8,
-    borderRadius: radius.lg,
+    borderRadius: radius.xl,
   },
   categoryIcon: {
     width: spacing.spacer20 * 3,

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -4,10 +4,11 @@ import {
   Linking,
   type NativeSyntheticEvent,
   type KeyboardEvent,
+  Platform,
 } from 'react-native';
 import { Card, Text, Button } from '@/ui';
 import { Stack } from '@/ui/layout';
-import { spacing, radius } from '@/ui/tokens';
+import { spacing, radius, shadows } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
@@ -150,7 +151,8 @@ const styles = StyleSheet.create({
     marginBottom: spacing.spacer16,
   },
   card: {
-    borderRadius: radius.lg,
+    borderRadius: radius.xl,
+    ...Platform.select(shadows.md),
   },
   title: {
     fontWeight: '600',

--- a/src/features/home/components/PromoCard.tsx
+++ b/src/features/home/components/PromoCard.tsx
@@ -75,7 +75,7 @@ export default function PromoCard({
 const styles = StyleSheet.create({
   card: {
     padding: spacing.spacer16,
-    borderRadius: radius.lg,
+    borderRadius: radius.xl,
     ...Platform.select(shadows.md),
   },
   touch: {

--- a/src/features/home/components/ServiceCard.tsx
+++ b/src/features/home/components/ServiceCard.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { Pressable, StyleSheet, AccessibilityRole, Image, ImageSourcePropType } from 'react-native';
+import {
+  Pressable,
+  StyleSheet,
+  AccessibilityRole,
+  Image,
+  ImageSourcePropType,
+  Platform,
+} from 'react-native';
 import { Card, Text } from '@/ui';
 import { Stack } from '@/ui/layout';
 import { useTheme } from '@/ui/ThemeProvider';
-import { radius } from '@/ui/tokens';
+import { radius, shadows } from '@/ui/tokens';
 
 interface ServiceCardProps {
   title: string;
@@ -45,7 +52,8 @@ export default function ServiceCard({
 const styles = StyleSheet.create({
   card: {
     width: 200,
-    borderRadius: radius.lg,
+    borderRadius: radius.xl,
+    ...Platform.select(shadows.md),
   },
   pressable: {
     flex: 1,

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -90,7 +90,6 @@ export default function RootLayout() {
             <Slot />
           </View>
         </View>
-        {!isLargeScreen && <SidebarTabBar items={navItems} />}
         {showCartWidget && <FloatingCartWidget />}
       </SafeAreaView>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- align global header to premium layout tokens and fix wallet chip baseline
- standardize home cards to radius.xl with shadows.md
- rely solely on sidebar navigation and drop bottom tab bar

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c32a9642688326b7d90616aa1ee3de