### PR TITLE
feat: enforce secure localized messaging

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -12,12 +12,10 @@ import {
 import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
-import { getClient } from '@/utils/transport';
-import { ensureNode, isWakuDisabled } from '@/services/waku';
+import { publish, isWakuDisabled } from '@/services/waku';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { errorLog } from '../utils/logger';
 import { buildTopic } from '../utils/wakuTopics';
-import { canonicalJson } from '@/utils/serialization';
 import {
   notificationsBacklog,
   notificationDeliveryLatency,
@@ -141,15 +139,9 @@ class NotificationsAgent {
     payload: Record<string, unknown> = {},
   ): Promise<void> {
     if (isWakuDisabled()) return;
-    const node = await ensureNode();
-    if (!node) return;
     try {
       const topic = buildTopic('analytics', '1');
-      const client = await getClient();
-      const encoder = client.createEncoder({ contentTopic: topic });
-      await node.lightPush.send(encoder, {
-        payload: client.utf8ToBytes(canonicalJson({ type: event, ...payload })),
-      });
+      await publish(topic, { type: event, ...payload });
     } catch (err) {
       errorLog('Failed to broadcast analytics event', err);
     }
@@ -160,19 +152,11 @@ class NotificationsAgent {
     event?: NotificationEvent,
     storeId = '1',
   ) {
-    const node = await ensureNode();
-    if (!node) return;
     try {
       const domain = event ? 'orders' : 'notifications';
       const topic = buildTopic(domain, storeId);
-      const client = await getClient();
-      const encoder = client.createEncoder({ contentTopic: topic });
-      const payload = event
-        ? { type: event, notification: item }
-        : item;
-      await node.lightPush.send(encoder, {
-        payload: client.utf8ToBytes(canonicalJson(payload)),
-      });
+      const payload = event ? { type: event, notification: item } : item;
+      await publish(topic, payload);
     } catch (err) {
       errorLog('Failed to broadcast notification', err);
     }

--- a/services/notification.ts
+++ b/services/notification.ts
@@ -4,11 +4,16 @@ import { uuid } from '../utils/uuid';
 import { Notification } from '../types';
 import notificationsAgent from '../agents/notifications-agent';
 import type { NotificationEvent } from '../types/waku';
+import { t } from '@/i18n';
 
 class NotificationService {
   private static instance: NotificationService;
 
   private constructor() {}
+
+  private localize(n: Notification): Notification {
+    return { ...n, title: t(n.title), message: t(n.message) };
+  }
 
   public static getInstance(): NotificationService {
     if (!NotificationService.instance) {
@@ -26,7 +31,8 @@ class NotificationService {
       const list = await notificationsAgent.getAll();
       return list
         .filter((n) => n.userId === userId)
-        .sort((a, b) => b.timestamp - a.timestamp);
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .map((n) => this.localize(n));
     } catch (error) {
       errorLog('Error in getNotifications:', error);
       return [];
@@ -89,7 +95,7 @@ class NotificationService {
         timestamp: Date.now(),
       };
       await notificationsAgent.add(newNotification);
-      return newNotification;
+      return this.localize(newNotification);
     } catch (error) {
       errorLog('Error in addNotification:', error);
       return null;
@@ -114,7 +120,7 @@ class NotificationService {
   // Subscribe to real-time notifications for a specific user
   subscribeToUserNotifications(userId: string, callback: (n: Notification) => void) {
     const handler = (n: Notification) => {
-      if (n.userId === userId) callback(n);
+      if (n.userId === userId) callback(this.localize(n));
     };
     notificationsAgent.subscribe(handler);
     return handler;

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -2,6 +2,7 @@ import type { LightNode } from '@waku/sdk';
 import { types } from 'near-lake-framework';
 import { getClient } from '@/utils/transport';
 import { errorLog } from '@/utils/logger';
+import { gzipSync } from 'zlib';
 import config from '@/config';
 import { canonicalJson } from '@/utils/serialization';
 import { retryWithBackoff } from '@/utils/retry';
@@ -35,6 +36,9 @@ let cachedNode: LightNode | null = null;
 const receivedIds = new Set<string>();
 let reconnectAttempt = 0;
 let lakeStarted = false;
+
+const MAX_GZ_PAYLOAD = 200 * 1024; // 200KB
+const PROMPT_TTI_MS = 2500; // 2.5s
 
 function getPublisherKey(): string {
   if (PUB) return PUB;
@@ -170,12 +174,21 @@ export async function publish(topic: string, message: any): Promise<string> {
   const client = await getClient();
   const id = message?.id || Date.now().toString();
   const payload = client.utf8ToBytes(canonicalJson({ ...message, id }));
+  const gzSize = gzipSync(Buffer.from(payload)).length;
+  if (gzSize > MAX_GZ_PAYLOAD) {
+    throw new Error('Payload exceeds 200KB gz limit');
+  }
   const encPayload = encrypt(topic, payload);
   try {
     const node = await ensureNode();
     if (!node) throw new Error('Waku disabled');
     const encoder = client.createEncoder({ contentTopic: topic });
-    await node.lightPush.send(encoder, { payload: encPayload });
+    await Promise.race([
+      node.lightPush.send(encoder, { payload: encPayload }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('TTI_EXCEEDED')), PROMPT_TTI_MS),
+      ),
+    ]);
   } catch {
     enqueue(topic, encPayload);
   }

--- a/tests/notificationLocalization.test.ts
+++ b/tests/notificationLocalization.test.ts
@@ -1,0 +1,28 @@
+import NotificationService from '../services/notification';
+import { setTranslations } from '@/i18n';
+
+jest.mock('../agents/notifications-agent', () => ({
+  getAll: jest.fn().mockResolvedValue([
+    {
+      id: '1',
+      userId: 'u1',
+      title: 'notify.orderCreated',
+      message: 'notify.orderCreated',
+      type: 'order',
+      read: false,
+      timestamp: 1,
+    },
+  ]),
+  add: jest.fn(),
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+}));
+
+describe('NotificationService localization', () => {
+  it('renders notifications in the user locale', async () => {
+    setTranslations({ notify: { orderCreated: 'Order Created!' } });
+    const svc = NotificationService.getInstance();
+    const list = await svc.getNotifications('u1');
+    expect(list[0].title).toBe('Order Created!');
+  });
+});

--- a/tests/wakuPublish.test.ts
+++ b/tests/wakuPublish.test.ts
@@ -1,0 +1,32 @@
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => ({
+    utf8ToBytes: (s: string) => Buffer.from(s),
+    createEncoder: jest.fn(),
+  })),
+}));
+
+import { publish } from '@/services/waku';
+import * as waku from '@/services/waku';
+
+describe('publish constraints', () => {
+  it('rejects payloads exceeding 200KB gz', async () => {
+    const big = { data: 'a'.repeat(210 * 1024) };
+    await expect(publish('/topic', big)).rejects.toThrow(
+      'Payload exceeds 200KB',
+    );
+  });
+
+  it('queues when send exceeds TTI', async () => {
+    jest.useFakeTimers();
+    const sendHang = jest.fn(() => new Promise(() => {}));
+    jest.spyOn(waku, 'ensureNode').mockResolvedValue({
+      lightPush: { send: sendHang },
+    } as any);
+    const enqueueSpy = jest.spyOn(require('@/utils/wakuStore'), 'enqueue');
+    const p = publish('/topic', { a: 1 });
+    jest.advanceTimersByTime(3000);
+    await p;
+    expect(enqueueSpy).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- route notifications and analytics through encrypted Waku publish with offline queueing and latency guard
- localize notification titles/messages using i18n hooks
- validate Waku payload size and timeout via tests

## Testing
- `yarn lint agents/notifications-agent.ts services/notification.ts services/waku.ts tests/notificationLocalization.test.ts tests/wakuPublish.test.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx jest tests/notificationsAgent.test.ts tests/notificationsPipeline.test.ts tests/notificationLocalization.test.ts tests/wakuPublish.test.ts` *(fails: Need to install the following packages: jest@30.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c80cbc09e08326a6765be3ffab7b60