### PR TITLE
Resolve schema merge markers and tenant import

### DIFF
--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -3,8 +3,5 @@ export * from './settings';
 export * from './notification';
 export * from './product.updated';
 export * from './order.status';
-<<<<<<< Updated upstream
 export * from './admin.requested';
-=======
 export * from './store.created';
->>>>>>> Stashed changes

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { jest } from '@jest/globals';
 import React from 'react';
 import { insertConfig } from './testUtils';
-import { loadTenantSettings } from '@/constants/tenant';
+import { loadTenantSettings } from '../constants/tenant';
 
 // Make this file a module so global augmentation works
 export {};


### PR DESCRIPTION
## Summary
- fix Waku schema index to export admin.requested and store.created
- use relative path for tenant settings in test setup

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', 'react'; File 'expo/tsconfig.base.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a2c2d76083269d81e1cf5b5e70e7