### PR TITLE
feat: add scoped session token service

### DIFF
--- a/services/session.ts
+++ b/services/session.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from 'events';
+import { uuid } from '@/utils/uuid';
+
+export const sessionEvents = new EventEmitter();
+
+const POLICY = new Set<string>(['read', 'write']);
+
+export interface SessionToken {
+  token: string;
+  scopes: string[];
+  exp: number;
+}
+
+function validateScopes(scopes: string[]): void {
+  const invalid = scopes.find((s) => !POLICY.has(s));
+  if (invalid) {
+    throw new Error('{E_SCOPE}');
+  }
+}
+
+export function requestScopes(
+  scopes: string[],
+  signer: (message: string) => string,
+  ttlMs = 60 * 60 * 1000,
+): SessionToken {
+  validateScopes(scopes);
+  const exp = Date.now() + ttlMs;
+  const payload = JSON.stringify({ scopes, exp });
+  const token = signer(payload) || uuid();
+  const record: SessionToken = { token, scopes, exp };
+  store.set(token, record);
+  return record;
+}
+
+const store = new Map<string, SessionToken>();
+
+export function validateToken(token: string, requiredScopes: string[]): void {
+  const rec = store.get(token);
+  if (!rec) throw new Error('{E_EXPIRED}');
+  if (Date.now() > rec.exp) {
+    store.delete(token);
+    throw new Error('{E_EXPIRED}');
+  }
+  validateScopes(requiredScopes);
+  const missing = requiredScopes.find((s) => !rec.scopes.includes(s));
+  if (missing) throw new Error('{E_SCOPE}');
+}
+
+export function refreshToken(
+  token: string,
+  signer: (message: string) => string,
+  ttlMs = 60 * 60 * 1000,
+): SessionToken {
+  const rec = store.get(token);
+  if (!rec) throw new Error('{E_EXPIRED}');
+  if (Date.now() > rec.exp) {
+    store.delete(token);
+    throw new Error('{E_EXPIRED}');
+  }
+  const next = requestScopes(rec.scopes, signer, ttlMs);
+  store.delete(token);
+  sessionEvents.emit('token.rotated', { old: token, token: next.token });
+  return next;
+}
+

--- a/tests/auth/session.test.ts
+++ b/tests/auth/session.test.ts
@@ -1,0 +1,24 @@
+import { requestScopes, validateToken, refreshToken, sessionEvents } from '@/services/session';
+
+describe('session tokens', () => {
+  const signer = (msg: string) => `sig:${msg}`;
+
+  it('rejects invalid scopes', () => {
+    expect(() => requestScopes(['foo'], signer)).toThrow('{E_SCOPE}');
+  });
+
+  it('throws when token expired', () => {
+    const { token } = requestScopes(['read'], signer, -1);
+    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+  });
+
+  it('rotates token on refresh', () => {
+    const { token } = requestScopes(['read'], signer, 1000);
+    const events: any[] = [];
+    sessionEvents.once('token.rotated', (e) => events.push(e));
+    const next = refreshToken(token, signer, 1000);
+    expect(events[0]).toEqual({ old: token, token: next.token });
+    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+    expect(() => validateToken(next.token, ['read'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- create session token service with scope validation and rotation
- add tests for scoped session tokens

## Testing
- `npx jest tests/auth/session.test.ts tests/auth/sessionRoleRefresh.test.ts tests/auth/keyRecovery.test.ts tests/auth/roleRevocation.test.tsx` *(fails: Need to install the following packages: jest@30.1.3)*
- `npm install --no-save jest@29.7.0 ts-jest@29.4.1 @types/jest@29` *(fails: Unsupported URL Type "link:")*

------
https://chatgpt.com/codex/tasks/task_e_68c77a7000c48326bd792229246887d5