### PR TITLE
chore: localize store not-found state

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -19,7 +19,7 @@ export default function StoreScreen() {
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
   const [store, setStore] = useState<Store | null>(null);
-  const router = useAppRouter();
+  const appRouter = useAppRouter();
   const {
     data: products = [],
     isLoading: productsLoading,
@@ -53,15 +53,16 @@ export default function StoreScreen() {
     };
   }, [storeId]);
 
+  // DOCME: store not-found i18n
   if (!store) {
     return (
       <View style={{ flex: 1, backgroundColor: colors.background }}>
         <EmptyState
           icon={Info}
-          title=''
-          message='החנות לא נמצאה'
-          actionText='חזור לדף הבית'
-          onAction={() => router.replace('/')}
+          title=""
+          message={t('stores.notFound')}
+          actionText={t('common.backToHome')}
+          onAction={() => appRouter.replace('/')}
         />
       </View>
     );

--- a/translations/en.json
+++ b/translations/en.json
@@ -26,6 +26,7 @@
     "reload": "Reload",
     "comingSoon": "Coming Soon",
     "goHome": "Go Home",
+    "backToHome": "Back to Home",
     "route": "Route:",
     "language": "Language"
   },

--- a/translations/he.json
+++ b/translations/he.json
@@ -26,6 +26,7 @@
     "reload": "טען מחדש",
     "comingSoon": "בקרוב",
     "goHome": "חזור לבית",
+    "backToHome": "חזרה לדף הבית",
     "route": "נתיב:",
     "language": "שפה"
   },


### PR DESCRIPTION
## Summary
- localize StoreScreen not-found state via i18n keys
- add `common.backToHome` translations in English and Hebrew

## Testing
- `node scripts/check-i18n.js app/store/[storeId]/_StoreScreen.tsx`
- `npx eslint app/store/[storeId]/_StoreScreen.tsx translations/en.json translations/he.json`
- `yarn typecheck` *(fails: Module '... ThemeProvider' has no exported member 't', etc.)*
- `yarn jest` *(fails: TypeError: Cannot read properties of undefined (reading 'sourceFile'))*

------
https://chatgpt.com/codex/tasks/task_e_68c3bdb79a0c8326b7283e1f1f0b6695