### PR TITLE
feat: track notification engagement

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -159,6 +159,7 @@ class NotificationsAgent {
       title,
       message,
       type: 'order',
+      link: `/orders/${payload.orderId}`,
       read: false,
       timestamp: Date.now(),
     };

--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -2,6 +2,10 @@ import React, { createContext, useState, useContext, ReactNode, useCallback } fr
 import NotificationPopup from './NotificationPopup';
 import AgentError from '@/types/AgentError';
 import { useNotificationSubscription } from '@/features/notifications';
+import NotificationService from '@/services/notification';
+import eventBus from '@/services/eventBus';
+import { useAppRouter } from '@/services';
+import { uuid } from '@/utils/uuid';
 
 interface NotificationState {
   unreadCount: number;
@@ -13,6 +17,8 @@ interface NotificationActions {
     title: string,
     message: string,
     type?: 'success' | 'info' | 'warning' | 'error',
+    link?: string,
+    id?: string,
   ) => void;
   showAgentError: (error: AgentError) => void;
 }
@@ -40,8 +46,10 @@ interface NotificationProviderProps {
 
 export function NotificationProvider({ children }: NotificationProviderProps) {
   const [activeNotification, setActiveNotification] = useState<{
+    id?: string;
     title: string;
     message: string;
+    link?: string;
     type: 'success' | 'info' | 'warning' | 'error';
   } | null>(null);
 
@@ -50,8 +58,10 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
       title: string,
       message: string,
       type: 'success' | 'info' | 'warning' | 'error' = 'info',
+      link?: string,
+      id?: string,
     ) => {
-      setActiveNotification({ title, message, type });
+      setActiveNotification({ id, title, message, type, link });
     },
     [],
   );
@@ -59,6 +69,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   const showAgentError = useCallback(
     (error: AgentError) => {
       setActiveNotification({
+        id: uuid(),
         title: error.source,
         message: `[${error.code}] ${error.message}`,
         type: 'error',
@@ -68,8 +79,20 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   );
 
   const { unreadCount, refreshNotifications } = useNotificationSubscription(showNotification);
+  const { push } = useAppRouter();
 
   const handleClose = () => setActiveNotification(null);
+
+  const handleNavigate = () => {
+    if (!activeNotification) return;
+    if (activeNotification.id) {
+      NotificationService.getInstance().setLastOpenedNotificationId(activeNotification.id);
+      eventBus.track('notification.opened', { notificationId: activeNotification.id });
+    }
+    if (activeNotification.link) {
+      push(activeNotification.link);
+    }
+  };
 
   return (
     <NotificationActionsContext.Provider value={{ showNotification, showAgentError }}>
@@ -81,6 +104,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
             message={activeNotification.message}
             type={activeNotification.type}
             onClose={handleClose}
+            onPress={handleNavigate}
           />
         )}
       </NotificationStateContext.Provider>

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -18,6 +18,7 @@ interface NotificationPopupProps {
   type?: 'success' | 'info' | 'warning' | 'error';
   duration?: number;
   onClose: () => void;
+  onPress?: () => void;
 }
 
 const { width } = Dimensions.get('window');
@@ -27,7 +28,8 @@ export default function NotificationPopup({
   message,
   type = 'info',
   duration = 3000,
-  onClose
+  onClose,
+  onPress,
 }: NotificationPopupProps) {
   const translateY = useRef(new Animated.Value(-100)).current;
   const opacity = useRef(new Animated.Value(0)).current;
@@ -73,6 +75,11 @@ export default function NotificationPopup({
     });
   };
 
+  const handlePress = () => {
+    onPress?.();
+    dismiss();
+  };
+
   const getBackgroundColor = () => {
     switch (type) {
       case 'success':
@@ -90,37 +97,39 @@ export default function NotificationPopup({
   return (
     <Portal>
       <Overlay />
-      <Animated.View
-        style={[
-          styles.container,
-          {
-            transform: [{ translateY }],
-            opacity,
-            backgroundColor: getBackgroundColor()
-          }
-        ]}
-      >
-        <View style={styles.content}>
-          <View style={styles.textContainer}>
-            <Heading
-              size="md"
-              style={[styles.title, { color: colors.text.inverse }]}
-            >
-              {title}
-            </Heading>
-            <Text
-              style={[styles.message, { color: colors.text.inverse }]}
-              numberOfLines={2}
-              variant="sm"
-            >
-              {message}
-            </Text>
+      <TouchableOpacity activeOpacity={0.9} onPress={handlePress}>
+        <Animated.View
+          style={[
+            styles.container,
+            {
+              transform: [{ translateY }],
+              opacity,
+              backgroundColor: getBackgroundColor()
+            }
+          ]}
+        >
+          <View style={styles.content}>
+            <View style={styles.textContainer}>
+              <Heading
+                size="md"
+                style={[styles.title, { color: colors.text.inverse }]}
+              >
+                {title}
+              </Heading>
+              <Text
+                style={[styles.message, { color: colors.text.inverse }]}
+                numberOfLines={2}
+                variant="sm"
+              >
+                {message}
+              </Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={dismiss}>
+              <X size={20} color={colors.text.inverse} />
+            </TouchableOpacity>
           </View>
-          <TouchableOpacity style={styles.closeButton} onPress={dismiss}>
-            <X size={20} color={colors.text.inverse} />
-          </TouchableOpacity>
-        </View>
-      </Animated.View>
+        </Animated.View>
+      </TouchableOpacity>
     </Portal>
   );
 }

--- a/schemas/waku/notification.ts
+++ b/schemas/waku/notification.ts
@@ -6,6 +6,7 @@ export const notificationSchema: z.ZodType<Notification> = z.object({
   userId: z.string(),
   title: z.string(),
   message: z.string(),
+  link: z.string().optional(),
   type: z.enum(['order', 'promo', 'message', 'system']),
   read: z.boolean(),
   timestamp: z.number(),

--- a/services/notification.ts
+++ b/services/notification.ts
@@ -5,9 +5,12 @@ import { Notification } from '../types';
 import notificationsAgent from '../agents/notifications-agent';
 import type { NotificationEvent } from '../types/waku';
 import { t } from '@/i18n';
+import eventBus from '@/services/eventBus';
 
 class NotificationService {
   private static instance: NotificationService;
+
+  private lastOpenedNotificationId: string | null = null;
 
   private constructor() {}
 
@@ -83,6 +86,7 @@ class NotificationService {
     title: string;
     message: string;
     type: 'order' | 'promo' | 'message' | 'system';
+    link?: string;
   }): Promise<Notification | null> {
     try {
       const newNotification: Notification = {
@@ -91,6 +95,7 @@ class NotificationService {
         title: notification.title,
         message: notification.message,
         type: notification.type,
+        link: notification.link,
         read: false,
         timestamp: Date.now(),
       };
@@ -120,7 +125,15 @@ class NotificationService {
   // Subscribe to real-time notifications for a specific user
   subscribeToUserNotifications(userId: string, callback: (n: Notification) => void) {
     const handler = (n: Notification) => {
-      if (n.userId === userId) callback(this.localize(n));
+      if (n.userId === userId) {
+        eventBus.track('notification.delivered', {
+          notificationId: n.id,
+          userId: n.userId,
+          type: n.type,
+          link: n.link,
+        });
+        callback(this.localize(n));
+      }
     };
     notificationsAgent.subscribe(handler);
     return handler;
@@ -129,6 +142,14 @@ class NotificationService {
   // Unsubscribe from real-time notifications
   unsubscribeFromNotifications(subscription: any) {
     notificationsAgent.unsubscribe(subscription);
+  }
+
+  setLastOpenedNotificationId(id: string) {
+    this.lastOpenedNotificationId = id;
+  }
+
+  getLastOpenedNotificationId(): string | null {
+    return this.lastOpenedNotificationId;
   }
 }
 

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -51,6 +51,7 @@ import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { requestTokenWithConsent } from '@/services/session';
 import { uuid } from '@/utils/uuid';
+import NotificationService from '@/services/notification';
 
 const PRODUCT_CACHE_TOPIC = '/blue-ocean/products/1';
 
@@ -298,6 +299,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         orderIds: orders.map((o) => o.id),
         total: getTotal(),
         cacheHitRatio: getCacheHitRatio(PRODUCT_CACHE_TOPIC),
+        sourceNotificationId: NotificationService.getInstance().getLastOpenedNotificationId(),
       });
       setOrderIds(orders.map((o) => o.id));
       setOrderPlaced(true);

--- a/src/features/notifications/hooks/useNotificationSubscription.ts
+++ b/src/features/notifications/hooks/useNotificationSubscription.ts
@@ -4,9 +4,16 @@ import NotificationService from '@/services/notification';
 import { useWaku } from '@/contexts/WakuContext';
 import { parseNotificationWakuPayload } from '@/schemas/waku';
 import { errorLog } from '@/utils/logger';
+import eventBus from '@/services/eventBus';
 
 export function useNotificationSubscription(
-  onNotification?: (title: string, message: string, type?: 'success' | 'info' | 'warning' | 'error') => void,
+  onNotification?: (
+    title: string,
+    message: string,
+    type?: 'success' | 'info' | 'warning' | 'error',
+    link?: string,
+    id?: string,
+  ) => void,
 ) {
   const [unreadCount, setUnreadCount] = useState(0);
   const { isLoggedIn, user } = useAuth();
@@ -21,8 +28,15 @@ export function useNotificationSubscription(
     }
     try {
       const notificationService = NotificationService.getInstance();
-      const count = await notificationService.getUnreadCount(user.id);
-      setUnreadCount(count);
+      const list = await notificationService.getNotifications(user.id);
+      const unread = list.filter((n) => !n.read);
+      setUnreadCount(unread.length);
+      if (unread.length) {
+        eventBus.track('notification.user_return', {
+          userId: user.id,
+          notificationIds: unread.map((n) => n.id),
+        });
+      }
     } catch (error) {
       errorLog('Error refreshing notifications:', error);
     }
@@ -61,6 +75,8 @@ export function useNotificationSubscription(
             : notification.type === 'promo' || notification.type === 'message'
               ? 'info'
               : 'info',
+          notification.link,
+          notification.id,
         );
       },
     );
@@ -86,6 +102,12 @@ export function useNotificationSubscription(
         if (!payload) return;
         const n = payload.notification;
         if (n.userId !== user.id) return;
+        eventBus.track('notification.delivered', {
+          notificationId: n.id,
+          userId: n.userId,
+          type: n.type,
+          link: n.link,
+        });
         setUnreadCount((prev) => prev + 1);
         onNotification?.(
           n.title,
@@ -95,6 +117,8 @@ export function useNotificationSubscription(
             : n.type === 'promo' || n.type === 'message'
               ? 'info'
               : 'info',
+          n.link,
+          n.id,
         );
       } catch (err) {
         errorLog('Failed to parse notification', err);

--- a/types/index.ts
+++ b/types/index.ts
@@ -163,6 +163,7 @@ export interface Notification {
   userId: string;
   title: string;
   message: string;
+  link?: string;
   type: 'order' | 'promo' | 'message' | 'system';
   read: boolean;
   timestamp: number;


### PR DESCRIPTION
## Summary
- add `link` field to notifications and broadcast deep links for order events
- track notification delivery, user returns, and opened-to-purchase conversions
- navigate from notification popups into shopping flows

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file, dependencies require newer Node)*
- `npm run typecheck` *(fails: tsc not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c81213eab88326b77a30792b8a0801