### PR TITLE
Allow wallet CTAs when disconnected

### DIFF
--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -82,8 +82,8 @@ export default function HomeOptions() {
             onKeyDown={(e) => handleKeyDown(e, handleCreateStore)}
             accessibilityRole="link"
             tooltip={walletAddress ? undefined : walletTooltip}
-            disabled={!walletAddress}
-            style={styles.fullWidth}
+            style={[styles.fullWidth, !walletAddress && styles.disabled]}
+            accessibilityState={{ disabled: !walletAddress }}
             testID="create-store-link"
           />
         </Stack>
@@ -100,8 +100,8 @@ export default function HomeOptions() {
             onKeyDown={(e) => handleKeyDown(e, handleBecomeDriver)}
             accessibilityRole="link"
             tooltip={walletAddress ? undefined : walletTooltip}
-            disabled={!walletAddress}
-            style={styles.fullWidth}
+            style={[styles.fullWidth, !walletAddress && styles.disabled]}
+            accessibilityState={{ disabled: !walletAddress }}
             testID="become-driver-button"
           />
         </Stack>
@@ -118,8 +118,8 @@ export default function HomeOptions() {
             onKeyDown={(e) => handleKeyDown(e, handleBusinessLogin)}
             accessibilityRole="link"
             tooltip={walletAddress ? undefined : walletTooltip}
-            disabled={!walletAddress}
-            style={styles.fullWidth}
+            style={[styles.fullWidth, !walletAddress && styles.disabled]}
+            accessibilityState={{ disabled: !walletAddress }}
             testID="business-login-button"
           />
         </Stack>
@@ -159,5 +159,8 @@ const styles = StyleSheet.create({
   },
   fullWidth: {
     width: '100%',
+  },
+  disabled: {
+    opacity: 0.5,
   },
 });


### PR DESCRIPTION
## Summary
- let Create Store, Become a Driver, and Business Login buttons open the wallet modal when disconnected
- add visual dimming for wallet-gated CTAs instead of disabling them

## Testing
- `yarn lint src/features/home/components/HomeOptions.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', and 'react')*
- `yarn install` *(fails: @waku/core@0.0.38 requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c39129822083268dd2bf72b3a3a31c