### PR TITLE
feat: add scoped token rollout flags

### DIFF
--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -7,6 +7,12 @@ const envSchema = z.object({
     .optional()
     .default(''),
   EXPO_PUBLIC_WARM_CACHE_ROLLBACK: z.string().optional().default('false'),
+  EXPO_PUBLIC_SCOPED_TOKENS: z.string().optional().default('false'),
+  EXPO_PUBLIC_SCOPED_TOKENS_WALLET_VENDORS: z
+    .string()
+    .optional()
+    .default(''),
+  EXPO_PUBLIC_SCOPED_TOKENS_ROLLBACK: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -26,6 +32,21 @@ const warmCacheFlag: WarmCacheFeatureFlag = {
   rollback: env.EXPO_PUBLIC_WARM_CACHE_ROLLBACK === 'true',
 };
 
+export interface ScopedTokensFeatureFlag {
+  enabled: boolean;
+  walletVendors: string[];
+  rollback: boolean;
+}
+
+const scopedTokensFlag: ScopedTokensFeatureFlag = {
+  enabled: env.EXPO_PUBLIC_SCOPED_TOKENS === 'true',
+  walletVendors: env.EXPO_PUBLIC_SCOPED_TOKENS_WALLET_VENDORS
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean),
+  rollback: env.EXPO_PUBLIC_SCOPED_TOKENS_ROLLBACK === 'true',
+};
+
 export function isWarmCacheEnabled(address?: string): boolean {
   if (warmCacheFlag.rollback) return false;
   if (warmCacheFlag.enabled) return true;
@@ -36,5 +57,17 @@ export function isWarmCacheEnabled(address?: string): boolean {
 export function triggerWarmCacheRollback(): void {
   warmCacheFlag.rollback = true;
 }
+
+export function isScopedTokensEnabled(vendor?: string): boolean {
+  if (scopedTokensFlag.rollback) return false;
+  if (scopedTokensFlag.enabled) return true;
+  if (!vendor) return false;
+  return scopedTokensFlag.walletVendors.includes(vendor);
+}
+
+export function triggerScopedTokensRollback(): void {
+  scopedTokensFlag.rollback = true;
+}
+export { scopedTokensFlag };
 
 export default warmCacheFlag;

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -28,3 +28,34 @@ describe('warm cache feature flag', () => {
     expect(mod.isWarmCacheEnabled('0x1')).toBe(false);
   });
 });
+
+describe('scoped tokens feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_SCOPED_TOKENS;
+    delete process.env.EXPO_PUBLIC_SCOPED_TOKENS_WALLET_VENDORS;
+    delete process.env.EXPO_PUBLIC_SCOPED_TOKENS_ROLLBACK;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isScopedTokensEnabled } = require('@/config/featureFlags');
+    expect(isScopedTokensEnabled('near-wallet')).toBe(false);
+  });
+
+  it('allows canary wallet vendors', () => {
+    process.env.EXPO_PUBLIC_SCOPED_TOKENS_WALLET_VENDORS = 'near-wallet,foo-wallet';
+    jest.resetModules();
+    const { isScopedTokensEnabled } = require('@/config/featureFlags');
+    expect(isScopedTokensEnabled('near-wallet')).toBe(true);
+    expect(isScopedTokensEnabled('bar-wallet')).toBe(false);
+  });
+
+  it('rollback disables feature', () => {
+    process.env.EXPO_PUBLIC_SCOPED_TOKENS = 'true';
+    jest.resetModules();
+    const mod = require('@/config/featureFlags');
+    expect(mod.isScopedTokensEnabled('near-wallet')).toBe(true);
+    mod.triggerScopedTokensRollback();
+    expect(mod.isScopedTokensEnabled('near-wallet')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add scoped token feature flag with wallet-vendor allowlist and rollback support
- test scoped token feature flag behavior

## Testing
- `npx jest tests/config/featureFlags.test.ts` *(fails: Need to install the following packages: jest@30.1.3)*
- `yarn install --silent --no-progress` *(aborted: command interrupted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c781da3c988326a9720cc7264b7ac1