### PR TITLE
feat: add mobile bottom navigation

### DIFF
--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -90,6 +90,7 @@ export default function RootLayout() {
           {isLargeScreen && <SidebarTabBar items={navItems} isSidebar />}
           <View style={{ flex: 1 }}>
             <Slot />
+            {!isLargeScreen && <SidebarTabBar items={navItems} />}
           </View>
         </View>
         {showCartWidget && <FloatingCartWidget />}


### PR DESCRIPTION
## Summary
- add bottom nav bar on small screens via `SidebarTabBar`

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: @waku/core@0.0.38 requires Node >=22)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c39134b14483268f6c888ac80d6d9b