### PR TITLE
fix: center container without stretching background

### DIFF
--- a/src/ui/layout/Container.tsx
+++ b/src/ui/layout/Container.tsx
@@ -19,21 +19,23 @@ export default function Container({
     width >= 768 ? spacing.spacer24 : spacing.spacer16;
 
   return (
-    <View
-      style={[
-        {
-          maxWidth: 1280,
-          marginHorizontal: 'auto' as any,
-          paddingVertical: 32,
-          paddingHorizontal: basePaddingHorizontal,
-        },
-        padding ? { padding: spacing[padding] } : null,
-        backgroundColor ? { backgroundColor } : null,
-        style,
-      ]}
-      {...rest}
-    >
-      {children}
+    <View style={{ width: '100%', alignItems: 'center' }}>
+      <View
+        style={[
+          {
+            width: '100%',
+            maxWidth: 1280,
+            paddingVertical: 32,
+            paddingHorizontal: basePaddingHorizontal,
+          },
+          padding ? { padding: spacing[padding] } : null,
+          backgroundColor ? { backgroundColor } : null,
+          style,
+        ]}
+        {...rest}
+      >
+        {children}
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Container with centering outer view so background doesn't span full width

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c3f19dc3a8832684d50021c03057a7