### PR TITLE
feat: secure offline cache and timestamp localization

### DIFF
--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -13,7 +13,18 @@ import {
   Platform,
 } from 'react-native';
 import SmartImage from './SmartImage';
-import { X, CircleCheck as CheckCircle, Circle, Package, Truck, MapPin, Star, Phone, MessageCircle, Copy } from 'lucide-react-native';
+import {
+  X,
+  CircleCheck as CheckCircle,
+  Circle,
+  Package,
+  Truck,
+  MapPin,
+  Star,
+  Phone,
+  MessageCircle,
+  Copy,
+} from 'lucide-react-native';
 import { Order, OrderStatus } from '../types';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useCurrency } from '../contexts/CurrencyContext';
@@ -21,6 +32,7 @@ import OrderService from '@/services/orders';
 import * as Clipboard from 'expo-clipboard';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/ui/ThemeProvider';
+import { formatTimestamp } from '@/utils/formatTimestamp';
 
 
 
@@ -136,17 +148,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
     }
   };
 
-  const formatDate = (dateString: string) => {
-    if (!dateString) return '';
-    const date = new Date(dateString);
-    return date.toLocaleString('he-IL', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
+  const formatDate = (dateString: string) => formatTimestamp(dateString);
 
   const contactCourier = () => {
     // In a real app, this would initiate a call or message to the courier

--- a/packages/sdk-near/src/waku/index.ts
+++ b/packages/sdk-near/src/waku/index.ts
@@ -36,7 +36,10 @@ async function ensureNode(): Promise<LightNode | null> {
  * Fetch and cache all historical messages for a given topic.
  * Subsequent calls only append new unseen messages, preventing duplicates.
  */
-export async function hydrateMessages(topic: string): Promise<any[]> {
+export async function hydrateMessages(
+  topic: string,
+  timeBudgetMs = 2500,
+): Promise<any[]> {
   const n = await ensureNode();
   if (!n) return messageCache.get(topic) || [];
   const client: any = await getClient();
@@ -44,11 +47,18 @@ export async function hydrateMessages(topic: string): Promise<any[]> {
   const decoder = client.createDecoder(topic, {});
   const existing = messageCache.get(topic) || [];
   const seen = seenCache.get(topic) || new Set<string>();
+  const start = Date.now();
+  let total = 0;
+  let duplicates = 0;
   for await (const batch of (n.store.queryGenerator as any)({ decoder })) {
-    for (const msg of (batch.messages || [])) {
+    for (const msg of batch.messages || []) {
       if (!msg.payload) continue;
+      total += 1;
       const key = Buffer.from(msg.payload).toString('hex');
-      if (seen.has(key)) continue;
+      if (seen.has(key)) {
+        duplicates += 1;
+        continue;
+      }
       seen.add(key);
       try {
         const parsed = JSON.parse(Buffer.from(msg.payload).toString('utf8'));
@@ -57,9 +67,23 @@ export async function hydrateMessages(topic: string): Promise<any[]> {
         // ignore unparsable messages
       }
     }
+    if (Date.now() - start > timeBudgetMs) {
+      break;
+    }
   }
+  const duration = Date.now() - start;
   seenCache.set(topic, seen);
   messageCache.set(topic, existing);
+  if (duration > timeBudgetMs) {
+    console.warn('hydrateMessages time budget exceeded', {
+      topic,
+      duration,
+      total,
+      duplicates,
+    });
+  } else if (process.env.NODE_ENV !== 'production') {
+    console.debug('hydrateMessages', { topic, duration, total, duplicates });
+  }
   return existing;
 }
 

--- a/src/features/products/services/productCache.ts
+++ b/src/features/products/services/productCache.ts
@@ -1,16 +1,34 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { aesEncrypt, aesDecrypt } from '@/utils/encryption';
 
 const PRODUCT_CACHE_KEY = 'product_index_cache';
+const PRODUCT_CACHE_SECRET = 'product_index_cache_secret';
+const MAX_CACHE_BYTES = 5 * 1024 * 1024; // 5MB quota
 
 export interface ProductCache {
   version: number;
   index: string[];
 }
 
+async function getKey(): Promise<CryptoKey> {
+  let secret = await SecureStore.getItemAsync(PRODUCT_CACHE_SECRET);
+  if (!secret) {
+    const bytes = crypto.getRandomValues(new Uint8Array(32));
+    secret = Buffer.from(bytes).toString('base64');
+    await SecureStore.setItemAsync(PRODUCT_CACHE_SECRET, secret);
+  }
+  const raw = Uint8Array.from(Buffer.from(secret, 'base64'));
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+}
+
 export async function getProductCache(): Promise<ProductCache | null> {
   try {
     const raw = await AsyncStorage.getItem(PRODUCT_CACHE_KEY);
-    return raw ? (JSON.parse(raw) as ProductCache) : null;
+    if (!raw) return null;
+    const key = await getKey();
+    const json = await aesDecrypt(raw, key);
+    return JSON.parse(json) as ProductCache;
   } catch {
     return null;
   }
@@ -18,7 +36,12 @@ export async function getProductCache(): Promise<ProductCache | null> {
 
 export async function setProductCache(cache: ProductCache): Promise<void> {
   try {
-    await AsyncStorage.setItem(PRODUCT_CACHE_KEY, JSON.stringify(cache));
+    const data = JSON.stringify(cache);
+    const size = new TextEncoder().encode(data).length;
+    if (size > MAX_CACHE_BYTES) return;
+    const key = await getKey();
+    const enc = await aesEncrypt(data, key);
+    await AsyncStorage.setItem(PRODUCT_CACHE_KEY, enc);
   } catch {
     /* ignore */
   }

--- a/src/utils/formatTimestamp.ts
+++ b/src/utils/formatTimestamp.ts
@@ -1,0 +1,16 @@
+export function formatTimestamp(dateString: string, options?: Intl.DateTimeFormatOptions): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  const locale = typeof navigator !== 'undefined' ? navigator.language : undefined;
+  const formatter = new Intl.DateTimeFormat(locale, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    ...options,
+  });
+  return formatter.format(date);
+}
+
+export default formatTimestamp;


### PR DESCRIPTION
## Summary
- add locale-aware timestamp formatter and use in order tracking modal
- encrypt product cache with size quota for offline-first privacy
- profile Waku hydration and enforce 2.5s time budget

## Testing
- `yarn lint` *(fails: Parsing error due to pre-existing merge conflict markers)*
- `yarn typecheck` *(fails: Merge conflict markers in src/features/stores files)*
- `yarn config:check` *(fails: Cannot find module 'config/vault')*
- `yarn test` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c734639e5c83268f84f4cc99be27bb