### PR TITLE
Hide unfinished premium and chat controls

### DIFF
--- a/app/store/[storeId]/admin/_DeliveriesScreen.tsx
+++ b/app/store/[storeId]/admin/_DeliveriesScreen.tsx
@@ -109,11 +109,6 @@ export default function AdminDeliveriesScreen() {
     }
   };
 
-  const openJobChat = (job: DeliveryJob) => {
-    // Chat via Matrix is currently disabled and tracked separately.
-    // TODO: re-enable Matrix later
-  };
-
   const formatDate = (date?: string) => {
     if (!date) return '';
     return new Date(date).toLocaleString('he-IL');
@@ -214,9 +209,8 @@ export default function AdminDeliveriesScreen() {
         </View>
 
         {jobs.map((job) => (
-          <TouchableOpacity
+          <View
             key={job.id}
-            onPress={() => openJobChat(job)}
             style={[
               styles.jobCard,
               {
@@ -306,7 +300,7 @@ export default function AdminDeliveriesScreen() {
                 </TouchableOpacity>
               )}
             </View>
-          </TouchableOpacity>
+          </View>
         ))}
       </ScrollView>
       <FullScreenMediaViewer

--- a/jest.config.js
+++ b/jest.config.js
@@ -119,6 +119,8 @@ const cfg = {
     '<rootDir>/tests/storeIsolation.test.ts',
     '<rootDir>/tests/admin-disputes.test.tsx',
     '<rootDir>/tests/storeDashboard.test.tsx',
+    '<rootDir>/tests/storeCreation.snapshot.test.tsx',
+    '<rootDir>/tests/adminDeliveries.snapshot.test.tsx',
     '<rootDir>/tests/admin-impersonate.test.tsx',
     '<rootDir>/tests/admin-store-detail.test.tsx',
     '<rootDir>/tests/not-found.test.tsx',

--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -15,13 +15,11 @@ import storesAgent from '@/agents/stores-agent';
 import DatabaseService from '@/services/database';
 import { useNotificationActions } from '@/components/NotificationContext';
 import { createStoreOnChain } from '@/features/stores/services/nearStores';
-import { chainAdapter } from '@/services/chain';
 import { useWallet } from '@/contexts/WalletProvider';
 import { errorLog } from '@/utils/logger';
 
 const StoreCreation: React.FC = () => {
   const [name, setName] = useState('');
-  const [plan, setPlan] = useState<'free' | 'premium'>('free');
   const queryClient = useQueryClient();
   const { t } = useLanguage();
   const { replace } = useAppRouter();
@@ -57,7 +55,13 @@ const StoreCreation: React.FC = () => {
     }
 
     try {
-      await storesAgent.add({ id, name: finalName, owner, nftId: id, plan });
+      await storesAgent.add({
+        id,
+        name: finalName,
+        owner,
+        nftId: id,
+        plan: 'free',
+      });
       try {
         await DatabaseService.getInstance().updateUserRole(
           owner,
@@ -65,7 +69,6 @@ const StoreCreation: React.FC = () => {
         );
       } catch {}
       setName('');
-      setPlan('free');
       if (onChainError) {
         // Informational success with fallback note
         Alert.alert(t('common.success'), t('stores.createSuccess'));
@@ -88,25 +91,6 @@ const StoreCreation: React.FC = () => {
     <View style={styles.container}>
       <Text style={styles.label}>{t('stores.storeName')}</Text>
       <TextInput style={styles.input} value={name} onChangeText={setName} />
-      <View style={styles.planRow}>
-        <Text style={styles.label}>{t('stores.plan')}</Text>
-        <View style={styles.planButtons}>
-          <Button
-            title={t('stores.planFree', 'Free')}
-            onPress={() => setPlan('free')}
-            color={plan === 'free' ? '#0a84ff' : undefined}
-          />
-          <Button
-            title={
-              t('stores.planPremium', 'Premium') +
-              ' · ' +
-              t('common.comingSoon', 'Coming Soon')
-            }
-            onPress={() => {}}
-            disabled
-          />
-        </View>
-      </View>
       <Button title={t('stores.mintStore')} onPress={mintStore} />
     </View>
   );
@@ -125,8 +109,6 @@ const styles = StyleSheet.create({
     padding: 8,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
   },
-  planRow: { gap: 8 },
-  planButtons: { flexDirection: 'row', gap: 12, justifyContent: 'flex-start' },
 });
 
 export default StoreCreation;

--- a/tests/__snapshots__/adminDeliveries.snapshot.test.tsx.snap
+++ b/tests/__snapshots__/adminDeliveries.snapshot.test.tsx.snap
@@ -1,0 +1,375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdminDeliveriesScreen snapshot renders delivery jobs without chat control 1`] = `
+<SafeAreaView
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      {
+        "backgroundColor": "#ffffff",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 12,
+        },
+        {
+          "borderBottomColor": "#222222",
+        },
+      ]
+    }
+  >
+    <TouchableOpacity
+      onPress={[Function]}
+    >
+      <Icon
+        color="#111111"
+        name="ArrowLeft"
+        size={24}
+      />
+    </TouchableOpacity>
+    <Text
+      style={
+        [
+          {
+            "fontSize": 18,
+            "fontWeight": "600",
+          },
+          {
+            "color": "#111111",
+          },
+        ]
+      }
+    >
+      משלוחים
+    </Text>
+    <View
+      style={
+        {
+          "height": 24,
+          "width": 24,
+        }
+      }
+    />
+  </View>
+  <ScrollView
+    style={
+      {
+        "flex": 1,
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flexDirection": "row-reverse",
+            "marginBottom": 16,
+            "padding": 8,
+          },
+          {
+            "borderColor": "#222222",
+          },
+        ]
+      }
+    >
+      <TextInput
+        onChangeText={[Function]}
+        placeholder="Order ID"
+        style={
+          [
+            {
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flex": 1,
+              "marginLeft": 8,
+              "paddingHorizontal": 8,
+            },
+            {
+              "borderColor": "#222222",
+              "color": "#111111",
+            },
+          ]
+        }
+        value=""
+      />
+      <View
+        style={
+          {
+            "flex": 1,
+            "position": "relative",
+          }
+        }
+      >
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row-reverse",
+                "justifyContent": "space-between",
+                "paddingHorizontal": 8,
+                "paddingVertical": 6,
+              },
+              {
+                "backgroundColor": "#f5f5f5",
+                "borderColor": "#222222",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 14,
+                },
+                {
+                  "color": "#111111",
+                },
+              ]
+            }
+          >
+            בחר נהג
+          </Text>
+          <Icon
+            color="#666666"
+            name="ChevronDown"
+            size={20}
+          />
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 20,
+              "height": 40,
+              "justifyContent": "center",
+              "marginLeft": 8,
+              "width": 40,
+            },
+            {
+              "backgroundColor": "#daa520",
+            },
+          ]
+        }
+      >
+        <Icon
+          color="#ffffff"
+          name="Plus"
+          size={20}
+        />
+      </TouchableOpacity>
+    </View>
+    <View
+      style={
+        [
+          {
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "marginBottom": 16,
+            "padding": 16,
+          },
+          {
+            "backgroundColor": "#f5f5f5",
+            "borderColor": "#222222",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row-reverse",
+            "marginBottom": 8,
+          }
+        }
+      >
+        <Icon
+          color="#daa520"
+          name="Truck"
+          size={24}
+        />
+        <Text
+          style={
+            [
+              {
+                "fontSize": 16,
+                "marginRight": 8,
+              },
+              {
+                "color": "#111111",
+              },
+            ]
+          }
+        >
+          הזמנה #
+          123456
+        </Text>
+      </View>
+      <Text
+        style={
+          [
+            {
+              "fontSize": 14,
+              "marginBottom": 4,
+              "textAlign": "right",
+            },
+            {
+              "color": "#666666",
+            },
+          ]
+        }
+      >
+        נהג:
+         
+        Driver One
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "fontSize": 14,
+              "marginBottom": 4,
+              "textAlign": "right",
+            },
+            {
+              "color": "#666666",
+            },
+          ]
+        }
+      >
+        סטטוס: 
+        pending
+      </Text>
+      <View
+        style={
+          {
+            "flexDirection": "row-reverse",
+            "marginTop": 8,
+          }
+        }
+      >
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            [
+              {
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "marginLeft": 8,
+                "paddingHorizontal": 12,
+                "paddingVertical": 6,
+              },
+              {
+                "borderColor": "#222222",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 14,
+                },
+                {
+                  "color": "#111111",
+                },
+              ]
+            }
+          >
+            התחל
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            [
+              {
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "marginLeft": 8,
+                "paddingHorizontal": 12,
+                "paddingVertical": 6,
+              },
+              {
+                "borderColor": "#222222",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 14,
+                },
+                {
+                  "color": "#111111",
+                },
+              ]
+            }
+          >
+            הושלם
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            [
+              {
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "marginLeft": 8,
+                "paddingHorizontal": 12,
+                "paddingVertical": 6,
+              },
+              {
+                "borderColor": "#222222",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 14,
+                },
+                {
+                  "color": "#111111",
+                },
+              ]
+            }
+          >
+            בטל
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  </ScrollView>
+</SafeAreaView>
+`;

--- a/tests/__snapshots__/storeCreation.snapshot.test.tsx.snap
+++ b/tests/__snapshots__/storeCreation.snapshot.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StoreCreation snapshot renders without premium plan controls 1`] = `
+<View
+  style={
+    {
+      "gap": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "fontSize": 16,
+        "fontWeight": "600",
+        "textAlign": "left",
+      }
+    }
+  >
+    stores.storeName
+  </Text>
+  <TextInput
+    onChangeText={[Function]}
+    style={
+      {
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "padding": 8,
+        "textAlign": "left",
+      }
+    }
+    value=""
+  />
+  <Button
+    onPress={[Function]}
+    title="stores.mintStore"
+  />
+</View>
+`;

--- a/tests/adminDeliveries.snapshot.test.tsx
+++ b/tests/adminDeliveries.snapshot.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import AdminDeliveriesScreen from '@app/store/[storeId]/admin/_DeliveriesScreen';
+
+jest.mock('@/utils/logger', () => ({
+  errorLog: jest.fn(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('@/services', () => ({
+  useAppRouter: () => ({ replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#ffffff',
+      text: { primary: '#111111', secondary: '#666666', inverse: '#ffffff' },
+      border: { primary: '#222222' },
+      surface: { primary: '#f5f5f5' },
+      interactive: { secondary: '#eeeeee' },
+      gold: '#daa520',
+    },
+  }),
+}));
+
+const mockDatabase = {
+  getAllDeliveryJobs: jest.fn(),
+  getAllUserProfiles: jest.fn(),
+  createDeliveryJob: jest.fn(),
+  updateDeliveryJobStatus: jest.fn(),
+};
+
+jest.mock('@/services/database', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => mockDatabase,
+  },
+}));
+
+jest.mock('@/components/FullScreenMediaViewer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/SmartImage', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('AdminDeliveriesScreen snapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDatabase.getAllDeliveryJobs.mockResolvedValue([
+      {
+        id: 'job-1',
+        orderId: 'order-123456',
+        driverId: 'driver-1',
+        status: 'pending',
+      },
+    ]);
+    mockDatabase.getAllUserProfiles.mockResolvedValue([
+      { id: 'driver-1', displayName: 'Driver One', role: 'driver' },
+    ]);
+    mockDatabase.createDeliveryJob.mockResolvedValue(undefined);
+    mockDatabase.updateDeliveryJobStatus.mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ isStoreOwner: true });
+  });
+
+  it('renders delivery jobs without chat control', async () => {
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<AdminDeliveriesScreen />);
+    });
+    await act(async () => Promise.resolve());
+    expect(root!.toJSON()).toMatchSnapshot();
+  });
+});

--- a/tests/storeCreation.snapshot.test.tsx
+++ b/tests/storeCreation.snapshot.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import StoreCreation from '@/features/stores/components/StoreCreation';
+
+jest.mock('@/services', () => ({
+  useAppRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: jest.fn(),
+  }),
+}));
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+jest.mock('@/agents/stores-agent', () => ({
+  add: jest.fn(),
+}));
+
+const mockDatabase = {
+  updateUserRole: jest.fn(),
+};
+
+jest.mock('@/services/database', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => mockDatabase,
+  },
+}));
+
+jest.mock('@/components/NotificationContext', () => ({
+  useNotificationActions: () => ({ showNotification: jest.fn() }),
+}));
+
+jest.mock('@/features/stores/services/nearStores', () => ({
+  createStoreOnChain: jest.fn(),
+}));
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: { getAccountId: jest.fn() },
+}));
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: '0x123456', connect: jest.fn() }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  errorLog: jest.fn(),
+}));
+
+const ReactNative = require('react-native');
+(ReactNative as any).Button = ({
+  title,
+  onPress,
+  color,
+  disabled,
+}: {
+  title: string;
+  onPress?: () => void;
+  color?: string;
+  disabled?: boolean;
+}) =>
+  React.createElement('Button', {
+    title,
+    onPress,
+    color,
+    disabled,
+  });
+
+describe('StoreCreation snapshot', () => {
+  beforeEach(() => {
+    mockDatabase.updateUserRole.mockClear();
+  });
+
+  it('renders without premium plan controls', () => {
+    const tree = renderer.create(<StoreCreation />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/translations/en.json
+++ b/translations/en.json
@@ -599,10 +599,6 @@
   "stores": {
     "storeName": "Store Name",
     "mintStore": "Mint Store",
-    "mintPremiumStore": "Create Premium Store",
-    "plan": "Plan",
-    "planFree": "Free",
-    "planPremium": "Premium",
     "transactionFailed": "Transaction failed",
     "insufficientFunds": "Insufficient funds to deploy the store",
     "transactionCancelled": "Transaction cancelled",


### PR DESCRIPTION
## Summary
- remove the premium plan UI from the store creation flow and keep new stores on the free tier
- drop the unused delivery chat trigger from the admin deliveries screen
- add snapshot tests that assert the store creation form and deliveries screen render without the inactive controls

## Testing
- npx --no-install jest tests/storeCreation.snapshot.test.tsx tests/adminDeliveries.snapshot.test.tsx --runInBand --updateSnapshot --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68c8336936248326a86dfc82289bb1db