### PR TITLE
docs: specify notifications contract

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,68 @@
+# Notifications Contract
+
+Defines the messaging contract for order events, localized notifications, and error semantics.
+
+## Event Schemas
+
+### `{order.created}`
+Emitted when an order is successfully created.
+
+- **Payload** (`orderCreatedEventSchema`)
+  - `orderId` (`string`): unique order identifier.
+  - `userId` (`string`): user who placed the order.
+  - `total` (`number`): order total amount.
+
+### `{order.failed}`
+Emitted when an order cannot be processed.
+
+- **Payload** (`orderFailedEventSchema`)
+  - `orderId` (`string`): affected order identifier.
+  - `userId` (`string`): user who attempted the order.
+  - `code` (`string`): error code describing the failure.
+  - `reason` (`string`): human readable explanation.
+
+### Output Payloads
+
+#### `{notify.orderCreated}`
+Broadcast notification to the user.
+
+- **Payload** (`notifyOrderCreatedSchema`)
+  - `notification` (`Notification`): localized title and message.
+
+#### `{notify.orderFailed}`
+Broadcast when an order fails.
+
+- **Payload** (`notifyOrderFailedSchema`)
+  - `notification` (`Notification`): localized title and message.
+
+## API Reference
+
+### `subscribe(filter)`
+Subscribes to notification outputs.
+
+- **Parameters**
+  - `filter` (`Record<string, unknown>`): selection criteria.
+- **Returns**: `() => void` unsubscribe function.
+- **Events**: receives `notify.orderCreated` and `notify.orderFailed` payloads.
+
+### `publish(event, payload)`
+Producers send order events to the network.
+
+- **Parameters**
+  - `event` (`'order.created' | 'order.failed'`)
+  - `payload` (matching event schema)
+- **Errors**: may reject with `{ code: 'E_BACKLOG', retryAfter: number }` when the node backlog is full.
+
+## Error Handling
+
+### `E_BACKLOG`
+Thrown when a node cannot accept more events.
+
+```json
+{
+  "code": "E_BACKLOG",
+  "retryAfter": 1000
+}
+```
+
+Producers should pause publishing and retry after at least `retryAfter` milliseconds. Consumers encountering this error should back off and resubscribe once the delay has passed.

--- a/schemas/notifications/E_BACKLOG.ts
+++ b/schemas/notifications/E_BACKLOG.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const backlogErrorSchema = z.object({
+  code: z.literal('E_BACKLOG'),
+  retryAfter: z.number().int().positive(),
+});
+
+export type BacklogError = z.infer<typeof backlogErrorSchema>;

--- a/schemas/notifications/index.ts
+++ b/schemas/notifications/index.ts
@@ -1,0 +1,5 @@
+export * from './order.created';
+export * from './order.failed';
+export * from './notify.orderCreated';
+export * from './notify.orderFailed';
+export * from './E_BACKLOG';

--- a/schemas/notifications/notify.orderCreated.ts
+++ b/schemas/notifications/notify.orderCreated.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { notificationSchema } from '../waku/notification';
+
+export const notifyOrderCreatedSchema = z.object({
+  type: z.literal('notify.orderCreated'),
+  notification: notificationSchema,
+});
+
+export type NotifyOrderCreated = z.infer<typeof notifyOrderCreatedSchema>;

--- a/schemas/notifications/notify.orderFailed.ts
+++ b/schemas/notifications/notify.orderFailed.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { notificationSchema } from '../waku/notification';
+
+export const notifyOrderFailedSchema = z.object({
+  type: z.literal('notify.orderFailed'),
+  notification: notificationSchema,
+});
+
+export type NotifyOrderFailed = z.infer<typeof notifyOrderFailedSchema>;

--- a/schemas/notifications/order.created.ts
+++ b/schemas/notifications/order.created.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from '../waku/message';
+
+export const orderCreatedEventSchema = wakuMessageSchema.extend({
+  type: z.literal('order.created'),
+  payload: z.object({
+    orderId: z.string(),
+    userId: z.string(),
+    total: z.number(),
+  }),
+});
+
+export type OrderCreatedEvent = z.infer<typeof orderCreatedEventSchema>;

--- a/schemas/notifications/order.failed.ts
+++ b/schemas/notifications/order.failed.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from '../waku/message';
+
+export const orderFailedEventSchema = wakuMessageSchema.extend({
+  type: z.literal('order.failed'),
+  payload: z.object({
+    orderId: z.string(),
+    userId: z.string(),
+    code: z.string(),
+    reason: z.string(),
+  }),
+});
+
+export type OrderFailedEvent = z.infer<typeof orderFailedEventSchema>;

--- a/tests/notificationSchemas.test.ts
+++ b/tests/notificationSchemas.test.ts
@@ -1,0 +1,71 @@
+import {
+  orderCreatedEventSchema,
+  orderFailedEventSchema,
+  notifyOrderCreatedSchema,
+  notifyOrderFailedSchema,
+  backlogErrorSchema,
+} from '../schemas/notifications';
+
+describe('notification schemas', () => {
+  test('orderCreatedEventSchema validates payload', () => {
+    const evt = {
+      type: 'order.created',
+      payload: { orderId: 'o1', userId: 'u1', total: 100 },
+      sender: { publicKey: 'k' },
+      signature: 's',
+    };
+    expect(orderCreatedEventSchema.parse(evt)).toEqual(evt);
+  });
+
+  test('orderFailedEventSchema validates payload', () => {
+    const evt = {
+      type: 'order.failed',
+      payload: {
+        orderId: 'o2',
+        userId: 'u2',
+        code: 'E_BACKLOG',
+        reason: 'backlog',
+      },
+      sender: { publicKey: 'k' },
+      signature: 's',
+    };
+    expect(orderFailedEventSchema.parse(evt)).toEqual(evt);
+  });
+
+  test('notifyOrderCreatedSchema validates structure', () => {
+    const payload = {
+      type: 'notify.orderCreated',
+      notification: {
+        id: 'n1',
+        userId: 'u1',
+        title: 't',
+        message: 'm',
+        type: 'order',
+        read: false,
+        timestamp: 1,
+      },
+    };
+    expect(notifyOrderCreatedSchema.parse(payload)).toEqual(payload);
+  });
+
+  test('notifyOrderFailedSchema validates structure', () => {
+    const payload = {
+      type: 'notify.orderFailed',
+      notification: {
+        id: 'n2',
+        userId: 'u2',
+        title: 't',
+        message: 'm',
+        type: 'order',
+        read: false,
+        timestamp: 1,
+      },
+    };
+    expect(notifyOrderFailedSchema.parse(payload)).toEqual(payload);
+  });
+
+  test('backlogErrorSchema validates structure', () => {
+    const err = { code: 'E_BACKLOG', retryAfter: 1000 };
+    expect(backlogErrorSchema.parse(err)).toEqual(err);
+  });
+});

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -1,0 +1,7 @@
+export {
+  type OrderCreatedEvent,
+  type OrderFailedEvent,
+  type NotifyOrderCreated,
+  type NotifyOrderFailed,
+  type BacklogError,
+} from '../schemas/notifications';


### PR DESCRIPTION
## Summary
- document order event and notification payload schemas
- define E_BACKLOG error schema and guidance
- publish notifications API reference

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: merge conflict markers in existing files)*
- `yarn config:check` *(fails: Cannot find module 'ts-node/register')*
- `yarn jest tests/notificationSchemas.test.ts` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a1f47c54832684abcdd4e905e62f