### PR TITLE
Document cache contract for caches and diff messages

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,51 @@
+# Cache Contract
+
+Defines the public interface for cache consumers and diff publishers.
+
+## Message History Stream
+History hydration delivers an array of entries. Each entry includes a stable `id`, a monotonically increasing `version`, and the full object value.
+
+Schema: [`schemas/cache/history.ts`](../schemas/cache/history.ts)
+
+## Real‑time Diff Messages
+After hydration, updates are sent as diffs describing mutations to an entry.
+
+Schema: [`schemas/cache/diff.ts`](../schemas/cache/diff.ts)
+
+## API Reference
+
+### `getById(id)`
+Retrieves an entry from the cache by its unique identifier.
+
+- **Parameters**
+  - `id` (`string`): cache key to look up.
+- **Returns**: `Promise<T | null>` resolving to the cached value or `null` if missing.
+- **Errors**: throws `{ code: 'E_STALE_DATA' }` when the stored snapshot hash does not match the expected hash.
+
+### `subscribe(filter)`
+Subscribes to real‑time diff messages.
+
+- **Parameters**
+  - `filter` (`Record<string, unknown>`): criteria to select which entries emit updates.
+- **Returns**: `() => void` unsubscribe function.
+- **Events**: receives messages matching `cacheDiffMessageSchema`.
+
+### `{cache.synced}` event
+Emitted once the message history stream finishes and the cache is up to date.
+
+- **Payload**: `{ id: string }` for the cache namespace that synced.
+
+## Error Handling
+
+### `E_STALE_DATA`
+Thrown when a local snapshot hash differs from the authoritative hash.
+
+```json
+{
+  "code": "E_STALE_DATA",
+  "expected": "<expected hash>",
+  "actual": "<actual hash>"
+}
+```
+
+Consumers should discard the snapshot and rehydrate from message history when this error is encountered.

--- a/schemas/cache/diff.ts
+++ b/schemas/cache/diff.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const cacheDiffOpSchema = z.object({
+  op: z.enum(['set', 'delete']),
+  path: z.string(),
+  value: z.unknown().optional(),
+});
+
+export const cacheDiffMessageSchema = z.object({
+  id: z.string(),
+  version: z.number(),
+  ops: z.array(cacheDiffOpSchema),
+});
+
+export type CacheDiffMessage<T = unknown> = z.infer<typeof cacheDiffMessageSchema> & {
+  ops: Array<z.infer<typeof cacheDiffOpSchema> & { value?: T }>;
+};
+
+export function parseCacheDiffMessage<T>(
+  data: unknown,
+  valueSchema: z.ZodType<T>,
+): CacheDiffMessage<T> | null {
+  const schema = cacheDiffMessageSchema.extend({
+    ops: z.array(cacheDiffOpSchema.extend({ value: valueSchema.optional() })),
+  });
+  const res = schema.safeParse(data);
+  return res.success ? (res.data as CacheDiffMessage<T>) : null;
+}

--- a/schemas/cache/errors.ts
+++ b/schemas/cache/errors.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const E_STALE_DATA = 'E_STALE_DATA' as const;
+
+export const staleDataErrorSchema = z.object({
+  code: z.literal(E_STALE_DATA),
+  expected: z.string(),
+  actual: z.string(),
+});
+
+export type StaleDataError = z.infer<typeof staleDataErrorSchema>;
+
+export function parseStaleDataError(data: unknown): StaleDataError | null {
+  const res = staleDataErrorSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/schemas/cache/history.ts
+++ b/schemas/cache/history.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const cacheHistoryEntrySchema = z.object({
+  id: z.string(),
+  version: z.number(),
+  value: z.unknown(),
+});
+
+export type CacheHistoryEntry<T = unknown> = z.infer<typeof cacheHistoryEntrySchema> & {
+  value: T;
+};
+
+export const cacheHistoryStreamSchema = z.array(cacheHistoryEntrySchema);
+export type CacheHistoryStream<T = unknown> = CacheHistoryEntry<T>[];
+
+export function parseCacheHistoryStream<T>(
+  data: unknown,
+  valueSchema: z.ZodType<T>,
+): CacheHistoryStream<T> | null {
+  const schema = cacheHistoryEntrySchema.extend({ value: valueSchema });
+  const res = z.array(schema).safeParse(data);
+  return res.success ? (res.data as CacheHistoryStream<T>) : null;
+}

--- a/schemas/cache/index.ts
+++ b/schemas/cache/index.ts
@@ -1,0 +1,3 @@
+export * from './history';
+export * from './diff';
+export * from './errors';

--- a/services/cache/index.ts
+++ b/services/cache/index.ts
@@ -2,6 +2,8 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import config from '@/config';
+import AgentError from '@/types/AgentError';
+import { E_STALE_DATA } from '@/schemas/cache';
 
 const CACHE_DIR = config.CACHE_DIR || path.join(process.cwd(), '.cache');
 const SECRET = config.CACHE_SECRET || 'blue-ocean';
@@ -37,9 +39,14 @@ export async function loadSnapshot<T>(key: string, expectedHash: string): Promis
     decipher.setAuthTag(tag);
     const json = Buffer.concat([decipher.update(enc), decipher.final()]);
     const hash = crypto.createHash('sha256').update(json).digest('hex');
-    if (hash !== expectedHash) return null;
+    if (hash !== expectedHash)
+      throw Object.assign(
+        new AgentError(E_STALE_DATA, 'Snapshot hash mismatch', 'cache'),
+        { expected: expectedHash, actual: hash },
+      );
     return JSON.parse(json.toString('utf8')) as T;
-  } catch {
+  } catch (err) {
+    if (err instanceof AgentError) throw err;
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- add cache history and diff schemas and expose from `schemas/cache`
- document cache consumer APIs and `E_STALE_DATA` handling in developer docs
- surface `E_STALE_DATA` in cache snapshot loader

## Testing
- `yarn lint docs/cache.md schemas/cache services/cache/index.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Merge conflict marker encountered)*
- `yarn test` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72469dda4832683831a83355f32e0