### PR TITLE
docs: document session token contract

### DIFF
--- a/docs/session-tokens.md
+++ b/docs/session-tokens.md
@@ -1,0 +1,49 @@
+# Session Tokens API
+
+Blue Ocean uses short-lived session tokens to authorize actions with fine-grained scopes.
+Tokens are created by signing a scope request with a user's wallet. Keys and signatures are
+never stored; only the resulting token string is kept in memory.
+
+## Issue Token
+
+`requestScopes(scopes, signer, ttlMs?)`
+
+The wallet signs the following payload (`ScopeRequestPayload`):
+
+```ts
+{
+  scopes: string[]; // requested capabilities
+  exp: number;      // Unix ms expiration
+}
+```
+
+The signature becomes the session token. The response contains:
+
+```json
+{
+  "token": "string",
+  "scopes": ["read"],
+  "exp": 1700000000000
+}
+```
+
+## Refresh Token
+
+`refreshToken(token, signer, ttlMs?)` rotates an existing token and emits a `{token.rotated}` event:
+
+```json
+{
+  "old": "previousToken",
+  "token": "newToken"
+}
+```
+
+Clients should replace the old token with the new value and discard the previous signature.
+
+## Errors
+
+- `{E_SCOPE}` – unknown or insufficient scope requested/validated.
+- `{E_EXPIRED}` – token missing or expired.
+
+Wallet signatures must be generated using privacy-first key usage: the signing key is kept in
+memory only for the duration of the operation and is never persisted to disk.

--- a/schemas/auth/index.ts
+++ b/schemas/auth/index.ts
@@ -1,0 +1,2 @@
+export * from './scope.request';
+export * from './wallet.signature';

--- a/schemas/auth/scope.request.ts
+++ b/schemas/auth/scope.request.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+// Payload that a wallet signs when requesting a scoped session token.
+// The payload itself is not stored; only the resulting signature (token)
+// is kept in memory.
+export const scopeRequestSchema = z.object({
+  scopes: z.array(z.string()),
+  exp: z.number().int().positive(),
+});
+
+export type ScopeRequestPayload = z.infer<typeof scopeRequestSchema>;

--- a/schemas/auth/wallet.signature.ts
+++ b/schemas/auth/wallet.signature.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// Result of signing an arbitrary message using a wallet's private key.
+// Signatures should be generated on demand and must not be persisted to disk.
+export const walletSignatureSchema = z.object({
+  message: z.string(),
+  signature: z.string(),
+});
+
+export type WalletSignature = z.infer<typeof walletSignatureSchema>;


### PR DESCRIPTION
## Summary
- document session token issuance, rotation and errors
- add zod schemas for scope request and wallet signature

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: Need to install jest@30.1.3)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run typecheck` *(fails: merge conflict markers and missing tsconfig base)*

------
https://chatgpt.com/codex/tasks/task_e_68c77c285a9c8326b2ca77ea6bd9c505