### PR TITLE
feat: instrument notification metrics

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -18,12 +18,21 @@ import ensureNearWallet from '../utils/ensureNearWallet';
 import { errorLog } from '../utils/logger';
 import { buildTopic } from '../utils/wakuTopics';
 import { canonicalJson } from '@/utils/serialization';
+import {
+  notificationsBacklog,
+  notificationDeliveryLatency,
+} from '../utils/observability';
 
 export const E_BACKLOG = 'E_BACKLOG';
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
-  private backlog: Array<{ event: NotificationEvent; item: Notification; storeId: string }> = [];
+  private backlog: Array<{
+    event: NotificationEvent;
+    item: Notification;
+    storeId: string;
+    queuedAt: number;
+  }> = [];
   private draining = false;
   private backlogLimit = 50;
 
@@ -64,7 +73,8 @@ class NotificationsAgent {
     if (this.backlog.length >= this.backlogLimit) {
       throw new AgentError(E_BACKLOG, 'Notification backlog limit exceeded', 'notifications-agent');
     }
-    this.backlog.push({ event, item, storeId });
+    this.backlog.push({ event, item, storeId, queuedAt: Date.now() });
+    notificationsBacklog.set(this.backlog.length);
     if (!this.draining) void this.drain();
   }
 
@@ -72,9 +82,12 @@ class NotificationsAgent {
     if (this.draining) return;
     this.draining = true;
     while (this.backlog.length) {
-      const { event, item, storeId } = this.backlog.shift()!;
+      const job = this.backlog.shift()!;
+      notificationsBacklog.set(this.backlog.length);
+      const { event, item, storeId, queuedAt } = job;
       try {
         await this.broadcast(event, item, storeId);
+        notificationDeliveryLatency.labels(event).observe((Date.now() - queuedAt) / 1000);
       } catch (err) {
         errorLog('Failed to process notification', err);
       }

--- a/tests/__mocks__/utils/observability.ts
+++ b/tests/__mocks__/utils/observability.ts
@@ -2,4 +2,15 @@ const serviceLatency = { startTimer: () => () => {} };
 const serviceFailures = { inc: jest.fn() };
 const logger = { info: jest.fn(), error: jest.fn() };
 const startMetricsServer = jest.fn();
-module.exports = { serviceLatency, serviceFailures, logger, startMetricsServer };
+const notificationsBacklog = { set: jest.fn() };
+const notificationDeliveryLatency = {
+  labels: () => ({ observe: jest.fn() }),
+};
+module.exports = {
+  serviceLatency,
+  serviceFailures,
+  logger,
+  startMetricsServer,
+  notificationsBacklog,
+  notificationDeliveryLatency,
+};

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -38,6 +38,26 @@ export const adminTransactionIntegrity =
       })
     : { inc: () => {} };
 
+export const notificationsBacklog =
+  prom
+    ? new prom.Gauge({
+        name: 'notifications_backlog',
+        help: 'Number of notifications pending delivery',
+      })
+    : { set: () => {} };
+
+export const notificationDeliveryLatency =
+  prom
+    ? new prom.Histogram({
+        name: 'notification_delivery_latency_seconds',
+        help: 'Notification delivery latency in seconds',
+        labelNames: ['event'],
+      })
+    : {
+        labels: () => ({ observe: () => {} }),
+        observe: () => {},
+      };
+
 let metricsStarted = false;
 export function startMetricsServer(
   port = Number(process.env.METRICS_PORT || 9464)


### PR DESCRIPTION
## Summary
- expose `notifications_backlog` gauge and `notification_delivery_latency_seconds` histogram in observability utilities
- track backlog size and delivery latency inside `notifications-agent`
- extend observability test mocks for new metrics

## Testing
- `npx jest` *(fails: Need to install the following packages: jest@30.1.3)*
- `yarn install --ignore-scripts` *(incomplete: No lockfile found; aborted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a43273b88326a3413b8de3ce0ae6