### PR TITLE
feat: add admin workflow metrics

### DIFF
--- a/agents/admin-agent.ts
+++ b/agents/admin-agent.ts
@@ -4,6 +4,10 @@ import { canonicalJson } from '@/utils/serialization';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 import AgentError from '@/types/AgentError';
 import type { WakuMessage } from '@/types/waku';
+import {
+  adminCountGauge,
+  adminUnauthorizedAttempts,
+} from '@/services/monitoring';
 
 interface AdminRecord {
   address: string;
@@ -40,6 +44,7 @@ export class AdminAgent extends EventEmitter {
     const admins = await this.getAdmins();
     admins.push(record);
     await writeRecords(ADMINS_KEY, admins);
+    adminCountGauge.set(admins.length);
   }
 
   private async queueRequest(record: AdminRecord): Promise<void> {
@@ -98,6 +103,7 @@ export class AdminAgent extends EventEmitter {
     const admins = await this.getAdmins();
     const isAdmin = admins.some((a) => a.publicKey === msg.sender.publicKey);
     if (!isAdmin) {
+      adminUnauthorizedAttempts.inc();
       throw new AgentError('E_UNAUTHORIZED', 'Only admins can approve', 'admin-agent');
     }
     const pending = await this.removeRequest(msg.payload.address);

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,10 +10,12 @@ Service modules use [pino](https://github.com/pinojs/pino) for structured loggin
 
 Metrics are exposed on `http://localhost:9464/metrics` by default. Set `METRICS_PORT` to change the port.
 
-Two metrics are exported:
+Key metrics:
 
 - `service_latency_seconds` – Histogram tracking service call latency.
 - `service_failures_total` – Counter of failed service calls.
+- `admin_unauthorized_attempts_total` – Counter of unauthorized admin actions.
+- `admin_count` – Gauge of currently registered admins.
 
 Prometheus alert thresholds are provided in [`scripts/monitoring/alerts.yml`](../scripts/monitoring/alerts.yml) for latency and failure rates.
 

--- a/scripts/monitoring/alerts.yml
+++ b/scripts/monitoring/alerts.yml
@@ -17,3 +17,11 @@ groups:
         annotations:
           summary: High service failure rate
           description: More than 5% of service calls failing over 5m.
+      - alert: AdminUnauthorizedAttempts
+        expr: rate(admin_unauthorized_attempts_total[1m]) > 3
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Excessive unauthorized admin attempts
+          description: More than 3 unauthorized admin actions per minute.

--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -6,6 +6,7 @@ import pino from 'pino';
 let Counter: any;
 let Histogram: any;
 let Registry: any;
+let Gauge: any;
 
 if (
   typeof process !== 'undefined' &&
@@ -16,15 +17,18 @@ if (
   Counter = promClient.Counter;
   Histogram = promClient.Histogram;
   Registry = promClient.Registry;
+  Gauge = promClient.Gauge;
 } else {
   class NoopMetric {
     startTimer() {
       return () => {};
     }
     inc() {}
+    set() {}
   }
   Counter = class extends NoopMetric {};
   Histogram = class extends NoopMetric {};
+  Gauge = class extends NoopMetric {};
   Registry = class {};
 }
 
@@ -42,6 +46,18 @@ export const failureCounter = new Counter({
   name: 'service_failures_total',
   help: 'Service call failures',
   labelNames: ['service'],
+  registers: [registry],
+});
+
+export const adminUnauthorizedAttempts = new Counter({
+  name: 'admin_unauthorized_attempts_total',
+  help: 'Unauthorized admin actions',
+  registers: [registry],
+});
+
+export const adminCountGauge = new Gauge({
+  name: 'admin_count',
+  help: 'Number of registered admins',
   registers: [registry],
 });
 

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -3,6 +3,11 @@ import { __clear } from './nearKvMock';
 import { sign, getPublicKey, utils } from '@noble/ed25519';
 import { canonicalJson } from '@/utils/serialization';
 import type { WakuMessage } from '@/types/waku';
+import {
+  adminCountGauge,
+  adminUnauthorizedAttempts,
+} from '@/services/monitoring';
+import '@/polyfills.web';
 
 jest.mock('@/services/nearKvStore', () => require('./nearKvMock'));
 
@@ -31,6 +36,8 @@ describe('AdminAgent', () => {
 
   beforeEach(() => {
     __clear();
+    adminUnauthorizedAttempts.reset();
+    adminCountGauge.set(0);
     agent = new AdminAgent();
   });
 
@@ -45,6 +52,7 @@ describe('AdminAgent', () => {
     await expect(event).resolves.toEqual({ address: 'addr1' });
     const admins = await agent.getAdmins();
     expect(admins).toHaveLength(1);
+    expect(adminCountGauge.hashMap[''].value).toBe(1);
   });
 
   it('queues subsequent admin requests for approval', async () => {
@@ -126,9 +134,12 @@ describe('AdminAgent', () => {
       priv3,
       pub3,
     );
+    const start = adminUnauthorizedAttempts.hashMap['']?.value || 0;
     await expect(agent.approveAdmin(badApprove)).rejects.toMatchObject({
       code: 'E_UNAUTHORIZED',
     });
+    const end = adminUnauthorizedAttempts.hashMap['']?.value || 0;
+    expect(end).toBe(start + 1);
   });
 
   it('rejects approvals with bad signatures', async () => {

--- a/tests/services/monitoring.test.ts
+++ b/tests/services/monitoring.test.ts
@@ -2,15 +2,16 @@ import { failureCounter, latencyHistogram, withMonitoring } from '@/services/mon
 
 describe('monitoring hooks', () => {
   it('records latency and failures', async () => {
-    const startCount = failureCounter.hashMap['service:test']?.value || 0;
+    const key = 'service:service:test,';
+    const start = failureCounter.hashMap[key]?.value || 0;
     await expect(
       withMonitoring('service:test', async () => {
         throw new Error('boom');
       }),
     ).rejects.toThrow('boom');
-    const endCount = failureCounter.hashMap['service:test']?.value || 0;
-    expect(endCount).toBe(startCount + 1);
-    const metric = latencyHistogram.hashMap['service:test'];
+    const end = failureCounter.hashMap[key]?.value || 0;
+    expect(end).toBe(start + 1);
+    const metric = latencyHistogram.hashMap[key];
     expect(metric).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- expose Prometheus metrics for admin count and unauthorized attempts
- update admin agent to emit metrics and configure alerting
- document new metrics and thresholds

## Testing
- `npx jest tests/adminAgent.test.ts --testMatch "**/tests/adminAgent.test.ts"`
- `npx jest tests/services/monitoring.test.ts --testMatch "**/tests/services/monitoring.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68c719af4104832688a504e4b40cbb43