### PR TITLE
Wrap network landing in responsive container

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -44,19 +44,6 @@ function HomeScreenContent() {
   const { appName, logoCid } = useAppInfo();
   const { width: windowWidth } = useWindowDimensions();
 
-  if (isNetwork) {
-    return (
-      <ScrollArea
-        testID="home-root"
-        backgroundColor={themeColors.canvas}
-        showsVerticalScrollIndicator={false}
-      >
-        <HeroCallout />
-        <HomeOptions />
-      </ScrollArea>
-    );
-  }
-
   const home = useHome(tenantId);
 
   const { refreshing, refresh, error } = home;
@@ -111,6 +98,38 @@ function HomeScreenContent() {
     closeInfoModal();
     refresh();
   }, [closeInfoModal, refresh]);
+
+  if (isNetwork) {
+    const containerPaddingHorizontal =
+      windowWidth >= 1024
+        ? spacing.spacer32
+        : windowWidth >= 768
+          ? spacing.spacer24
+          : spacing.spacer16;
+    const containerPaddingVertical =
+      windowWidth >= 768 ? spacing.spacer32 : spacing.spacer24;
+
+    return (
+      <ScrollArea
+        testID="home-root"
+        backgroundColor={themeColors.canvas}
+        showsVerticalScrollIndicator={false}
+      >
+        <Container
+          style={{
+            maxWidth: 1200,
+            paddingHorizontal: containerPaddingHorizontal,
+            paddingVertical: containerPaddingVertical,
+          }}
+        >
+          <Stack gap="spacer24">
+            <HeroCallout />
+            <HomeOptions />
+          </Stack>
+        </Container>
+      </ScrollArea>
+    );
+  }
 
   if (error) {
     return (

--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -6,7 +6,7 @@ import {
   type NativeSyntheticEvent,
   type KeyboardEvent,
 } from 'react-native';
-import { router } from 'expo-router';
+import { useAppRouter } from '@/services/useAppRouter';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Button, Heading, Text } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
@@ -22,8 +22,10 @@ export default function HeroCallout() {
   const { width } = useWindowDimensions();
   const isWide = width >= 768;
 
+  const appRouter = useAppRouter();
+
   const handlePress = () => {
-    router.push(`/store/${SHOP_TENANT_ID}`);
+    appRouter.push(`/store/${SHOP_TENANT_ID}`);
   };
 
   const handleKeyDown = (e: NativeSyntheticEvent<KeyboardEvent>) => {
@@ -38,8 +40,6 @@ export default function HeroCallout() {
     <PromoCard
       backgroundColor={colors.surface.primary}
       style={{
-        marginHorizontal: spacing.spacer16,
-        marginBottom: spacing.spacer24,
         height: isWide ? 112 : 96,
       }}
     >

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { Card, Text, Button } from '@/ui';
 import { Stack } from '@/ui/layout';
-import { spacing, radius, shadows } from '@/ui/tokens';
+import { radius, shadows } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
@@ -70,7 +70,7 @@ export default function HomeOptions() {
   };
 
   return (
-    <Stack gap="spacer16" style={styles.container}>
+    <Stack gap="spacer16">
       <Card style={styles.card}>
         <Stack gap="spacer8">
           <Text style={[styles.title, { color: colors.text.primary }]}>
@@ -146,10 +146,6 @@ export default function HomeOptions() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    marginHorizontal: spacing.spacer16,
-    marginBottom: spacing.spacer16,
-  },
   card: {
     borderRadius: radius.xl,
     ...Platform.select(shadows.md),


### PR DESCRIPTION
## Summary
- wrap network landing content in `<Container>` with responsive paddings and max-width for consistent layout
- remove extra margins and switch HeroCallout to `useAppRouter`

## Testing
- `npx eslint app/index.tsx src/features/home/components/HeroCallout.tsx src/features/home/components/HomeOptions.tsx`
- `npx tsc --noEmit -p tsconfig.json` *(fails: Module and typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c398ae9d5c83268699100160821f59