### PR TITLE
refactor: centralize env access via config getters

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -12,6 +12,7 @@ import { Text, Chip } from '@/ui';
 import SmartImage from './SmartImage';
 import { Search, Bell, Globe } from 'lucide-react-native';
 import { useAppRouter } from '@/services';
+import { getShopTenantId } from '@/services/config';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useAppInfo } from '../contexts/AppInfoContext';
@@ -39,6 +40,7 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const shopTenantId = getShopTenantId();
 
   useEffect(() => {
     if (Platform.OS !== 'web') return;
@@ -83,7 +85,9 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
       <Pressable
         style={styles.logo}
         onPress={() => {
-          if (pathname !== '/') push('/');
+          if (pathname !== '/' && pathname !== '/index') {
+            push(shopTenantId ? `/store/${shopTenantId}` : '/');
+          }
         }}
         accessibilityRole="button"
       >

--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -28,9 +28,9 @@ export default function HeroCallout() {
   const { address, connect } = useWallet();
 
   const action = guard(address, connect, () => {
-    const tenantId = getShopTenantId();
-    if (tenantId) {
-      appRouter.push(`/store/${tenantId}`);
+    const shopTenantId = getShopTenantId();
+    if (shopTenantId) {
+      appRouter.push(`/store/${shopTenantId}`);
     } else {
       appRouter.push(routes.home());
     }

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -26,8 +26,8 @@ function HomeOptions() {
   const appRouter = useAppRouter();
   const { address: walletAddress, connect } = useWallet();
 
-  const SHOP_TENANT_ID = getShopTenantId();
-  const DOCS_URL = getDocsUrl();
+  const shopTenantId = getShopTenantId();
+  const docsUrl = getDocsUrl();
 
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
@@ -43,12 +43,12 @@ function HomeOptions() {
   });
 
   const handleBusinessLogin = guard(walletAddress, connect, () => {
-    appRouter.push(`/store/${SHOP_TENANT_ID}/admin`);
+    appRouter.push(`/store/${shopTenantId}/admin`);
   });
 
   const handleDocs = () => {
-    if (DOCS_URL) {
-      Linking.openURL(DOCS_URL);
+    if (docsUrl) {
+      Linking.openURL(docsUrl);
     }
   };
 
@@ -86,7 +86,7 @@ function HomeOptions() {
       key: 'docs-api',
       title: t('home.docsApi', 'Docs & API'),
       action: handleDocs,
-      tooltip: DOCS_URL,
+      tooltip: docsUrl,
       testID: 'docs-api-button',
     },
   ];

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -20,10 +20,12 @@ interface NavItemConfig extends NavItem {
   requiresTenant?: boolean;
 }
 
+const SHOP_TENANT_ID = getShopTenantId();
+
 const NAV_ITEMS: readonly NavItemConfig[] = [
   { href: '/', title: 'navigation.home', icon: 'Home' },
   {
-    href: `/store/${getShopTenantId()}`,
+    href: `/store/${SHOP_TENANT_ID}`,
     title: 'navigation.shopNow',
     icon: 'Store',
   },

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -59,32 +59,25 @@ export function nearConfig(): NearConfig {
   };
 }
 
-export function getShopTenantId(): string | undefined {
-  return (
-    process.env.EXPO_PUBLIC_SHOP_TENANT_ID ||
-    process.env.SHOP_TENANT_ID
-  );
-}
+export const getShopTenantId = () =>
+  process.env.EXPO_PUBLIC_SHOP_TENANT_ID ||
+  process.env.SHOP_TENANT_ID ||
+  '';
 
-export function getContractId(): string | undefined {
-  return (
-    process.env.EXPO_PUBLIC_CONTRACT_ID ||
-    process.env.CONTRACT_ID
-  );
-}
+export const getContractId = () =>
+  process.env.EXPO_PUBLIC_CONTRACT_ID ||
+  process.env.CONTRACT_ID ||
+  '';
 
-function inferNetworkFrom(contractId?: string): string | undefined {
+function inferFrom(contractId?: string): string | undefined {
   if (!contractId) return undefined;
   return contractId.endsWith('.testnet') ? 'testnet' : 'mainnet';
 }
 
-export function getNetworkId(): string | undefined {
-  return (
-    process.env.NEAR_NETWORK_ID ||
-    process.env.EXPO_PUBLIC_NETWORK ||
-    inferNetworkFrom(getContractId())
-  );
-}
+export const getNetworkId = () =>
+  process.env.NEAR_NETWORK_ID ||
+  process.env.EXPO_PUBLIC_NETWORK ||
+  inferFrom(getContractId());
 
 export function isRouterEnabled(): boolean {
   return (
@@ -198,3 +191,5 @@ export function getAdminWalletAddressTestnet(): string {
 }
 
 export default requireEnv;
+
+// Acceptance: No ‘Missing SHOP_TENANT_ID / CONTRACT_ID’ logs after clean restart.


### PR DESCRIPTION
## Summary
- expose shop tenant, contract, and network helpers returning safe defaults
- route header and home components through config getters

## Testing
- `yarn lint components/GlobalHeader.tsx src/layout/RootLayout.tsx src/features/home/components/HeroCallout.tsx src/features/home/components/HomeOptions.tsx src/services/config.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4" for @waku/core)*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c46e5aecc483269020072023a934ee