### PR TITLE
Center layout container and refine hero card

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -37,7 +37,11 @@ export default function HeroCallout() {
   return (
     <PromoCard
       backgroundColor={colors.surface.primary}
-      style={{ marginHorizontal: spacing.spacer16, marginBottom: spacing.spacer16 }}
+      style={{
+        marginHorizontal: spacing.spacer16,
+        marginBottom: spacing.spacer24,
+        height: isWide ? 112 : 96,
+      }}
     >
       <Stack
         direction={isWide ? 'horizontal' : 'vertical'}
@@ -46,7 +50,7 @@ export default function HeroCallout() {
         style={{ justifyContent: 'space-between' }}
       >
         <View style={styles.textContainer}>
-          <Heading size="lg" style={{ color: colors.text.primary }}>
+          <Heading size="xl" style={{ color: colors.text.primary }}>
             {t('home.heroTitle')}
           </Heading>
           <Text

--- a/src/ui/layout/Container.tsx
+++ b/src/ui/layout/Container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, ViewProps } from 'react-native';
+import { View, ViewProps, useWindowDimensions } from 'react-native';
 import { spacing } from '../tokens';
 
 interface ContainerProps extends ViewProps {
@@ -7,10 +7,26 @@ interface ContainerProps extends ViewProps {
   backgroundColor?: string;
 }
 
-export default function Container({ padding, backgroundColor, style, children, ...rest }: ContainerProps) {
+export default function Container({
+  padding,
+  backgroundColor,
+  style,
+  children,
+  ...rest
+}: ContainerProps) {
+  const { width } = useWindowDimensions();
+  const basePaddingHorizontal =
+    width >= 768 ? spacing.spacer24 : spacing.spacer16;
+
   return (
     <View
       style={[
+        {
+          maxWidth: 1280,
+          marginHorizontal: 'auto' as any,
+          paddingVertical: 32,
+          paddingHorizontal: basePaddingHorizontal,
+        },
         padding ? { padding: spacing[padding] } : null,
         backgroundColor ? { backgroundColor } : null,
         style,


### PR DESCRIPTION
## Summary
- Center layout Container with max-width, auto margins, and responsive padding
- Increase hero callout heading to xl, enforce card height, and adjust spacing

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: engine "node" incompatible; requires >=22)*
- `yarn typecheck` *(fails: missing type definitions and tsconfig base)*

------
https://chatgpt.com/codex/tasks/task_e_68c34fa45aac832681c680b066dcf5e0