### PR TITLE
feat: add friendly store not-found CTA

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -1,3 +1,4 @@
+// TOUCHPOINT: app/store/[storeId]/_StoreScreen.tsx renders in production — Fix Pack v2
 import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
@@ -11,7 +12,7 @@ import { selectStore } from '@/agents/stores-agent';
 import type { Store } from '@/types';
 import { spacing } from '@/shared/ui/tokens';
 import EmptyState from '@/shared/ui/EmptyState';
-import { Info } from 'lucide-react-native';
+import Button from '@/ui/primitives/Button';
 import { useAppRouter } from '@/services/useAppRouter';
 
 export default function StoreScreen() {
@@ -19,7 +20,7 @@ export default function StoreScreen() {
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
   const [store, setStore] = useState<Store | null>(null);
-  const appRouter = useAppRouter();
+  const { push } = useAppRouter();
   const {
     data: products = [],
     isLoading: productsLoading,
@@ -53,16 +54,13 @@ export default function StoreScreen() {
     };
   }, [storeId]);
 
-  // DOCME: store not-found i18n
   if (!store) {
     return (
       <View style={{ flex: 1, backgroundColor: colors.background }}>
         <EmptyState
-          icon={Info}
-          title={t('stores.notFound')}
-          message=""
-          actionText={t('common.backToHome')}
-          onAction={() => appRouter.replace('/')}
+          title={t('store.not_found')}
+          description={t('store.not_found_sub')}
+          action={<Button onPress={() => push('/')}>{t('cta.back_home')}</Button>}
         />
       </View>
     );
@@ -154,4 +152,6 @@ const styles = StyleSheet.create({
   },
   sectionText: {},
 });
+
+// AC: Missing store renders friendly EmptyState with Back to Home button.
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -571,6 +571,13 @@
     "connect": "Connect Wallet",
     "notConnected": "Not connected"
   },
+  "store": {
+    "not_found": "Store not found",
+    "not_found_sub": "We couldn't find that store."
+  },
+  "cta": {
+    "back_home": "Back to Home"
+  },
   "proofUploader": {
     "permissionRequired": "Permission Required",
     "permissionMessage": "Please allow access to media on the device.",

--- a/translations/he.json
+++ b/translations/he.json
@@ -565,6 +565,13 @@
     "connect": "התחבר לארנק",
     "notConnected": "לא מחובר"
   },
+  "store": {
+    "not_found": "החנות לא נמצאה",
+    "not_found_sub": "לא מצאנו את החנות הזו."
+  },
+  "cta": {
+    "back_home": "חזרה לדף הבית"
+  },
   "proofUploader": {
     "permissionRequired": "נדרשת הרשאה",
     "permissionMessage": "אנא אפשר גישה למדיה במכשיר.",


### PR DESCRIPTION
## Summary
- render store not-found state with localized Back to Home button
- add `store.*` and `cta.back_home` i18n keys

## Testing
- `npx eslint app/store/[storeId]/_StoreScreen.tsx`
- `node scripts/check-i18n.js app/store/[storeId]/_StoreScreen.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4856321d08326a424e290d8ad4914