### PR TITLE
feat: add notifications pipeline flag with safeguards

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -22,6 +22,10 @@ import {
   notificationsBacklog,
   notificationDeliveryLatency,
 } from '../utils/observability';
+import { onBacklog } from '@/utils/wakuStore';
+import {
+  isNotificationsPipelineEnabled,
+} from '@/config/featureFlags';
 
 export const E_BACKLOG = 'E_BACKLOG';
 
@@ -35,12 +39,19 @@ class NotificationsAgent {
   }> = [];
   private draining = false;
   private backlogLimit = 50;
+  private paused = false;
+  private latencyLimit = 5000; // ms
+
+  constructor() {
+    onBacklog(() => this.pause());
+  }
 
   private async ensureWallet() {
     await ensureNearWallet('Please connect your NEAR wallet to send notifications.');
   }
 
   async add(item: Notification, storeId = '1'): Promise<void> {
+    if (this.paused || !isNotificationsPipelineEnabled(item.userId)) return;
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
@@ -49,6 +60,7 @@ class NotificationsAgent {
   }
 
   async update(item: Notification, storeId = '1'): Promise<void> {
+    if (this.paused || !isNotificationsPipelineEnabled(item.userId)) return;
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
@@ -70,7 +82,9 @@ class NotificationsAgent {
   }
 
   private enqueue(event: NotificationEvent, item: Notification, storeId: string) {
+    if (this.paused || !isNotificationsPipelineEnabled(item.userId)) return;
     if (this.backlog.length >= this.backlogLimit) {
+      this.pause();
       throw new AgentError(E_BACKLOG, 'Notification backlog limit exceeded', 'notifications-agent');
     }
     this.backlog.push({ event, item, storeId, queuedAt: Date.now() });
@@ -79,15 +93,17 @@ class NotificationsAgent {
   }
 
   private async drain() {
-    if (this.draining) return;
+    if (this.draining || this.paused) return;
     this.draining = true;
-    while (this.backlog.length) {
+    while (this.backlog.length && !this.paused) {
       const job = this.backlog.shift()!;
       notificationsBacklog.set(this.backlog.length);
       const { event, item, storeId, queuedAt } = job;
       try {
         await this.broadcast(event, item, storeId);
-        notificationDeliveryLatency.labels(event).observe((Date.now() - queuedAt) / 1000);
+        const latency = Date.now() - queuedAt;
+        notificationDeliveryLatency.labels(event).observe(latency / 1000);
+        if (latency > this.latencyLimit) this.pause();
       } catch (err) {
         errorLog('Failed to process notification', err);
       }
@@ -99,6 +115,7 @@ class NotificationsAgent {
     type: 'order.created' | 'order.failed',
     payload: { orderId: string; userId: string; storeId?: string },
   ): void {
+    if (this.paused || !isNotificationsPipelineEnabled(payload.userId)) return;
     const event: NotificationEvent =
       type === 'order.created' ? 'notify.orderCreated' : 'notify.orderFailed';
     const notification: Notification = {
@@ -118,6 +135,7 @@ class NotificationsAgent {
     item: Notification,
     storeId = '1',
   ): Promise<void> {
+    if (this.paused || !isNotificationsPipelineEnabled(item.userId)) return;
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
@@ -140,7 +158,7 @@ class NotificationsAgent {
     event: string,
     payload: Record<string, unknown> = {},
   ): Promise<void> {
-    if (isWakuDisabled()) return;
+    if (this.paused || isWakuDisabled()) return;
     const node = await ensureNode();
     if (!node) return;
     try {
@@ -160,6 +178,7 @@ class NotificationsAgent {
     event?: NotificationEvent,
     storeId = '1',
   ) {
+    if (this.paused) return;
     const node = await ensureNode();
     if (!node) return;
     try {
@@ -176,6 +195,20 @@ class NotificationsAgent {
     } catch (err) {
       errorLog('Failed to broadcast notification', err);
     }
+  }
+
+  pause(): void {
+    this.paused = true;
+  }
+
+  resume(): void {
+    if (!this.paused) return;
+    this.paused = false;
+    if (this.backlog.length && !this.draining) void this.drain();
+  }
+
+  isPaused(): boolean {
+    return this.paused;
   }
 }
 

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -13,6 +13,12 @@ const envSchema = z.object({
     .optional()
     .default(''),
   EXPO_PUBLIC_SCOPED_TOKENS_ROLLBACK: z.string().optional().default('false'),
+  EXPO_PUBLIC_NOTIFICATIONS_PIPELINE: z.string().optional().default('false'),
+  EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_CANARY_USERS: z
+    .string()
+    .optional()
+    .default(''),
+  EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_ROLLBACK: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -47,6 +53,21 @@ const scopedTokensFlag: ScopedTokensFeatureFlag = {
   rollback: env.EXPO_PUBLIC_SCOPED_TOKENS_ROLLBACK === 'true',
 };
 
+export interface NotificationsPipelineFeatureFlag {
+  enabled: boolean;
+  canaryUsers: string[];
+  rollback: boolean;
+}
+
+const notificationsPipelineFlag: NotificationsPipelineFeatureFlag = {
+  enabled: env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE === 'true',
+  canaryUsers: env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_CANARY_USERS
+    .split(',')
+    .map((u) => u.trim().toLowerCase())
+    .filter(Boolean),
+  rollback: env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_ROLLBACK === 'true',
+};
+
 export function isWarmCacheEnabled(address?: string): boolean {
   if (warmCacheFlag.rollback) return false;
   if (warmCacheFlag.enabled) return true;
@@ -69,5 +90,17 @@ export function triggerScopedTokensRollback(): void {
   scopedTokensFlag.rollback = true;
 }
 export { scopedTokensFlag };
+
+export function isNotificationsPipelineEnabled(userId?: string): boolean {
+  if (notificationsPipelineFlag.rollback) return false;
+  if (notificationsPipelineFlag.enabled) return true;
+  if (!userId) return false;
+  return notificationsPipelineFlag.canaryUsers.includes(userId.toLowerCase());
+}
+
+export function triggerNotificationsPipelineRollback(): void {
+  notificationsPipelineFlag.rollback = true;
+}
+export { notificationsPipelineFlag };
 
 export default warmCacheFlag;

--- a/docs/notifications-topics.md
+++ b/docs/notifications-topics.md
@@ -2,6 +2,11 @@
 
 Reference of Waku topics used by the notifications pipeline.
 
+> The notifications pipeline can be toggled via the `notificationsPipeline` feature flag
+> (`EXPO_PUBLIC_NOTIFICATIONS_PIPELINE`). Canary rollout is supported through
+> `EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_CANARY_USERS` and the pipeline automatically
+> pauses when backlog or latency alerts fire.
+
 ## Topic Map
 
 | Topic | Purpose |

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -59,3 +59,34 @@ describe('scoped tokens feature flag', () => {
     expect(mod.isScopedTokensEnabled('near-wallet')).toBe(false);
   });
 });
+
+describe('notifications pipeline feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;
+    delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_CANARY_USERS;
+    delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_ROLLBACK;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isNotificationsPipelineEnabled } = require('@/config/featureFlags');
+    expect(isNotificationsPipelineEnabled('u1')).toBe(false);
+  });
+
+  it('allows canary users', () => {
+    process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_CANARY_USERS = 'u1,u2';
+    jest.resetModules();
+    const { isNotificationsPipelineEnabled } = require('@/config/featureFlags');
+    expect(isNotificationsPipelineEnabled('u1')).toBe(true);
+    expect(isNotificationsPipelineEnabled('u3')).toBe(false);
+  });
+
+  it('rollback disables feature', () => {
+    process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE = 'true';
+    jest.resetModules();
+    const mod = require('@/config/featureFlags');
+    expect(mod.isNotificationsPipelineEnabled('u1')).toBe(true);
+    mod.triggerNotificationsPipelineRollback();
+    expect(mod.isNotificationsPipelineEnabled('u1')).toBe(false);
+  });
+});

--- a/tests/notificationsAgent.test.ts
+++ b/tests/notificationsAgent.test.ts
@@ -74,5 +74,13 @@ describe('notificationsAgent order pipeline', () => {
       }),
     ).toThrowError(expect.objectContaining({ code: E_BACKLOG }));
     await new Promise((r) => setImmediate(r));
+    expect(notificationsAgent.isPaused()).toBe(true);
+  });
+
+  it('auto-pauses on high latency', async () => {
+    (notificationsAgent as any).latencyLimit = -1;
+    notificationsAgent.handleOrderEvent('order.created', { orderId: 'o1', userId: 'u1' });
+    await new Promise((r) => setImmediate(r));
+    expect(notificationsAgent.isPaused()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- gate notifications pipeline behind new `notificationsPipeline` feature flag with canary users and rollback
- pause notifications pipeline automatically on backlog or latency alerts
- document notification rollout guardrails

## Testing
- `npx -y jest` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80cb113e48326b7fd72be472e02ce