### PR TITLE
feat: add rollout feature flag

### DIFF
--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  EXPO_PUBLIC_FEATURE_ROLLOUT: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS: z
+    .string()
+    .optional()
+    .default(''),
+  EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK: z.string().optional().default('false'),
+});
+
+const env = envSchema.parse(process.env);
+
+export interface RolloutFeatureFlag {
+  enabled: boolean;
+  canaryAdmins: string[];
+  rollback: boolean;
+}
+
+const rolloutFlag: RolloutFeatureFlag = {
+  enabled: env.EXPO_PUBLIC_FEATURE_ROLLOUT === 'true',
+  canaryAdmins: env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS
+    .split(',')
+    .map((a) => a.trim().toLowerCase())
+    .filter(Boolean),
+  rollback: env.EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK === 'true',
+};
+
+export function isRolloutEnabled(address?: string): boolean {
+  if (rolloutFlag.rollback) return false;
+  if (rolloutFlag.enabled) return true;
+  if (!address) return false;
+  return rolloutFlag.canaryAdmins.includes(address.toLowerCase());
+}
+
+export function triggerRolloutRollback(): void {
+  rolloutFlag.rollback = true;
+}
+
+export default rolloutFlag;

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -1,0 +1,30 @@
+describe('rollout feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT;
+    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS;
+    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isRolloutEnabled } = require('@/config/featureFlags');
+    expect(isRolloutEnabled('0x1')).toBe(false);
+  });
+
+  it('allows canary admins', () => {
+    process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS = '0xabc,0xdef';
+    jest.resetModules();
+    const { isRolloutEnabled } = require('@/config/featureFlags');
+    expect(isRolloutEnabled('0xAbC')).toBe(true);
+    expect(isRolloutEnabled('0x123')).toBe(false);
+  });
+
+  it('rollback disables feature', () => {
+    process.env.EXPO_PUBLIC_FEATURE_ROLLOUT = 'true';
+    jest.resetModules();
+    const mod = require('@/config/featureFlags');
+    expect(mod.isRolloutEnabled('0x1')).toBe(true);
+    mod.triggerRolloutRollback();
+    expect(mod.isRolloutEnabled('0x1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add feature flag config with canary admin rollout and rollback support
- test coverage for default disabled, canary access, and rollback

## Testing
- `npx eslint config/featureFlags.ts tests/config/featureFlags.test.ts && echo 'ESLint passed'`
- `yarn jest --runTestsByPath tests/config/featureFlags.test.ts` *(fails: No tests found; project config excludes the file)*

------
https://chatgpt.com/codex/tasks/task_e_68c719cb918883268ee8291ba6a7c76a