### PR TITLE
fix wallet selector failover provider

### DIFF
--- a/services/walletSelector.ts
+++ b/services/walletSelector.ts
@@ -2,9 +2,17 @@
 import { setupWalletSelector, WalletSelector } from '@near-wallet-selector/core';
 import { setupNearWallet } from '@near-wallet-selector/near-wallet';
 import '@near-wallet-selector/wallet-utils';
+import * as nearAPI from 'near-api-js';
 import { Buffer } from 'buffer';
 import { useEffect, useState } from 'react';
 import { nearConfig } from '@/services/config';
+
+// Ensure FailoverRpcProvider is available as a constructor
+const providers: any = (nearAPI as any).providers;
+if (providers && typeof providers.FailoverRpcProvider !== 'function') {
+  providers.FailoverRpcProvider =
+    providers.FailoverRpcProvider?.default || providers.JsonRpcProvider;
+}
 
 // Exported for test overrides
 export let selector: WalletSelector | null = null;


### PR DESCRIPTION
## Summary
- ensure FailoverRpcProvider falls back to JsonRpcProvider when missing

## Testing
- `yarn lint services/walletSelector.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn test tests/wallet/provider.test.ts` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3aff8e7d88326a090009891ab9cfa