### PR TITLE
feat: add admin join request schema

### DIFF
--- a/docs/join-requests.md
+++ b/docs/join-requests.md
@@ -1,0 +1,21 @@
+# Admin Join Requests
+
+Wallets request admin access by broadcasting a signed Waku message.
+
+## Message
+
+```
+{
+  "type": "admin.requested",
+  "payload": { "wallet": "<address>" },
+  "sender": { "publicKey": "0x..." },
+  "signature": "0x..."
+}
+```
+
+The system answers with `admin.registered` once the wallet is approved.
+
+## Errors
+
+- `E_SIGNATURE_INVALID` – signature could not be verified.
+- `E_UNAUTHORIZED` – wallet not on allowlist.

--- a/schemas/waku/admin.requested.ts
+++ b/schemas/waku/admin.requested.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+export const adminJoinRequestSchema = wakuMessageSchema.extend({
+  type: z.literal('admin.requested'),
+  payload: z.object({
+    wallet: z.string(),
+  }),
+});
+
+export type AdminJoinRequestMessage = z.infer<typeof adminJoinRequestSchema>;

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -3,3 +3,4 @@ export * from './settings';
 export * from './notification';
 export * from './product.updated';
 export * from './order.status';
+export * from './admin.requested';

--- a/utils/verifyBeforeWrite.ts
+++ b/utils/verifyBeforeWrite.ts
@@ -10,17 +10,17 @@ export async function verifyBeforeWrite<T>(
 ): Promise<WakuMessage<T> | null> {
   const res = schema.safeParse(data);
   if (!res.success) {
-    errorLog('Invalid Waku message', res.error.flatten());
+    errorLog('Invalid Waku message');
     return null;
   }
   const msg = res.data;
   const ok = await verifyMessageSignature(msg, msg.sender.publicKey);
   if (!ok) {
-    errorLog('Invalid message signature', msg);
+    errorLog('E_SIGNATURE_INVALID');
     return null;
   }
   if (allowedPublicKeys && !allowedPublicKeys.includes(msg.sender.publicKey)) {
-    errorLog('Unauthorized sender', msg.sender.publicKey);
+    errorLog('E_UNAUTHORIZED');
     return null;
   }
   return msg;


### PR DESCRIPTION
## Summary
- define `admin.requested` signed join request schema
- clarify admin join events and auth errors
- avoid logging keys in signature verification

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npx jest` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c709ff5d408326b4eb50b5525e3767