### PR TITLE
feat: instrument auth metrics and alerts

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -16,6 +16,9 @@ Key metrics:
 - `service_failures_total` – Counter of failed service calls.
 - `admin_unauthorized_attempts_total` – Counter of unauthorized admin actions.
 - `admin_count` – Gauge of currently registered admins.
+- `auth_rate_limit_total` – Counter of auth requests rejected by rate limiting.
+- `auth_scope_requests_total` – Counter of auth scope checks.
+- `auth_invalid_scope_total` – Counter of auth scope checks with invalid scopes.
 
 Prometheus alert thresholds are provided in [`scripts/monitoring/alerts.yml`](../scripts/monitoring/alerts.yml) for latency and failure rates.
 

--- a/scripts/monitoring/alerts.yml
+++ b/scripts/monitoring/alerts.yml
@@ -25,3 +25,19 @@ groups:
         annotations:
           summary: Excessive unauthorized admin attempts
           description: More than 3 unauthorized admin actions per minute.
+      - alert: AuthRateLimitSpike
+        expr: rate(auth_rate_limit_total[1m]) > 5
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Spike in auth rate limiting
+          description: More than 5 auth requests per minute rejected due to rate limiting.
+      - alert: InvalidAuthScope
+        expr: sum(rate(auth_invalid_scope_total[5m])) / sum(rate(auth_scope_requests_total[5m])) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High rate of invalid auth scope requests
+          description: Invalid scope requests exceed 1% of total over 5m.

--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -75,6 +75,24 @@ export const cacheHitRatioGauge = new Gauge({
   registers: [registry],
 });
 
+export const authRateLimitCounter = new Counter({
+  name: 'auth_rate_limit_total',
+  help: 'Number of auth requests rejected due to rate limiting',
+  registers: [registry],
+});
+
+export const authScopeRequestCounter = new Counter({
+  name: 'auth_scope_requests_total',
+  help: 'Total auth scope requests',
+  registers: [registry],
+});
+
+export const authInvalidScopeCounter = new Counter({
+  name: 'auth_invalid_scope_total',
+  help: 'Auth scope requests with invalid scopes',
+  registers: [registry],
+});
+
 export async function withMonitoring<T>(
   service: string,
   fn: () => Promise<T>,

--- a/services/session.ts
+++ b/services/session.ts
@@ -2,10 +2,34 @@ import { EventEmitter } from 'events';
 import { uuid } from '@/utils/uuid';
 import { saveSession, loadSessions, removeSession } from '@/services/tokenCache';
 import { requestConsent } from '@/services/consent';
+import {
+  authRateLimitCounter,
+  authScopeRequestCounter,
+  authInvalidScopeCounter,
+} from '@/services/monitoring';
 
 export const sessionEvents = new EventEmitter();
 
 const POLICY = new Set<string>(['read', 'write']);
+
+// Simple fixed-window rate limiter for scope requests
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 60;
+let rateWindowStart = Date.now();
+let rateCount = 0;
+
+function assertRateLimit() {
+  const now = Date.now();
+  if (now - rateWindowStart > RATE_LIMIT_WINDOW_MS) {
+    rateWindowStart = now;
+    rateCount = 0;
+  }
+  rateCount += 1;
+  if (rateCount > RATE_LIMIT_MAX) {
+    authRateLimitCounter.inc();
+    throw new Error('{E_RATE_LIMIT}');
+  }
+}
 
 export interface SessionToken {
   token: string;
@@ -14,8 +38,10 @@ export interface SessionToken {
 }
 
 function validateScopes(scopes: string[]): void {
+  authScopeRequestCounter.inc();
   const invalid = scopes.find((s) => !POLICY.has(s));
   if (invalid) {
+    authInvalidScopeCounter.inc();
     throw new Error('{E_SCOPE}');
   }
 }
@@ -25,6 +51,7 @@ export function requestScopes(
   signer: (message: string) => string,
   ttlMs = 60 * 60 * 1000,
 ): SessionToken {
+  assertRateLimit();
   validateScopes(scopes);
   const exp = Date.now() + ttlMs;
   const payload = JSON.stringify({ scopes, exp });


### PR DESCRIPTION
## Summary
- add auth rate limit, scope request, and invalid scope metrics
- implement basic auth scope rate limiting and tracking
- alert on auth rate limit spikes and invalid scope ratios

## Testing
- `npx eslint services/monitoring.ts services/session.ts`
- `npx tsc -p tsconfig.json --noEmit` *(fails: merge conflict markers in unrelated files)*
- `npx jest tests/auth/session.test.ts tests/auth/session.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c781b4a2f083268ea916e73c94d934