### PR TITLE
test: ensure single QueryClientProvider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -63,6 +63,7 @@ module.exports = {
     '<rootDir>/tests/smoke.test.ts',
     '<rootDir>/tests/navigation.test.ts',
     '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
+    '<rootDir>/tests/appProvidersSingleQueryClient.test.tsx',
     '<rootDir>/tests/signupLogic.test.ts',
     '<rootDir>/tests/nearKvPersistence.test.ts',
     '<rootDir>/tests/homeScreenRender.test.tsx',

--- a/tests/appProvidersSingleQueryClient.test.tsx
+++ b/tests/appProvidersSingleQueryClient.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import AppProviders from '@/providers/AppProviders';
+
+// Test to ensure AppProviders mounts with a single CheckedQueryClientProvider
+// and does not emit a duplicate provider error.
+describe('AppProviders QueryClientProvider usage', () => {
+  const originalDev = (globalThis as any).__DEV__;
+
+  beforeEach(() => {
+    (globalThis as any).__DEV__ = true;
+  });
+
+  afterEach(() => {
+    (globalThis as any).__DEV__ = originalDev;
+  });
+
+  it('mounts without multiple QueryClientProvider error', () => {
+    expect(() => {
+      act(() => {
+        const root = renderer.create(
+          React.createElement(AppProviders, {}, React.createElement(React.Fragment)),
+        );
+        root.unmount();
+      });
+    }).not.toThrow();
+  });
+
+  it('throws when mounting two AppProviders simultaneously', () => {
+    const roots: renderer.ReactTestRenderer[] = [];
+    expect(() => {
+      act(() => {
+        roots.push(
+          renderer.create(
+            React.createElement(AppProviders, {}, React.createElement(React.Fragment)),
+          ),
+        );
+        renderer.create(
+          React.createElement(AppProviders, {}, React.createElement(React.Fragment)),
+        );
+      });
+    }).toThrow('Multiple QueryClientProvider instances detected');
+
+    act(() => {
+      roots.forEach((r) => r.unmount());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests verifying AppProviders uses a single CheckedQueryClientProvider
- register new test in Jest configuration

## Testing
- `npx jest tests/appProvidersSingleQueryClient.test.tsx tests/CheckedQueryClientProvider.test.tsx` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b6c229e8832694a1f3d70145c256