### PR TITLE
feat: bootstrap admin with approval queue

### DIFF
--- a/agents/admin-agent.ts
+++ b/agents/admin-agent.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from 'events';
+import { getValue, setValue } from '@/services/nearKvStore';
+import { canonicalJson } from '@/utils/serialization';
+import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
+import AgentError from '@/types/AgentError';
+import type { WakuMessage } from '@/types/waku';
+
+interface AdminRecord {
+  address: string;
+  publicKey: string;
+}
+
+const KV_ADDRESS = 'admin-agent';
+const ADMINS_KEY = 'admins';
+const PENDING_KEY = 'pending';
+
+async function readRecords(key: string): Promise<AdminRecord[]> {
+  const raw = await getValue(KV_ADDRESS, key);
+  return raw ? (JSON.parse(raw) as AdminRecord[]) : [];
+}
+
+async function writeRecords(key: string, records: AdminRecord[]): Promise<void> {
+  await setValue(KV_ADDRESS, key, canonicalJson(records));
+}
+
+export type AdminAgentEvent =
+  | { type: 'admin.registered'; payload: { address: string } }
+  | { type: 'admin.requested'; payload: { address: string } };
+
+export class AdminAgent extends EventEmitter {
+  async getAdmins(): Promise<AdminRecord[]> {
+    return await readRecords(ADMINS_KEY);
+  }
+
+  async getPendingRequests(): Promise<AdminRecord[]> {
+    return await readRecords(PENDING_KEY);
+  }
+
+  private async addAdmin(record: AdminRecord): Promise<void> {
+    const admins = await this.getAdmins();
+    admins.push(record);
+    await writeRecords(ADMINS_KEY, admins);
+  }
+
+  private async queueRequest(record: AdminRecord): Promise<void> {
+    const pending = await this.getPendingRequests();
+    pending.push(record);
+    await writeRecords(PENDING_KEY, pending);
+  }
+
+  private async removeRequest(address: string): Promise<AdminRecord | null> {
+    const pending = await this.getPendingRequests();
+    const idx = pending.findIndex((p) => p.address === address);
+    if (idx === -1) return null;
+    const [rec] = pending.splice(idx, 1);
+    await writeRecords(PENDING_KEY, pending);
+    return rec;
+  }
+
+  async requestAdmin(
+    msg: WakuMessage<{ address: string }>,
+  ): Promise<AdminAgentEvent['type']> {
+    const valid = await verifyMessageSignature(msg, msg.sender.publicKey);
+    if (!valid) {
+      throw new AgentError('E_SIGNATURE_INVALID', 'Invalid signature', 'admin-agent');
+    }
+    const record: AdminRecord = {
+      address: msg.payload.address,
+      publicKey: msg.sender.publicKey,
+    };
+    const admins = await this.getAdmins();
+    if (admins.length === 0) {
+      await this.addAdmin(record);
+      this.emit('admin.registered', { address: record.address });
+      return 'admin.registered';
+    }
+    // already admin? return registered event without queue
+    if (admins.some((a) => a.address === record.address)) {
+      this.emit('admin.registered', { address: record.address });
+      return 'admin.registered';
+    }
+    // otherwise queue
+    const pending = await this.getPendingRequests();
+    if (!pending.some((p) => p.address === record.address)) {
+      await this.queueRequest(record);
+    }
+    this.emit('admin.requested', { address: record.address });
+    return 'admin.requested';
+  }
+
+  async approveAdmin(
+    msg: WakuMessage<{ address: string }>,
+  ): Promise<'admin.registered'> {
+    const valid = await verifyMessageSignature(msg, msg.sender.publicKey);
+    if (!valid) {
+      throw new AgentError('E_SIGNATURE_INVALID', 'Invalid signature', 'admin-agent');
+    }
+    const admins = await this.getAdmins();
+    const isAdmin = admins.some((a) => a.publicKey === msg.sender.publicKey);
+    if (!isAdmin) {
+      throw new AgentError('E_UNAUTHORIZED', 'Only admins can approve', 'admin-agent');
+    }
+    const pending = await this.removeRequest(msg.payload.address);
+    if (pending) {
+      await this.addAdmin(pending);
+      this.emit('admin.registered', { address: pending.address });
+    }
+    return 'admin.registered';
+  }
+}
+
+export default new AdminAgent();

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -1,0 +1,145 @@
+import { AdminAgent } from '../agents/admin-agent';
+import { __clear } from './nearKvMock';
+import { sign, getPublicKey, utils } from '@noble/ed25519';
+import { canonicalJson } from '@/utils/serialization';
+import type { WakuMessage } from '@/types/waku';
+
+jest.mock('@/services/nearKvStore', () => require('./nearKvMock'));
+
+async function createSignedMessage<T>(
+  type: string,
+  payload: T,
+  priv: Uint8Array,
+  pub: Uint8Array,
+): Promise<WakuMessage<T>> {
+  const message: WakuMessage<T> = {
+    type,
+    payload,
+    sender: { publicKey: Buffer.from(pub).toString('hex') },
+    signature: '',
+  };
+  const bytes = new TextEncoder().encode(
+    canonicalJson({ type: message.type, payload, sender: message.sender }),
+  );
+  const sig = await sign(bytes, priv);
+  message.signature = Buffer.from(sig).toString('hex');
+  return message;
+}
+
+describe('AdminAgent', () => {
+  let agent: AdminAgent;
+
+  beforeEach(() => {
+    __clear();
+    agent = new AdminAgent();
+  });
+
+  it('registers first wallet as admin', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const msg = await createSignedMessage('admin.request', { address: 'addr1' }, priv, pub);
+    const event = new Promise((resolve) =>
+      agent.once('admin.registered', resolve as any),
+    );
+    await agent.requestAdmin(msg);
+    await expect(event).resolves.toEqual({ address: 'addr1' });
+    const admins = await agent.getAdmins();
+    expect(admins).toHaveLength(1);
+  });
+
+  it('queues subsequent admin requests for approval', async () => {
+    // seed first admin
+    const priv1 = utils.randomPrivateKey();
+    const pub1 = await getPublicKey(priv1);
+    const first = await createSignedMessage('admin.request', { address: 'addr1' }, priv1, pub1);
+    await agent.requestAdmin(first);
+
+    // second request should be queued
+    const priv2 = utils.randomPrivateKey();
+    const pub2 = await getPublicKey(priv2);
+    const second = await createSignedMessage('admin.request', { address: 'addr2' }, priv2, pub2);
+    const event = new Promise((resolve) =>
+      agent.once('admin.requested', resolve as any),
+    );
+    await agent.requestAdmin(second);
+    await expect(event).resolves.toEqual({ address: 'addr2' });
+    const pending = await agent.getPendingRequests();
+    expect(pending).toHaveLength(1);
+  });
+
+  it('approves queued requests with existing admin', async () => {
+    const priv1 = utils.randomPrivateKey();
+    const pub1 = await getPublicKey(priv1);
+    const first = await createSignedMessage('admin.request', { address: 'addr1' }, priv1, pub1);
+    await agent.requestAdmin(first);
+
+    const priv2 = utils.randomPrivateKey();
+    const pub2 = await getPublicKey(priv2);
+    const second = await createSignedMessage('admin.request', { address: 'addr2' }, priv2, pub2);
+    await agent.requestAdmin(second);
+
+    const approve = await createSignedMessage(
+      'admin.approve',
+      { address: 'addr2' },
+      priv1,
+      pub1,
+    );
+    const event = new Promise((resolve) =>
+      agent.once('admin.registered', resolve as any),
+    );
+    await agent.approveAdmin(approve);
+    await expect(event).resolves.toEqual({ address: 'addr2' });
+    const admins = await agent.getAdmins();
+    expect(admins.map((a) => a.address)).toEqual(['addr1', 'addr2']);
+    const pending = await agent.getPendingRequests();
+    expect(pending).toHaveLength(0);
+  });
+
+  it('rejects unauthorized approvals', async () => {
+    const priv1 = utils.randomPrivateKey();
+    const pub1 = await getPublicKey(priv1);
+    const first = await createSignedMessage('admin.request', { address: 'addr1' }, priv1, pub1);
+    await agent.requestAdmin(first);
+
+    const priv2 = utils.randomPrivateKey();
+    const pub2 = await getPublicKey(priv2);
+    const second = await createSignedMessage('admin.request', { address: 'addr2' }, priv2, pub2);
+    await agent.requestAdmin(second);
+
+    // user3 tries to approve but is not admin
+    const priv3 = utils.randomPrivateKey();
+    const pub3 = await getPublicKey(priv3);
+    const badApprove = await createSignedMessage(
+      'admin.approve',
+      { address: 'addr2' },
+      priv3,
+      pub3,
+    );
+    await expect(agent.approveAdmin(badApprove)).rejects.toMatchObject({
+      code: 'E_UNAUTHORIZED',
+    });
+  });
+
+  it('rejects approvals with bad signatures', async () => {
+    const priv1 = utils.randomPrivateKey();
+    const pub1 = await getPublicKey(priv1);
+    const first = await createSignedMessage('admin.request', { address: 'addr1' }, priv1, pub1);
+    await agent.requestAdmin(first);
+
+    const priv2 = utils.randomPrivateKey();
+    const pub2 = await getPublicKey(priv2);
+    const second = await createSignedMessage('admin.request', { address: 'addr2' }, priv2, pub2);
+    await agent.requestAdmin(second);
+
+    const wrongPriv = utils.randomPrivateKey();
+    const approve = await createSignedMessage(
+      'admin.approve',
+      { address: 'addr2' },
+      wrongPriv,
+      pub1, // sender claims to be admin1 but signature is wrong
+    );
+    await expect(agent.approveAdmin(approve)).rejects.toMatchObject({
+      code: 'E_SIGNATURE_INVALID',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add AdminAgent for role-aware admin bootstrap with approval queue
- cover registration workflow in new tests

## Testing
- `npx --yes jest tests/adminAgent.test.ts --runInBand --watchAll=false` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c709a2e43c8326a14626e4be50f366