### PR TITLE
fix: center container without stretching background

### DIFF
--- a/src/ui/layout/Container.tsx
+++ b/src/ui/layout/Container.tsx
@@ -22,10 +22,11 @@ export default function Container({
     <View
       style={[
         {
+          width: '100%',
           maxWidth: 1280,
-          marginHorizontal: 'auto' as any,
           paddingVertical: 32,
           paddingHorizontal: basePaddingHorizontal,
+          alignSelf: 'center',
         },
         padding ? { padding: spacing[padding] } : null,
         backgroundColor ? { backgroundColor } : null,


### PR DESCRIPTION
## Summary
- center shared Container by applying `alignSelf: 'center'` directly

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c3f19dc3a8832684d50021c03057a7