### PR TITLE
docs: clarify single React Query provider usage

### DIFF
--- a/docs/provider-invariants.md
+++ b/docs/provider-invariants.md
@@ -1,3 +1,3 @@
 # Provider Invariants
 
-- Only a single `QueryClientProvider` should be mounted at any time. Multiple providers create separate React Query caches and can lead to inconsistent data. The `CheckedQueryClientProvider` component in [`src/providers/CheckedQueryClientProvider.tsx`](../src/providers/CheckedQueryClientProvider.tsx) enforces this during development and will throw if another provider mounts.
+- Only a single `QueryClientProvider` should be mounted at any time. Multiple providers create separate React Query caches and can lead to inconsistent data. The `CheckedQueryClientProvider` component in [`src/providers/CheckedQueryClientProvider.tsx`](../src/providers/CheckedQueryClientProvider.tsx) enforces this during development and will throw if another provider mounts. Consumers that need direct access to the client should use the `useQueryClient()` hook instead of nesting another provider.

--- a/src/providers/CheckedQueryClientProvider.tsx
+++ b/src/providers/CheckedQueryClientProvider.tsx
@@ -4,6 +4,12 @@ import {
   type QueryClientProviderProps,
 } from '@tanstack/react-query';
 
+/**
+ * Development wrapper around React Query's `QueryClientProvider` that guards
+ * against mounting more than one instance. Components that need access to the
+ * client should call `useQueryClient()` rather than introducing an additional
+ * provider.
+ */
 let mountedInstances = 0;
 
 export function CheckedQueryClientProvider(props: QueryClientProviderProps) {

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -21,6 +21,8 @@
 
 - `ThemeProvider` and `LanguageProvider` must appear before any component that uses theming or i18n.
 - `CheckedQueryClientProvider` must wrap providers that rely on React Query, including the `WalletProvider`.
+- `CheckedQueryClientProvider` is the **only** `QueryClientProvider` in the app. If a component needs direct access to the
+  query client, use the `useQueryClient()` hook rather than adding another provider.
 - `WalletProvider` supplies wallet state for network layers and comes before providers that require it, such as `WakuProvider`.
 - `ErrorBoundary` wraps the remaining providers to surface runtime errors.
 


### PR DESCRIPTION
## Summary
- document that only one QueryClientProvider may be mounted
- advise using `useQueryClient` instead of nesting providers
- clarify CheckedQueryClientProvider's purpose with inline comment

## Testing
- `npx eslint src/providers/CheckedQueryClientProvider.tsx`
- `npx jest` *(fails: Cannot read properties of undefined (reading 'sourceFile'))*

------
https://chatgpt.com/codex/tasks/task_e_68c488b902fc8326a78807c8b5a33a55