### PR TITLE
chore: add missing i18n keys

### DIFF
--- a/src/features/home/components/HeroCallout.tsx
+++ b/src/features/home/components/HeroCallout.tsx
@@ -59,20 +59,20 @@ export default function HeroCallout() {
       >
         <View style={styles.textContainer}>
           <Heading size="xl" style={{ color: colors.text.primary }}>
-            {t('home.heroTitle')}
+            {t('home.hero_title')}
           </Heading>
           <Text
             style={[typography.sm, { color: colors.text.secondary, marginTop: spacing.spacer8 }]}
           >
-            {t('home.heroSubtitle')}
+            {t('home.hero_subtitle')}
           </Text>
         </View>
         <Button
-          title={t('home.heroAction')}
+          title={t('home.hero_action')}
           onPress={action}
           accessibilityRole="link"
           onKeyDown={handleKeyDown}
-          tooltip={t('home.heroAction')}
+          tooltip={t('home.hero_action')}
         />
       </Stack>
     </PromoCard>

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -66,25 +66,25 @@ function HomeOptions() {
   const options = [
     {
       key: 'create-store',
-      title: t('home.createStore', 'Create a Store'),
+      title: t('cta.create_store', 'Create a Store'),
       action: handleCreateStore,
       testID: 'create-store-link',
     },
     {
       key: 'become-driver',
-      title: t('home.becomeDriver', 'Become a Driver'),
+      title: t('cta.become_driver', 'Become a Driver'),
       action: handleBecomeDriver,
       testID: 'become-driver-button',
     },
     {
       key: 'business-login',
-      title: t('home.businessLogin', 'Business Login'),
+      title: t('cta.business_login', 'Business Login'),
       action: handleBusinessLogin,
       testID: 'business-login-button',
     },
     {
       key: 'docs-api',
-      title: t('home.docsApi', 'Docs & API'),
+      title: t('cta.docs_api', 'Docs & API'),
       action: handleDocs,
       tooltip: docsUrl,
       testID: 'docs-api-button',

--- a/src/features/home/components/HomeServices.tsx
+++ b/src/features/home/components/HomeServices.tsx
@@ -24,14 +24,14 @@ export default function HomeServices() {
   return (
     <Stack direction="horizontal" gap="spacer16" style={styles.container}>
       <ServiceCard
-        title={t('home.createStore')}
+        title={t('cta.create_store')}
         icon={<Store size={32} color={colors.gold} />}
         onPress={handleCreateStore}
         accessibilityRole="link"
         testID="create-store-link"
       />
       <ServiceCard
-        title={t('home.becomeDriver')}
+        title={t('cta.become_driver')}
         icon={<Truck size={32} color={colors.gold} />}
         onPress={handleBecomeDriver}
         accessibilityRole="button"

--- a/tests/homeScreenRender.test.tsx
+++ b/tests/homeScreenRender.test.tsx
@@ -119,7 +119,7 @@ describe('HomeScreen render', () => {
 
     const tree = root!.toJSON();
     const str = JSON.stringify(tree);
-    expect(str).toContain('home.heroTitle');
+    expect(str).toContain('home.hero_title');
     expect(mockCategoryChips).not.toHaveBeenCalled();
     expect(mockProductGrid).not.toHaveBeenCalled();
     expect(mockUseHome).toHaveBeenCalledWith(null);

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,3 +1,4 @@
+// TOUCHPOINT: translations/en.json updated with new i18n keys — Fix Pack v2
 {
   "common": {
     "save": "Save",
@@ -86,7 +87,8 @@
     "fullNamePlaceholder": "Enter your full name",
     "createPasswordPlaceholder": "Create password",
     "confirmPasswordPlaceholder": "Confirm your password",
-    "logoutConfirm": "Are you sure you want to logout?"
+    "logoutConfirm": "Are you sure you want to logout?",
+    "not_connected": "Not connected"
   },
   "home": {
     "searchPlaceholder": "Search products...",
@@ -97,9 +99,9 @@
     "noBanners": "No banners",
     "addBanners": "Add banners to get started",
     "bannersComingSoon": "Banners coming soon",
-    "heroTitle": "Discover unique products",
-    "heroSubtitle": "Experience decentralized shopping",
-    "heroAction": "Shop now",
+    "hero_title": "Discover unique products",
+    "hero_subtitle": "Experience decentralized shopping",
+    "hero_action": "Shop now",
     "noCategories": "No categories",
     "categoriesComingSoon": "Categories coming soon",
     "noProducts": "No products",
@@ -118,13 +120,13 @@
     "priceHighLow": "Price: High to Low",
     "highRating": "High Rating",
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
-    "createStore": "Create a Store",
-    "becomeDriver": "Become a Driver",
-    "businessLogin": "Business Login",
-    "docs": "Docs",
-    "apiDocs": "API Docs",
-    "docsApi": "Docs & API",
     "connectWalletToContinue": "Connect wallet to continue"
+  },
+  "cta": {
+    "create_store": "Create a Store",
+    "become_driver": "Become a Driver",
+    "business_login": "Business Login",
+    "docs_api": "Docs & API"
   },
   "categories": {
     "all": "All",
@@ -538,6 +540,28 @@
     "notFoundMessage": "We couldn't find that order",
     "statusUpdated": "Order status updated",
     "updateStatusFailed": "Failed to update status"
+  },
+  "store": {
+    "store_name": "Store Name",
+    "mint_store": "Mint Store",
+    "transaction_failed": "Transaction failed",
+    "insufficient_funds": "Insufficient funds to deploy the store",
+    "transaction_cancelled": "Transaction cancelled",
+    "create_success": "Store created successfully",
+    "not_found": "Store not found",
+    "about": "About this store",
+    "about_description": "Decentralized store on NEAR. Owner-managed with P2P updates via Waku.",
+    "reviews_coming_soon": "Reviews coming soon.",
+    "reputation": "Reputation:",
+    "tabs": {
+      "products": "Products",
+      "about": "About",
+      "reviews": "Reviews"
+    },
+    "metrics": {
+      "orders": "Orders:",
+      "revenue": "Revenue:"
+    }
   },
   "stores": {
     "storeName": "Store Name",

--- a/translations/he.json
+++ b/translations/he.json
@@ -1,3 +1,4 @@
+// TOUCHPOINT: translations/he.json updated with new i18n keys — Fix Pack v2
 {
   "common": {
     "save": "שמור",
@@ -86,7 +87,8 @@
     "fullNamePlaceholder": "הכנס את שמך המלא",
     "createPasswordPlaceholder": "צור סיסמה",
     "confirmPasswordPlaceholder": "אשר את הסיסמה",
-    "logoutConfirm": "האם אתה בטוח שברצונך להתנתק?"
+    "logoutConfirm": "האם אתה בטוח שברצונך להתנתק?",
+    "not_connected": "לא מחובר"
   },
   "home": {
     "searchPlaceholder": "חיפוש מוצרים...",
@@ -97,9 +99,9 @@
     "noBanners": "אין באנרים",
     "addBanners": "הוסף באנרים כדי להתחיל",
     "bannersComingSoon": "באנרים יתווספו בקרוב",
-    "heroTitle": "גלה מוצרים ייחודיים",
-    "heroSubtitle": "קנה ישירות מחנויות מבוזרות",
-    "heroAction": "קנה עכשיו",
+    "hero_title": "גלה מוצרים ייחודיים",
+    "hero_subtitle": "קנה ישירות מחנויות מבוזרות",
+    "hero_action": "קנה עכשיו",
     "noCategories": "אין קטגוריות",
     "categoriesComingSoon": "קטגוריות יתווספו בקרוב",
     "noProducts": "אין מוצרים",
@@ -118,13 +120,13 @@
     "priceHighLow": "מחיר: גבוה לנמוך",
     "highRating": "דירוג גבוה",
     "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש.",
-    "createStore": "צור חנות",
-    "becomeDriver": "הפוך לשליח",
-    "businessLogin": "כניסת עסקים",
-    "docs": "תיעוד",
-    "apiDocs": "ממשק API",
-    "docsApi": "מסמכים & API",
     "connectWalletToContinue": "חבר ארנק כדי להמשיך"
+  },
+  "cta": {
+    "create_store": "צור חנות",
+    "become_driver": "הפוך לשליח",
+    "business_login": "כניסת עסקים",
+    "docs_api": "מסמכים & API"
   },
   "categories": {
     "all": "הכל",
@@ -538,6 +540,28 @@
     "notFoundMessage": "לא הצלחנו למצוא את ההזמנה הזו",
     "statusUpdated": "סטטוס ההזמנה עודכן",
     "updateStatusFailed": "עדכון הסטטוס נכשל"
+  },
+  "store": {
+    "store_name": "שם החנות",
+    "mint_store": "צור חנות",
+    "transaction_failed": "העסקה נכשלה",
+    "insufficient_funds": "אין מספיק כספים לפריסת החנות",
+    "transaction_cancelled": "העסקה בוטלה",
+    "create_success": "החנות נוצרה בהצלחה",
+    "not_found": "החנות לא נמצאה",
+    "about": "אודות החנות",
+    "about_description": "חנות מבוזרת ב‑NEAR. מנוהלת על ידי הבעלים עם עדכוני P2P דרך Waku.",
+    "reviews_coming_soon": "ביקורות בקרוב.",
+    "reputation": "מוניטין:",
+    "tabs": {
+      "products": "מוצרים",
+      "about": "אודות",
+      "reviews": "ביקורות"
+    },
+    "metrics": {
+      "orders": "הזמנות:",
+      "revenue": "הכנסות:"
+    }
   },
   "stores": {
     "storeName": "שם החנות",


### PR DESCRIPTION
## Summary
- add missing i18n strings for home hero, CTA options, auth "not connected", and store metadata
- update components to use new translation keys
- document translation updates with touchpoint comments

## Testing
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*
- `yarn install` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*
- `npx jest tests/homeScreenRender.test.tsx` *(fails: Need to install the following packages: jest@30.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c48570fadc83268366794cfbbf1e29