### PR TITLE
docs: rename testing matrix to testing checklist

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
-# Testing Matrix
+# Testing Checklist
 
-The following matrix outlines mandatory test scenarios that must be exercised before shipping changes.
+The following checklist outlines mandatory test scenarios that must be exercised before shipping changes.
 
 | Area | Scenarios | Tools |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- rename "Testing Matrix" documentation to "Testing Checklist"
- remove matrix wording from testing doc

## Testing
- `npx eslint docs/testing.md` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c3c67cd300832682f57021e1cc1d95