### PR TITLE
Fix store agent merge conflicts and test setup import

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,7 +1,7 @@
 import { Store } from '@/types';
-import { chainAdapter, assertNearChain } from '@/services/chain';
+import { assertNearChain } from '@/services/chain';
 import {
-  addStore,
+  setStore,
   updateStore,
   removeStore,
   selectStore as fetchStore,
@@ -14,6 +14,7 @@ import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
 import { sign } from '@noble/ed25519';
 import { canonicalJson } from '@/utils/serialization';
 import type { WakuMessage } from '@/types/waku';
+import ensureNearWallet from '@/utils/ensureNearWallet';
 
 assertNearChain();
 
@@ -100,14 +101,13 @@ class StoresAgent {
     this.subscribers.delete(cb);
   }
 
+  private async ensureWallet() {
+    await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
+  }
+
   async add(item: Store): Promise<void> {
-    if (!chainAdapter.getAccountId()) {
-      await chainAdapter.openModal();
-    }
+    await this.ensureWallet();
     const normalized = normalizeMessage<Store>('Store', item);
-<<<<<<< Updated upstream
-    await addStore(this.toRecord(normalized));
-=======
     const record = this.toRecord({
       createdAt: normalized.createdAt || new Date().toISOString(),
       ...normalized,
@@ -115,24 +115,11 @@ class StoresAgent {
     await setStore(record.id, record);
     await setStore('default', record);
     await this.broadcastCreated(record);
->>>>>>> Stashed changes
   }
 
   async update(item: Store): Promise<void> {
-    if (!chainAdapter.getAccountId()) {
-      await chainAdapter.openModal();
-    }
+    await this.ensureWallet();
     const normalized = normalizeMessage<Store>('Store', item);
-<<<<<<< Updated upstream
-    await updateStore(this.toRecord(normalized));
-  }
-
-  async remove(id: string): Promise<void> {
-    if (!chainAdapter.getAccountId()) {
-      await chainAdapter.openModal();
-    }
-    await removeStore(id);
-=======
     const rec = this.toRecord(normalized);
     await setStore(rec.id, rec);
     await setStore('default', rec);
@@ -140,9 +127,7 @@ class StoresAgent {
 
   async remove(id: string): Promise<void> {
     await this.ensureWallet();
-    await removeStore(id, id);
-    await removeStore('default', id);
->>>>>>> Stashed changes
+    await removeStore(id);
   }
 
   /**

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -1,10 +1,7 @@
 import { Store } from '@/types';
 import { chainAdapter, assertNearChain } from '@/services/chain';
 import { requireStoreId } from '@blue-ocean/utils';
-import {
-  getStore as contractGetStore,
-  listStores as contractListStores,
-} from '@/services/nearStoreContract';
+import { listStores as contractListStores } from '@/services/nearStoreContract';
 import { canonicalJson } from '@/utils/serialization';
 import { nearConfig } from '@/services/config';
 import { getSelector } from '@/services/walletSelector';
@@ -138,20 +135,6 @@ export async function selectStore(
     return null;
   }
 }
-
-export async function setStore(storeId: string, store: Store) {
-  const sid = requireStoreId(storeId);
-  await persistStore(store, sid);
-}
-
-export async function removeStore(arg1: string, arg2?: string): Promise<void> {
-  const id = arg2 ?? arg1;
-  const sid = arg2 ? requireStoreId(arg1) : requireStoreId(id);
-  await sendTx('remove', { id });
-  await removeValue(ADDRESS, storeKey(id, sid));
-  await removeValue(ADDRESS, indexKey(id));
-}
-
 export async function listStores(storeId: string): Promise<Store[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { jest } from '@jest/globals';
 import React from 'react';
 import { insertConfig } from './testUtils';
+import { loadTenantSettings } from '@/constants/tenant';
 
 // Make this file a module so global augmentation works
 export {};
@@ -68,6 +69,5 @@ beforeEach(async () => {
     EXPO_PUBLIC_NETWORK: 'testnet',
   });
 
-  const { loadTenantSettings } = await import('@/constants/tenant');
   await loadTenantSettings();
 });


### PR DESCRIPTION
## Summary
- resolve merge conflicts in `stores-agent` and use `setStore` with wallet checks
- consolidate store service functions to remove duplicate exports
- fix test environment import for tenant settings

## Testing
- `npx eslint agents/stores-agent.ts src/features/stores/services/nearStores.ts tests/setupEnv.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Merge conflict marker encountered; missing expo/tsconfig.base.json)*
- `npx jest tests/storeIsolation.test.ts` *(fails: jest package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a091bd80832685a5cfb7fe41f2f9