### PR TITLE
feat: attach checkout session tokens to orders

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -63,6 +63,7 @@ class OrdersAgent {
       storeId: order.items?.[0]?.product?.storeId || '',
       buyerAddress: order.buyerAddress,
       sellerAddress: order.sellerAddress,
+      sessionToken: order.sessionToken,
       payment: {
         method: order.paymentMethod,
         contractAddress: order.paymentContractAddress,

--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -93,6 +93,13 @@ export const authInvalidScopeCounter = new Counter({
   registers: [registry],
 });
 
+export const checkoutTokenIntegrity = new Counter({
+  name: 'checkout_token_integrity_total',
+  help: 'Checkout attempts labeled by token validity and success',
+  labelNames: ['token_valid', 'success'],
+  registers: [registry],
+});
+
 export async function withMonitoring<T>(
   service: string,
   fn: () => Promise<T>,

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -19,18 +19,24 @@ import config from '../utils/appConfig';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
 import { validateToken } from '@/services/session';
+import { checkoutTokenIntegrity } from '@/services/monitoring';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
 const LOW_STOCK_THRESHOLD = 5;
 
-export async function emitOrderEvents(order: Order, storeId: string) {
+export async function emitOrderEvents(
+  order: Order,
+  storeId: string,
+  sessionToken?: string,
+) {
   const baseEvent = {
     id: order.id,
     orderId: order.id,
     storeId,
     buyerAddress: order.buyerAddress,
     sellerAddress: order.sellerAddress,
+    sessionToken,
     payment: {
       method: order.paymentMethod,
       contractAddress: order.paymentContractAddress,
@@ -160,6 +166,7 @@ class OrderService {
       paymentMethod: pay?.method ?? 'cash_on_delivery',
       buyerAddress: pay?.buyerAddress,
       sellerAddress: pay?.sellerAddress,
+      sessionToken,
       paymentContractAddress: pay?.contractAddress,
       escrowAddr: pay?.contractAddress,
       paymentTxHash: pay?.txHash,
@@ -190,6 +197,7 @@ class OrderService {
         tokenValid: false,
         success: false,
       });
+      checkoutTokenIntegrity.inc({ token_valid: 'false', success: 'false' });
       throw err;
     }
     try {
@@ -228,19 +236,21 @@ class OrderService {
           payment,
           sessionToken,
         );
-        await emitOrderEvents(order, storeId);
+        await emitOrderEvents(order, storeId, sessionToken);
         orders.push(order);
       }
       void eventBus.track('checkout.token_integrity', {
         tokenValid: true,
         success: true,
       });
+      checkoutTokenIntegrity.inc({ token_valid: 'true', success: 'true' });
       return orders;
     } catch (err) {
       void eventBus.track('checkout.token_integrity', {
         tokenValid: true,
         success: false,
       });
+      checkoutTokenIntegrity.inc({ token_valid: 'true', success: 'false' });
       throw err;
     }
   }

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -10,6 +10,8 @@ import { getEd25519KeyPair } from '@/services/localIdentity';
 import { t } from '@/i18n';
 import { Buffer } from 'buffer';
 import { getUser as getChainUser, setUser as setChainUser } from './services/nearUsers';
+import { requestScopes } from '@/services/session';
+import { uuid } from '@/utils/uuid';
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -19,6 +21,7 @@ interface AuthContextType {
   isPlatformAdmin: boolean;
   user: User | null;
   loading: boolean;
+  sessionToken: string | null;
   login: () => Promise<void>;
   signup: () => Promise<void>;
   logout: () => Promise<void>;
@@ -34,6 +37,7 @@ const AuthContext = createContext<AuthContextType>({
   isPlatformAdmin: false,
   user: null,
   loading: false,
+  sessionToken: null,
   login: async () => {},
   signup: async () => {},
   logout: async () => {},
@@ -49,6 +53,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const { address, connect, disconnect } = useWallet();
   const [user, setUser] = useState<User | null>(null);
   const [initialized, setInitialized] = useState(false);
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
 
   const checkAuthState = async () => {
     // Prefer WalletProvider address; fall back to adapter's plain getters only
@@ -148,6 +153,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const login = async () => {
     try {
       await connect();
+      const { token } = requestScopes(['write'], () => uuid());
+      setSessionToken(token);
     } catch (err: unknown) {
       errorLog(
         t('auth.walletConnectionFailed', 'Wallet connection failed'),
@@ -168,6 +175,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const logout = async () => {
     try {
       await disconnect();
+      setSessionToken(null);
     } catch (err) {
       errorLog(t('auth.logoutFailed', 'Logout failed'), err);
     }
@@ -193,6 +201,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         isPlatformAdmin,
         user,
         loading: false,
+        sessionToken,
         login,
         signup,
         logout,

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -1,0 +1,109 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { AuthProvider, useAuth } from '@/features/auth/AuthContext';
+import OrderService from '@/services/orders';
+import { CartItem, ShippingAddress } from '@/types';
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({
+    address: 'buyer.near',
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const store: Record<string, any> = {};
+jest.mock('@/services/nearOrders', () => ({
+  setOrder: jest.fn(async (o: any) => { store[o.id] = o; }),
+  getOrder: jest.fn(async (id: string) => store[id] || null),
+  listOrders: jest.fn().mockResolvedValue([]),
+  removeOrder: jest.fn(),
+  listOrdersBySeller: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/services/eventBus', () => ({ publish: jest.fn(), track: jest.fn() }));
+
+jest.mock('@/features/auth/services/nearAuth', () => ({
+  getAccountId: jest.fn().mockReturnValue('buyer.near'),
+  signIn: jest.fn(),
+}));
+
+jest.mock('@/features/stores/services/nearStores', () => ({
+  getStore: jest.fn(async (id: string) => ({ id, name: id, owner: `seller_${id}` })),
+}));
+
+const mockProducts: Record<string, any> = {};
+jest.mock('@/features/products/services/nearProducts', () => ({
+  getProduct: jest.fn(async (id: string) => mockProducts[id] || null),
+  setProduct: jest.fn(async (p: any) => { mockProducts[p.id] = p; }),
+}));
+
+jest.mock('@/services/eventLog', () => ({ logOrderEvent: jest.fn() }));
+
+const addMock = jest.fn();
+jest.mock('../../agents/orders-agent', () => ({
+  __esModule: true,
+  default: {
+    subscribe: jest.fn(),
+    add: addMock,
+    get: jest.fn(),
+    getAll: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+  },
+}));
+
+function Grab() {
+  (Grab as any).ctx = useAuth();
+  return null;
+}
+
+describe('login issues session token used in checkout', () => {
+  it('creates an order with attached session token', async () => {
+    const svc = OrderService.getInstance();
+    await act(async () => {
+      renderer.create(
+        React.createElement(AuthProvider, null, React.createElement(Grab, null)),
+      );
+    });
+    const ctx = (Grab as any).ctx;
+    await act(async () => {
+      await ctx.login();
+    });
+    expect(ctx.sessionToken).toBeTruthy();
+
+    const item: CartItem = {
+      id: 'i1',
+      productId: 'p1',
+      product: {
+        id: 'p1',
+        name: 'P1',
+        price: 5,
+        description: 'd',
+        category: 'c',
+        images: [],
+        rating: 0,
+        reviews: 0,
+        storeId: 's1',
+        stock: 10,
+      },
+      quantity: 1,
+      addedAt: '',
+    };
+    mockProducts['p1'] = { ...item.product };
+
+    const shipping: ShippingAddress = {
+      name: 'A',
+      phone: '1',
+      street: 'st',
+      city: 'c',
+      postalCode: 'p',
+    };
+
+    await svc.createOrdersFromCart('user1', [item], shipping, 'cash_on_delivery', ctx.sessionToken!);
+
+    expect(addMock).toHaveBeenCalled();
+    const passedOrder = addMock.mock.calls[0][0];
+    expect(passedOrder.sessionToken).toBe(ctx.sessionToken);
+  });
+});
+

--- a/types/index.ts
+++ b/types/index.ts
@@ -251,6 +251,7 @@ export interface Order {
   buyerAddress?: string;
   sellerAddress?: string;
   driverAddress?: string;
+  sessionToken?: string;
   paymentContractAddress?: string;
   escrowAddr?: string;
   disputeEvidenceUri?: string;


### PR DESCRIPTION
## Summary
- issue and store scoped session token on login
- add session token field to orders and include in Waku events
- track checkout token integrity with Prometheus metrics
- add integration test for login → token issuance → checkout

## Testing
- `npx --yes jest@29.7.0 tests/auth/checkoutSessionToken.test.ts` *(fails: Preset ts-jest/presets/default-esm not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c815fb44608326be9161c7ed4fb3ea