### PR TITLE
Translate store screen strings and support RTL

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -14,7 +14,7 @@ import { spacing } from '@/shared/ui/tokens';
 export default function StoreScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
-  const { t } = useLanguage();
+  const { t, isRTL } = useLanguage();
   const [store, setStore] = useState<Store | null>(null);
   const {
     data: products = [],
@@ -91,17 +91,32 @@ export default function StoreScreen() {
       )}
       {tab === 'about' && (
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+          <Text
+            style={[
+              styles.sectionTitle,
+              { color: colors.text.primary, textAlign: isRTL ? 'right' : 'left' },
+            ]}
+          >
             {t('stores.about')}
           </Text>
-          <Text style={[styles.sectionText, { color: colors.text.secondary }]}>
+          <Text
+            style={[
+              styles.sectionText,
+              { color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' },
+            ]}
+          >
             {t('stores.aboutDescription')}
           </Text>
         </View>
       )}
       {tab === 'reviews' && (
         <View style={styles.section}>
-          <Text style={[styles.sectionText, { color: colors.text.secondary }]}>
+          <Text
+            style={[
+              styles.sectionText,
+              { color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' },
+            ]}
+          >
             {t('stores.reviewsComingSoon')}
           </Text>
         </View>

--- a/src/features/stores/components/store/StoreHeader.tsx
+++ b/src/features/stores/components/store/StoreHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, Image, Platform } from 'react-native';
-import { useTheme } from '@/ui/ThemeProvider';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 
 interface Props {
   name: string;
@@ -12,6 +12,7 @@ interface Props {
 
 export default function StoreHeader({ name, reputation = 0, bannerUri, avatarUri, tagline }: Props) {
   const { colors } = useTheme();
+  const { t, isRTL } = useLanguage();
   return (
     <View>
       <View style={{ width: '100%', height: 160, backgroundColor: colors.surface.secondary }}>
@@ -19,7 +20,15 @@ export default function StoreHeader({ name, reputation = 0, bannerUri, avatarUri
           <Image source={{ uri: bannerUri }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
         ) : null}
       </View>
-      <View style={{ marginTop: -28, paddingHorizontal: 16, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+      <View
+        style={{
+          marginTop: -28,
+          paddingHorizontal: 16,
+          flexDirection: isRTL ? 'row-reverse' : 'row',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
         <View
           style={{
             width: 56,
@@ -39,12 +48,21 @@ export default function StoreHeader({ name, reputation = 0, bannerUri, avatarUri
               color: colors.text.primary,
               fontSize: 22,
               fontWeight: Platform.OS === 'web' ? ('700' as any) : '700',
+              textAlign: isRTL ? 'right' : 'left',
             }}
           >
             {name}
           </Text>
-          <Text style={{ color: colors.text.secondary }}>Reputation: {reputation.toFixed(1)}</Text>
-          {!!tagline && <Text style={{ color: colors.text.tertiary }}>{tagline}</Text>}
+          <Text
+            style={{ color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' }}
+          >
+            {t('stores.reputation')} {reputation.toFixed(1)}
+          </Text>
+          {!!tagline && (
+            <Text style={{ color: colors.text.tertiary, textAlign: isRTL ? 'right' : 'left' }}>
+              {tagline}
+            </Text>
+          )}
         </View>
       </View>
       <View style={{ height: 8 }} />

--- a/src/features/stores/components/store/StoreTabs.tsx
+++ b/src/features/stores/components/store/StoreTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
-import { useTheme } from '@/ui/ThemeProvider';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 
 type TabKey = 'products' | 'about' | 'reviews';
 
@@ -12,15 +12,16 @@ export default function StoreTabs({
   onChange: (key: TabKey) => void;
 }) {
   const { colors } = useTheme();
+  const { t, isRTL } = useLanguage();
   const tabs: { key: TabKey; label: string }[] = [
-    { key: 'products', label: 'Products' },
-    { key: 'about', label: 'About' },
-    { key: 'reviews', label: 'Reviews' },
+    { key: 'products', label: t('stores.tabs.products') },
+    { key: 'about', label: t('stores.tabs.about') },
+    { key: 'reviews', label: t('stores.tabs.reviews') },
   ];
   return (
     <View
       style={{
-        flexDirection: 'row',
+        flexDirection: isRTL ? 'row-reverse' : 'row',
         gap: 8,
         paddingHorizontal: 16,
         paddingTop: 8,
@@ -40,6 +41,7 @@ export default function StoreTabs({
               style={{
                 color: isActive ? colors.text.primary : colors.text.secondary,
                 fontWeight: isActive ? ('700' as any) : '500',
+                textAlign: isRTL ? 'right' : 'left',
               }}
             >
               {t.label}

--- a/translations/en.json
+++ b/translations/en.json
@@ -548,6 +548,12 @@
     "about": "About this store",
     "aboutDescription": "Decentralized store on NEAR. Owner-managed with P2P updates via Waku.",
     "reviewsComingSoon": "Reviews coming soon.",
+    "reputation": "Reputation:",
+    "tabs": {
+      "products": "Products",
+      "about": "About",
+      "reviews": "Reviews"
+    },
     "metrics": {
       "orders": "Orders:",
       "revenue": "Revenue:"

--- a/translations/he.json
+++ b/translations/he.json
@@ -548,6 +548,12 @@
     "about": "אודות החנות",
     "aboutDescription": "חנות מבוזרת ב‑NEAR. מנוהלת על ידי הבעלים עם עדכוני P2P דרך Waku.",
     "reviewsComingSoon": "ביקורות בקרוב.",
+    "reputation": "מוניטין:",
+    "tabs": {
+      "products": "מוצרים",
+      "about": "אודות",
+      "reviews": "ביקורות"
+    },
     "metrics": {
       "orders": "הזמנות:",
       "revenue": "הכנסות:"


### PR DESCRIPTION
## Summary
- replace store screen hard-coded text with i18n translations
- add RTL-aware layout for store header and tabs
- provide English and Hebrew translations for new strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*


------
https://chatgpt.com/codex/tasks/task_e_68c398c51fc883268a1566d39d35563e