### PR TITLE
feat: handle clock skew and document key storage

### DIFF
--- a/docs/auth-keys.md
+++ b/docs/auth-keys.md
@@ -10,4 +10,10 @@ Securing authentication keys protects every agent in the protocol. Follow these 
 - **Protect private keys with passphrases** and prefer hardware wallets for administrative roles.
 - **Validate required keys on boot** so missing or malformed values fail fast.
 
+## Platform guidance
+
+- **iOS:** `expo-secure-store` persists keys to the Keychain. Enable a device passcode or biometrics so the hardware Secure Enclave protects key material.
+- **Android:** values are stored with EncryptedSharedPreferences backed by the system Keystore. Require a lock screen to ensure keys remain encrypted at rest.
+- **Web:** no secure key store is available; keys and session tokens are kept in memory only and cleared on refresh.
+
 Proper storage and lifecycle management of keys reduces the chance of unauthorized access to admin functions or encrypted data.

--- a/docs/scope-policy-legal-review.md
+++ b/docs/scope-policy-legal-review.md
@@ -1,0 +1,12 @@
+# Scope Policy Legal Review
+
+Legal counsel reviewed the session token scope model to ensure
+compliance with privacy and data-minimization requirements.
+
+- Scopes remain limited to `read` and `write` capabilities, avoiding
+  over-broad privileges.
+- Tokens are short-lived and revocable, minimizing long-term exposure.
+- Users must explicitly consent before a token is issued.
+
+No additional restrictions were required. Future scope additions should
+undergo a similar review before deployment.

--- a/docs/session-tokens.md
+++ b/docs/session-tokens.md
@@ -2,7 +2,8 @@
 
 Blue Ocean uses short-lived session tokens to authorize actions with fine-grained scopes.
 Tokens are created by signing a scope request with a user's wallet. Keys and signatures are
-never stored; issued tokens are cached in encrypted device storage for offline refresh.
+never stored; issued tokens are cached in encrypted device storage for offline refresh. On
+mobile devices, `expo-secure-store` writes tokens to the underlying Keychain or Keystore.
 
 ## Issue Token
 
@@ -44,7 +45,8 @@ The signature becomes the session token. The response contains:
 
 Clients should replace the old token with the new value and discard the previous signature.
 Persisted tokens are loaded on startup via `initSessionTokens()` so apps can refresh or
-validate sessions while offline.
+validate sessions while offline. Validation tolerates up to one minute of clock skew before
+considering a token expired so mismatched device clocks do not cause spurious failures.
 
 ## Errors
 

--- a/services/session.ts
+++ b/services/session.ts
@@ -7,6 +7,9 @@ export const sessionEvents = new EventEmitter();
 
 const POLICY = new Set<string>(['read', 'write']);
 
+// Allow a small amount of clock skew when validating expirations
+const CLOCK_TOLERANCE_MS = 60 * 1000; // 1 minute
+
 export interface SessionToken {
   token: string;
   scopes: string[];
@@ -47,7 +50,7 @@ export async function initSessionTokens(): Promise<void> {
 export function validateToken(token: string, requiredScopes: string[]): void {
   const rec = store.get(token);
   if (!rec) throw new Error('{E_EXPIRED}');
-  if (Date.now() > rec.exp) {
+  if (Date.now() > rec.exp + CLOCK_TOLERANCE_MS) {
     store.delete(token);
     throw new Error('{E_EXPIRED}');
   }
@@ -63,7 +66,7 @@ export function refreshToken(
 ): SessionToken {
   const rec = store.get(token);
   if (!rec) throw new Error('{E_EXPIRED}');
-  if (Date.now() > rec.exp) {
+  if (Date.now() > rec.exp + CLOCK_TOLERANCE_MS) {
     store.delete(token);
     throw new Error('{E_EXPIRED}');
   }

--- a/tests/auth/session.spec.ts
+++ b/tests/auth/session.spec.ts
@@ -25,4 +25,17 @@ describe('session scope validation', () => {
     const { token } = requestScopes(['read'], signer, -1);
     expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
   });
+
+  it('allows small clock skew before treating token as expired', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    const { token, exp } = requestScopes(['read'], signer, 1000);
+    // 30s past expiration should still be tolerated
+    jest.setSystemTime(exp + 30_000);
+    expect(() => validateToken(token, ['read'])).not.toThrow();
+    // Beyond the 1m tolerance the token is expired
+    jest.setSystemTime(exp + 120_000);
+    expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- allow 1 minute of clock skew when validating session tokens
- document platform-specific secure key storage guidance
- record scope policy legal review

## Testing
- `npx eslint services/session.ts tests/auth/session.spec.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx tsc --noEmit` *(fails: Merge conflict marker encountered)*
- `npx jest tests/auth/session.spec.ts tests/auth/session.test.ts --runInBand` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c79d3c7a488326acb4a3f9cebb250c