### PR TITLE
feat: add warm cache with diff hydration

### DIFF
--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'events';
+import { fetchHistory, subscribeWithAck } from '@/services/waku';
+
+export const E_STALE_DATA = 'E_STALE_DATA';
+
+export interface DiffMessage<T> {
+  id: string;
+  rev: number;
+  op: 'set' | 'delete';
+  value?: T;
+}
+
+export interface WarmCache<T> {
+  getById(id: string): T | undefined;
+  subscribe(
+    filter: (id: string, value: T | undefined) => boolean,
+    cb: (id: string, value: T | undefined) => void,
+  ): () => void;
+  onSynced(cb: () => void): () => void;
+}
+
+export function createWarmCache<T>(topic: string): WarmCache<T> {
+  const store = new Map<string, { value: T; rev: number }>();
+  const emitter = new EventEmitter();
+  let synced = false;
+  let stale = false;
+  const buffer: DiffMessage<T>[] = [];
+
+  function apply(msg: DiffMessage<T>): void {
+    const current = store.get(msg.id);
+    if (current && msg.rev !== current.rev + 1) {
+      stale = true;
+      emitter.emit('error', { code: E_STALE_DATA, id: msg.id });
+      return;
+    }
+    if (msg.op === 'delete') {
+      store.delete(msg.id);
+    } else if (msg.value !== undefined) {
+      store.set(msg.id, { value: msg.value, rev: msg.rev });
+    }
+    emitter.emit('update', msg.id, store.get(msg.id)?.value);
+  }
+
+  (async () => {
+    try {
+      const unsub = await subscribeWithAck(topic, (msg: DiffMessage<T>) => {
+        if (!synced) buffer.push(msg);
+        else apply(msg);
+      });
+      await fetchHistory(topic, apply);
+      buffer.forEach(apply);
+      buffer.length = 0;
+      synced = true;
+      emitter.emit('cache.synced');
+      // expose unsubscribe on emitter
+      (emitter as any).unsub = unsub;
+    } catch (err) {
+      stale = true;
+      emitter.emit('error', { code: E_STALE_DATA, err });
+    }
+  })();
+
+  return {
+    getById(id: string) {
+      if (stale) throw { code: E_STALE_DATA };
+      return store.get(id)?.value;
+    },
+    subscribe(filter, cb) {
+      const handler = (id: string, value: T | undefined) => {
+        if (filter(id, value)) cb(id, value);
+      };
+      emitter.on('update', handler);
+      return () => emitter.off('update', handler);
+    },
+    onSynced(cb: () => void) {
+      if (synced) cb();
+      emitter.on('cache.synced', cb);
+      return () => emitter.off('cache.synced', cb);
+    },
+  };
+}
+
+export default { createWarmCache, E_STALE_DATA };

--- a/tests/services/warmCache.test.ts
+++ b/tests/services/warmCache.test.ts
@@ -1,0 +1,35 @@
+import { createWarmCache, E_STALE_DATA, DiffMessage } from '@/services/warmCache';
+
+const history: DiffMessage<any>[] = [
+  { id: '1', rev: 1, op: 'set', value: { name: 'a' } },
+  { id: '2', rev: 1, op: 'set', value: { name: 'b' } },
+];
+
+let liveHandler: ((msg: DiffMessage<any>) => void) | null = null;
+
+jest.mock('@/services/waku', () => ({
+  fetchHistory: jest.fn(async (_topic: string, cb: (m: DiffMessage<any>) => void) => {
+    history.forEach(cb);
+  }),
+  subscribeWithAck: jest.fn(async (_topic: string, cb: (m: DiffMessage<any>) => void) => {
+    liveHandler = cb;
+    return () => {};
+  }),
+}));
+
+describe('warmCache', () => {
+  it('hydrates and applies diffs', async () => {
+    const cache = createWarmCache<any>('topic');
+    await new Promise((res) => cache.onSynced(res));
+    expect(cache.getById('1')).toEqual({ name: 'a' });
+    liveHandler && liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'a2' } });
+    expect(cache.getById('1')).toEqual({ name: 'a2' });
+  });
+
+  it('detects stale data', async () => {
+    const cache = createWarmCache<any>('topic');
+    await new Promise((res) => cache.onSynced(res));
+    liveHandler && liveHandler({ id: '1', rev: 4, op: 'set', value: { name: 'bad' } });
+    expect(() => cache.getById('1')).toThrowErrorMatchingObject({ code: E_STALE_DATA });
+  });
+});


### PR DESCRIPTION
## Summary
- add warm cache service that hydrates from history and applies live diffs
- expose getById, subscribe, and sync events with stale detection
- cover warm cache behavior with unit tests

## Testing
- `npx eslint services/warmCache.ts tests/services/warmCache.test.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: merge conflict markers and missing tsconfig base)*
- `npx jest tests/services/warmCache.test.ts` *(fails: requires installing jest@30.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c7238d04388326aab51296afbfafaa