### PR TITLE
Fix metro countLines import and specify Expo tsconfig path

### DIFF
--- a/scripts/patch-metro-config.js
+++ b/scripts/patch-metro-config.js
@@ -140,11 +140,11 @@ try {
     let content = fs.readFileSync(envSerializer, 'utf8');
     const replaced = content
       .replace(
-        'require("metro/src/lib/CountingSet")',
+        /require\(["']metro\/src\/lib\/CountingSet(?:\.js)?["']\)/g,
         'require("@expo/metro/metro/lib/CountingSet")'
       )
       .replace(
-        'require("metro/src/lib/countLines")',
+        /require\(["']metro\/src\/lib\/countLines(?:\.js)?["']\)/g,
         'require("@expo/metro/metro/lib/countLines")'
       );
     if (replaced !== content) {
@@ -156,15 +156,15 @@ try {
     let content = fs.readFileSync(baseBundle, 'utf8');
     const replaced = content
       .replace(
-        'require("metro/src/lib/CountingSet")',
+        /require\(["']metro\/src\/lib\/CountingSet(?:\.js)?["']\)/g,
         'require("@expo/metro/metro/lib/CountingSet")'
       )
       .replace(
-        'require("metro/src/lib/countLines")',
+        /require\(["']metro\/src\/lib\/countLines(?:\.js)?["']\)/g,
         'require("@expo/metro/metro/lib/countLines")'
       )
       .replace(
-        'require("metro/src/lib/getAppendScripts")',
+        /require\(["']metro\/src\/lib\/getAppendScripts(?:\.js)?["']\)/g,
         'require("@expo/metro/metro/lib/getAppendScripts")'
       );
     if (replaced !== content) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -92,5 +92,5 @@
     "types/**/*.d.ts"
   ],
   "exclude": ["tests"],
-  "extends": "expo/tsconfig.base"
+  "extends": "expo/tsconfig.base.json"
 }


### PR DESCRIPTION
## Summary
- patch Metro config to handle `countLines`/`CountingSet` deep imports with optional `.js` extension
- explicitly reference Expo's base tsconfig file

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest' and 'expo/tsconfig.base.json')*
- `yarn config:check` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68c4a077c79483269b036293f7199052