### PR TITLE
feat: enable S3 persistence for NEAR Lake store

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Common variables include:
 | `NEAR_LAKE_BUCKET` | no | S3 bucket for NEAR Lake key-value storage. |
 | `NEAR_LAKE_REGION` | no | Region for the NEAR Lake bucket (default `eu-central-1`). |
 | `NEAR_LAKE_ENDPOINT` | no | Custom S3-compatible endpoint for NEAR Lake. |
+| `NEAR_ACCESS_KEY` | no | Access key for the NEAR Lake S3 bucket. |
+| `NEAR_SECRET_KEY` | no | Secret key for the NEAR Lake S3 bucket. |
 | `EXPO_PUBLIC_CONTRACT_ID` | yes | Marketplace contract account the app interacts with. |
 | `EXPO_PUBLIC_DEBUG_LOGS` | no | Set to `true` to enable verbose logging. |
 | `EXPO_PUBLIC_PINATA_API_KEY` | no | Pinata API key for authenticated uploads. |
@@ -137,6 +139,16 @@ The OrderPayment factory contract address is configured by admins through the
 - `EXPO_PUBLIC_PINATA_JWT` – Pinata JWT used by `scripts/pinata-upload.ts` to pin assets (optional)
 
 These values are read at build time and cannot be changed from the UI.
+
+Run a quick persistence check with:
+
+```sh
+node -r ts-node/register scripts/kv-smoke.js
+```
+
+The script writes a test value using `nearKvStore`, spawns a new process, and
+verifies the value is still available, ensuring the S3-backed store is
+configured correctly.
 
 ### Secure Key Management
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -37,6 +37,8 @@ const envSchema = z.object({
   NEAR_LAKE_DIR: z.string().optional().default(''),
   NEAR_LAKE_START_BLOCK: z.string().optional().default('0'),
   NEAR_LAKE_ENDPOINT: z.string().optional().default(''),
+  NEAR_ACCESS_KEY: z.string().optional().default(''),
+  NEAR_SECRET_KEY: z.string().optional().default(''),
   AWS_ACCESS_KEY_ID: z.string().optional().default(''),
   AWS_SECRET_ACCESS_KEY: z.string().optional().default(''),
   CACHE_DIR: z.string().optional().default(''),

--- a/scripts/kv-smoke.js
+++ b/scripts/kv-smoke.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const required = ['NEAR_LAKE_BUCKET', 'NEAR_ACCESS_KEY', 'NEAR_SECRET_KEY'];
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`Missing required env var: ${key}`);
+    process.exit(1);
+  }
+}
+
+function run(code) {
+  const res = spawnSync('node', ['-r', 'ts-node/register', '-e', code], {
+    cwd: path.resolve(__dirname, '..'),
+    env: process.env,
+    encoding: 'utf-8',
+  });
+  if (res.status !== 0) {
+    throw new Error(res.stderr);
+  }
+  return res.stdout.trim();
+}
+
+run("const kv=require('./services/nearKvStore'); (async()=>{await kv.setValue('smoke','ping','pong');})();");
+const out = run("const kv=require('./services/nearKvStore'); (async()=>{const v=await kv.getValue('smoke','ping'); console.log(v ?? '')})();");
+
+if (out !== 'pong') {
+  console.error('Persistence check failed');
+  process.exit(1);
+}
+console.log('S3 persistence check passed');

--- a/services/nearKvStore.ts
+++ b/services/nearKvStore.ts
@@ -73,9 +73,11 @@ async function ensureLake() {
         opts.endPoint = `s3.${region}.amazonaws.com`;
         opts.useSSL = true;
       }
-      if (config.AWS_ACCESS_KEY_ID && config.AWS_SECRET_ACCESS_KEY) {
-        opts.accessKey = config.AWS_ACCESS_KEY_ID;
-        opts.secretKey = config.AWS_SECRET_ACCESS_KEY;
+      const accessKey = config.NEAR_ACCESS_KEY || config.AWS_ACCESS_KEY_ID;
+      const secretKey = config.NEAR_SECRET_KEY || config.AWS_SECRET_ACCESS_KEY;
+      if (accessKey && secretKey) {
+        opts.accessKey = accessKey;
+        opts.secretKey = secretKey;
       }
       if (!useMemoryStore && !S3Client) {
         const { Client } = require('minio');
@@ -83,7 +85,24 @@ async function ensureLake() {
       }
       if (S3Client) {
         s3 = new S3Client(opts);
-
+        lakeStarted = true;
+        if (s3) {
+          try {
+            const stream = s3.listObjectsV2(bucketName, '', true);
+            const addresses = new Set<string>();
+            for await (const obj of stream as any) {
+              const name = obj.name as string;
+              const idx = name.indexOf('/');
+              if (idx > 0) addresses.add(name.substring(0, idx));
+            }
+            for (const addr of addresses) {
+              await listValues(addr);
+            }
+          } catch {
+            // ignore hydration errors
+          }
+        }
+        return;
       }
     }
   } catch {
@@ -91,6 +110,8 @@ async function ensureLake() {
   }
   lakeStarted = true;
 }
+
+ensureLake().catch(() => {});
 
 function objectKey(address: string, key: string): string {
   validateSegment(address);
@@ -199,8 +220,19 @@ export async function listValues(
       for await (const obj of stream as any) {
         const fullKey = obj.name as string;
         const key = fullKey.substring(prefix.length);
-        const val = await getValue(address, key);
-        if (val !== null) out.push({ key, value: val });
+        try {
+          const valStream = await s3.getObject(bucket, fullKey);
+          const value = await streamToString(valStream as Readable);
+          out.push({ key, value });
+          let addrStore = memStore.get(address);
+          if (!addrStore) {
+            addrStore = new Map();
+            memStore.set(address, addrStore);
+          }
+          addrStore.set(key, value);
+        } catch {
+          // ignore individual objects
+        }
       }
     } catch {
       // ignore


### PR DESCRIPTION
## Summary
- wire nearKvStore to initialize NEAR Lake S3 with NEAR_ACCESS_KEY/NEAR_SECRET_KEY
- hydrate key-value state from S3 on startup
- document env vars and add kv-smoke script

## Testing
- `yarn lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `yarn typecheck` *(fails: Cannot find type definition file for 'jest', 'node', 'react'; File 'expo/tsconfig.base.json' not found)*
- `yarn jest tests/nearKvPersistence.test.ts` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80ce5b6bc8326b2dad0ab43d67c79