### PR TITLE
Localize store not-found state

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -59,8 +59,8 @@ export default function StoreScreen() {
       <View style={{ flex: 1, backgroundColor: colors.background }}>
         <EmptyState
           icon={Info}
-          title=""
-          message={t('stores.notFound')}
+          title={t('stores.notFound')}
+          message=""
           actionText={t('common.backToHome')}
           onAction={() => appRouter.replace('/')}
         />


### PR DESCRIPTION
## Summary
- localize store not-found empty state and annotate for docs

## Testing
- `yarn lint app/store/'[storeId]'/_StoreScreen.tsx`
- `yarn typecheck` *(fails: Overload 2 of 2, '...', gave the following error)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e34ab1f88326bc721a6087542082