### PR TITLE
feat: route NEAR payments through mixer

### DIFF
--- a/docs/near-dev-packet.md
+++ b/docs/near-dev-packet.md
@@ -375,13 +375,31 @@ RELAYER_PRIVATE_KEY=ed25519:...
 
 ---
 
-## 9) Optional: Privacy Stub (Mixer Button)
+## 9) Privacy: Mixer-Based Payments
+
+The SDK exposes `payPrivately` which attempts to send the payment through a
+configured NEAR mixer service. It will try the primary mixer first and fall
+back to a secondary mixer if provided. If all mixers fail the call will throw.
+
+Required environment variables:
+
+```bash
+EXPO_PUBLIC_MIXER_URL=https://mixer.example
+EXPO_PUBLIC_MIXER_FALLBACK_URL=https://fallback-mixer.example
+```
+
+Usage:
 
 ```ts
-export async function payPrivately({ storeId, itemId, amountYocto }: any) {
-  // TODO: integrate mixer; for now fallback to normal buy
-  return buyListing({ storeId, itemId, amountYocto });
-}
+import { payPrivately } from '@blue-ocean/sdk-near';
+
+await payPrivately({ storeId, itemId, amountYocto });
+```
+
+Testing:
+
+```bash
+yarn test tests/payPrivatelyButton.test.tsx
 ```
 
 ---

--- a/packages/sdk-near/src/config.ts
+++ b/packages/sdk-near/src/config.ts
@@ -6,6 +6,7 @@ const config: Record<string, string> = {
   EXPO_PUBLIC_INDEXER_URL: process.env.EXPO_PUBLIC_INDEXER_URL || '',
   EXPO_PUBLIC_TRANSPORT: process.env.EXPO_PUBLIC_TRANSPORT || '',
   EXPO_PUBLIC_MIXER_URL: process.env.EXPO_PUBLIC_MIXER_URL || '',
+  EXPO_PUBLIC_MIXER_FALLBACK_URL: process.env.EXPO_PUBLIC_MIXER_FALLBACK_URL || '',
 };
 
 export default config;

--- a/packages/sdk-near/src/index.ts
+++ b/packages/sdk-near/src/index.ts
@@ -103,14 +103,20 @@ export async function buyListing(args: BuyListingArgs): Promise<any> {
 /**
  * Pay for a listing while attempting to preserve privacy.
  * Tries to route the payment through an external mixer service.
- * If the mixer is misconfigured or fails, falls back to a normal
- * `buyListing` request so the user can still complete the purchase.
+ * If the primary mixer is unavailable, attempts any configured fallback
+ * mixer services before ultimately throwing an error.
  */
 export async function payPrivately(args: BuyListingArgs): Promise<any> {
   const sid = requireStoreId(args.storeId);
-  const mixerUrl = config.EXPO_PUBLIC_MIXER_URL;
-  if (!mixerUrl) return buyListing(args);
-  try {
+  const mixers = [
+    config.EXPO_PUBLIC_MIXER_URL,
+    config.EXPO_PUBLIC_MIXER_FALLBACK_URL,
+  ].filter(Boolean) as string[];
+  if (mixers.length === 0) {
+    throw new Error('Mixer service not configured');
+  }
+
+  const attempt = async (mixerUrl: string) => {
     // Step 1: request a proof from the mixer for this payment
     const proofRes = await fetch(`${mixerUrl}/proof`, {
       method: 'POST',
@@ -128,7 +134,11 @@ export async function payPrivately(args: BuyListingArgs): Promise<any> {
     const mixRes = await fetch(`${mixerUrl}/mix`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: canonicalJson({ storeId: sid, proof, args: { itemId: args.itemId, amountYocto: args.amountYocto } }),
+      body: canonicalJson({
+        storeId: sid,
+        proof,
+        args: { itemId: args.itemId, amountYocto: args.amountYocto },
+      }),
     });
     if (!mixRes.ok) {
       throw new Error(`Mixer payment failed: ${mixRes.status} ${mixRes.statusText}`);
@@ -138,10 +148,18 @@ export async function payPrivately(args: BuyListingArgs): Promise<any> {
       throw new Error(mixJson.error.message || 'Mixer error');
     }
     return mixJson;
-  } catch (err) {
-    console.warn('payPrivately mixer failed, falling back to buyListing', err);
-    return buyListing(args);
+  };
+
+  let lastError: any;
+  for (const url of mixers) {
+    try {
+      return await attempt(url);
+    } catch (err) {
+      console.warn(`payPrivately mixer failed at ${url}`, err);
+      lastError = err;
+    }
   }
+  throw lastError;
 }
 
 export default { getListings, addListing, buyListing, payPrivately };

--- a/tests/payPrivatelyButton.test.tsx
+++ b/tests/payPrivatelyButton.test.tsx
@@ -59,6 +59,7 @@ describe('payPrivately mixer integration', () => {
     process.env = {
       ...OLD_ENV,
       EXPO_PUBLIC_MIXER_URL: 'https://mixer.example',
+      EXPO_PUBLIC_MIXER_FALLBACK_URL: 'https://fallback-mixer.example',
       EXPO_PUBLIC_RELAYER_URL: 'https://relayer.example',
     } as any;
   });
@@ -80,16 +81,20 @@ describe('payPrivately mixer integration', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://mixer.example/mix', expect.any(Object));
   });
 
-  it('falls back to buyListing on mixer failure', async () => {
+  it('falls back to secondary mixer on failure', async () => {
     const fetchMock = jest
       .fn()
+      // primary mixer proof call fails
       .mockRejectedValueOnce(new Error('mixer down'))
+      // fallback mixer proof succeeds
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ proof: 'abc' }) })
+      // fallback mixer mix succeeds
       .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) });
     (global as any).fetch = fetchMock;
-    const sdk = await import('@blue-ocean/sdk-near');
-    const buySpy = jest.spyOn(sdk, 'buyListing').mockResolvedValue('fallback');
-    const res = await sdk.payPrivately({ storeId: 's1', itemId: 1, amountYocto: '5' });
-    expect(buySpy).toHaveBeenCalled();
-    expect(res).toBe('fallback');
+    const { payPrivately } = await import('@blue-ocean/sdk-near');
+    await payPrivately({ storeId: 's1', itemId: 1, amountYocto: '5' });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://mixer.example/proof', expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://fallback-mixer.example/proof', expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(3, 'https://fallback-mixer.example/mix', expect.any(Object));
   });
 });


### PR DESCRIPTION
## Summary
- add mixer fallback URL to SDK config
- route payPrivately through primary and secondary mixer services
- document mixer-based payment flow and env vars

## Testing
- `npx --yes jest tests/payPrivatelyButton.test.tsx` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c6bab8148326a20bfea7d9447494