### PR TITLE
feat: prompt store creation for new admins

### DIFF
--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -22,6 +22,7 @@ interface InfoModalProps {
   type?: InfoType;
   buttonText?: string;
   onClose: () => void;
+  onConfirm?: () => void;
   autoClose?: boolean;
   autoCloseTime?: number;
 }
@@ -33,6 +34,7 @@ export default function InfoModal({
   type = 'info',
   buttonText,
   onClose,
+  onConfirm,
   autoClose = true,
   autoCloseTime = 3000,
 }: InfoModalProps) {
@@ -130,7 +132,7 @@ export default function InfoModal({
 
           <Button
             title={buttonLabel}
-            onPress={onClose}
+            onPress={onConfirm ?? onClose}
             style={{
               minWidth: 120,
               paddingHorizontal: spacing.spacer24,

--- a/src/features/home/components/HomeOptions.tsx
+++ b/src/features/home/components/HomeOptions.tsx
@@ -1,5 +1,5 @@
 // TOUCHPOINT: src/features/home/components/HomeOptions.tsx renders in production — Fix Pack v2
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import {
   StyleSheet,
   Linking,
@@ -22,12 +22,15 @@ import { useWallet } from '@/contexts/WalletProvider';
 import guard from '@/utils/guard';
 import { getShopTenantId, getDocsUrl } from '@/services/config';
 import { prefetchStoreBundle } from '@/features/stores/services/prefetch';
+import { useStores } from '@/services/useStores';
+import InfoModal from '@/components/InfoModal';
 
 function HomeOptions() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const appRouter = useAppRouter();
   const { address: walletAddress, connect } = useWallet();
+  const { data: stores = [] } = useStores('default');
 
   const shopTenantId = getShopTenantId();
   const docsUrl = getDocsUrl();
@@ -39,6 +42,8 @@ function HomeOptions() {
   const horizontalPadding = spacing.spacer16;
 
   const [containerWidth, setContainerWidth] = useState(0);
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const [prompted, setPrompted] = useState(false);
 
   // Always render 4 columns; tiles shrink/expand as needed
   const cols = 4;
@@ -73,6 +78,23 @@ function HomeOptions() {
     if (docsUrl) {
       Linking.openURL(docsUrl);
     }
+  };
+
+  useEffect(() => {
+    if (prompted || !walletAddress) return;
+    const ownsStore = stores.some(
+      (s) => s.owner?.toLowerCase() === walletAddress.toLowerCase()
+    );
+    if (!ownsStore) {
+      setShowOnboarding(true);
+      setPrompted(true);
+    }
+  }, [walletAddress, stores, prompted]);
+
+  const handleOnboardingClose = () => setShowOnboarding(false);
+  const handleOnboardingConfirm = () => {
+    setShowOnboarding(false);
+    handleCreateStore();
   };
 
   const handleKeyDown = (e: any, action: () => void) => {
@@ -158,22 +180,38 @@ function HomeOptions() {
   );
 
   return (
-    <View
-      onLayout={onLayoutGrid}
-      style={[
-        styles.desktopRow,
-        {
-          flexDirection: isRTL ? 'row-reverse' : 'row',
-          flexWrap: 'wrap',
-          gap: gapPx,
-          paddingHorizontal: horizontalPadding,
-          // Keep content clear of the sticky bottom tab bar but minimize scroll
-          paddingBottom: 72,
-        },
-      ]}
-    >
-      {options.map(renderCard)}
-    </View>
+    <>
+      <InfoModal
+        visible={showOnboarding}
+        title={t('home.create_store_prompt_title', 'Create your store')}
+        message={
+          t(
+            'home.create_store_prompt_message',
+            'You have no store yet. Create one to start selling.'
+          )
+        }
+        buttonText={t('home.create_store_prompt_action', 'Create Store')}
+        onClose={handleOnboardingClose}
+        onConfirm={handleOnboardingConfirm}
+        autoClose={false}
+      />
+      <View
+        onLayout={onLayoutGrid}
+        style={[
+          styles.desktopRow,
+          {
+            flexDirection: isRTL ? 'row-reverse' : 'row',
+            flexWrap: 'wrap',
+            gap: gapPx,
+            paddingHorizontal: horizontalPadding,
+            // Keep content clear of the sticky bottom tab bar but minimize scroll
+            paddingBottom: 72,
+          },
+        ]}
+      >
+        {options.map(renderCard)}
+      </View>
+    </>
   );
 }
 

--- a/tests/homeOnboardingPrompt.test.tsx
+++ b/tests/homeOnboardingPrompt.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+const InfoModalMock = jest.fn(() => null);
+jest.mock('@/components/InfoModal', () => (props: any) => {
+  InfoModalMock(props);
+  return null;
+});
+
+const mockUseLanguage = { t: (s: string, d?: string) => d || s };
+const mockUseTheme = {
+  colors: {
+    text: { primary: '#000', secondary: '#333' },
+    gold: '#FFD700',
+    surface: { primary: '#fff', elevated: '#eee' },
+  },
+};
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => mockUseLanguage,
+  useTheme: () => mockUseTheme,
+}));
+
+const mockAppRouter = { push: jest.fn() };
+jest.mock('@/services/useAppRouter', () => ({ useAppRouter: () => mockAppRouter }));
+
+const mockWallet = { address: '0xabc', connect: jest.fn() };
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => mockWallet,
+}));
+
+const mockUseStores = jest.fn();
+jest.mock('@/services/useStores', () => ({
+  useStores: () => mockUseStores(),
+}));
+
+import HomeOptions from '@/features/home/components/HomeOptions';
+
+describe('HomeOptions store onboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows prompt when user has no store', async () => {
+    mockUseStores.mockReturnValue({ data: [] });
+    await act(async () => {
+      renderer.create(<HomeOptions />);
+    });
+    expect(InfoModalMock).toHaveBeenCalled();
+    const props = InfoModalMock.mock.calls[0][0];
+    expect(props.visible).toBe(true);
+  });
+
+  it('does not show prompt when user owns a store', async () => {
+    mockUseStores.mockReturnValue({ data: [{ id: '1', owner: '0xabc', name: 'S' }] });
+    await act(async () => {
+      renderer.create(<HomeOptions />);
+    });
+    expect(InfoModalMock).not.toHaveBeenCalled();
+  });
+});

--- a/translations/en.json
+++ b/translations/en.json
@@ -129,7 +129,10 @@
     "priceHighLow": "Price: High to Low",
     "highRating": "High Rating",
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
-    "connectWalletToContinue": "Connect wallet to continue"
+    "connectWalletToContinue": "Connect wallet to continue",
+    "create_store_prompt_title": "Create your store",
+    "create_store_prompt_message": "You have no store yet. Create one to start selling.",
+    "create_store_prompt_action": "Create Store"
   },
   "cta": {
     "create_store": "Create a Store",

--- a/translations/he.json
+++ b/translations/he.json
@@ -129,7 +129,10 @@
     "priceHighLow": "מחיר: גבוה לנמוך",
     "highRating": "דירוג גבוה",
     "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש.",
-    "connectWalletToContinue": "חבר ארנק כדי להמשיך"
+    "connectWalletToContinue": "חבר ארנק כדי להמשיך",
+    "create_store_prompt_title": "צור את החנות שלך",
+    "create_store_prompt_message": "אין לך עדיין חנות. צור אחת כדי להתחיל למכור.",
+    "create_store_prompt_action": "צור חנות"
   },
   "cta": {
     "create_store": "צור חנות",


### PR DESCRIPTION
## Summary
- prompt wallet-connected users without a store to create one via onboarding modal
- add onConfirm handler to InfoModal for separate CTA actions
- localize new onboarding copy and test visibility logic

## Testing
- `npx eslint components/InfoModal.tsx src/features/home/components/HomeOptions.tsx tests/homeOnboardingPrompt.test.tsx` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx -y jest tests/homeOnboardingPrompt.test.tsx` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c816515cb08326b6a3f118f8230d76