### PR TITLE
refactor: use explicit store operations

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -1,7 +1,7 @@
 import { Store } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import {
-  setStore,
+  addStore,
   updateStore,
   removeStore,
   selectStore as fetchStore,
@@ -112,8 +112,7 @@ class StoresAgent {
       createdAt: normalized.createdAt || new Date().toISOString(),
       ...normalized,
     });
-    await setStore(record.id, record);
-    await setStore('default', record);
+    await addStore(record);
     await this.broadcastCreated(record);
   }
 
@@ -121,8 +120,7 @@ class StoresAgent {
     await this.ensureWallet();
     const normalized = normalizeMessage<Store>('Store', item);
     const rec = this.toRecord(normalized);
-    await setStore(rec.id, rec);
-    await setStore('default', rec);
+    await updateStore(rec);
   }
 
   async remove(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- replace missing setStore usage with addStore/updateStore
- keep store state updates consistent across add/update

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: variant prop and other unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a4a849208326a6056e580eaab2d5