### PR TITLE
feat: restrict home options to network

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -99,6 +99,7 @@ function HomeScreenContent() {
     refresh();
   }, [closeInfoModal, refresh]);
 
+  // DOCME: network-only home options
   if (isNetwork) {
     const containerPaddingHorizontal =
       windowWidth >= 1024
@@ -190,8 +191,6 @@ function HomeScreenContent() {
           maxPrice={maxPrice}
           setMaxPrice={setMaxPrice}
         />
-          <HomeOptions />
-
         {/* Categories Section */}
         <Container
           style={[


### PR DESCRIPTION
## Summary
- limit home options to network view
- document network-only home options

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c3bd9c7984832696c5b079d76306f0