### PR TITLE
Require admin approval for revenue transactions

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -22,6 +22,7 @@ import { errorLog } from '@/utils/logger';
 import { buildTopic } from '@/utils/wakuTopics';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import AgentError from '@/types/AgentError';
+import isAdmin from '@/utils/isAdmin';
 
 import {
   getProductCache,
@@ -172,8 +173,13 @@ class ProductsAgent {
   private async assertStoreOwner(storeId: string) {
     const { address } = await this.ensureWallet();
     const store = await getStore(storeId, storeId);
-    if (!store || store.owner !== address) {
-      throw new AgentError('UNAUTHORIZED', 'Only the store owner can manage products', 'products-agent');
+    const admin = await isAdmin();
+    if (!store || store.owner !== address || !admin) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only approved admins can manage products',
+        'products-agent',
+      );
     }
   }
 

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -4,7 +4,13 @@ import { fetchSettings } from './nearSettings';
 import { assertNearChain } from './chain';
 import config from '@/config';
 import { retryWithBackoff } from '@/utils/retry';
-import { logger, serviceLatency, serviceFailures } from '@/utils/observability';
+import {
+  logger,
+  serviceLatency,
+  serviceFailures,
+  adminTransactionIntegrity,
+} from '@/utils/observability';
+import isAdmin from '@/utils/isAdmin';
 
 assertNearChain();
 
@@ -24,9 +30,17 @@ async function sendNear(message: string): Promise<string> {
   return retryWithBackoff(async () => chainAdapter.signMessage?.(message) || '');
 }
 
+async function assertAdmin(action: string) {
+  if (!(await isAdmin())) {
+    adminTransactionIntegrity.inc({ action, result: 'unauthorized' });
+    throw new Error('Admin privileges required');
+  }
+}
+
 export async function deployOrderPayment(
   amount: number,
 ): Promise<{ contractAddress: string; txHash: string }> {
+  await assertAdmin('near.deployOrderPayment');
   const end = serviceLatency.startTimer({ service: 'near.deployOrderPayment' });
   try {
     const factoryAddress = await getOrderPaymentFactoryAddress();
@@ -37,11 +51,13 @@ export async function deployOrderPayment(
       `Pay:${amount}:${feeAddress}:${feeBps}`,
     );
     logger.info({ service: 'near.deployOrderPayment', txHash }, 'Order payment deployed');
+    adminTransactionIntegrity.inc({ action: 'near.deployOrderPayment', result: 'success' });
     return { contractAddress: factoryAddress, txHash };
   } catch (e) {
     serviceFailures.inc({ service: 'near.deployOrderPayment' });
     errorLog('Failed to deploy order payment', e);
     logger.error({ err: e }, 'Failed to deploy order payment');
+    adminTransactionIntegrity.inc({ action: 'near.deployOrderPayment', result: 'failure' });
     throw e;
   } finally {
     end();
@@ -49,15 +65,18 @@ export async function deployOrderPayment(
 }
 
 export async function releasePayment(contractAddress: string): Promise<string> {
+  await assertAdmin('near.releasePayment');
   const end = serviceLatency.startTimer({ service: 'near.releasePayment' });
   try {
     const tx = await sendNear(`Release:${contractAddress}`);
     logger.info({ service: 'near.releasePayment', contractAddress }, 'Payment released');
+    adminTransactionIntegrity.inc({ action: 'near.releasePayment', result: 'success' });
     return tx;
   } catch (e) {
     serviceFailures.inc({ service: 'near.releasePayment' });
     errorLog('Failed to release payment', e);
     logger.error({ err: e }, 'Failed to release payment');
+    adminTransactionIntegrity.inc({ action: 'near.releasePayment', result: 'failure' });
     throw e;
   } finally {
     end();
@@ -65,15 +84,18 @@ export async function releasePayment(contractAddress: string): Promise<string> {
 }
 
 export async function refundPayment(contractAddress: string): Promise<string> {
+  await assertAdmin('near.refundPayment');
   const end = serviceLatency.startTimer({ service: 'near.refundPayment' });
   try {
     const tx = await sendNear(`Refund:${contractAddress}`);
     logger.info({ service: 'near.refundPayment', contractAddress }, 'Payment refunded');
+    adminTransactionIntegrity.inc({ action: 'near.refundPayment', result: 'success' });
     return tx;
   } catch (e) {
     serviceFailures.inc({ service: 'near.refundPayment' });
     errorLog('Failed to refund payment', e);
     logger.error({ err: e }, 'Failed to refund payment');
+    adminTransactionIntegrity.inc({ action: 'near.refundPayment', result: 'failure' });
     throw e;
   } finally {
     end();
@@ -84,17 +106,20 @@ export async function adminResolve(
   contractAddress: string,
   toSeller: boolean,
 ): Promise<string> {
+  await assertAdmin('near.adminResolve');
   const end = serviceLatency.startTimer({ service: 'near.adminResolve' });
   try {
     const tx = await sendNear(
       `AdminResolve:${contractAddress}:${toSeller ? 1 : 0}`,
     );
     logger.info({ service: 'near.adminResolve', contractAddress }, 'Dispute resolved');
+    adminTransactionIntegrity.inc({ action: 'near.adminResolve', result: 'success' });
     return tx;
   } catch (e) {
     serviceFailures.inc({ service: 'near.adminResolve' });
     errorLog('Failed to resolve dispute', e);
     logger.error({ err: e }, 'Failed to resolve dispute');
+    adminTransactionIntegrity.inc({ action: 'near.adminResolve', result: 'failure' });
     throw e;
   } finally {
     end();

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -29,6 +29,15 @@ export const serviceFailures =
       })
     : { inc: () => {} };
 
+export const adminTransactionIntegrity =
+  prom
+    ? new prom.Counter({
+        name: 'admin_transaction_integrity_total',
+        help: 'Admin transaction results',
+        labelNames: ['action', 'result'],
+      })
+    : { inc: () => {} };
+
 let metricsStarted = false;
 export function startMetricsServer(
   port = Number(process.env.METRICS_PORT || 9464)


### PR DESCRIPTION
## Summary
- restrict product management to approved admins
- enforce admin checks on NEAR payment actions and record integrity metrics
- expose `admin_transaction_integrity_total` counter for admin transaction results

## Testing
- `npx eslint agents/products-agent.ts services/nearContract.ts utils/observability.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx jest tests/admin-disputes.test.tsx tests/cardCheckoutFee.test.ts tests/ordersAgent.test.ts tests/monitoring.test.ts tests/databaseService.test.ts` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_68c7217dfe988326b729fc228e3ec662