### PR TITLE
test: add auth session coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -142,6 +142,7 @@ const cfg = {
     '<rootDir>/tests/indexers/**/*.test.ts',
     '<rootDir>/tests/auth/**/*.test.ts',
     '<rootDir>/tests/auth/**/*.test.tsx',
+    '<rootDir>/tests/auth/**/*.spec.ts',
   ],
 
   setupFiles: ['<rootDir>/tests/initGlobals.ts'],

--- a/tests/auth/session.spec.ts
+++ b/tests/auth/session.spec.ts
@@ -1,0 +1,28 @@
+import { requestScopes, validateToken } from '@/services/session';
+
+describe('session scope validation', () => {
+  const signer = (msg: string) => `sig:${msg}`;
+
+  it('rejects invalid scope requests', () => {
+    expect(() => requestScopes(['foo'], signer)).toThrow('{E_SCOPE}');
+  });
+
+  it('throws on validating with unknown scopes', () => {
+    const { token } = requestScopes(['read'], signer);
+    expect(() => validateToken(token, ['foo'])).toThrow('{E_SCOPE}');
+  });
+
+  it('throws when required scope not granted', () => {
+    const { token } = requestScopes(['read'], signer);
+    expect(() => validateToken(token, ['write'])).toThrow('{E_SCOPE}');
+  });
+
+  it('throws when token missing', () => {
+    expect(() => validateToken('nope', ['read'])).toThrow('{E_EXPIRED}');
+  });
+
+  it('throws when token expired', () => {
+    const { token } = requestScopes(['read'], signer, -1);
+    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+  });
+});

--- a/tests/auth/session.test.ts
+++ b/tests/auth/session.test.ts
@@ -1,24 +1,29 @@
 import { requestScopes, validateToken, refreshToken, sessionEvents } from '@/services/session';
 
-describe('session tokens', () => {
+describe('session token lifecycle', () => {
   const signer = (msg: string) => `sig:${msg}`;
 
-  it('rejects invalid scopes', () => {
-    expect(() => requestScopes(['foo'], signer)).toThrow('{E_SCOPE}');
-  });
-
-  it('throws when token expired', () => {
-    const { token } = requestScopes(['read'], signer, -1);
-    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
-  });
-
-  it('rotates token on refresh', () => {
-    const { token } = requestScopes(['read'], signer, 1000);
+  it('refreshToken rotates token and extends expiry', async () => {
+    const { token, exp } = requestScopes(['read'], signer, 50);
     const events: any[] = [];
     sessionEvents.once('token.rotated', (e) => events.push(e));
-    const next = refreshToken(token, signer, 1000);
+
+    // simulate background refresh before expiry
+    await new Promise((r) => setTimeout(r, 10));
+    const next = refreshToken(token, signer, 50);
+
     expect(events[0]).toEqual({ old: token, token: next.token });
-    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+    expect(next.exp).toBeGreaterThan(exp);
     expect(() => validateToken(next.token, ['read'])).not.toThrow();
+  });
+
+  it('revoked token fails validation with {E_EXPIRED}', async () => {
+    const { token } = requestScopes(['read'], signer, 1000);
+    await new Promise((r) => setTimeout(r, 10));
+    const next = refreshToken(token, signer, 1000);
+
+    expect(next.token).not.toBe(token);
+    expect(() => validateToken(next.token, ['read'])).not.toThrow();
+    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for session scope validation and error handling
- exercise token rotation and revocation in integration tests
- run jest over both spec and test files

## Testing
- `npx eslint tests/auth/session.spec.ts tests/auth/session.test.ts jest.config.js`
- `npx jest tests/auth/session.spec.ts tests/auth/session.test.ts --collectCoverage=false --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c77c589c808326a8a067070fd23680