### PR TITLE
feat: poll notifications on high latency

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -39,6 +39,9 @@ class NotificationsAgent {
   private backlogLimit = 50;
   private paused = false;
   private latencyLimit = 5000; // ms
+  private delivered = new Set<string>();
+  private pollTimer: NodeJS.Timeout | null = null;
+  private pollInterval = 30000;
 
   constructor() {
     onBacklog(() => this.pause());
@@ -53,7 +56,10 @@ class NotificationsAgent {
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
-    this.subscribers.forEach((cb) => cb(normalized));
+    if (!this.delivered.has(normalized.id)) {
+      this.delivered.add(normalized.id);
+      this.subscribers.forEach((cb) => cb(normalized));
+    }
     await this.broadcastWaku(normalized, undefined, storeId);
   }
 
@@ -62,7 +68,10 @@ class NotificationsAgent {
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
-    this.subscribers.forEach((cb) => cb(normalized));
+    if (!this.delivered.has(normalized.id)) {
+      this.delivered.add(normalized.id);
+      this.subscribers.forEach((cb) => cb(normalized));
+    }
     await this.broadcastWaku(normalized, undefined, storeId);
   }
 
@@ -107,6 +116,40 @@ class NotificationsAgent {
       }
     }
     this.draining = false;
+  }
+
+  private async poll(): Promise<void> {
+    try {
+      const items = await listNotifications();
+      items.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+      let prev = 0;
+      for (const n of items) {
+        if (prev > (n.timestamp || 0)) {
+          errorLog('Out-of-order notification', {
+            prev,
+            current: n.timestamp,
+          });
+        }
+        prev = n.timestamp || 0;
+        if (this.delivered.has(n.id)) continue;
+        this.delivered.add(n.id);
+        this.subscribers.forEach((cb) => cb(n));
+      }
+    } catch (err) {
+      errorLog('Failed to poll notifications', err);
+    }
+  }
+
+  private startPolling(): void {
+    if (this.pollTimer) return;
+    void this.poll();
+    this.pollTimer = setInterval(() => void this.poll(), this.pollInterval);
+  }
+
+  private stopPolling(): void {
+    if (!this.pollTimer) return;
+    clearInterval(this.pollTimer);
+    this.pollTimer = null;
   }
 
   handleOrderEvent(
@@ -174,7 +217,10 @@ class NotificationsAgent {
     await this.ensureWallet();
     const normalized = normalizeMessage<Notification>('Notification', item);
     await setNotification(normalized);
-    this.subscribers.forEach((cb) => cb(normalized));
+    if (!this.delivered.has(normalized.id)) {
+      this.delivered.add(normalized.id);
+      this.subscribers.forEach((cb) => cb(normalized));
+    }
     // Broadcast the user-facing notification
     await this.broadcastWaku(normalized, undefined, storeId);
     // Broadcast the order event for other agents
@@ -218,12 +264,15 @@ class NotificationsAgent {
   }
 
   pause(): void {
+    if (this.paused) return;
     this.paused = true;
+    this.startPolling();
   }
 
   resume(): void {
     if (!this.paused) return;
     this.paused = false;
+    this.stopPolling();
     if (this.backlog.length && !this.draining) void this.drain();
   }
 

--- a/scripts/check-notification-keys.js
+++ b/scripts/check-notification-keys.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.join(__dirname, '..', 'translations');
+const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+const locales = files.map((f) => ({
+  locale: f.replace(/\.json$/, ''),
+  data: JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')),
+}));
+
+if (locales.length === 0) {
+  console.error('No locale files found');
+  process.exit(1);
+}
+
+const ref = locales.find((l) => l.locale === 'en') || locales[0];
+const required = ['notifications', 'notify'];
+let missing = [];
+
+for (const { locale, data } of locales) {
+  for (const section of required) {
+    const refSection = ref.data[section] || {};
+    const locSection = data[section] || {};
+    for (const key of Object.keys(refSection)) {
+      if (!(key in locSection)) {
+        missing.push(`${locale}: missing ${section}.${key}`);
+      }
+    }
+  }
+}
+
+if (missing.length) {
+  console.error('Missing notification translations:\n' + missing.join('\n'));
+  process.exit(1);
+}

--- a/tests/notificationsAgent.test.ts
+++ b/tests/notificationsAgent.test.ts
@@ -83,4 +83,31 @@ describe('notificationsAgent order pipeline', () => {
     await new Promise((r) => setImmediate(r));
     expect(notificationsAgent.isPaused()).toBe(true);
   });
+
+  it('falls back to polling when paused', async () => {
+    jest.useFakeTimers();
+    (notificationsAgent as any).latencyLimit = -1;
+    (notificationsAgent as any).pollInterval = 10;
+    const sub = jest.fn();
+    notificationsAgent.subscribe(sub);
+    notificationsAgent.handleOrderEvent('order.created', { orderId: 'o1', userId: 'u1' });
+    await new Promise((r) => setImmediate(r));
+    expect(notificationsAgent.isPaused()).toBe(true);
+    const polled = {
+      id: 'p1',
+      userId: 'u1',
+      title: 't',
+      message: 'm',
+      type: 'order',
+      read: false,
+      timestamp: Date.now(),
+    };
+    const list = require('@/services/nearNotifications').listNotifications as jest.Mock;
+    list.mockResolvedValueOnce([polled]);
+    jest.advanceTimersByTime(10);
+    await Promise.resolve();
+    expect(sub).toHaveBeenCalledWith(expect.objectContaining({ id: 'p1' }));
+    notificationsAgent.unsubscribe(sub);
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- add idempotent notification delivery with polling fallback when push latency is high
- check translation files for missing notification keys
- cover polling fallback with tests

## Testing
- `node scripts/check-notification-keys.js`
- `npx -y jest tests/notificationsAgent.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c811e55b3883269e425e32690a6df9