### PR TITLE
feat: move store persistence to near contract

### DIFF
--- a/services/nearStoreContract.ts
+++ b/services/nearStoreContract.ts
@@ -1,0 +1,111 @@
+import { providers } from 'near-api-js';
+import { Buffer } from 'buffer';
+import { nearConfig } from '@/services/config';
+import { getAccountId, getSelector } from './walletSelector';
+
+export interface ChainStore {
+  id: string;
+  name: string;
+  owner_id: string;
+  nft_id: string;
+  reputation?: number;
+}
+
+function getProvider() {
+  const { rpcUrl } = nearConfig();
+  return new providers.JsonRpcProvider({ url: rpcUrl });
+}
+
+function getContractId(): string {
+  return nearConfig().contractId;
+}
+
+function parseResult(res: any) {
+  return JSON.parse(Buffer.from(res.result).toString());
+}
+
+export async function getStore(id: string): Promise<ChainStore | null> {
+  try {
+    const provider = getProvider();
+    const res: any = await provider.query({
+      request_type: 'call_function',
+      account_id: getContractId(),
+      method_name: 'get_store',
+      args_base64: Buffer.from(JSON.stringify({ id })).toString('base64'),
+      finality: 'optimistic',
+    });
+    const data = parseResult(res);
+    if (!data) return null;
+    return {
+      id: data.id ?? data.store_id ?? '',
+      name: data.name ?? '',
+      owner_id: data.owner_id ?? data.owner ?? '',
+      nft_id: data.nft_id ?? '',
+      reputation:
+        typeof data.reputation === 'string'
+          ? Number(data.reputation)
+          : data.reputation,
+    };
+  } catch (e: any) {
+    throw new Error(`get_store failed: ${e.message || e}`);
+  }
+}
+
+export async function listStores(): Promise<ChainStore[]> {
+  try {
+    const provider = getProvider();
+    const res: any = await provider.query({
+      request_type: 'call_function',
+      account_id: getContractId(),
+      method_name: 'list_stores',
+      args_base64: Buffer.from('{}').toString('base64'),
+      finality: 'optimistic',
+    });
+    const data = parseResult(res);
+    if (!Array.isArray(data)) return [];
+    return data.map((s: any) => ({
+      id: s.id ?? s.store_id ?? '',
+      name: s.name ?? '',
+      owner_id: s.owner_id ?? s.owner ?? '',
+      nft_id: s.nft_id ?? '',
+      reputation:
+        typeof s.reputation === 'string' ? Number(s.reputation) : s.reputation,
+    }));
+  } catch (e: any) {
+    throw new Error(`list_stores failed: ${e.message || e}`);
+  }
+}
+
+export async function mintStore(store: ChainStore): Promise<string> {
+  try {
+    const selector = getSelector();
+    const accountId = getAccountId();
+    if (!selector || !accountId) {
+      throw new Error('Wallet not initialized');
+    }
+    const wallet = await selector.wallet();
+    const res: any = await wallet.signAndSendTransaction({
+      signerId: accountId,
+      receiverId: getContractId(),
+      actions: [
+        {
+          type: 'FunctionCall',
+          params: {
+            methodName: 'mint_store',
+            args: {
+              store_id: store.id,
+              name: store.name,
+              owner_id: store.owner_id,
+              nft_id: store.nft_id,
+            },
+            gas: '30000000000000',
+            deposit: '0',
+          },
+        },
+      ],
+    });
+    return res.transaction?.hash || '';
+  } catch (e: any) {
+    throw new Error(`mint_store failed: ${e.message || e}`);
+  }
+}

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -1,78 +1,65 @@
-import {
-  getValue,
-  setValue,
-  listValues,
-  removeValue,
-} from '@/services/nearKvStore';
 import { Store } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { requireStoreId } from '@blue-ocean/utils';
-import { canonicalJson } from '@/utils/serialization';
+import {
+  mintStore as contractMintStore,
+  getStore as contractGetStore,
+  listStores as contractListStores,
+} from '@/services/nearStoreContract';
 
 assertNearChain();
 
-const ADDRESS = 'stores';
-const DISABLED = false;
-let SEEDED = false;
-
-function ensureSeed() {
-  if (!DISABLED || SEEDED) return;
-  try {
-
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const data = require('@/assets/seed/seed-data.json');
-    if (data?.stores) {
-      let hasAlpha = false;
-      for (const s of data.stores as Store[]) {
-        if (s.id === 'alpha') hasAlpha = true;
-        // Index under a shared namespace so listStores('default') works
-        void setValue(ADDRESS, `${ADDRESS}:default:${s.id}`, canonicalJson(s));
-        // And index under its own namespace so getStore(id, id) resolves
-        void setValue(ADDRESS, `${ADDRESS}:${s.id}:${s.id}`, canonicalJson(s));
-      }
-      if (!hasAlpha) {
-        const alpha: Store = { id: 'alpha', name: 'Alpha Store', owner: 'demo', nftId: '', reputation: 0 } as Store;
-        void setValue(ADDRESS, `${ADDRESS}:default:${alpha.id}`, canonicalJson(alpha));
-        void setValue(ADDRESS, `${ADDRESS}:${alpha.id}:${alpha.id}`, canonicalJson(alpha));
-      }
-    }
-  } catch {}
-  SEEDED = true;
+function fromChain(data: any): Store {
+  return {
+    id: data.id ?? data.store_id ?? '',
+    name: data.name ?? '',
+    owner: data.owner_id ?? data.owner ?? '',
+    nftId: data.nft_id ?? data.nftId ?? '',
+    reputation:
+      typeof data.reputation === 'string'
+        ? Number(data.reputation)
+        : data.reputation,
+  } as Store;
 }
 
-export async function getStore(storeId: string, id: string): Promise<Store | null> {
-  ensureSeed();
-  const sid = requireStoreId(storeId);
-  const res = await getValue(ADDRESS, `${ADDRESS}:${sid}:${id}`);
-  if (res) return JSON.parse(res) as Store;
-  if (DISABLED) {
-
-    const fallback: Store = {
-      id,
-      name: `Store ${id}`,
-      owner: 'demo',
-      nftId: '',
-      reputation: 0,
-    } as Store;
-    return fallback;
+export async function getStore(
+  storeId: string,
+  id: string,
+): Promise<Store | null> {
+  requireStoreId(storeId);
+  try {
+    const res = await contractGetStore(id);
+    return res ? fromChain(res) : null;
+  } catch (e: any) {
+    throw new Error(`Failed to get store ${id}: ${e.message || e}`);
   }
-  return null;
 }
 
 export async function setStore(storeId: string, store: Store) {
-  const sid = requireStoreId(storeId);
-  await setValue(ADDRESS, `${ADDRESS}:${sid}:${store.id}`, canonicalJson(store));
+  requireStoreId(storeId);
+  try {
+    await contractMintStore({
+      id: store.id,
+      name: store.name,
+      owner_id: store.owner,
+      nft_id: store.nftId,
+      reputation: store.reputation,
+    });
+  } catch (e: any) {
+    throw new Error(`Failed to mint store ${store.id}: ${e.message || e}`);
+  }
 }
 
-export async function removeStore(storeId: string, id: string) {
-  const sid = requireStoreId(storeId);
-  await removeValue(ADDRESS, `${ADDRESS}:${sid}:${id}`);
+export async function removeStore(_storeId: string, _id: string) {
+  throw new Error('removeStore is not supported on-chain');
 }
+
 export async function listStores(storeId: string): Promise<Store[]> {
-  ensureSeed();
-  const sid = requireStoreId(storeId);
-  const items = await listValues(ADDRESS);
-  return items
-    .filter((i) => i.key.startsWith(`${ADDRESS}:${sid}:`))
-    .map((i) => JSON.parse(i.value) as Store);
+  requireStoreId(storeId);
+  try {
+    const res = await contractListStores();
+    return res.map(fromChain);
+  } catch (e: any) {
+    throw new Error(`Failed to list stores: ${e.message || e}`);
+  }
 }


### PR DESCRIPTION
## Summary
- add NEAR store contract client wrapping mint_store, get_store, list_stores
- replace nearKvStore store operations with contract calls and error handling

## Testing
- `npx eslint services/nearStoreContract.ts src/features/stores/services/nearStores.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c62cfbe8ac8326911dc92b86bb1bea