### PR TITLE
Avoid useHome hook when network view

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -41,7 +41,6 @@ function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
   const { t } = useLanguage();
   const { colors: themeColors } = useTheme();
-  const home = useHome(tenantId);
   const { appName, logoCid } = useAppInfo();
   const { width: windowWidth } = useWindowDimensions();
 
@@ -57,6 +56,8 @@ function HomeScreenContent() {
       </ScrollArea>
     );
   }
+
+  const home = useHome(tenantId);
 
   const { refreshing, refresh, error } = home;
   const {


### PR DESCRIPTION
## Summary
- Skip `useHome` when rendering network landing to avoid unnecessary product/category queries

## Testing
- `yarn lint app/index.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: @waku/core@0.0.38 requires node >=22)*
- `npx --yes jest tests/homeScreenRender.test.tsx` *(fails: preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3947926248326b0f3759ea76de744