### PR TITLE
fix: improve mobile layout and sticky navigation

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -114,6 +114,7 @@ function HomeScreenContent() {
         testID="home-root"
         backgroundColor={themeColors.canvas}
         showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ flexGrow: 0 }}
       >
         <Container
           style={{

--- a/components/SidebarTabBar.tsx
+++ b/components/SidebarTabBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Pressable, Text, Platform } from 'react-native';
+import { View, Pressable, Text, Platform, StyleProp, ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Lucide from 'lucide-react-native';
 import { usePathname } from 'expo-router';
@@ -20,9 +20,10 @@ const SIDEBAR_COLLAPSED_WIDTH = 80;
 interface SidebarTabBarProps {
   items: readonly NavItem[];
   isSidebar?: boolean;
+  style?: StyleProp<ViewStyle>;
 }
 
-export const SidebarTabBar: React.FC<SidebarTabBarProps> = ({ items, isSidebar }) => {
+export const SidebarTabBar: React.FC<SidebarTabBarProps> = ({ items, isSidebar, style }) => {
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
   const { push } = useAppRouter();
@@ -46,7 +47,7 @@ export const SidebarTabBar: React.FC<SidebarTabBarProps> = ({ items, isSidebar }
 
   return (
     <View
-      style={
+      style={[
         isSidebar
           ? {
               width: collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH,
@@ -60,8 +61,9 @@ export const SidebarTabBar: React.FC<SidebarTabBarProps> = ({ items, isSidebar }
               backgroundColor: colors.tabBar.background,
               paddingBottom: insets.bottom,
               height: spacing.spacer24 * 3,
-            }
-      }
+            },
+        style,
+      ]}
     >
       <View>
         {items.map((item, index) => {

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { View, useWindowDimensions } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { Slot, usePathname } from 'expo-router';
 import GlobalHeader from '@/components/GlobalHeader';
@@ -12,6 +12,7 @@ import SidebarTabBar, { NavItem } from '@/components/SidebarTabBar';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTenant } from '@/contexts/TenantContext';
 import { getShopTenantId } from '@/services/config';
+import { spacing } from '@/shared/ui/tokens';
 
 interface NavItemConfig extends NavItem {
   requiresAuth?: boolean;
@@ -61,6 +62,7 @@ export default function RootLayout() {
   const { isRTL } = useLanguage();
   const pathname = usePathname();
   const { width } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
   const { isLoggedIn, isStoreOwner } = useAuth();
   const { tenantId } = useTenant();
   const isLargeScreen = width >= LARGE_SCREEN;
@@ -86,13 +88,24 @@ export default function RootLayout() {
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
         <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.canvas} />
         <GlobalHeader showSearch={showSearch} />
-        <View style={{ flex: 1, flexDirection: isRTL ? 'row-reverse' : 'row' }}>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: isRTL ? 'row-reverse' : 'row',
+            paddingBottom: isLargeScreen ? 0 : spacing.spacer24 * 3 + insets.bottom,
+          }}
+        >
           {isLargeScreen && <SidebarTabBar items={navItems} isSidebar />}
           <View style={{ flex: 1 }}>
             <Slot />
-            {!isLargeScreen && <SidebarTabBar items={navItems} />}
           </View>
         </View>
+        {!isLargeScreen && (
+          <SidebarTabBar
+            items={navItems}
+            style={{ position: 'absolute', left: 0, right: 0, bottom: 0 }}
+          />
+        )}
         {showCartWidget && <FloatingCartWidget />}
       </SafeAreaView>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- keep hero above fold and ensure consistent gap for network landing
- make mobile bottom nav sticky and hide on larger screens
- allow SidebarTabBar to accept style overrides

## Testing
- ⚠️ `yarn lint` *(missing @typescript-eslint/parser)*
- ⚠️ `yarn typecheck` *(missing type definitions)*


------
https://chatgpt.com/codex/tasks/task_e_68c3b335ade48326a46bebb127a72fea