### PR TITLE
Use NEAR contract to mint store

### DIFF
--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -11,8 +11,7 @@ import {
 import { useAppRouter } from '@/services';
 import { useQueryClient } from '@tanstack/react-query';
 import { useLanguage } from '@/ui/ThemeProvider';
-import storesAgent from '@/agents/stores-agent';
-import { chainAdapter } from '@/services/chain';
+import { mintStore as mintStoreOnChain, getStore } from '@/features/stores/services/nearStores';
 import { useWallet } from '@/contexts/WalletProvider';
 import { errorLog } from '@/utils/logger';
 
@@ -31,11 +30,10 @@ const StoreCreation: React.FC = () => {
       return;
     }
     try {
-      const id = Date.now().toString();
-      await chainAdapter.signMessage?.(`MintStore:${id}`);
-      await storesAgent.add({ id, name, owner, nftId: id });
+      const { id, txHash } = await mintStoreOnChain(name);
+      await getStore(id, id);
       setName('');
-      Alert.alert(t('common.success'), t('stores.createSuccess'));
+      Alert.alert(t('common.success'), `${t('stores.createSuccess')}` + `\n${txHash}`);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['home'] }),
         queryClient.invalidateQueries({ queryKey: ['store'] }),
@@ -46,7 +44,7 @@ const StoreCreation: React.FC = () => {
       if (err?.message?.toLowerCase().includes('insufficient')) {
         Alert.alert(t('stores.transactionFailed'), t('stores.insufficientFunds'));
       } else {
-        Alert.alert(t('stores.transactionCancelled'));
+        Alert.alert(t('stores.transactionFailed'), err?.message || t('stores.transactionCancelled'));
       }
       errorLog('mint', 'shop', 'fail', err);
     }

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -8,6 +8,9 @@ import { Store } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { requireStoreId } from '@blue-ocean/utils';
 import { canonicalJson } from '@/utils/serialization';
+import { nearConfig } from '@/services/config';
+import { getSelector } from '@/services/walletSelector';
+import { Buffer } from 'buffer';
 
 assertNearChain();
 
@@ -38,6 +41,50 @@ function ensureSeed() {
     }
   } catch {}
   SEEDED = true;
+}
+
+export async function mintStore(name: string): Promise<{ id: string; nftId: string; txHash: string }> {
+  const { contractId } = nearConfig();
+  if (!contractId) throw new Error('CONTRACT_ID required');
+  const selector = getSelector();
+  if (!selector) throw new Error('Wallet not initialized');
+  const wallet = await selector.wallet();
+  const res: any = await wallet.signAndSendTransactions({
+    transactions: [
+      {
+        receiverId: contractId,
+        actions: [
+          {
+            type: 'FunctionCall',
+            params: {
+              methodName: 'mint_store',
+              args: { name },
+              gas: '30000000000000',
+              deposit: '0',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  const outcome = Array.isArray(res) ? res[0] : res;
+  const txHash: string = outcome?.transaction?.hash || '';
+  let id = '';
+  let nftId = '';
+  try {
+    const val =
+      outcome?.status?.SuccessValue ||
+      outcome?.transaction_outcome?.outcome?.status?.SuccessValue;
+    if (val) {
+      const decoded = Buffer.from(val, 'base64').toString();
+      const parsed = JSON.parse(decoded);
+      id = parsed.store_id || parsed.storeId || parsed.id || '';
+      nftId = parsed.nft_id || parsed.nftId || '';
+    }
+  } catch {}
+  if (!id) throw new Error('mint_store failed');
+  return { id, nftId, txHash };
 }
 
 export async function getStore(storeId: string, id: string): Promise<Store | null> {


### PR DESCRIPTION
## Summary
- mint store via NEAR contract using wallet selector
- display transaction hash and handle errors

## Testing
- `yarn lint src/features/stores/components/StoreCreation.tsx src/features/stores/services/nearStores.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c62d0b72a483269e7926db61e3e74c