### PR TITLE
Add encrypted workspace metadata broadcast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ See [src/providers/README.md](src/providers/README.md) for the order and invaria
 | `/blue-ocean/users/1`    | Registered users + roles + keys     |
 | `/blue-ocean/products/1` | Product catalog                     |
 | `/blue-ocean/stores/1`   | Store registry + metadata           |
+| `/blue-ocean/workspaces/1` | Workspace discovery metadata (encrypted) |
 | `/blue-ocean/orders/1`   | Orders placed by users & status updates |
 | `/blue-ocean/notifications/1` | System-wide notifications        |
 | `/blue-ocean/reviews/1`  | Product reviews                     |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ Blue Ocean operates entirely peer-to-peer over the Waku network. Each domain use
 | `/blue-ocean/{tenantId}/users/1` | Registered users and roles |
 | `/blue-ocean/{tenantId}/products/1` | Product catalog |
 | `/blue-ocean/{tenantId}/stores/1` | Store registry |
+| `/blue-ocean/workspaces/1` | Workspace discovery metadata (encrypted) |
 | `/blue-ocean/{tenantId}/orders/1` | Orders and status updates |
 | `/blue-ocean/{tenantId}/notifications/1` | System notifications |
 | `/blue-ocean/{tenantId}/reviews/1` | Product reviews |

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -5,3 +5,4 @@ export * from './product.updated';
 export * from './order.status';
 export * from './admin.requested';
 export * from './store.created';
+export * from './workspace.created';

--- a/schemas/waku/workspace.created.ts
+++ b/schemas/waku/workspace.created.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { wakuMessageSchema } from './message';
+
+export const workspaceCreatedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  session: z.string(),
+  timestamp: z.number(),
+});
+
+export const workspaceCreatedSchema = wakuMessageSchema.extend({
+  type: z.literal('workspace.created'),
+  payload: workspaceCreatedPayloadSchema,
+});
+
+export type WorkspaceCreatedMessage = z.infer<typeof workspaceCreatedSchema>;
+
+export type WorkspaceCreatedPayload = z.infer<
+  typeof workspaceCreatedPayloadSchema
+>;
+
+export function parseWorkspaceCreatedMessage(
+  data: unknown,
+): WorkspaceCreatedMessage | null {
+  const res = workspaceCreatedSchema.safeParse(data);
+  return res.success ? res.data : null;
+}
+

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,0 +1,124 @@
+import { sign } from '@noble/ed25519';
+import { z } from 'zod';
+
+import type { WorkspaceCreatedMessage } from '@/types/waku';
+import { publish, subscribeWithAck } from '@/services/waku';
+import { decrypt, encrypt } from '@/utils/wakuCrypto';
+import { canonicalJson } from '@/utils/serialization';
+import { parseWorkspaceCreatedMessage } from '@/schemas/waku/workspace.created';
+import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
+import type { SessionToken } from '@/services/session';
+
+export const WORKSPACE_TOPIC = '/blue-ocean/workspaces/1';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const sessionSchema = z.object({
+  token: z.string(),
+  scopes: z.array(z.string()),
+  exp: z.number(),
+});
+
+export type WorkspaceSessionMetadata = z.infer<typeof sessionSchema>;
+
+export interface WorkspaceMetadata {
+  workspaceId: string;
+  session: WorkspaceSessionMetadata;
+  timestamp: number;
+}
+
+function encodeSession(session: WorkspaceSessionMetadata): string {
+  const bytes = encoder.encode(canonicalJson(session));
+  const ciphertext = encrypt(WORKSPACE_TOPIC, bytes);
+  return Buffer.from(ciphertext).toString('base64');
+}
+
+export function decodeWorkspaceSession(
+  value: string,
+): WorkspaceSessionMetadata | null {
+  try {
+    const raw = Uint8Array.from(Buffer.from(value, 'base64'));
+    const decrypted = decrypt(WORKSPACE_TOPIC, raw);
+    const parsed = JSON.parse(decoder.decode(decrypted));
+    const result = sessionSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function makeSignedMessage(
+  payload: WorkspaceCreatedMessage['payload'],
+): Promise<WorkspaceCreatedMessage> {
+  const [privKey, pubKey] = await Promise.all([
+    getPrivateKey(),
+    getPublicKeyHex(),
+  ]);
+  const message: WorkspaceCreatedMessage = {
+    type: 'workspace.created',
+    payload,
+    sender: { publicKey: pubKey, role: 'workspace' },
+    signature: '',
+  };
+  const toSign = encoder.encode(
+    canonicalJson({
+      type: message.type,
+      payload: message.payload,
+      sender: message.sender,
+    }),
+  );
+  const signature = await sign(toSign, privKey);
+  message.signature = Buffer.from(signature).toString('hex');
+  return message;
+}
+
+export async function broadcastWorkspaceMetadata(
+  workspaceId: string,
+  session: SessionToken,
+  timestamp: number = Date.now(),
+): Promise<string> {
+  const payload: WorkspaceCreatedMessage['payload'] = {
+    workspaceId,
+    session: encodeSession(sessionSchema.parse(session)),
+    timestamp,
+  };
+  const message = await makeSignedMessage(payload);
+  return publish(WORKSPACE_TOPIC, message);
+}
+
+function toWorkspaceMetadata(
+  message: WorkspaceCreatedMessage,
+): WorkspaceMetadata | null {
+  const session = decodeWorkspaceSession(message.payload.session);
+  if (!session) return null;
+  return {
+    workspaceId: message.payload.workspaceId,
+    session,
+    timestamp: message.payload.timestamp,
+  };
+}
+
+export type WorkspaceMetadataHandler = (
+  metadata: WorkspaceMetadata,
+  message: WorkspaceCreatedMessage,
+) => void;
+
+export async function subscribeToWorkspaceMetadata(
+  handler: WorkspaceMetadataHandler,
+): Promise<() => void> {
+  return subscribeWithAck(WORKSPACE_TOPIC, (raw) => {
+    const parsed = parseWorkspaceCreatedMessage(raw);
+    if (!parsed) return;
+    const metadata = toWorkspaceMetadata(parsed);
+    if (!metadata) return;
+    handler(metadata, parsed);
+  });
+}
+
+export function toWorkspaceSession(
+  message: WorkspaceCreatedMessage,
+): WorkspaceSessionMetadata | null {
+  return decodeWorkspaceSession(message.payload.session);
+}
+

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -19,6 +19,7 @@
       "@/ui/*": ["src/ui/*"],
       "@/ui": ["src/ui/index"],
       "@/layout/*": ["src/layout/*"],
+      "@/core/*": ["src/core/*"],
       "@/services": ["src/services/index"],
       "@/services/*": ["src/services/*", "services/*"],
       "@/utils/*": ["src/utils/*", "utils/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,9 @@
       "@/layout/*": [
         "src/layout/*"
       ],
+      "@/core/*": [
+        "src/core/*"
+      ],
       "@/services": [
         "src/services/index.ts"
       ],

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -5,4 +5,6 @@ export {
   type NotificationWakuPayload,
   type ProductUpdatedMessage,
   type OrderStatusMessage,
+  type WorkspaceCreatedMessage,
+  type WorkspaceCreatedPayload,
 } from '../schemas/waku';


### PR DESCRIPTION
## Summary
- document the new `/blue-ocean/workspaces/1` discovery topic in the agent and architecture guides
- add a `workspace.created` Waku schema and re-export it through the shared waku types
- implement core workspace helpers that encrypt session metadata, sign messages, publish to the new topic, and expose subscription/decoding utilities
- add a path alias for `@/core/*` so the new helpers can be resolved in app and test builds

## Testing
- yarn lint *(fails: requires @typescript-eslint/parser in this environment)*
- yarn typecheck *(fails: missing bundled expo/jest/react type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84bc583b4832687c5b1cce3527b93