### PR TITLE
feat: add secure token cache and consent prompts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { View, Text } from 'react-native';
@@ -8,6 +8,7 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { Spinner } from '@/ui';
 import AppProviders from '@/providers/AppProviders';
 import { isRouterEnabled } from '@/services/config';
+import { initSessionTokens } from '@/services/session';
 
 const USE_ROUTER = isRouterEnabled();
 
@@ -25,6 +26,9 @@ function FallbackScreen() {
 }
 
 function MainApp() {
+  useEffect(() => {
+    initSessionTokens();
+  }, []);
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>

--- a/components/ConsentPrompt.tsx
+++ b/components/ConsentPrompt.tsx
@@ -1,0 +1,15 @@
+import { Alert, Platform } from 'react-native';
+
+export default function consentPrompt(scopes: string[]): Promise<boolean> {
+  const msg = `Allow access to: ${scopes.join(', ')}?`;
+  return new Promise((resolve) => {
+    if (Platform.OS === 'web') {
+      resolve(window.confirm(msg));
+      return;
+    }
+    Alert.alert('Permissions', msg, [
+      { text: 'Deny', style: 'cancel', onPress: () => resolve(false) },
+      { text: 'Allow', onPress: () => resolve(true) },
+    ]);
+  });
+}

--- a/docs/session-tokens.md
+++ b/docs/session-tokens.md
@@ -2,11 +2,15 @@
 
 Blue Ocean uses short-lived session tokens to authorize actions with fine-grained scopes.
 Tokens are created by signing a scope request with a user's wallet. Keys and signatures are
-never stored; only the resulting token string is kept in memory.
+never stored; issued tokens are cached in encrypted device storage for offline refresh.
 
 ## Issue Token
 
 `requestScopes(scopes, signer, ttlMs?)`
+
+For UX flows that require explicit approval, `requestTokenWithConsent(scopes, signer, ttlMs?)`
+will lazily load a lightweight consent prompt and measure the time to interactive. If the
+prompt takes longer than 2.5 s to appear, a warning is logged.
 
 The wallet signs the following payload (`ScopeRequestPayload`):
 
@@ -39,6 +43,8 @@ The signature becomes the session token. The response contains:
 ```
 
 Clients should replace the old token with the new value and discard the previous signature.
+Persisted tokens are loaded on startup via `initSessionTokens()` so apps can refresh or
+validate sessions while offline.
 
 ## Errors
 

--- a/services/consent.ts
+++ b/services/consent.ts
@@ -1,0 +1,11 @@
+export async function requestConsent(scopes: string[]): Promise<boolean> {
+  const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const prompt = (await import('@/components/ConsentPrompt')).default;
+  const ok = await prompt(scopes);
+  const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const tti = end - start;
+  if (tti > 2500) {
+    console.warn(`[consent] prompt TTI ${Math.round(tti)}ms`);
+  }
+  return ok;
+}

--- a/services/session.ts
+++ b/services/session.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 import { uuid } from '@/utils/uuid';
+import { saveSession, loadSessions, removeSession } from '@/services/tokenCache';
+import { requestConsent } from '@/services/consent';
 
 export const sessionEvents = new EventEmitter();
 
@@ -29,10 +31,18 @@ export function requestScopes(
   const token = signer(payload) || uuid();
   const record: SessionToken = { token, scopes, exp };
   store.set(token, record);
+  void saveSession(record);
   return record;
 }
 
 const store = new Map<string, SessionToken>();
+
+export async function initSessionTokens(): Promise<void> {
+  const records = await loadSessions();
+  for (const r of records) {
+    store.set(r.token, r);
+  }
+}
 
 export function validateToken(token: string, requiredScopes: string[]): void {
   const rec = store.get(token);
@@ -59,7 +69,18 @@ export function refreshToken(
   }
   const next = requestScopes(rec.scopes, signer, ttlMs);
   store.delete(token);
+  void removeSession(token);
   sessionEvents.emit('token.rotated', { old: token, token: next.token });
   return next;
+}
+
+export async function requestTokenWithConsent(
+  scopes: string[],
+  signer: (message: string) => string,
+  ttlMs = 60 * 60 * 1000,
+): Promise<SessionToken> {
+  const ok = await requestConsent(scopes);
+  if (!ok) throw new Error('{E_DENIED}');
+  return requestScopes(scopes, signer, ttlMs);
 }
 

--- a/services/tokenCache.ts
+++ b/services/tokenCache.ts
@@ -1,0 +1,54 @@
+import * as SecureStore from 'expo-secure-store';
+import type { SessionToken } from '@/services/session';
+
+const INDEX_KEY = 'session-token-index';
+
+async function readIndex(): Promise<string[]> {
+  try {
+    const raw = await SecureStore.getItemAsync(INDEX_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeIndex(list: string[]): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(INDEX_KEY, JSON.stringify(list));
+  } catch {}
+}
+
+export async function saveSession(record: SessionToken): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(
+      `session-${record.token}`,
+      JSON.stringify(record),
+    );
+    const idx = await readIndex();
+    if (!idx.includes(record.token)) {
+      idx.push(record.token);
+      await writeIndex(idx);
+    }
+  } catch {}
+}
+
+export async function loadSessions(): Promise<SessionToken[]> {
+  const idx = await readIndex();
+  const out: SessionToken[] = [];
+  for (const token of idx) {
+    try {
+      const raw = await SecureStore.getItemAsync(`session-${token}`);
+      if (raw) out.push(JSON.parse(raw));
+    } catch {}
+  }
+  return out;
+}
+
+export async function removeSession(token: string): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(`session-${token}`);
+    const idx = await readIndex();
+    const next = idx.filter((t) => t !== token);
+    await writeIndex(next);
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- persist session tokens in encrypted secure store for offline refresh
- request tokens via consent prompt with TTI profiling
- hydrate session cache on app boot

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Merge conflict marker encountered)*

------
https://chatgpt.com/codex/tasks/task_e_68c7821bc46c8326a1d5866f9236508d