### PR TITLE
fix: add wallet translations and update near-api-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lucide-react-native": "^0.543.0",
     "minio": "^8.0.5",
     "multiformats": "13.4.0",
-    "near-api-js": "2.1.4",
+    "near-api-js": "^5.1.1",
     "near-lake-framework": "^2.0.0",
     "pg": "^8.16.3",
     "pino": "^9.9.5",
@@ -152,7 +152,7 @@
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/native-stack": "6.9.12",
     "use-latest-callback": "0.2.4",
-    "near-api-js": "2.1.4",
+    "near-api-js": "^5.1.1",
     "@waku/core": "0.0.38",
     "@waku/sdk": "0.0.34"
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -44,7 +44,8 @@
     "shopNow": "Shop Now",
     "messages": "Messages",
     "dashboard": "Dashboard",
-    "settings": "Settings"
+    "settings": "Settings",
+    "collapse": "Collapse"
   },
   "commandPalette": {
     "navigate": "Navigate",
@@ -121,7 +122,8 @@
     "businessLogin": "Business Login",
     "docs": "Docs",
     "apiDocs": "API Docs",
-    "docsApi": "Docs & API"
+    "docsApi": "Docs & API",
+    "connectWalletToContinue": "Connect wallet to continue"
   },
   "categories": {
     "all": "All",
@@ -552,6 +554,9 @@
     "noDisputes": "No disputes",
     "noEvidence": "No evidence",
     "loadingEvidence": "Loading evidence..."
+  },
+  "wallet": {
+    "connect": "Connect Wallet"
   },
   "proofUploader": {
     "permissionRequired": "Permission Required",

--- a/translations/he.json
+++ b/translations/he.json
@@ -44,7 +44,8 @@
     "shopNow": "קנה עכשיו",
     "messages": "הודעות",
     "dashboard": "לוח בקרה",
-    "settings": "הגדרות"
+    "settings": "הגדרות",
+    "collapse": "צמצם"
   },
   "commandPalette": {
     "navigate": "ניווט",
@@ -121,7 +122,8 @@
     "businessLogin": "כניסת עסקים",
     "docs": "תיעוד",
     "apiDocs": "ממשק API",
-    "docsApi": "מסמכים & API"
+    "docsApi": "מסמכים & API",
+    "connectWalletToContinue": "התחבר לארנק כדי להמשיך"
   },
   "categories": {
     "all": "הכל",
@@ -546,6 +548,9 @@
       "orders": "הזמנות:",
       "revenue": "הכנסות:"
     }
+  },
+  "wallet": {
+    "connect": "התחבר לארנק"
   },
   "proofUploader": {
     "permissionRequired": "נדרשת הרשאה",


### PR DESCRIPTION
## Summary
- add missing translation keys for wallet actions and navigation collapse
- upgrade near-api-js to v5 to restore FailoverRpcProvider compatibility

## Testing
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c3543e06008326abdb544b28a58218