### PR TITLE
Require session token for checkout

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -36,6 +36,7 @@ Events published on `/blue-ocean/{tenantId}/analytics/1` follow this structure:
 | `cart.clear` | `{}` |
 | `checkout.start` | `{ items: number, total: number }` |
 | `checkout.complete` | `{ orderIds: string[], total: number, cacheHitRatio: number }` |
+| `checkout.token_integrity` | `{ tokenValid: boolean, success: boolean }` |
 | `chat.view` | `{ messageCount: number }` |
 | `chat.load_more` | `{ messageCount: number }` |
 

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -18,6 +18,7 @@ import { adminResolve, deployOrderPayment } from './nearContract';
 import config from '../utils/appConfig';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
+import { validateToken } from '@/services/session';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
@@ -119,7 +120,9 @@ class OrderService {
       buyerAddress?: string;
       sellerAddress?: string;
     },
+    sessionToken: string,
   ): Promise<Order> {
+    validateToken(sessionToken, ['write']);
     const total = items.reduce((sum, item) => {
       const price = item.unitPrice ?? item.product.price;
       return sum + price * item.quantity;
@@ -178,45 +181,68 @@ class OrderService {
     cartItems: CartItem[],
     shippingAddress: ShippingAddress,
     paymentMethod: 'cash_on_delivery' | 'near' | 'card' = 'cash_on_delivery',
+    sessionToken: string,
   ): Promise<Order[]> {
-    const grouped: Record<string, CartItem[]> = {};
-    for (const item of cartItems) {
-      const storeId = item.product.storeId;
-      if (!grouped[storeId]) grouped[storeId] = [];
-      grouped[storeId].push(item);
+    try {
+      validateToken(sessionToken, ['write']);
+    } catch (err) {
+      void eventBus.track('checkout.token_integrity', {
+        tokenValid: false,
+        success: false,
+      });
+      throw err;
     }
+    try {
+      const grouped: Record<string, CartItem[]> = {};
+      for (const item of cartItems) {
+        const storeId = item.product.storeId;
+        if (!grouped[storeId]) grouped[storeId] = [];
+        grouped[storeId].push(item);
+      }
 
-    const orders: Order[] = [];
-    for (const [storeId, items] of Object.entries(grouped)) {
-      const store = await getStore(storeId, storeId);
-      const payment =
-        paymentMethod === 'near'
-          ? {
-              method: 'near' as const,
-              buyerAddress: chainAdapter.getAccountId() || undefined,
-              sellerAddress: store?.owner,
-            }
-          : paymentMethod === 'card'
-          ? {
-              method: 'card' as const,
-              buyerAddress: chainAdapter.getAccountId() || undefined,
-              sellerAddress: store?.owner,
-            }
-          : {
-              method: 'cash_on_delivery' as const,
-              buyerAddress: chainAdapter.getAccountId() || undefined,
-              sellerAddress: store?.owner,
-            };
-      const order = await this.createOrder(
-        userId,
-        items,
-        shippingAddress,
-        payment,
-      );
-      await emitOrderEvents(order, storeId);
-      orders.push(order);
+      const orders: Order[] = [];
+      for (const [storeId, items] of Object.entries(grouped)) {
+        const store = await getStore(storeId, storeId);
+        const payment =
+          paymentMethod === 'near'
+            ? {
+                method: 'near' as const,
+                buyerAddress: chainAdapter.getAccountId() || undefined,
+                sellerAddress: store?.owner,
+              }
+            : paymentMethod === 'card'
+            ? {
+                method: 'card' as const,
+                buyerAddress: chainAdapter.getAccountId() || undefined,
+                sellerAddress: store?.owner,
+              }
+            : {
+                method: 'cash_on_delivery' as const,
+                buyerAddress: chainAdapter.getAccountId() || undefined,
+                sellerAddress: store?.owner,
+              };
+        const order = await this.createOrder(
+          userId,
+          items,
+          shippingAddress,
+          payment,
+          sessionToken,
+        );
+        await emitOrderEvents(order, storeId);
+        orders.push(order);
+      }
+      void eventBus.track('checkout.token_integrity', {
+        tokenValid: true,
+        success: true,
+      });
+      return orders;
+    } catch (err) {
+      void eventBus.track('checkout.token_integrity', {
+        tokenValid: true,
+        success: false,
+      });
+      throw err;
     }
-    return orders;
   }
 
   private async decrementProductStock(items: CartItem[]): Promise<void> {

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -49,6 +49,8 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
+import { requestTokenWithConsent } from '@/services/session';
+import { uuid } from '@/utils/uuid';
 
 const PRODUCT_CACHE_TOPIC = '/blue-ocean/products/1';
 
@@ -97,6 +99,15 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     cancelText: '',
     action: () => {},
   });
+
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
+
+  const ensureSessionToken = async (): Promise<string> => {
+    if (sessionToken) return sessionToken;
+    const { token } = await requestTokenWithConsent(['write'], () => uuid());
+    setSessionToken(token);
+    return token;
+  };
 
 
   useEffect(() => {
@@ -272,6 +283,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
 
   const placeOrder = async () => {
     if (!validateShippingAddress()) return;
+    const token = await ensureSessionToken();
 
     setLoading(true);
     try {
@@ -279,7 +291,8 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         user?.id || 'guest',
         cartItems,
         shippingAddress,
-        'near'
+        'near',
+        token,
       );
       eventBus.track('checkout.complete', {
         orderIds: orders.map((o) => o.id),
@@ -297,13 +310,22 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       );
 
       setTimeout(() => onClose(), 5000);
-    } catch (error) {
-      setInfoModal({
-        visible: true,
-        title: t('common.error'),
-        message: t('cart.orderCreationError'),
-        type: 'error',
-      });
+    } catch (error: any) {
+      if (error?.message === '{E_EXPIRED}' || error?.message === '{E_SCOPE}') {
+        setInfoModal({
+          visible: true,
+          title: t('common.error'),
+          message: t('cart.invalidSession'),
+          type: 'error',
+        });
+      } else {
+        setInfoModal({
+          visible: true,
+          title: t('common.error'),
+          message: t('cart.orderCreationError'),
+          type: 'error',
+        });
+      }
     } finally {
       setLoading(false);
     }

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -1,5 +1,6 @@
 import OrderService from '@/services/orders';
 import { CartItem, ShippingAddress } from '../types';
+import { requestScopes } from '@/services/session';
 
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
@@ -89,7 +90,8 @@ describe('card checkout fee deduction', () => {
       postalCode: 'p',
     };
 
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'card');
+    const { token } = requestScopes(['write'], () => 'sig');
+    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'card', token);
     expect(orders).toHaveLength(1);
     const order = orders[0];
     expect(order.total).toBe(100);

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -1,6 +1,7 @@
 import OrderService from '@/services/orders';
 import { deployOrderPayment } from '@/services/nearContract';
 import { CartItem, ShippingAddress } from '../types';
+import { requestScopes } from '@/services/session';
 
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
@@ -114,7 +115,8 @@ describe('multi-seller checkout flow', () => {
       postalCode: 'p',
     };
 
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'near');
+    const { token } = requestScopes(['write'], () => 'sig');
+    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'near', token);
     expect(orders).toHaveLength(2);
     expect(deployOrderPayment).toHaveBeenCalledTimes(2);
     const totals = orders.map((o) => o.total).sort();

--- a/translations/en.json
+++ b/translations/en.json
@@ -481,6 +481,7 @@
     "orderReceived": "Order Received",
     "ordersCreated": "Created {count} orders successfully",
     "orderCreationError": "An error occurred while creating the order",
+    "invalidSession": "Session expired. Please refresh and try again",
     "shippingAddress": "Shipping Address",
     "fullName": "Full Name *",
     "fullNamePlaceholder": "Enter full name",

--- a/translations/he.json
+++ b/translations/he.json
@@ -471,6 +471,7 @@
     "orderReceived": "הזמנה התקבלה",
     "ordersCreated": "נוצרו {count} הזמנות בהצלחה",
     "orderCreationError": "אירעה שגיאה ביצירת ההזמנה",
+    "invalidSession": "אסימון הסשן פג. נא לרענן ולנסות שוב",
     "shippingAddress": "כתובת משלוח",
     "fullName": "שם מלא *",
     "fullNamePlaceholder": "הכנס שם מלא",


### PR DESCRIPTION
## Summary
- require scoped session tokens when creating orders and log token integrity metrics
- cart modal requests session tokens and handles expired tokens with user feedback
- document checkout token metrics and add translations for invalid sessions

## Testing
- `node scripts/check-i18n.js` *(fails: Cannot find module 'typescript')*
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Merge conflict marker encountered, missing tsconfig base)*
- `npx jest tests/multiSellerCheckout.test.ts tests/cardCheckoutFee.test.ts` *(fails: need to install jest package)*

------
https://chatgpt.com/codex/tasks/task_e_68c79d48736883268e99872d93ea06df