### PR TITLE
Refactor home hero and premium card layout

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,3 +1,4 @@
+// TOUCHPOINT: app/index.tsx renders in production — Fix Pack v2
 import React, { Suspense, useCallback, useState } from 'react';
 import {
   View,
@@ -101,34 +102,21 @@ function HomeScreenContent() {
 
   // DOCME: network-only home options
   if (isNetwork) {
-    const containerPaddingHorizontal =
-      windowWidth >= 1024
-        ? spacing.spacer32
-        : windowWidth >= 768
-          ? spacing.spacer24
-          : spacing.spacer16;
-    const containerPaddingVertical =
-      windowWidth >= 768 ? spacing.spacer32 : spacing.spacer24;
-
     return (
       <ScrollArea
         testID="home-root"
         backgroundColor={themeColors.canvas}
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ flexGrow: 0 }}
+        contentContainerStyle={{ flexGrow: 1 }}
       >
-        <Container
-          style={{
-            maxWidth: 1200,
-            paddingHorizontal: containerPaddingHorizontal,
-            paddingVertical: containerPaddingVertical,
-          }}
-        >
-          <Stack gap="spacer24">
+        <main className="mx-auto max-w-screen-xl p-6 space-y-6">
+          <section>
             <HeroCallout />
+          </section>
+          <section className="overflow-x-auto scroll-snap-x mandatory">
             <HomeOptions />
-          </Stack>
-        </Container>
+          </section>
+        </main>
       </ScrollArea>
     );
   }
@@ -396,3 +384,5 @@ export default function HomeScreen() {
     </ErrorBoundary>
   );
 }
+
+// AC: Cards are 4-wide on md+; on mobile they scroll horizontally with snap; hero no longer overlaps; page has no white bottom.

--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -1,3 +1,4 @@
+// TOUCHPOINT: src/features/home/components/HeroCallout.tsx renders in production — Fix Pack v2
 import React from 'react';
 import {
   View,
@@ -13,6 +14,8 @@ import { Stack } from '@/ui/layout';
 import { spacing, typography } from '@/ui/tokens';
 import { getShopTenantId } from '@/services/config';
 import { routes } from '@/utils/routes';
+import { useWallet } from '@/contexts/WalletProvider';
+import guard from '@/utils/guard';
 import PromoCard from './PromoCard';
 
 export default function HeroCallout() {
@@ -22,21 +25,22 @@ export default function HeroCallout() {
   const isWide = width >= 768;
 
   const appRouter = useAppRouter();
+  const { address, connect } = useWallet();
 
-  const handlePress = () => {
+  const action = guard(address, connect, () => {
     const tenantId = getShopTenantId();
     if (tenantId) {
       appRouter.push(`/store/${tenantId}`);
     } else {
       appRouter.push(routes.home());
     }
-  };
+  });
 
   const handleKeyDown = (e: NativeSyntheticEvent<KeyboardEvent>) => {
     const key = e.nativeEvent.key;
     if (key === 'Enter' || key === ' ') {
       e.preventDefault();
-      handlePress();
+      action();
     }
   };
 
@@ -65,7 +69,7 @@ export default function HeroCallout() {
         </View>
         <Button
           title={t('home.heroAction')}
-          onPress={handlePress}
+          onPress={action}
           accessibilityRole="link"
           onKeyDown={handleKeyDown}
           tooltip={t('home.heroAction')}

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -1,3 +1,4 @@
+// TOUCHPOINT: src/features/home/components/HomeOptions.tsx renders in production — Fix Pack v2
 import React from 'react';
 import {
   StyleSheet,
@@ -6,7 +7,6 @@ import {
   type KeyboardEvent,
   Platform,
   View,
-  ScrollView,
   I18nManager,
   useWindowDimensions,
 } from 'react-native';
@@ -17,6 +17,7 @@ import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
 import { useWallet } from '@/contexts/WalletProvider';
+import guard from '@/utils/guard';
 import { getShopTenantId, getDocsUrl } from '@/services/config';
 
 function HomeOptions() {
@@ -27,39 +28,23 @@ function HomeOptions() {
 
   const SHOP_TENANT_ID = getShopTenantId();
   const DOCS_URL = getDocsUrl();
-  const walletTooltip = t(
-    'home.connectWalletToContinue',
-    'חבר ארנק כדי להמשיך',
-  );
 
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
   const isRTL = I18nManager.isRTL;
   const cardHeight = isDesktop ? 112 : 96;
 
-  const handleCreateStore = async () => {
-    if (!walletAddress) {
-      await connect();
-      return;
-    }
+  const handleCreateStore = guard(walletAddress, connect, () => {
     appRouter.push(routes.createStore());
-  };
+  });
 
-  const handleBecomeDriver = async () => {
-    if (!walletAddress) {
-      await connect();
-      return;
-    }
+  const handleBecomeDriver = guard(walletAddress, connect, () => {
     appRouter.push(routes.driver());
-  };
+  });
 
-  const handleBusinessLogin = async () => {
-    if (!walletAddress) {
-      await connect();
-      return;
-    }
+  const handleBusinessLogin = guard(walletAddress, connect, () => {
     appRouter.push(`/store/${SHOP_TENANT_ID}/admin`);
-  };
+  });
 
   const handleDocs = () => {
     if (DOCS_URL) {
@@ -83,25 +68,19 @@ function HomeOptions() {
       key: 'create-store',
       title: t('home.createStore', 'Create a Store'),
       action: handleCreateStore,
-      tooltip: walletAddress ? undefined : walletTooltip,
       testID: 'create-store-link',
-      disabled: !walletAddress,
     },
     {
       key: 'become-driver',
       title: t('home.becomeDriver', 'Become a Driver'),
       action: handleBecomeDriver,
-      tooltip: walletAddress ? undefined : walletTooltip,
       testID: 'become-driver-button',
-      disabled: !walletAddress,
     },
     {
       key: 'business-login',
       title: t('home.businessLogin', 'Business Login'),
       action: handleBusinessLogin,
-      tooltip: walletAddress ? undefined : walletTooltip,
       testID: 'business-login-button',
-      disabled: !walletAddress,
     },
     {
       key: 'docs-api',
@@ -109,7 +88,6 @@ function HomeOptions() {
       action: handleDocs,
       tooltip: DOCS_URL,
       testID: 'docs-api-button',
-      disabled: false,
     },
   ];
 
@@ -119,7 +97,6 @@ function HomeOptions() {
     action,
     tooltip,
     testID,
-    disabled,
   }: (typeof options)[number]) => (
     <Card
       key={key}
@@ -137,7 +114,7 @@ function HomeOptions() {
           onKeyDown={(e) => handleKeyDown(e, action)}
           accessibilityRole="link"
           tooltip={tooltip}
-          style={[styles.fullWidth, disabled && styles.disabled]}
+          style={styles.fullWidth}
           testID={testID}
         />
       </Stack>
@@ -158,17 +135,14 @@ function HomeOptions() {
   }
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={[
-        styles.scrollContent,
+    <View
+      style={[
+        styles.mobileRow,
         { flexDirection: isRTL ? 'row-reverse' : 'row' },
       ]}
-      style={styles.scroll}
     >
       {options.map(renderCard)}
-    </ScrollView>
+    </View>
   );
 }
 
@@ -181,12 +155,7 @@ const styles = StyleSheet.create({
     gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
     paddingHorizontal: spacing.spacer16,
   },
-  scroll: {
-    ...Platform.select({
-      web: { scrollSnapType: 'x mandatory' as any },
-    }),
-  },
-  scrollContent: {
+  mobileRow: {
     paddingHorizontal: spacing.spacer16,
     gap: spacing.spacer16,
   },
@@ -209,9 +178,6 @@ const styles = StyleSheet.create({
   },
   fullWidth: {
     width: '100%',
-  },
-  disabled: {
-    opacity: 0.5,
   },
 });
 

--- a/utils/guard.ts
+++ b/utils/guard.ts
@@ -1,0 +1,16 @@
+// TOUCHPOINT: utils/guard.ts renders in production — Fix Pack v2
+export function guard(
+  address: string | null,
+  connect: () => Promise<void>,
+  action: () => void,
+) {
+  return async () => {
+    if (!address) {
+      await connect();
+    } else {
+      action();
+    }
+  };
+}
+
+export default guard;


### PR DESCRIPTION
## Summary
- refactor network home shell to use `<main>` and scroll-snapping sections
- wrap hero and option CTAs with wallet guard helper
- add shared guard utility

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c45985277883269499558c51055deb