### PR TITLE
fix: center container on web

### DIFF
--- a/src/ui/layout/Container.tsx
+++ b/src/ui/layout/Container.tsx
@@ -23,7 +23,8 @@ export default function Container({
       style={[
         {
           maxWidth: 1280,
-          marginHorizontal: 'auto' as any,
+          width: '100%',
+          alignSelf: 'center',
           paddingVertical: 32,
           paddingHorizontal: basePaddingHorizontal,
         },


### PR DESCRIPTION
## Summary
- center Container layout on web by replacing unsupported margin auto with full-width and self-aligning style

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Could not find a declaration file for module 'metro-runtime/src/modules/HMRClient' and many other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f19dc3a8832684d50021c03057a7