### PR TITLE
feat: gate warm cache behind feature flag

### DIFF
--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -1,40 +1,40 @@
 import { z } from 'zod';
 
 const envSchema = z.object({
-  EXPO_PUBLIC_FEATURE_ROLLOUT: z.string().optional().default('false'),
-  EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS: z
+  EXPO_PUBLIC_WARM_CACHE: z.string().optional().default('false'),
+  EXPO_PUBLIC_WARM_CACHE_CANARY_ADMINS: z
     .string()
     .optional()
     .default(''),
-  EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK: z.string().optional().default('false'),
+  EXPO_PUBLIC_WARM_CACHE_ROLLBACK: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
 
-export interface RolloutFeatureFlag {
+export interface WarmCacheFeatureFlag {
   enabled: boolean;
   canaryAdmins: string[];
   rollback: boolean;
 }
 
-const rolloutFlag: RolloutFeatureFlag = {
-  enabled: env.EXPO_PUBLIC_FEATURE_ROLLOUT === 'true',
-  canaryAdmins: env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS
+const warmCacheFlag: WarmCacheFeatureFlag = {
+  enabled: env.EXPO_PUBLIC_WARM_CACHE === 'true',
+  canaryAdmins: env.EXPO_PUBLIC_WARM_CACHE_CANARY_ADMINS
     .split(',')
     .map((a) => a.trim().toLowerCase())
     .filter(Boolean),
-  rollback: env.EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK === 'true',
+  rollback: env.EXPO_PUBLIC_WARM_CACHE_ROLLBACK === 'true',
 };
 
-export function isRolloutEnabled(address?: string): boolean {
-  if (rolloutFlag.rollback) return false;
-  if (rolloutFlag.enabled) return true;
+export function isWarmCacheEnabled(address?: string): boolean {
+  if (warmCacheFlag.rollback) return false;
+  if (warmCacheFlag.enabled) return true;
   if (!address) return false;
-  return rolloutFlag.canaryAdmins.includes(address.toLowerCase());
+  return warmCacheFlag.canaryAdmins.includes(address.toLowerCase());
 }
 
-export function triggerRolloutRollback(): void {
-  rolloutFlag.rollback = true;
+export function triggerWarmCacheRollback(): void {
+  warmCacheFlag.rollback = true;
 }
 
-export default rolloutFlag;
+export default warmCacheFlag;

--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { fetchHistory, subscribeWithAck } from '@/services/waku';
+import { isWarmCacheEnabled } from '@/config/featureFlags';
 
 export const E_STALE_DATA = 'E_STALE_DATA';
 
@@ -17,6 +18,10 @@ export interface WarmCache<T> {
     cb: (id: string, value: T | undefined) => void,
   ): () => void;
   onSynced(cb: () => void): () => void;
+  registerReconciler(
+    address: string,
+    fn: (id: string, value: T | undefined) => void,
+  ): () => void;
 }
 
 export function createWarmCache<T>(topic: string): WarmCache<T> {
@@ -25,6 +30,7 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
   let synced = false;
   let stale = false;
   const buffer: DiffMessage<T>[] = [];
+  const reconcilers = new Map<string, (id: string, value: T | undefined) => void>();
 
   function apply(msg: DiffMessage<T>): void {
     const current = store.get(msg.id);
@@ -38,7 +44,11 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
     } else if (msg.value !== undefined) {
       store.set(msg.id, { value: msg.value, rev: msg.rev });
     }
-    emitter.emit('update', msg.id, store.get(msg.id)?.value);
+    const value = store.get(msg.id)?.value;
+    emitter.emit('update', msg.id, value);
+    reconcilers.forEach((fn, addr) => {
+      if (isWarmCacheEnabled(addr)) fn(msg.id, value);
+    });
   }
 
   (async () => {
@@ -62,7 +72,7 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
 
   return {
     getById(id: string) {
-      if (stale) throw { code: E_STALE_DATA };
+      if (stale || !isWarmCacheEnabled()) throw { code: E_STALE_DATA };
       return store.get(id)?.value;
     },
     subscribe(filter, cb) {
@@ -76,6 +86,11 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
       if (synced) cb();
       emitter.on('cache.synced', cb);
       return () => emitter.off('cache.synced', cb);
+    },
+    registerReconciler(address, fn) {
+      const key = address.toLowerCase();
+      reconcilers.set(key, fn);
+      return () => reconcilers.delete(key);
     },
   };
 }

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -1,30 +1,30 @@
-describe('rollout feature flag', () => {
+describe('warm cache feature flag', () => {
   beforeEach(() => {
-    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT;
-    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS;
-    delete process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_ROLLBACK;
+    delete process.env.EXPO_PUBLIC_WARM_CACHE;
+    delete process.env.EXPO_PUBLIC_WARM_CACHE_CANARY_ADMINS;
+    delete process.env.EXPO_PUBLIC_WARM_CACHE_ROLLBACK;
     jest.resetModules();
   });
 
   it('is disabled by default', () => {
-    const { isRolloutEnabled } = require('@/config/featureFlags');
-    expect(isRolloutEnabled('0x1')).toBe(false);
+    const { isWarmCacheEnabled } = require('@/config/featureFlags');
+    expect(isWarmCacheEnabled('0x1')).toBe(false);
   });
 
   it('allows canary admins', () => {
-    process.env.EXPO_PUBLIC_FEATURE_ROLLOUT_CANARY_ADMINS = '0xabc,0xdef';
+    process.env.EXPO_PUBLIC_WARM_CACHE_CANARY_ADMINS = '0xabc,0xdef';
     jest.resetModules();
-    const { isRolloutEnabled } = require('@/config/featureFlags');
-    expect(isRolloutEnabled('0xAbC')).toBe(true);
-    expect(isRolloutEnabled('0x123')).toBe(false);
+    const { isWarmCacheEnabled } = require('@/config/featureFlags');
+    expect(isWarmCacheEnabled('0xAbC')).toBe(true);
+    expect(isWarmCacheEnabled('0x123')).toBe(false);
   });
 
   it('rollback disables feature', () => {
-    process.env.EXPO_PUBLIC_FEATURE_ROLLOUT = 'true';
+    process.env.EXPO_PUBLIC_WARM_CACHE = 'true';
     jest.resetModules();
     const mod = require('@/config/featureFlags');
-    expect(mod.isRolloutEnabled('0x1')).toBe(true);
-    mod.triggerRolloutRollback();
-    expect(mod.isRolloutEnabled('0x1')).toBe(false);
+    expect(mod.isWarmCacheEnabled('0x1')).toBe(true);
+    mod.triggerWarmCacheRollback();
+    expect(mod.isWarmCacheEnabled('0x1')).toBe(false);
   });
 });

--- a/tests/services/warmCache.test.ts
+++ b/tests/services/warmCache.test.ts
@@ -1,4 +1,7 @@
-import { createWarmCache, E_STALE_DATA, DiffMessage } from '@/services/warmCache';
+import type { DiffMessage } from '@/services/warmCache';
+
+let createWarmCache: any;
+let E_STALE_DATA: string;
 
 let history: DiffMessage<any>[] = [];
 let liveHandler: ((msg: DiffMessage<any>) => void) | null = null;
@@ -16,6 +19,11 @@ jest.mock('@/services/waku', () => ({
 }));
 
 beforeEach(() => {
+  process.env.EXPO_PUBLIC_WARM_CACHE = 'true';
+  delete process.env.EXPO_PUBLIC_WARM_CACHE_CANARY_ADMINS;
+  delete process.env.EXPO_PUBLIC_WARM_CACHE_ROLLBACK;
+  jest.resetModules();
+  ({ createWarmCache, E_STALE_DATA } = require('@/services/warmCache'));
   history = [
     { id: '1', rev: 1, op: 'set', value: { name: 'a' } },
     { id: '2', rev: 1, op: 'set', value: { name: 'b' } },
@@ -66,6 +74,21 @@ describe('warmCache', () => {
     const cache = createWarmCache<any>('topic');
     await new Promise((res) => setTimeout(res, 0));
     expect(() => cache.getById('1')).toThrowErrorMatchingObject({ code: E_STALE_DATA });
+  });
+
+  it('processes canary reconcilers only for allowed admins', async () => {
+    const flags = require('@/config/featureFlags');
+    flags.default.canaryAdmins = ['0xabc'];
+    const cache = createWarmCache<any>('topic');
+    await new Promise((res) => cache.onSynced(res));
+    const hitsA: any[] = [];
+    const hitsB: any[] = [];
+    cache.registerReconciler('0xAbC', (id, value) => hitsA.push({ id, value }));
+    cache.registerReconciler('0xdef', (id, value) => hitsB.push({ id, value }));
+    liveHandler &&
+      liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'a2' } });
+    expect(hitsA).toEqual([{ id: '1', value: { name: 'a2' } }]);
+    expect(hitsB).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `warmCache` feature flag with canary admins and rollback switch
- wire warm cache service to feature flag and support canary reconcilers
- expand tests for warm cache rollout behaviour

## Testing
- `npx -y jest tests/config/featureFlags.test.ts tests/services/warmCache.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c732e5737c8326a5ef02fd2006fdbd