### PR TITLE
Track warm cache revisions across deletes

### DIFF
--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -30,6 +30,7 @@ export interface WarmCache<T> {
 
 export function createWarmCache<T>(topic: string): WarmCache<T> {
   const store = new Map<string, { value: T; rev: number }>();
+  const revisions = new Map<string, number>();
   const emitter = new EventEmitter();
   let synced = false;
   let stale = false;
@@ -40,12 +41,19 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
   const endHydration = cacheHydrationHistogram.startTimer({ cache: topic });
 
   function apply(msg: DiffMessage<T>): void {
-    const current = store.get(msg.id);
-    if (current && msg.rev !== current.rev + 1) {
+    const currentRev = revisions.get(msg.id) ?? 0;
+    const expected = currentRev === 0 ? msg.rev : currentRev + 1;
+    if (currentRev !== 0 && msg.rev !== expected) {
       stale = true;
-      emitter.emit('error', { code: E_STALE_DATA, id: msg.id });
+      emitter.emit('error', {
+        code: E_STALE_DATA,
+        id: msg.id,
+        expected,
+        actual: msg.rev,
+      });
       return;
     }
+    revisions.set(msg.id, msg.rev);
     if (msg.op === 'delete') {
       store.delete(msg.id);
     } else if (msg.value !== undefined) {
@@ -95,7 +103,9 @@ export function createWarmCache<T>(topic: string): WarmCache<T> {
     },
     values() {
       if (stale || !isWarmCacheEnabled()) throw { code: E_STALE_DATA };
-      return Array.from(store.values()).map((v) => v.value);
+      return Array.from(store.values())
+        .map((v) => v.value)
+        .filter((value): value is T => value !== undefined);
     },
     subscribe(filter, cb) {
       const handler = (id: string, value: T | undefined) => {

--- a/tests/services/warmCache.test.ts
+++ b/tests/services/warmCache.test.ts
@@ -78,6 +78,18 @@ describe('warmCache', () => {
     });
   });
 
+  it('tracks revision numbers after deletes to catch stale updates', async () => {
+    const cache = createWarmCache<any>('topic');
+    await new Promise((res) => cache.onSynced(res));
+    liveHandler && liveHandler({ id: '1', rev: 2, op: 'delete' });
+    expect(cache.getById('1')).toBeUndefined();
+    liveHandler &&
+      liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'bad' } });
+    expect(() => cache.getById('1')).toThrowErrorMatchingObject({
+      code: E_STALE_DATA,
+    });
+  });
+
   it('falls back when history fails', async () => {
     failHistory = true;
     const cache = createWarmCache<any>('topic');


### PR DESCRIPTION
## Summary
- track per-entry revision counters so stale diffs are rejected even after deletions
- keep warm cache value iteration from returning tombstones when entries are removed
- add a regression test covering stale updates following a delete event

## Testing
- `yarn install --no-progress` *(fails: @waku/core@0.0.38 expects Node >=22, environment provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c85516595c83268df0ab70391b1758