### PR TITLE
feat: add mixer support for private payments

### DIFF
--- a/packages/sdk-near/src/config.ts
+++ b/packages/sdk-near/src/config.ts
@@ -5,6 +5,7 @@ const config: Record<string, string> = {
   EXPO_PUBLIC_RELAYER_URL: process.env.EXPO_PUBLIC_RELAYER_URL || '',
   EXPO_PUBLIC_INDEXER_URL: process.env.EXPO_PUBLIC_INDEXER_URL || '',
   EXPO_PUBLIC_TRANSPORT: process.env.EXPO_PUBLIC_TRANSPORT || '',
+  EXPO_PUBLIC_MIXER_URL: process.env.EXPO_PUBLIC_MIXER_URL || '',
 };
 
 export default config;

--- a/packages/sdk-near/src/index.ts
+++ b/packages/sdk-near/src/index.ts
@@ -102,11 +102,46 @@ export async function buyListing(args: BuyListingArgs): Promise<any> {
 
 /**
  * Pay for a listing while attempting to preserve privacy.
- * TODO: integrate with mixer for on-chain privacy once available.
+ * Tries to route the payment through an external mixer service.
+ * If the mixer is misconfigured or fails, falls back to a normal
+ * `buyListing` request so the user can still complete the purchase.
  */
 export async function payPrivately(args: BuyListingArgs): Promise<any> {
-  // For MVP, private payment falls back to the same relayer path.
-  return buyListing(args);
+  const sid = requireStoreId(args.storeId);
+  const mixerUrl = config.EXPO_PUBLIC_MIXER_URL;
+  if (!mixerUrl) return buyListing(args);
+  try {
+    // Step 1: request a proof from the mixer for this payment
+    const proofRes = await fetch(`${mixerUrl}/proof`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: canonicalJson({ storeId: sid, itemId: args.itemId, amountYocto: args.amountYocto }),
+    });
+    if (!proofRes.ok) {
+      throw new Error(`Proof request failed: ${proofRes.status} ${proofRes.statusText}`);
+    }
+    const proofJson = await proofRes.json();
+    const proof = proofJson.proof;
+    if (!proof) throw new Error('Mixer proof missing');
+
+    // Step 2: submit the mixed payment with the proof
+    const mixRes = await fetch(`${mixerUrl}/mix`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: canonicalJson({ storeId: sid, proof, args: { itemId: args.itemId, amountYocto: args.amountYocto } }),
+    });
+    if (!mixRes.ok) {
+      throw new Error(`Mixer payment failed: ${mixRes.status} ${mixRes.statusText}`);
+    }
+    const mixJson = await mixRes.json();
+    if (mixJson.error) {
+      throw new Error(mixJson.error.message || 'Mixer error');
+    }
+    return mixJson;
+  } catch (err) {
+    console.warn('payPrivately mixer failed, falling back to buyListing', err);
+    return buyListing(args);
+  }
 }
 
 export default { getListings, addListing, buyListing, payPrivately };

--- a/tests/payPrivatelyButton.test.tsx
+++ b/tests/payPrivatelyButton.test.tsx
@@ -50,3 +50,46 @@ describe('PayPrivatelyButton', () => {
     });
   });
 });
+
+describe('payPrivately mixer integration', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      EXPO_PUBLIC_MIXER_URL: 'https://mixer.example',
+      EXPO_PUBLIC_RELAYER_URL: 'https://relayer.example',
+    } as any;
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    (global as any).fetch = undefined;
+  });
+
+  it('invokes mixer API when configured', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ proof: 'abc' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) });
+    (global as any).fetch = fetchMock;
+    const { payPrivately } = await import('@blue-ocean/sdk-near');
+    await payPrivately({ storeId: 's1', itemId: 1, amountYocto: '5' });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://mixer.example/proof', expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://mixer.example/mix', expect.any(Object));
+  });
+
+  it('falls back to buyListing on mixer failure', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('mixer down'))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) });
+    (global as any).fetch = fetchMock;
+    const sdk = await import('@blue-ocean/sdk-near');
+    const buySpy = jest.spyOn(sdk, 'buyListing').mockResolvedValue('fallback');
+    const res = await sdk.payPrivately({ storeId: 's1', itemId: 1, amountYocto: '5' });
+    expect(buySpy).toHaveBeenCalled();
+    expect(res).toBe('fallback');
+  });
+});


### PR DESCRIPTION
## Summary
- integrate mixer-based private payment flow and fallback to public purchase
- expose mixer endpoint via SDK config
- test mixer invocation and fallback scenarios

## Testing
- `npx -y jest tests/payPrivatelyButton.test.tsx` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c0f8111c832687ec17dc4b51c79f