### PR TITLE
fix: remove duplicate wallet button

### DIFF
--- a/apps/web/app/_layout.tsx
+++ b/apps/web/app/_layout.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import { View } from 'react-native';
 import { Stack } from 'expo-router';
 import '../services/chainGuard';
-import WalletButton from '../components/WalletButton';
-import { isWalletEnabled } from '@/services/config';
 
 export default function RootLayout() {
-  const walletEnabled = isWalletEnabled();
-
   return (
     <View style={{ flex: 1 }}>
       <Stack screenOptions={{ headerShown: false }} />
-      {walletEnabled && <WalletButton />}
     </View>
   );
 }

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -206,9 +206,10 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
             },
           ]}
         >
-          <Globe size={24} color={colors.text.primary} />
+        <Globe size={24} color={colors.text.primary} />
         </Pressable>
 
+        // DOCME: wallet status chip
         <Chip
           label={walletLabel}
           onPress={handleWalletPress}


### PR DESCRIPTION
## Summary
- remove standalone wallet button from web layout
- document wallet status chip in global header

## Testing
- `yarn lint apps/web/app/_layout.tsx components/GlobalHeader.tsx` (fails: Cannot find module '@typescript-eslint/parser')
- `yarn install` (fails: @waku/core requires Node >=22)
- `yarn typecheck` (fails: Cannot find type definition file for 'jest', 'node', 'react')


------
https://chatgpt.com/codex/tasks/task_e_68c3bbac185c8326b0fc73cd49de28e8