### PR TITLE
feat: persist wallet session and format chip

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -61,7 +61,9 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
     if (pathname !== '/' && pathname !== '/index') push('/');
   };
 
-  const walletLabel = address || t('wallet.connect', 'Connect Wallet');
+  const walletLabel = address
+    ? `@${address}`
+    : t('wallet.connect', 'Connect Wallet');
   const handleWalletPress = async () => {
     if (address) {
       await disconnect();

--- a/contexts/WalletProvider.tsx
+++ b/contexts/WalletProvider.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { chainAdapter } from '@/services/chain';
 import { getUser } from '@/features/auth/services/nearUsers';
 
@@ -25,7 +32,20 @@ interface Props {
 }
 
 export function WalletProvider({ children }: Props) {
-  const address = chainAdapter.useAccount();
+  const account = chainAdapter.useAccount();
+  const [address, setAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    setAddress(account);
+  }, [account]);
+
+  useEffect(() => {
+    (async () => {
+      await chainAdapter.init();
+      const id = chainAdapter.getAccountId();
+      if (id) setAddress(id);
+    })();
+  }, []);
 
   const connect = useCallback(async () => {
     const { error } = await chainAdapter.init();

--- a/tests/wallet/provider.test.ts
+++ b/tests/wallet/provider.test.ts
@@ -2,10 +2,12 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { WalletProvider, useWallet } from '@/contexts/WalletProvider';
 
+const mockUseAccount = jest.fn().mockReturnValue('alice.testnet');
+
 jest.mock('@/services/chain', () => ({
   chainAdapter: {
     init: jest.fn().mockResolvedValue({ error: null }),
-    useAccount: () => 'alice.testnet',
+    useAccount: mockUseAccount,
     openModal: jest.fn().mockResolvedValue(undefined),
     signMessage: jest.fn().mockResolvedValue('signed'),
     getAccountId: jest.fn().mockReturnValue('alice.testnet'),
@@ -71,5 +73,22 @@ describe('WalletProvider', () => {
     });
     expect(getUser).toHaveBeenCalledWith('alice.testnet');
     expect(role).toBe('admin');
+  });
+
+  it('initializes address from adapter on mount', async () => {
+    const { chainAdapter } = require('@/services/chain');
+    mockUseAccount.mockReturnValueOnce(null);
+    chainAdapter.getAccountId.mockReturnValueOnce('alice.testnet');
+    let addr: string | null = null;
+    const Grabber = () => {
+      const wallet = useWallet();
+      addr = wallet.address;
+      return null;
+    };
+    renderer.create(
+      React.createElement(WalletProvider, null, React.createElement(Grabber)),
+    );
+    await act(async () => {});
+    expect(addr).toBe('alice.testnet');
   });
 });


### PR DESCRIPTION
## Summary
- format connected wallet chip as `@address`
- rehydrate wallet state from chainAdapter on mount
- cover wallet provider with address persistence test

## Testing
- `npx -y jest` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c340f0621c83268843b3d2c7d3ad57