### PR TITLE
docs: add cache invalidation guide and quickstart examples

### DIFF
--- a/docs/cache-invalidation.md
+++ b/docs/cache-invalidation.md
@@ -1,0 +1,50 @@
+# Cache Invalidation
+
+Guidelines for keeping cache entries fresh across peers.
+
+## When to Invalidate
+
+The cache persists snapshots locally so the app can start in an offline-first mode. Invalidate a record when:
+
+- `getById` throws `E_STALE_DATA` indicating a hash mismatch.
+- A newer `version` or `updatedAt` timestamp is detected from a message.
+- The entry has been explicitly revoked or deleted by an admin event.
+
+## Handling `E_STALE_DATA`
+
+```ts
+try {
+  const value = await cache.getById(id);
+} catch (err) {
+  if (err.code === 'E_STALE_DATA') {
+    // Drop the persisted snapshot and rehydrate from message history
+    await cache.hydrate(id);
+  }
+}
+```
+
+## Manual Busting
+
+If an entry becomes invalid due to business rules or a soft delete, remove it from the local store:
+
+```ts
+await persistentStore.remove(id);
+```
+
+On the next subscription update the cache will rehydrate the item if it still exists remotely.
+
+## Timestamp-Based TTL
+
+For data that should expire, compare the `updatedAt` timestamp to a locally derived threshold. Always convert the ISO value into the user's locale to avoid timezone drift:
+
+```ts
+const expiresAt = new Date(entry.updatedAt);
+if (expiresAt.toLocaleString() < new Date().toLocaleString()) {
+  await persistentStore.remove(entry.id);
+}
+```
+
+## Offline-First Considerations
+
+All invalidation steps should operate on the persisted snapshot so that stale records are removed even when the device is offline. Localized timestamps ensure that comparisons work consistently regardless of user locale.
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart
+
+Get up and running with the cache API.
+
+## Load an Entry with `getById`
+
+```ts
+import { cache } from '@blue-ocean/cache';
+
+async function bootstrap() {
+  const product = await cache.getById('product:1');
+  if (product) {
+    // Convert timestamps for the current locale
+    console.log(new Date(product.updatedAt).toLocaleString());
+  }
+}
+```
+
+`getById` resolves from the offline snapshot first so the UI can render immediately even without a network connection.
+
+## Listen for Updates with `subscribe`
+
+```ts
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const unsubscribe = cache.subscribe({ type: 'product' }, async diff => {
+  // Merge diff into local model
+  const next = applyDiff(diff);
+  // Persist the update for offline-first usage
+  await AsyncStorage.setItem(`product:${next.id}`, JSON.stringify(next));
+  // Work with localized timestamps
+  console.log(new Date(next.updatedAt).toLocaleString());
+});
+```
+
+Remember to call `unsubscribe()` when the listener is no longer needed.
+
+## Offline-First & Timestamp Handling
+
+Persisting snapshots (e.g. with `AsyncStorage`) allows the cache to survive restarts and offline periods. Always convert ISO timestamp strings with `toLocaleString` or `Intl.DateTimeFormat` so users see values in their local timezone.
+


### PR DESCRIPTION
## Summary
- document cache invalidation strategies
- add quickstart examples for `getById` and `subscribe`

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: merge conflict markers in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c7319bd2fc832697f3a2fd43b0f7a7