### PR TITLE
feat: hide header app title on mobile

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -97,9 +97,11 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
         ) : (
           <View style={[styles.logoIcon, { backgroundColor: colors.gold }]} />
         )}
-        <Text style={[styles.logoText, { color: colors.gold }]}>
-          {appName || t('ageVerification.platformName')}
-        </Text>
+        {isMd && (
+          <Text style={[styles.logoText, { color: colors.gold }]}> 
+            {appName || t('ageVerification.platformName')}
+          </Text>
+        )}
       </Pressable>
       <View
         style={[


### PR DESCRIPTION
## Summary
- show app title in header only on larger screens

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install --ignore-scripts` *(fails: @waku/core requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b50febb48326a858d73fbbf33ea6