### PR TITLE
Handle clock skew and wallet provider outages

### DIFF
--- a/docs/admin-revocation.md
+++ b/docs/admin-revocation.md
@@ -1,0 +1,22 @@
+# Admin Revocation Policy
+
+Administrators are tracked in the `admins` setting. Any wallet listed there may approve new
+admins and manage privileged settings. Removing a wallet from this list immediately revokes
+its admin powers across the network.
+
+## Revoking an Admin
+
+1. An existing admin opens the settings dashboard.
+2. The admin updates the `admins` list, removing the target wallet address.
+3. A signed `settings.write` event is broadcast so other peers prune the revoked admin.
+
+## Recovery
+
+* **Re‑approval:** A revoked wallet can broadcast a new `admin.request`. Another active admin
+  must approve the request to restore access.
+* **Lost all admins:** If the admin list becomes empty, the next valid `admin.request` is
+  automatically registered as the first admin. Operators can also set
+  `ADMIN_WALLET_ADDRESS` and restart the node to bootstrap a recovery wallet.
+
+Follow these steps to ensure admin privileges can be safely revoked and restored without
+compromising network integrity.

--- a/services/walletSelector.ts
+++ b/services/walletSelector.ts
@@ -6,6 +6,7 @@ import * as nearAPI from 'near-api-js';
 import { Buffer } from 'buffer';
 import { useEffect, useState } from 'react';
 import { nearConfig } from '@/services/config';
+import { getNearRpcUrls } from '@/utils/appConfig';
 
 // Ensure FailoverRpcProvider is available as a constructor
 const providers: any = (nearAPI as any).providers;
@@ -23,7 +24,9 @@ async function init() {
     return { selector: selector || undefined, error: initError } as const;
   }
   try {
-    const { networkId, contractId, walletUrl, rpcUrl, helperUrl } = nearConfig();
+    const { networkId, contractId, walletUrl, helperUrl } = nearConfig();
+    const rpcUrls = getNearRpcUrls();
+    const rpcUrl = await getHealthyRpcUrl(rpcUrls);
     if (contractId && (networkId === 'testnet') !== contractId.endsWith('.testnet')) {
       console.error(`CONTRACT_ID (${contractId}) does not match network ${networkId}`);
     }
@@ -40,6 +43,22 @@ async function init() {
     initError = e instanceof Error ? e : new Error(String(e));
   }
   return { selector: selector || undefined, error: initError } as const;
+}
+
+async function checkRpcHealth(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${url}/status`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function getHealthyRpcUrl(urls: string[]): Promise<string> {
+  for (const url of urls) {
+    if (await checkRpcHealth(url)) return url;
+  }
+  throw new Error('No healthy RPC URL available');
 }
 
 async function signIn(): Promise<void> {

--- a/tests/verifyBeforeWrite.test.ts
+++ b/tests/verifyBeforeWrite.test.ts
@@ -1,5 +1,8 @@
 import { getPublicKey, sign, utils } from '@noble/ed25519';
-import { verifyBeforeWrite } from '../utils/verifyMessageSignature';
+import {
+  verifyBeforeWrite,
+  TIMESTAMP_TOLERANCE_MS,
+} from '../utils/verifyMessageSignature';
 import { wakuMessageSchema } from '../schemas/waku';
 import { z } from 'zod';
 import { canonicalJson } from '../utils/serialization';
@@ -29,5 +32,37 @@ describe('verifyBeforeWrite', () => {
     await expect(
       verifyBeforeWrite(msg, schema, ['deadbeef']),
     ).resolves.toBeNull();
+  });
+
+  it('enforces timestamp tolerance window', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const pubHex = Buffer.from(pub).toString('hex');
+
+    const schema = wakuMessageSchema.extend({
+      type: z.literal('test'),
+      payload: z.object({ timestamp: z.number() }),
+    });
+
+    const makeMsg = async (ts: number) => {
+      const msg: WakuMessage<{ timestamp: number }> = {
+        type: 'test',
+        payload: { timestamp: ts },
+        sender: { publicKey: pubHex },
+        signature: '',
+      };
+      const bytes = new TextEncoder().encode(
+        canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+      );
+      const sig = await sign(bytes, priv);
+      msg.signature = Buffer.from(sig).toString('hex');
+      return msg;
+    };
+
+    const within = await makeMsg(Date.now());
+    await expect(verifyBeforeWrite(within, schema)).resolves.not.toBeNull();
+
+    const future = await makeMsg(Date.now() + TIMESTAMP_TOLERANCE_MS + 1000);
+    await expect(verifyBeforeWrite(future, schema)).resolves.toBeNull();
   });
 });

--- a/tests/walletSelector.test.ts
+++ b/tests/walletSelector.test.ts
@@ -1,0 +1,25 @@
+import { getHealthyRpcUrl } from '../services/walletSelector';
+
+describe('getHealthyRpcUrl', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    (global.fetch as any).mockClear?.();
+    global.fetch = originalFetch;
+  });
+
+  it('falls back to secondary RPC when primary fails', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValue({ ok: true } as any);
+    global.fetch = mockFetch as any;
+
+    const url = await getHealthyRpcUrl([
+      'https://primary.rpc',
+      'https://secondary.rpc',
+    ]);
+    expect(url).toBe('https://secondary.rpc');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/utils/verifyMessageSignature.ts
+++ b/utils/verifyMessageSignature.ts
@@ -4,6 +4,8 @@ import { canonicalJson } from './serialization';
 import { z } from 'zod';
 import { errorLog } from './logger';
 
+export const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
+
 export async function verifyMessageSignature<T>(
   message: WakuMessage<T>,
   publicKey: string,
@@ -43,6 +45,14 @@ export async function verifyBeforeWrite<T>(
   if (!ok) {
     errorLog('E_SIGNATURE_INVALID');
     return null;
+  }
+  const ts = (msg.payload as any)?.timestamp;
+  if (typeof ts === 'number') {
+    const skew = Math.abs(Date.now() - ts);
+    if (skew > TIMESTAMP_TOLERANCE_MS) {
+      errorLog('E_TIMESTAMP_SKEW');
+      return null;
+    }
   }
   if (allowedPublicKeys && !allowedPublicKeys.includes(msg.sender.publicKey)) {
     errorLog('E_UNAUTHORIZED');


### PR DESCRIPTION
## Summary
- add timestamp tolerance window during signature verification
- introduce RPC health checks with fallback selection for wallet provider
- document admin revocation policy and recovery steps

## Testing
- `npx -y jest tests/verifyBeforeWrite.test.ts tests/walletSelector.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npx -y eslint utils/verifyMessageSignature.ts services/walletSelector.ts tests/verifyBeforeWrite.test.ts tests/walletSelector.test.ts` *(fails: Cannot find module '@typescript-eslint/parser')*


------
https://chatgpt.com/codex/tasks/task_e_68c72172a9ec832690a40b34c7933296