### PR TITLE
Implement wallet-scoped sessions

### DIFF
--- a/services/session.ts
+++ b/services/session.ts
@@ -15,10 +15,21 @@ const POLICY = new Set<string>(['read', 'write']);
 // Allow a small amount of clock skew when validating expirations
 const CLOCK_TOLERANCE_MS = 60 * 1000; // 1 minute
 
+export interface EncryptedScopePayload {
+  cipher: string;
+  walletPublicKey: string;
+  identityPublicKey: string;
+}
+
 export interface SessionToken {
   token: string;
   scopes: string[];
   exp: number;
+  sealed?: EncryptedScopePayload;
+}
+
+export interface ScopeRequestOptions {
+  sealed?: EncryptedScopePayload | (() => EncryptedScopePayload | undefined);
 }
 
 export type SyncSessionSigner = (message: string) => string;
@@ -58,16 +69,19 @@ export function requestScopes(
   scopes: string[],
   signer: (message: string) => string,
   ttlMs?: number,
+  options?: ScopeRequestOptions,
 ): SessionToken;
 export function requestScopes(
   scopes: string[],
   signer: (message: string) => Promise<string>,
   ttlMs?: number,
+  options?: ScopeRequestOptions,
 ): Promise<SessionToken>;
 export function requestScopes(
   scopes: string[],
   signer: SessionSigner,
   ttlMs = 60 * 60 * 1000,
+  options: ScopeRequestOptions = {},
 ): SessionToken | Promise<SessionToken> {
   assertRateLimit();
   validateScopes(scopes);
@@ -77,7 +91,11 @@ export function requestScopes(
 
   const persist = (maybeToken: string | undefined): SessionToken => {
     const token = maybeToken || uuid();
-    const record: SessionToken = { token, scopes, exp };
+    const sealed =
+      typeof options.sealed === 'function' ? options.sealed() : options.sealed;
+    const record: SessionToken = sealed
+      ? { token, scopes, exp, sealed }
+      : { token, scopes, exp };
     store.set(token, record);
     void saveSession(record);
     return record;
@@ -91,11 +109,33 @@ export function requestScopes(
 }
 
 const store = new Map<string, SessionToken>();
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+function purgeExpiredSessions(now = Date.now()): void {
+  for (const [token, rec] of [...store.entries()]) {
+    if (now > rec.exp + CLOCK_TOLERANCE_MS) {
+      store.delete(token);
+      void removeSession(token);
+    }
+  }
+}
 
 export async function initSessionTokens(): Promise<void> {
   const records = await loadSessions();
+  const now = Date.now();
   for (const r of records) {
+    if (now > r.exp + CLOCK_TOLERANCE_MS) {
+      void removeSession(r.token);
+      continue;
+    }
     store.set(r.token, r);
+  }
+  if (!sweepTimer) {
+    sweepTimer = setInterval(purgeExpiredSessions, SWEEP_INTERVAL_MS);
+    if (typeof (sweepTimer as any).unref === 'function') {
+      (sweepTimer as any).unref();
+    }
   }
 }
 
@@ -115,16 +155,19 @@ export function refreshToken(
   token: string,
   signer: (message: string) => string,
   ttlMs?: number,
+  options?: ScopeRequestOptions,
 ): SessionToken;
 export function refreshToken(
   token: string,
   signer: (message: string) => Promise<string>,
   ttlMs?: number,
+  options?: ScopeRequestOptions,
 ): Promise<SessionToken>;
 export function refreshToken(
   token: string,
   signer: SessionSigner,
   ttlMs = 60 * 60 * 1000,
+  options: ScopeRequestOptions = {},
 ): SessionToken | Promise<SessionToken> {
   const rec = store.get(token);
   if (!rec) throw new Error('{E_EXPIRED}');
@@ -144,7 +187,8 @@ export function refreshToken(
     scopes: string[],
     signer: SessionSigner,
     ttlMs?: number,
-  ) => SessionToken | Promise<SessionToken>)(rec.scopes, signer, ttlMs);
+    options?: ScopeRequestOptions,
+  ) => SessionToken | Promise<SessionToken>)(rec.scopes, signer, ttlMs, options);
   if (isPromise<SessionToken>(next)) {
     return next.then(handleNext);
   }
@@ -155,6 +199,7 @@ export async function requestTokenWithConsent(
   scopes: string[],
   signer: SessionSigner,
   ttlMs = 60 * 60 * 1000,
+  options: ScopeRequestOptions = {},
 ): Promise<SessionToken> {
   const ok = await requestConsent(scopes);
   if (!ok) throw new Error('{E_DENIED}');
@@ -162,7 +207,21 @@ export async function requestTokenWithConsent(
     scopes: string[],
     signer: SessionSigner,
     ttlMs?: number,
-  ) => SessionToken | Promise<SessionToken>)(scopes, signer, ttlMs);
+    options?: ScopeRequestOptions,
+  ) => SessionToken | Promise<SessionToken>)(scopes, signer, ttlMs, options);
   return await issued;
+}
+
+export function getSession(token: string): SessionToken | undefined {
+  return store.get(token);
+}
+
+export async function revokeToken(token: string): Promise<void> {
+  store.delete(token);
+  await removeSession(token);
+}
+
+export function sweepExpiredTokens(now = Date.now()): void {
+  purgeExpiredSessions(now);
 }
 

--- a/src/auth/wallet.ts
+++ b/src/auth/wallet.ts
@@ -1,0 +1,151 @@
+import { useCallback } from 'react';
+import { Buffer } from 'buffer';
+import { useWallet } from '@/contexts/WalletProvider';
+import { chainAdapter } from '@/services/chain';
+import {
+  requestScopes,
+  refreshToken,
+  validateToken,
+  getSession,
+  SessionToken,
+  EncryptedScopePayload,
+} from '@/services/session';
+import { getEd25519KeyPair } from '@/services/localIdentity';
+import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from '@/utils/encryption';
+
+const SESSION_ENCRYPTION_INFO = 'wallet.session';
+
+function requireWalletPublicKey(): string {
+  const getter = chainAdapter.getPublicKey;
+  const publicKey = typeof getter === 'function' ? getter.call(chainAdapter) : null;
+  if (!publicKey) {
+    throw new Error('Wallet public key unavailable');
+  }
+  return publicKey;
+}
+
+async function sealPayload(
+  payload: string,
+  walletPublicKey: string,
+): Promise<EncryptedScopePayload> {
+  const { privateKey, publicKey } = await getEd25519KeyPair();
+  const identityPublicKey = Buffer.from(publicKey).toString('hex');
+  const salt = deriveChatSalt(identityPublicKey, walletPublicKey);
+  const key = await deriveSharedKey(privateKey, walletPublicKey, SESSION_ENCRYPTION_INFO, salt);
+  const cipher = await aesEncrypt(payload, key);
+  return {
+    cipher,
+    walletPublicKey,
+    identityPublicKey,
+  };
+}
+
+function compareScopes(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+async function verifySealedPayload(record: SessionToken): Promise<void> {
+  const sealed = record.sealed;
+  if (!sealed) return;
+
+  const { privateKey, publicKey } = await getEd25519KeyPair();
+  const identityPublicKey = Buffer.from(publicKey).toString('hex');
+  if (sealed.identityPublicKey !== identityPublicKey) {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+
+  try {
+    const salt = deriveChatSalt(sealed.identityPublicKey, sealed.walletPublicKey);
+    const key = await deriveSharedKey(privateKey, sealed.walletPublicKey, SESSION_ENCRYPTION_INFO, salt);
+    const decrypted = await aesDecrypt(sealed.cipher, key);
+    const parsed = JSON.parse(decrypted) as { scopes: unknown; exp: unknown };
+
+    if (!Array.isArray(parsed.scopes) || parsed.scopes.some((s) => typeof s !== 'string')) {
+      throw new Error('{E_SESSION_PROOF}');
+    }
+    if (typeof parsed.exp !== 'number') {
+      throw new Error('{E_SESSION_PROOF}');
+    }
+    if (!compareScopes(record.scopes, parsed.scopes)) {
+      throw new Error('{E_SESSION_PROOF}');
+    }
+    if (parsed.exp !== record.exp) {
+      throw new Error('{E_SESSION_PROOF}');
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message === '{E_SESSION_PROOF}') {
+      throw err;
+    }
+    throw new Error('{E_SESSION_PROOF}');
+  }
+}
+
+export function useWalletSessions(): {
+  loginWithWallet: (scopes: string[]) => Promise<SessionToken>;
+  useToken: (token: string, scopes: string[]) => Promise<SessionToken>;
+} {
+  const { sign } = useWallet();
+
+  const loginWithWallet = useCallback(
+    async (scopes: string[]): Promise<SessionToken> => {
+      if (!Array.isArray(scopes) || scopes.length === 0) {
+        throw new Error('{E_SCOPE}');
+      }
+      const walletPublicKey = requireWalletPublicKey();
+      let sealed: EncryptedScopePayload | undefined;
+      const session = await requestScopes(
+        scopes,
+        async (payload) => {
+          sealed = await sealPayload(payload, walletPublicKey);
+          return sign(sealed.cipher);
+        },
+        undefined,
+        {
+          sealed: () => sealed,
+        },
+      );
+      await verifySealedPayload(session);
+      return session;
+    },
+    [sign],
+  );
+
+  const useToken = useCallback(
+    async (token: string, scopes: string[]): Promise<SessionToken> => {
+      if (!Array.isArray(scopes) || scopes.length === 0) {
+        throw new Error('{E_SCOPE}');
+      }
+      const record = getSession(token);
+      if (!record) {
+        throw new Error('{E_EXPIRED}');
+      }
+
+      await verifySealedPayload(record);
+      validateToken(token, scopes);
+
+      const walletPublicKey = record.sealed?.walletPublicKey ?? requireWalletPublicKey();
+      let sealed: EncryptedScopePayload | undefined;
+      const refreshed = await refreshToken(
+        token,
+        async (payload) => {
+          sealed = await sealPayload(payload, walletPublicKey);
+          return sign(sealed.cipher);
+        },
+        undefined,
+        {
+          sealed: () => sealed,
+        },
+      );
+      await verifySealedPayload(refreshed);
+      return refreshed;
+    },
+    [sign],
+  );
+
+  return { loginWithWallet, useToken };
+}
+
+export type WalletSession = SessionToken;

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -10,8 +10,8 @@ import { getEd25519KeyPair } from '@/services/localIdentity';
 import { t } from '@/i18n';
 import { Buffer } from 'buffer';
 import { getUser as getChainUser, setUser as setChainUser } from './services/nearUsers';
-import { requestScopes } from '@/services/session';
-import { uuid } from '@/utils/uuid';
+import { sessionEvents, revokeToken } from '@/services/session';
+import { useWalletSessions } from '@/auth/wallet';
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -51,9 +51,20 @@ interface AuthProviderProps { children: ReactNode }
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const { address, connect, disconnect } = useWallet();
+  const { loginWithWallet } = useWalletSessions();
   const [user, setUser] = useState<User | null>(null);
   const [initialized, setInitialized] = useState(false);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleRotation = ({ old, token }: { old: string; token: string }) => {
+      setSessionToken((current) => (current === old ? token : current));
+    };
+    sessionEvents.on('token.rotated', handleRotation);
+    return () => {
+      sessionEvents.off('token.rotated', handleRotation);
+    };
+  }, []);
 
   const checkAuthState = async () => {
     // Prefer WalletProvider address; fall back to adapter's plain getters only
@@ -153,8 +164,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const login = async () => {
     try {
       await connect();
-      const { token } = requestScopes(['write'], () => uuid());
-      setSessionToken(token);
+      const session = await loginWithWallet(['write']);
+      setSessionToken(session.token);
     } catch (err: unknown) {
       errorLog(
         t('auth.walletConnectionFailed', 'Wallet connection failed'),
@@ -175,6 +186,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const logout = async () => {
     try {
       await disconnect();
+      if (sessionToken) {
+        await revokeToken(sessionToken);
+      }
       setSessionToken(null);
     } catch (err) {
       errorLog(t('auth.logoutFailed', 'Logout failed'), err);


### PR DESCRIPTION
## Summary
- add encrypted payload metadata and sweeping to the session service while exposing helpers to retrieve and revoke stored sessions
- implement a wallet session hook that signs encrypted scope payloads, validates sealed data, and rotates tokens through the session API
- switch the auth context to the wallet-scoped login flow, listen for token rotation events, and revoke persisted tokens on logout

## Testing
- pnpm exec jest tests/auth/session.test.ts *(fails: ts-jest configuration raises missing @jest/globals typings and Waku encoder type errors in generated coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68c84a6fda2083269a15df18dedc07af