### PR TITLE
docs: add notification topic map and broker tuning guide

### DIFF
--- a/docs/broker-tuning.md
+++ b/docs/broker-tuning.md
@@ -1,0 +1,19 @@
+# Broker Tuning Guide
+
+Guidelines for configuring message brokers to avoid overload.
+
+## Back-Pressure Thresholds
+
+Set a backlog limit to protect the node. When the queue exceeds this threshold the broker returns `E_BACKLOG` and publishers should pause before retrying.
+
+- **Recommended**: start throttling when pending messages exceed **1,000** per topic.
+- Expose `retryAfter` in errors so clients know when to resume.
+
+## Queue Sizing
+
+Right-size queues to balance memory use and throughput.
+
+- Allocate at least **10×** the expected peak burst to prevent drops.
+- Monitor high-water marks and adjust based on observed traffic.
+
+Keeping these limits documented helps operators tune for predictable latency without exhausting resources.

--- a/docs/notifications-topics.md
+++ b/docs/notifications-topics.md
@@ -1,0 +1,16 @@
+# Notification Topics
+
+Reference of Waku topics used by the notifications pipeline.
+
+## Topic Map
+
+| Topic | Purpose |
+|-------|---------|
+| `/blue-ocean/orders/1` | Order events published by the orders agent. |
+| `/blue-ocean/notifications/1` | User-facing notifications broadcast by the notifications agent. |
+
+## Usage
+
+Producers emit order events on `/blue-ocean/orders/1`. The notifications agent listens for these events and forwards localized messages on `/blue-ocean/notifications/1` for subscribers.
+
+For schema details see [notifications.md](./notifications.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,6 +35,22 @@ const unsubscribe = cache.subscribe({ type: 'product' }, async diff => {
 
 Remember to call `unsubscribe()` when the listener is no longer needed.
 
+## Subscribe to Localized Notifications
+
+```ts
+import { notifications } from '@blue-ocean/notifications';
+
+// Receive messages in the user's locale
+const stop = notifications.subscribe({ locale: navigator.language }, note => {
+  console.log(note.notification.title);
+});
+
+// Later when done listening
+stop();
+```
+
+Localized notifications carry translated titles and messages so the UI can render text directly without additional lookup.
+
 ## Offline-First & Timestamp Handling
 
 Persisting snapshots (e.g. with `AsyncStorage`) allows the cache to survive restarts and offline periods. Always convert ISO timestamp strings with `toLocaleString` or `Intl.DateTimeFormat` so users see values in their local timezone.


### PR DESCRIPTION
## Summary
- document Waku topics for notifications
- add broker tuning guide with back-pressure and queue sizing
- show how to subscribe to localized notifications in quickstart

## Testing
- `yarn lint docs/quickstart.md docs/broker-tuning.md docs/notifications-topics.md` (fails: Cannot find module '@typescript-eslint/parser')
- `yarn typecheck` (fails: Cannot find type definition file for 'jest')


------
https://chatgpt.com/codex/tasks/task_e_68c7a4277b208326826c6c25224f09af