### PR TITLE
feat: add scoped admin permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,10 @@ additional guidance.
 
 Admin privileges are controlled by a list of wallet addresses stored in the
 on-chain settings contract. Use the **Admin → Settings** screen or
-`SettingsAgent.setAdmins()` to add or remove addresses. Only wallets in this
-allowlist can manage users, products or other system settings.
+`SettingsAgent.setAdmins()` to add or remove addresses. Each admin is assigned
+explicit scopes such as `admin:settings`, `admin:users`, or `admin:orders`
+to limit privileges. Only wallets in this allowlist with the proper scope can
+manage the associated resources.
 
 ### Credit Card Checkout
 

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -190,7 +190,9 @@ class OrdersAgent {
       order.driverAddress,
     ].filter(Boolean) as string[];
     if (!address || !allowed.includes(address)) {
-      const admins = await SettingsAgent.getInstance().getAdmins();
+      const admins = await SettingsAgent.getInstance().getAdminsWithScope(
+        'admin:orders',
+      );
       allowed = allowed.concat(admins);
       if (!address || !allowed.includes(address)) {
         throw new AgentError('UNAUTHORIZED', 'Unauthorized order update', 'orders-agent');

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -5,6 +5,8 @@ import {
   setSetting,
   getAdmins as fetchAdmins,
   setAdmins as storeAdmins,
+  getAdminScopes as fetchAdminScopes,
+  setAdminScopes as storeAdminScopes,
   getAdminPublicKeys as fetchAdminPublicKeys,
   setAdminPublicKeys as storeAdminPublicKeys,
   subscribeToSettingsWrites,
@@ -12,6 +14,8 @@ import {
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { canonicalJson } from '@/utils/serialization';
+import type { AdminScope } from '@/types';
+import { ALL_ADMIN_SCOPES } from '@/types';
 
 // In tests, the chain module may be partially mocked. Avoid hard-failing on import.
 if (typeof assertNearChain === 'function') {
@@ -37,6 +41,8 @@ class SettingsAgent {
   private adminsFetchedAt = 0;
   private adminPublicKeys: string[] = [];
   private adminPublicKeysFetchedAt = 0;
+  private adminScopes: Record<string, AdminScope[]> = {};
+  private adminScopesFetchedAt = 0;
   private static ADMIN_CACHE_TTL = 60000; // 1 minute
 
   private constructor() {
@@ -48,6 +54,10 @@ class SettingsAgent {
       if (evt.key === 'adminPublicKeys') {
         this.adminPublicKeys = [];
         this.adminPublicKeysFetchedAt = 0;
+      }
+      if (evt.key === 'adminScopes') {
+        this.adminScopes = {};
+        this.adminScopesFetchedAt = 0;
       }
     });
   }
@@ -75,6 +85,9 @@ class SettingsAgent {
   }
 
   async getAdmins(): Promise<string[]> {
+    await this.loadAdminScopes();
+    const scoped = Object.keys(this.adminScopes);
+    if (scoped.length > 0) return scoped;
     const now = Date.now();
     if (
       this.admins.length === 0 ||
@@ -86,12 +99,56 @@ class SettingsAgent {
     return this.admins;
   }
 
+  private async loadAdminScopes() {
+    const now = Date.now();
+    if (
+      Object.keys(this.adminScopes).length === 0 ||
+      now - this.adminScopesFetchedAt > SettingsAgent.ADMIN_CACHE_TTL
+    ) {
+      this.adminScopes = await fetchAdminScopes();
+      this.adminScopesFetchedAt = now;
+    }
+  }
+
+  async getAdminsWithScope(scope: AdminScope): Promise<string[]> {
+    await this.loadAdminScopes();
+    return Object.keys(this.adminScopes).filter((a) =>
+      this.adminScopes[a]?.includes(scope),
+    );
+  }
+
+  async hasAdminScope(address: string, scope: AdminScope): Promise<boolean> {
+    await this.loadAdminScopes();
+    return this.adminScopes[address]?.includes(scope) ?? false;
+  }
+
   async setAdmins(admins: string[]): Promise<void> {
     await this.ensureWallet();
     const actor = nearAuth.getAccountId()!;
     const normalized = normalizeMessage<string[]>('Admins', admins as any);
     await storeAdmins(normalized, actor);
     this.admins = normalized;
+    this.adminsFetchedAt = Date.now();
+    const scopes: Record<string, AdminScope[]> = {};
+    normalized.forEach((a) => {
+      scopes[a] = ALL_ADMIN_SCOPES;
+    });
+    await storeAdminScopes(scopes, actor);
+    this.adminScopes = scopes;
+    this.adminScopesFetchedAt = Date.now();
+  }
+
+  async setAdminScopes(scopes: Record<string, AdminScope[]>): Promise<void> {
+    await this.ensureWallet();
+    const actor = nearAuth.getAccountId()!;
+    const normalized = normalizeMessage<Record<string, AdminScope[]>>(
+      'AdminScopes',
+      scopes as any,
+    );
+    await storeAdminScopes(normalized, actor);
+    this.adminScopes = normalized;
+    this.adminScopesFetchedAt = Date.now();
+    this.admins = Object.keys(normalized);
     this.adminsFetchedAt = Date.now();
   }
 

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -35,9 +35,16 @@ class UsersAgent {
   async add(user: User): Promise<void> {
     const normalized = normalizeMessage<User>('User', user);
     const { address, publicKey } = await this.ensureWallet();
-    const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== normalized.address && !admins.includes(address)) {
-      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can add this user', 'users-agent');
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (address !== normalized.address && !hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only the user or an admin with scope admin:users can add this user',
+        'users-agent',
+      );
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = {
@@ -55,9 +62,16 @@ class UsersAgent {
   async update(user: User): Promise<void> {
     const normalized = normalizeMessage<User>('User', user);
     const { address, publicKey } = await this.ensureWallet();
-    const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== normalized.address && !admins.includes(address)) {
-      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can update this user', 'users-agent');
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (address !== normalized.address && !hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only the user or an admin with scope admin:users can update this user',
+        'users-agent',
+      );
     }
     const chatPublicKey = await getPublicKeyHex();
     const enriched: User = {
@@ -76,9 +90,16 @@ class UsersAgent {
     const { address } = await this.ensureWallet();
     const user = await getUser(id);
     if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
-    const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== user.address && !admins.includes(address)) {
-      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can remove this user', 'users-agent');
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (address !== user.address && !hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only the user or an admin with scope admin:users can remove this user',
+        'users-agent',
+      );
     }
     await removeUser(id);
   }
@@ -88,9 +109,16 @@ class UsersAgent {
     const { address, publicKey } = await this.ensureWallet();
     const user = await getUser(userId);
     if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
-    const admins = await SettingsAgent.getInstance().getAdmins();
-    if (address !== user.address && !admins.includes(address)) {
-      throw new AgentError('UNAUTHORIZED', 'Only the user or an admin can request KYC', 'users-agent');
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (address !== user.address && !hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only the user or an admin with scope admin:users can request KYC',
+        'users-agent',
+      );
     }
     const enriched: User = normalizeMessage<User>('User', {
       ...user,
@@ -110,9 +138,16 @@ class UsersAgent {
     adminId?: string,
   ): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
-    const admins = await SettingsAgent.getInstance().getAdmins();
-    if (!admins.includes(address)) {
-      throw new AgentError('UNAUTHORIZED', 'Only admins can update KYC', 'users-agent');
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (!hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only admins with scope admin:users can update KYC',
+        'users-agent',
+      );
     }
     const user = await getUser(userId);
     if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');

--- a/docs/admin-revocation.md
+++ b/docs/admin-revocation.md
@@ -1,0 +1,15 @@
+# Admin Revocation Procedure
+
+Compromised administrators must be removed quickly to prevent abuse. Follow these steps:
+
+1. **Broadcast Revocation**
+   - An authorized admin with `admin:settings` scope sends an updated `adminScopes` map removing the compromised address.
+   - Optionally, remove the address from the `admins` list entirely.
+2. **Propagate Update**
+   - All nodes listening to `/blue-ocean/settings/1` receive the `settings.write` event and refresh cached admin scopes.
+3. **Invalidate Sessions**
+   - Purge any local sessions or keys associated with the revoked admin.
+4. **Audit**
+   - Record the revocation event and monitor for any further activity from the compromised key.
+
+Revocation takes effect once the settings update is processed across the network.

--- a/services/__mocks__/nearSettings.ts
+++ b/services/__mocks__/nearSettings.ts
@@ -1,4 +1,6 @@
 import { canonicalJson } from '@/utils/serialization';
+import { ALL_ADMIN_SCOPES } from '@/types';
+import type { AdminScope } from '@/types';
 
 const store: Record<string, string> = {};
 
@@ -16,6 +18,19 @@ export async function getAdmins(): Promise<string[]> {
 
 export async function setAdmins(admins: string[]): Promise<void> {
   store['admins'] = canonicalJson(admins);
+  const scopes: Record<string, AdminScope[]> = {};
+  admins.forEach((a) => {
+    scopes[a] = ALL_ADMIN_SCOPES;
+  });
+  store['adminScopes'] = canonicalJson(scopes);
+}
+
+export async function getAdminScopes(): Promise<Record<string, AdminScope[]>> {
+  return store['adminScopes'] ? JSON.parse(store['adminScopes']) : {};
+}
+
+export async function setAdminScopes(scopes: Record<string, AdminScope[]>): Promise<void> {
+  store['adminScopes'] = canonicalJson(scopes);
 }
 
 export async function fetchSettings() {
@@ -28,6 +43,7 @@ export async function fetchSettings() {
     feeAddress: store['feeAddress'] ?? '',
     feeBps: store['feeBps'] ? Number(store['feeBps']) : 0,
     admins: store['admins'] ? JSON.parse(store['admins']) : [],
+    adminScopes: store['adminScopes'] ? JSON.parse(store['adminScopes']) : {},
     rpcUrl: store['rpcUrl'] ?? '',
     rpcFallbackUrls: store['rpcFallbackUrls']
       ? JSON.parse(store['rpcFallbackUrls'])

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 import { sign } from '@noble/ed25519';
 import { canonicalJson } from '@/utils/serialization';
 import { getPrivateKey, getPublicKeyHex } from './localIdentity';
+import type { AdminScope } from '@/types';
+import { ALL_ADMIN_SCOPES } from '@/types';
 
 assertNearChain();
 
@@ -41,6 +43,7 @@ export interface NearSettings {
   feeAddress?: string;
   feeBps?: number;
   admins: string[];
+  adminScopes: Record<string, AdminScope[]>;
   adminPublicKeys: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
@@ -183,6 +186,12 @@ export async function fetchSettings(): Promise<NearSettings> {
   }
   const admins = map['admins'] ? JSON.parse(map['admins']) : [];
   const finalAdmins = admins.length > 0 ? admins : [ADMIN_ADDRESS].filter(Boolean);
+  const adminScopes = map['adminScopes'] ? JSON.parse(map['adminScopes']) : {};
+  if (Object.keys(adminScopes).length === 0) {
+    finalAdmins.forEach((a) => {
+      adminScopes[a] = ALL_ADMIN_SCOPES;
+    });
+  }
   return {
     tenantId: map['tenantId'] ?? 'blue-ocean',
     appName: map['appName'] ?? 'Blue Ocean',
@@ -192,6 +201,7 @@ export async function fetchSettings(): Promise<NearSettings> {
     feeAddress: map['feeAddress'] ?? '',
     feeBps,
     admins: finalAdmins,
+    adminScopes,
     adminPublicKeys: map['adminPublicKeys']
       ? JSON.parse(map['adminPublicKeys'])
       : [],
@@ -222,8 +232,29 @@ export async function getAdmins(): Promise<string[]> {
   }
 }
 
+export async function getAdminScopes(): Promise<Record<string, AdminScope[]>> {
+  const raw = await getSetting('adminScopes');
+  try {
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function setAdminScopes(
+  scopes: Record<string, AdminScope[]>,
+  actor: string,
+): Promise<void> {
+  await setSetting('adminScopes', canonicalJson(scopes), actor);
+}
+
 export async function setAdmins(admins: string[], actor: string): Promise<void> {
   await setSetting('admins', canonicalJson(admins), actor);
+  const scopes: Record<string, AdminScope[]> = {};
+  admins.forEach((a) => {
+    scopes[a] = ALL_ADMIN_SCOPES;
+  });
+  await setAdminScopes(scopes, actor);
 }
 
 export async function getAdminPublicKeys(): Promise<string[]> {

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -20,10 +20,12 @@ jest.mock('@/services/nearOrders', () => ({
 jest.mock('../agents/notifications-agent', () => ({ broadcast: jest.fn() }));
 jest.mock('../agents/stores-agent', () => ({ updateReputationByOwner: jest.fn() }));
 
-const getAdminsMock = jest.fn().mockResolvedValue(['admin']);
+const getAdminsWithScopeMock = jest.fn().mockResolvedValue(['admin']);
 jest.mock('../agents/settings-agent', () => ({
   __esModule: true,
-  default: { getInstance: () => ({ getAdmins: getAdminsMock }) },
+  default: {
+    getInstance: () => ({ getAdminsWithScope: getAdminsWithScopeMock }),
+  },
 }));
 
 jest.mock('@/services/nearContract', () => ({

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -55,7 +55,7 @@ describe('SettingsAgent NEAR integration', () => {
   });
 
   it('refreshes admin list on settings write event', async () => {
-    const getSpy = jest.spyOn(nearSettings, 'getAdmins');
+    const getSpy = jest.spyOn(nearSettings, 'getAdminScopes');
     const agent = SettingsAgent.getInstance();
     await agent.setAdmins(['addr_admin']);
 
@@ -94,7 +94,7 @@ describe('SettingsAgent NEAR integration', () => {
   });
 
   it('resets admin cache TTL after setAdmins', async () => {
-    const getSpy = jest.spyOn(nearSettings, 'getAdmins');
+    const getSpy = jest.spyOn(nearSettings, 'getAdminScopes');
     const agent = SettingsAgent.getInstance();
     await agent.setAdmins(['addr_admin']);
     jest.advanceTimersByTime(20);

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -1,4 +1,5 @@
 import usersAgent from '../agents/users-agent';
+import SettingsAgent from '../agents/settings-agent';
 
 jest.mock('../utils/validateNearAddress', () => ({
   __esModule: true,
@@ -16,13 +17,18 @@ jest.mock('@/services/localIdentity', () => ({
 }));
 
 jest.mock('@/services/nearKvStore', () => require('./nearKvMock'));
-import { __clear } from './nearKvMock';
-import { setAdmins } from '@/services/nearSettings';
+import { __clear, setValue } from './nearKvMock';
 
 describe('UsersAgent NEAR integration', () => {
   beforeEach(() => {
     __clear();
-    void setAdmins(['addr_admin'], 'addr_admin');
+    (SettingsAgent as any).instance = undefined;
+    setValue('settings', 'admins', JSON.stringify(['addr_admin']));
+    setValue(
+      'settings',
+      'adminScopes',
+      JSON.stringify({ addr_admin: ['admin:settings', 'admin:users', 'admin:orders'] }),
+    );
   });
 
   it('adds and retrieves users via NEAR service', async () => {
@@ -74,5 +80,21 @@ describe('UsersAgent NEAR integration', () => {
       publicKey: '',
     };
     await expect(usersAgent.add(user)).rejects.toThrow('Invalid NEAR address');
+  });
+
+  it('denies admin without users scope', async () => {
+    const user: any = {
+      id: 'u4',
+      username: 'dave',
+      displayName: 'Dave',
+      role: 'user',
+      address: '',
+      publicKey: '',
+    };
+    await usersAgent.add(user);
+    setValue('settings', 'adminScopes', JSON.stringify({ addr_admin: ['admin:settings'] }));
+    await expect(usersAgent.updateKyc('u4', 'verified')).rejects.toThrow(
+      'Only admins',
+    );
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -126,6 +126,12 @@ export interface ChatRoom {
 export type KycStatus = 'none' | 'pending' | 'verified' | 'rejected';
 export type CustomerTier = 'new' | 'regular' | 'vip' | 'banned';
 export type UserRole = 'user' | 'driver' | 'admin' | 'store-owner' | 'platform-admin';
+export type AdminScope = 'admin:settings' | 'admin:users' | 'admin:orders';
+export const ALL_ADMIN_SCOPES: AdminScope[] = [
+  'admin:settings',
+  'admin:users',
+  'admin:orders',
+];
 
 export interface User {
   id: string;

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,9 +1,13 @@
 import { chainAdapter } from '@/services/chain';
 import SettingsAgent from '../agents/settings-agent';
+import type { AdminScope } from '@/types';
 
-export default async function isAdmin(): Promise<boolean> {
+export default async function isAdmin(scope?: AdminScope): Promise<boolean> {
   const address = chainAdapter.getAccountId();
   if (!address) return false;
+  if (scope) {
+    return await SettingsAgent.getInstance().hasAdminScope(address, scope);
+  }
   const admins = await SettingsAgent.getInstance().getAdmins();
   return admins.includes(address);
 }


### PR DESCRIPTION
## Summary
- define admin scopes and default permissions
- enforce scoped admin checks in agents
- document admin revocation procedure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx --no-install jest` *(fails: missing packages "jest@30.1.3")*

------
https://chatgpt.com/codex/tasks/task_e_68c7216385a0832694850c7675dd2ed0