### PR TITLE
feat: add gadget lab pwa shell

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <title>Blue Ocean</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0ea5e9" />
+    <meta
+      name="description"
+      content="Offline-ready Gadget Lab dashboard for Blue Ocean mesh operations."
+    />
+    <link rel="manifest" href="/manifest.webmanifest" />
 
     <meta
       http-equiv="Content-Security-Policy"

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,10 @@
+{
+  "name": "Blue Ocean Gadget Lab",
+  "short_name": "GadgetLab",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#0ea5e9",
+  "description": "Offline-ready operations console for Blue Ocean gadget deployments.",
+  "icons": []
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,42 +1,121 @@
-const CACHE = 'static-v1';
-const IMG_CACHE = 'images-v1';
+const SHELL_CACHE = 'bo-shell-v2';
+const RUNTIME_CACHE = 'bo-runtime-v2';
+const IMMUTABLE_CACHE = 'bo-immutable-v1';
+const SHELL_ASSETS = ['/', '/index.html', '/manifest.webmanifest'];
 
-self.addEventListener('install', () => {
-  self.skipWaiting();
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.addAll(SHELL_ASSETS))
+      .then(() => self.skipWaiting()),
+  );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys.map((key) => {
-          if (![CACHE, IMG_CACHE].includes(key)) {
-            return caches.delete(key);
-          }
-          return undefined;
-        }),
+    Promise.all([
+      caches.keys().then((keys) =>
+        Promise.all(
+          keys.map((key) => {
+            if (![SHELL_CACHE, RUNTIME_CACHE, IMMUTABLE_CACHE].includes(key)) {
+              return caches.delete(key);
+            }
+            return undefined;
+          }),
+        ),
       ),
-    ),
+      self.clients.claim(),
+    ]),
   );
 });
 
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+const cacheFirst = (request, cacheName) =>
+  caches.open(cacheName).then((cache) =>
+    cache.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request).then((response) => {
+        cache.put(request, response.clone());
+        return response;
+      });
+    }),
+  );
+
+const staleWhileRevalidate = (request) =>
+  caches.open(RUNTIME_CACHE).then((cache) =>
+    cache.match(request).then((cached) => {
+      const fetchPromise = fetch(request)
+        .then((response) => {
+          cache.put(request, response.clone());
+          return response;
+        })
+        .catch(() => cached);
+      return cached || fetchPromise;
+    }),
+  );
+
+const networkFirst = (request) =>
+  caches.open(RUNTIME_CACHE).then((cache) =>
+    fetch(request)
+      .then((response) => {
+        cache.put(request, response.clone());
+        return response;
+      })
+      .catch(() => cache.match(request)),
+  );
+
 self.addEventListener('fetch', (event) => {
   const { request } = event;
-  if (request.destination === 'image') {
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (request.mode === 'navigate') {
     event.respondWith(
-      caches.open(IMG_CACHE).then((cache) =>
-        cache.match(request).then((resp) => {
-          if (resp) return resp;
-          return fetch(request).then((networkResp) => {
-            cache.put(request, networkResp.clone());
-            return networkResp;
-          });
-        }),
-      ),
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(SHELL_CACHE).then((cache) => cache.put('/index.html', copy));
+          return response;
+        })
+        .catch(() => caches.match('/index.html')),
     );
     return;
   }
-  event.respondWith(
-    fetch(request).catch(() => caches.match(request)),
-  );
+
+  if (SHELL_ASSETS.includes(url.pathname)) {
+    event.respondWith(cacheFirst(request, SHELL_CACHE));
+    return;
+  }
+
+  if (url.origin === self.location.origin && url.pathname.startsWith('/locales/')) {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (request.destination === 'style' || request.destination === 'script' || request.destination === 'font') {
+    event.respondWith(cacheFirst(request, IMMUTABLE_CACHE));
+    return;
+  }
+
+  if (request.destination === 'image') {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
 });

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/types/pwa.d.ts
+++ b/types/pwa.d.ts
@@ -1,0 +1,5 @@
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,64 @@
+import React, { Suspense, useMemo } from 'react';
+
+import GadgetLabLayout from './components/GadgetLabLayout';
+import GadgetTile from './components/GadgetTile';
+import MetricCard from './components/MetricCard';
+import QuickActions from './components/QuickActions';
+import OfflineToast from './components/OfflineToast';
+import InstallPromptBanner from './components/InstallPromptBanner';
+import DeferredPanelFallback from './components/DeferredPanelFallback';
+import { useDashboardData } from './hooks/useDashboardData';
+import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion';
+import { useOnlineStatus } from './hooks/useOnlineStatus';
+import { usePwaInstallPrompt } from './hooks/usePwaInstallPrompt';
+
+const InsightGrid = React.lazy(() => import('./components/InsightGrid'));
+const ActivityFeed = React.lazy(() => import('./components/ActivityFeed'));
+
+const App: React.FC = () => {
+  const { metrics, gadgets, events, quickActions, insights } = useDashboardData();
+  const reduceMotion = usePrefersReducedMotion();
+  const isOnline = useOnlineStatus();
+  const installPrompt = usePwaInstallPrompt();
+
+  const heroTiles = useMemo(
+    () =>
+      gadgets.slice(0, 3).map((gadget) => (
+        <GadgetTile key={gadget.id} gadget={gadget} reduceMotion={reduceMotion} />
+      )),
+    [gadgets, reduceMotion],
+  );
+
+  return (
+    <>
+      <GadgetLabLayout
+        title="Gadget Lab"
+        subtitle="Offline-ready operations console"
+        hero={<div className="lab-hero-grid">{heroTiles}</div>}
+        sidebar={
+          <Suspense fallback={<DeferredPanelFallback lines={3} />}>
+            <InsightGrid insights={insights} reduceMotion={reduceMotion} />
+          </Suspense>
+        }
+        actions={<QuickActions actions={quickActions} reduceMotion={reduceMotion} />}
+      >
+        <section className="lab-metrics-grid" aria-label="Live telemetry">
+          {metrics.map((metric) => (
+            <MetricCard key={metric.id} metric={metric} reduceMotion={reduceMotion} />
+          ))}
+        </section>
+        <section className="lab-activity" aria-label="Recent operations">
+          <Suspense fallback={<DeferredPanelFallback lines={5} />}>
+            <ActivityFeed events={events} />
+          </Suspense>
+        </section>
+      </GadgetLabLayout>
+      <OfflineToast offline={!isOnline} />
+      {!installPrompt.isStandalone && installPrompt.canInstall ? (
+        <InstallPromptBanner onInstall={installPrompt.promptInstall} />
+      ) : null}
+    </>
+  );
+};
+
+export default App;

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import type { ActivityEvent } from '../hooks/useDashboardData';
+
+interface ActivityFeedProps {
+  events: ActivityEvent[];
+}
+
+const ActivityFeed: React.FC<ActivityFeedProps> = ({ events }) => (
+  <section className="activity-feed" aria-label="Recent activity">
+    <ol className="activity-feed__list">
+      {events.map((event) => (
+        <li key={event.id} className="activity-feed__item">
+          <div className={`activity-feed__marker activity-feed__marker--${event.severity}`} aria-hidden="true" />
+          <div className="activity-feed__content">
+            <header className="activity-feed__header">
+              <h3 className="activity-feed__title">{event.title}</h3>
+              <time dateTime={event.timestampISO} className="activity-feed__timestamp">
+                {event.timestamp}
+              </time>
+            </header>
+            <p className="activity-feed__description">{event.description}</p>
+            <p className="activity-feed__meta">
+              {event.actor}
+              {event.location ? ` · ${event.location}` : ''}
+            </p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  </section>
+);
+
+export default ActivityFeed;

--- a/web/src/components/DeferredPanelFallback.tsx
+++ b/web/src/components/DeferredPanelFallback.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface DeferredPanelFallbackProps {
+  lines?: number;
+}
+
+const DeferredPanelFallback: React.FC<DeferredPanelFallbackProps> = ({ lines = 4 }) => (
+  <div className="deferred-fallback" aria-hidden="true">
+    {Array.from({ length: lines }).map((_, index) => (
+      <div key={index.toString()} className="deferred-fallback__line" />
+    ))}
+  </div>
+);
+
+export default DeferredPanelFallback;

--- a/web/src/components/GadgetLabLayout.tsx
+++ b/web/src/components/GadgetLabLayout.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface GadgetLabLayoutProps {
+  title: string;
+  subtitle?: string;
+  hero?: React.ReactNode;
+  actions?: React.ReactNode;
+  sidebar?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const GadgetLabLayout: React.FC<GadgetLabLayoutProps> = ({
+  title,
+  subtitle,
+  hero,
+  actions,
+  sidebar,
+  children,
+}) => (
+  <div className="gadget-lab-shell">
+    <header className="lab-header">
+      <div>
+        {subtitle ? <p className="lab-header__subtitle">{subtitle}</p> : null}
+        <h1 className="lab-header__title">{title}</h1>
+      </div>
+      {actions ? <div className="lab-header__actions">{actions}</div> : null}
+    </header>
+    {hero ? (
+      <section className="lab-hero" aria-label="Mission-critical gadgets">
+        {hero}
+      </section>
+    ) : null}
+    <div className="lab-content">
+      <main className="lab-main" role="main">
+        {children}
+      </main>
+      {sidebar ? (
+        <aside className="lab-sidebar" aria-label="Insight sidebar">
+          {sidebar}
+        </aside>
+      ) : null}
+    </div>
+  </div>
+);
+
+export default React.memo(GadgetLabLayout);

--- a/web/src/components/GadgetTile.tsx
+++ b/web/src/components/GadgetTile.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useMemo, useState } from 'react';
+
+import type { GadgetSummary } from '../hooks/useDashboardData';
+
+interface GadgetTileProps {
+  gadget: GadgetSummary;
+  reduceMotion?: boolean;
+}
+
+const GadgetTile: React.FC<GadgetTileProps> = ({ gadget, reduceMotion = false }) => {
+  const [tilt, setTilt] = useState({ x: 0, y: 0 });
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (reduceMotion) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const relativeX = (event.clientX - rect.left) / rect.width - 0.5;
+      const relativeY = (event.clientY - rect.top) / rect.height - 0.5;
+      setTilt({
+        x: Number((relativeX * 12).toFixed(2)),
+        y: Number((-relativeY * 12).toFixed(2)),
+      });
+    },
+    [reduceMotion],
+  );
+
+  const resetTilt = useCallback(() => {
+    setTilt({ x: 0, y: 0 });
+  }, []);
+
+  const style = useMemo(() => {
+    const baseShadow = `0 12px 24px -12px ${gadget.accent}80`;
+    const accentBackground = `linear-gradient(150deg, ${gadget.accent}33, rgba(15, 23, 42, 0.82))`;
+    if (reduceMotion) {
+      return {
+        boxShadow: baseShadow,
+        background: accentBackground,
+        borderColor: `${gadget.accent}55`,
+      };
+    }
+    return {
+      transform: `perspective(960px) rotateX(${tilt.y}deg) rotateY(${tilt.x}deg)`,
+      transition: 'transform 180ms ease, box-shadow 200ms ease',
+      boxShadow: `${baseShadow}, 0 1px 0 0 #0ea5e955 inset`,
+      background: accentBackground,
+      borderColor: `${gadget.accent}55`,
+    };
+  }, [gadget.accent, reduceMotion, tilt.x, tilt.y]);
+
+  return (
+    <article
+      className="gadget-tile"
+      style={style}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={resetTilt}
+      onPointerUp={resetTilt}
+      onFocus={resetTilt}
+      tabIndex={0}
+      aria-label={`${gadget.name} status ${gadget.status}`}
+    >
+      <div className="gadget-tile__shine" aria-hidden="true" />
+      <div className="gadget-tile__header">
+        <span className={`gadget-tile__status gadget-tile__status--${gadget.status}`}>
+          {gadget.statusLabel}
+        </span>
+        <span className="gadget-tile__tag">{gadget.signal}</span>
+      </div>
+      <h2 className="gadget-tile__title">{gadget.name}</h2>
+      <p className="gadget-tile__body">{gadget.description}</p>
+      <footer className="gadget-tile__footer">
+        <span>{gadget.throughput}</span>
+        <span className="gadget-tile__footer-accent">{gadget.health}</span>
+      </footer>
+    </article>
+  );
+};
+
+export default React.memo(GadgetTile);

--- a/web/src/components/InsightGrid.tsx
+++ b/web/src/components/InsightGrid.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import type { InsightSummary } from '../hooks/useDashboardData';
+
+interface InsightGridProps {
+  insights: InsightSummary[];
+  reduceMotion?: boolean;
+}
+
+const InsightGrid: React.FC<InsightGridProps> = ({ insights, reduceMotion = false }) => (
+  <section className="insight-grid" aria-label="Operational insights">
+    {insights.map((insight) => {
+      const width = `${Math.round(insight.confidence * 100)}%`;
+      return (
+        <article key={insight.id} className="insight-grid__item">
+          <header className="insight-grid__header">
+            <span className={`insight-grid__badge insight-grid__badge--${insight.intent}`}>
+              {insight.intentLabel}
+            </span>
+            <time dateTime={insight.timestampISO} className="insight-grid__timestamp">
+              {insight.timestamp}
+            </time>
+          </header>
+          <h3 className="insight-grid__title">{insight.title}</h3>
+          <p className="insight-grid__summary">{insight.summary}</p>
+          <div className="insight-grid__confidence" aria-label={`Confidence ${width}`}>
+            <div className="insight-grid__confidence-track">
+              <div
+                className="insight-grid__confidence-fill"
+                style={
+                  reduceMotion
+                    ? { width }
+                    : { width, transition: 'width 320ms ease-in-out' }
+                }
+              />
+            </div>
+            <span className="insight-grid__confidence-label">{width}</span>
+          </div>
+        </article>
+      );
+    })}
+  </section>
+);
+
+export default InsightGrid;

--- a/web/src/components/InstallPromptBanner.tsx
+++ b/web/src/components/InstallPromptBanner.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback, useState } from 'react';
+
+interface InstallPromptBannerProps {
+  onInstall: () => Promise<boolean> | boolean;
+}
+
+const InstallPromptBanner: React.FC<InstallPromptBannerProps> = ({ onInstall }) => {
+  const [dismissed, setDismissed] = useState(false);
+  const [installing, setInstalling] = useState(false);
+
+  const handleInstall = useCallback(async () => {
+    setInstalling(true);
+    try {
+      const accepted = await onInstall();
+      if (accepted) {
+        setDismissed(true);
+      }
+    } finally {
+      setInstalling(false);
+    }
+  }, [onInstall]);
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <aside className="install-banner" role="region" aria-label="Install Gadget Lab">
+      <div>
+        <strong>Install Gadget Lab</strong>
+        <p>Run the dashboard offline as a standalone workspace.</p>
+      </div>
+      <div className="install-banner__actions">
+        <button type="button" className="install-banner__dismiss" onClick={() => setDismissed(true)}>
+          Not now
+        </button>
+        <button
+          type="button"
+          className="install-banner__cta"
+          onClick={handleInstall}
+          disabled={installing}
+        >
+          {installing ? 'Preparing…' : 'Install'}
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+export default InstallPromptBanner;

--- a/web/src/components/MetricCard.tsx
+++ b/web/src/components/MetricCard.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+
+import type { MetricSummary } from '../hooks/useDashboardData';
+
+interface MetricCardProps {
+  metric: MetricSummary;
+  reduceMotion?: boolean;
+}
+
+const buildSparklinePath = (points: number[]) => {
+  if (!points.length) {
+    return {
+      stroke: 'M0 12 L100 12',
+      area: 'M0 24 L100 24',
+    };
+  }
+  const max = Math.max(...points);
+  const min = Math.min(...points);
+  const range = Math.max(max - min, 0.0001);
+  const step = points.length > 1 ? 100 / (points.length - 1) : 100;
+
+  const strokeSegments: string[] = [];
+  const areaSegments: string[] = [];
+
+  points.forEach((point, index) => {
+    const x = Number((step * index).toFixed(2));
+    const normalized = (point - min) / range;
+    const y = Number((22 - normalized * 18).toFixed(2));
+    strokeSegments.push(`${index === 0 ? 'M' : 'L'}${x} ${y}`);
+    areaSegments.push(`${index === 0 ? 'M' : 'L'}${x} ${y}`);
+  });
+
+  const areaPath = `${areaSegments.join(' ')} L100 24 L0 24 Z`;
+
+  return {
+    stroke: strokeSegments.join(' '),
+    area: areaPath,
+  };
+};
+
+const formatMetricValue = (metric: MetricSummary) => {
+  if (metric.format === 'percentage') {
+    return `${metric.value.toFixed(3)}%`;
+  }
+  if (metric.format === 'duration') {
+    return `${Math.round(metric.value)}${metric.unit ? ` ${metric.unit}` : ''}`;
+  }
+  if (metric.unit) {
+    return `${Math.round(metric.value).toLocaleString()} ${metric.unit}`;
+  }
+  return Math.round(metric.value).toLocaleString();
+};
+
+const MetricCard: React.FC<MetricCardProps> = ({ metric, reduceMotion = false }) => {
+  const { stroke, area } = useMemo(() => buildSparklinePath(metric.trend), [metric.trend]);
+
+  const delta = metric.delta >= 0 ? `+${metric.delta.toFixed(1)}` : metric.delta.toFixed(1);
+  const deltaClass = metric.delta >= 0 ? 'metric-card__delta--up' : 'metric-card__delta--down';
+
+  return (
+    <article className="metric-card">
+      <header className="metric-card__header">
+        <span className="metric-card__label">{metric.label}</span>
+        <span className={`metric-card__delta ${deltaClass}`}>
+          {delta}%
+        </span>
+      </header>
+      <div className="metric-card__value">{formatMetricValue(metric)}</div>
+      <svg className="metric-card__spark" viewBox="0 0 100 24" role="presentation" aria-hidden="true">
+        <path className="metric-card__spark-area" d={area} />
+        <path
+          className="metric-card__spark-line"
+          d={stroke}
+          style={reduceMotion ? undefined : { strokeDasharray: 120, strokeDashoffset: 0 }}
+        />
+      </svg>
+      <footer className="metric-card__footer">{metric.caption}</footer>
+    </article>
+  );
+};
+
+export default React.memo(MetricCard);

--- a/web/src/components/OfflineToast.tsx
+++ b/web/src/components/OfflineToast.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+interface OfflineToastProps {
+  offline: boolean;
+}
+
+const OfflineToast: React.FC<OfflineToastProps> = ({ offline }) => {
+  const [visible, setVisible] = useState(offline);
+
+  useEffect(() => {
+    if (offline) {
+      setVisible(true);
+      return () => undefined;
+    }
+    const timeout = window.setTimeout(() => setVisible(false), 1200);
+    return () => window.clearTimeout(timeout);
+  }, [offline]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`offline-toast ${offline ? 'offline-toast--down' : 'offline-toast--restored'}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="offline-toast__dot" aria-hidden="true" />
+      <span>{offline ? 'You are offline. Working from local cache.' : 'Connection restored. Syncing updates…'}</span>
+    </div>
+  );
+};
+
+export default OfflineToast;

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback } from 'react';
+
+import type { QuickAction } from '../hooks/useDashboardData';
+
+interface QuickActionsProps {
+  actions: QuickAction[];
+  reduceMotion?: boolean;
+}
+
+const QuickActions: React.FC<QuickActionsProps> = ({ actions, reduceMotion = false }) => {
+  const handleActivate = useCallback(
+    (action: QuickAction) => {
+      if (!reduceMotion && typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+        try {
+          navigator.vibrate?.(12);
+        } catch {
+          // Some browsers throw for short vibrations, ignore.
+        }
+      }
+      if (action.onTrigger) {
+        action.onTrigger();
+      }
+    },
+    [reduceMotion],
+  );
+
+  return (
+    <nav className="quick-actions" aria-label="Quick actions">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          className="quick-actions__item"
+          onClick={() => handleActivate(action)}
+        >
+          <span className="quick-actions__label">{action.label}</span>
+          {action.hint ? <span className="quick-actions__hint">{action.hint}</span> : null}
+        </button>
+      ))}
+    </nav>
+  );
+};
+
+export default React.memo(QuickActions);

--- a/web/src/hooks/useDashboardData.ts
+++ b/web/src/hooks/useDashboardData.ts
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { scheduleIdleTask } from '../utils/scheduler';
+
+export interface MetricSummary {
+  id: string;
+  label: string;
+  value: number;
+  unit?: string;
+  delta: number;
+  caption: string;
+  trend: number[];
+  format?: 'percentage' | 'duration' | 'count';
+}
+
+export type GadgetStatus = 'online' | 'degraded' | 'standby';
+
+export interface GadgetSummary {
+  id: string;
+  name: string;
+  description: string;
+  status: GadgetStatus;
+  statusLabel: string;
+  accent: string;
+  throughput: string;
+  signal: string;
+  health: string;
+}
+
+export type InsightIntent = 'alert' | 'upgrade' | 'success';
+
+export interface InsightSummary {
+  id: string;
+  title: string;
+  summary: string;
+  intent: InsightIntent;
+  intentLabel: string;
+  confidence: number;
+  timestamp: string;
+  timestampISO: string;
+}
+
+export type ActivitySeverity = 'critical' | 'warning' | 'info' | 'success';
+
+export interface ActivityEvent {
+  id: string;
+  title: string;
+  actor: string;
+  timestamp: string;
+  timestampISO: string;
+  description: string;
+  severity: ActivitySeverity;
+  location?: string;
+}
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  hint?: string;
+  onTrigger?: () => void;
+}
+
+interface DashboardState {
+  metrics: MetricSummary[];
+  gadgets: GadgetSummary[];
+  events: ActivityEvent[];
+  insights: InsightSummary[];
+}
+
+const STORAGE_KEY = 'bo:gadget-lab::state-v1';
+
+const DEFAULT_STATE: DashboardState = {
+  metrics: [
+    {
+      id: 'uptime',
+      label: 'Mesh uptime',
+      value: 99.982,
+      unit: '%',
+      delta: 0.12,
+      caption: 'vs. previous 24h',
+      trend: [99.7, 99.74, 99.79, 99.81, 99.86, 99.9],
+      format: 'percentage',
+    },
+    {
+      id: 'orders',
+      label: 'Orders settled',
+      value: 182,
+      delta: 3.4,
+      caption: 'last 60 minutes',
+      trend: [118, 126, 133, 144, 158, 182],
+      format: 'count',
+    },
+    {
+      id: 'latency',
+      label: 'Relay latency P95',
+      value: 184,
+      unit: 'ms',
+      delta: -7.1,
+      caption: 'across 18 relays',
+      trend: [212, 207, 201, 194, 189, 184],
+      format: 'duration',
+    },
+  ],
+  gadgets: [
+    {
+      id: 'relay',
+      name: 'Arctic Relay Node',
+      description: 'Routes encrypted orders with adaptive load shedding across the mesh.',
+      status: 'online',
+      statusLabel: 'ONLINE',
+      accent: '#38bdf8',
+      throughput: '2.4k pkts/s',
+      signal: 'Signal lock',
+      health: '99.4% health',
+    },
+    {
+      id: 'vault',
+      name: 'ZeroTrace Vault',
+      description: 'Sharded cold storage with deterministic sealing and tamper proofs.',
+      status: 'standby',
+      statusLabel: 'STANDBY',
+      accent: '#8b5cf6',
+      throughput: '512 MB/s write',
+      signal: 'Seal verified',
+      health: 'Awaiting rotate',
+    },
+    {
+      id: 'uplink',
+      name: 'Subcarrier Uplink',
+      description: 'Burst uplink for covert drops with predictive throttling.',
+      status: 'degraded',
+      statusLabel: 'DEGRADED',
+      accent: '#f97316',
+      throughput: '420 kbps',
+      signal: '3 hops',
+      health: 'Needs recalibration',
+    },
+  ],
+  events: [
+    {
+      id: 'event-1',
+      title: 'Mesh handshake complete',
+      actor: 'Ops mesh',
+      timestamp: '08:58',
+      timestampISO: '2024-05-15T08:58:00Z',
+      description: 'All 18 nodes responded under 200ms.',
+      severity: 'info',
+      location: 'Global mesh',
+    },
+    {
+      id: 'event-2',
+      title: 'Cold vault resealed',
+      actor: 'ZeroTrace',
+      timestamp: '09:12',
+      timestampISO: '2024-05-15T09:12:00Z',
+      description: 'Integrity proofs rotated and signed by quorum.',
+      severity: 'success',
+      location: 'Vault cluster',
+    },
+    {
+      id: 'event-3',
+      title: 'Anomaly flagged on uplink',
+      actor: 'Signal daemon',
+      timestamp: '09:24',
+      timestampISO: '2024-05-15T09:24:00Z',
+      description: 'Packet loss spiked beyond baseline. Adaptive throttling engaged.',
+      severity: 'warning',
+      location: 'Subcarrier-7',
+    },
+    {
+      id: 'event-4',
+      title: 'Encrypted drop delivered',
+      actor: 'Courier swarm',
+      timestamp: '09:51',
+      timestampISO: '2024-05-15T09:51:00Z',
+      description: 'Payload decrypted successfully on recipient enclave.',
+      severity: 'info',
+    },
+  ],
+  insights: [
+    {
+      id: 'insight-1',
+      title: 'Photon spool nearing saturation',
+      summary: 'Route overflow to cold storage before 23:00 UTC to avoid congestion.',
+      intent: 'alert',
+      intentLabel: 'Alert',
+      confidence: 0.82,
+      timestamp: '09:20 UTC',
+      timestampISO: '2024-05-15T09:20:00Z',
+    },
+    {
+      id: 'insight-2',
+      title: 'Vault seal rotation ready',
+      summary: 'Next zero-knowledge seal cycle precomputed. Safe to roll during off-peak window.',
+      intent: 'upgrade',
+      intentLabel: 'Maintenance',
+      confidence: 0.64,
+      timestamp: '09:34 UTC',
+      timestampISO: '2024-05-15T09:34:00Z',
+    },
+    {
+      id: 'insight-3',
+      title: 'Courier swarm energy surplus',
+      summary: 'Batteries charged above 92%. Schedule extended patrol or shift to analytics.',
+      intent: 'success',
+      intentLabel: 'Good news',
+      confidence: 0.93,
+      timestamp: '09:48 UTC',
+      timestampISO: '2024-05-15T09:48:00Z',
+    },
+  ],
+};
+
+const formatTime = (date: Date) =>
+  date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+const persistState = (state: DashboardState) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  scheduleIdleTask(() => {
+    try {
+      const payload = JSON.stringify({
+        metrics: state.metrics,
+        gadgets: state.gadgets,
+        events: state.events.slice(0, 8),
+        insights: state.insights.slice(0, 4),
+      });
+      window.localStorage?.setItem(STORAGE_KEY, payload);
+    } catch {
+      // Ignore quota or private mode failures.
+    }
+  }, 600);
+};
+
+const restoreState = (): DashboardState => {
+  if (typeof window === 'undefined') {
+    return DEFAULT_STATE;
+  }
+  try {
+    const stored = window.localStorage?.getItem(STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_STATE;
+    }
+    const parsed = JSON.parse(stored) as Partial<DashboardState>;
+    return {
+      metrics: parsed.metrics ?? DEFAULT_STATE.metrics,
+      gadgets: parsed.gadgets ?? DEFAULT_STATE.gadgets,
+      events: parsed.events ?? DEFAULT_STATE.events,
+      insights: parsed.insights ?? DEFAULT_STATE.insights,
+    };
+  } catch {
+    return DEFAULT_STATE;
+  }
+};
+
+export function useDashboardData() {
+  const [state, setState] = useState<DashboardState>(() => restoreState());
+
+  useEffect(() => {
+    persistState(state);
+  }, [state]);
+
+  const runMeshSync = useCallback(() => {
+    setState((prev) => {
+      const now = new Date();
+      const iso = now.toISOString();
+      const event: ActivityEvent = {
+        id: `sync-${iso}`,
+        title: 'Workspace sync dispatched',
+        actor: 'Mesh orchestrator',
+        timestamp: formatTime(now),
+        timestampISO: iso,
+        description: 'Queued delta sync for offline peers.',
+        severity: 'info',
+        location: 'Distributed mesh',
+      };
+      return {
+        ...prev,
+        events: [event, ...prev.events].slice(0, 7),
+      };
+    });
+  }, []);
+
+  const captureSnapshot = useCallback(() => {
+    setState((prev) => {
+      const metrics = prev.metrics.map((metric) => {
+        if (metric.id === 'uptime') {
+          const nextTrend = [...metric.trend.slice(1), metric.trend[metric.trend.length - 1] + 0.02];
+          return {
+            ...metric,
+            value: Math.min(metric.value + 0.01, 99.995),
+            delta: Number(Math.min(metric.delta + 0.05, 0.6).toFixed(2)),
+            trend: nextTrend,
+          };
+        }
+        if (metric.id === 'orders') {
+          const nextValue = metric.value + 6;
+          const nextTrend = [...metric.trend.slice(1), nextValue];
+          return {
+            ...metric,
+            value: nextValue,
+            delta: Number((metric.delta + 0.3).toFixed(1)),
+            trend: nextTrend,
+          };
+        }
+        if (metric.id === 'latency') {
+          const nextTrend = [...metric.trend.slice(1), Math.max(metric.trend[metric.trend.length - 1] - 3, 160)];
+          return {
+            ...metric,
+            value: Math.max(metric.value - 4, 150),
+            delta: Number(Math.max(metric.delta - 0.4, -12).toFixed(1)),
+            trend: nextTrend,
+          };
+        }
+        return metric;
+      });
+      return {
+        ...prev,
+        metrics,
+      };
+    });
+  }, []);
+
+  const broadcastStatus = useCallback(() => {
+    setState((prev) => {
+      const now = new Date();
+      const iso = now.toISOString();
+      const insight: InsightSummary = {
+        id: `insight-${iso}`,
+        title: 'Mesh broadcast scheduled',
+        summary: 'Notifications queued for field teams with offline fallback packages.',
+        intent: 'success',
+        intentLabel: 'Broadcast',
+        confidence: 0.68,
+        timestamp: `${formatTime(now)} UTC`,
+        timestampISO: iso,
+      };
+      return {
+        ...prev,
+        insights: [insight, ...prev.insights].slice(0, 4),
+      };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      setState((prev) => {
+        const metrics = prev.metrics.map((metric) => {
+          if (metric.id !== 'orders') {
+            return metric;
+          }
+          const variation = Math.sin(Date.now() / 120000) * 2;
+          const nextValue = metric.value + variation;
+          const nextTrend = [...metric.trend.slice(1), Math.max(nextValue, 1)];
+          return {
+            ...metric,
+            value: Math.max(nextValue, 0),
+            trend: nextTrend,
+          };
+        });
+        return {
+          ...prev,
+          metrics,
+        };
+      });
+    }, 20000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const quickActions = useMemo<QuickAction[]>(
+    () => [
+      {
+        id: 'sync',
+        label: 'Sync mesh',
+        hint: '⇧R',
+        onTrigger: runMeshSync,
+      },
+      {
+        id: 'snapshot',
+        label: 'Capture snapshot',
+        hint: '⌘K',
+        onTrigger: captureSnapshot,
+      },
+      {
+        id: 'broadcast',
+        label: 'Broadcast status',
+        hint: 'B',
+        onTrigger: broadcastStatus,
+      },
+    ],
+    [broadcastStatus, captureSnapshot, runMeshSync],
+  );
+
+  return {
+    metrics: state.metrics,
+    gadgets: state.gadgets,
+    events: state.events,
+    insights: state.insights,
+    quickActions,
+  };
+}

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() => {
+    if (typeof navigator === 'undefined') {
+      return true;
+    }
+    return navigator.onLine;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/web/src/hooks/usePrefersReducedMotion.ts
+++ b/web/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const mediaQuery = window.matchMedia(QUERY);
+    const handleChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    setPrefersReducedMotion(mediaQuery.matches);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/web/src/hooks/usePwaInstallPrompt.ts
+++ b/web/src/hooks/usePwaInstallPrompt.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface InstallPromptState {
+  canInstall: boolean;
+  promptInstall: () => Promise<boolean>;
+  isStandalone: boolean;
+}
+
+export function usePwaInstallPrompt(): InstallPromptState {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isStandalone, setIsStandalone] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.matchMedia?.('(display-mode: standalone)').matches ?? false;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const updateStandalone = () => {
+      const matchesDisplayMode = window.matchMedia?.('(display-mode: standalone)').matches ?? false;
+      const standaloneNavigator = (navigator as Navigator & { standalone?: boolean }).standalone ?? false;
+      setIsStandalone(Boolean(matchesDisplayMode || standaloneNavigator));
+    };
+
+    const handlePrompt = (event: BeforeInstallPromptEvent) => {
+      event.preventDefault();
+      setDeferredPrompt(event);
+    };
+
+    window.addEventListener('beforeinstallprompt', handlePrompt as EventListener);
+    window.addEventListener('appinstalled', updateStandalone);
+    updateStandalone();
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handlePrompt as EventListener);
+      window.removeEventListener('appinstalled', updateStandalone);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) {
+      return false;
+    }
+    deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    return choice.outcome === 'accepted';
+  }, [deferredPrompt]);
+
+  return {
+    canInstall: deferredPrompt !== null,
+    promptInstall,
+    isStandalone,
+  };
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,0 +1,59 @@
+import React, { StrictMode, startTransition } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import './styles.css';
+import { registerServiceWorker } from './pwa/registerServiceWorker';
+import { warmRuntimeCaches } from './pwa/cacheWarmup';
+import { scheduleIdleTask } from './utils/scheduler';
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Failed to find root container for the Gadget Lab PWA');
+}
+
+const root = createRoot(container);
+
+const BootSplash: React.FC = () => (
+  <div className="boot-splash" role="status" aria-live="polite">
+    <div className="boot-splash__pulse" />
+    <p>Launching Gadget Lab…</p>
+  </div>
+);
+
+root.render(
+  <StrictMode>
+    <BootSplash />
+  </StrictMode>,
+);
+
+const hydrate = () => {
+  void import('./App').then(({ default: App }) => {
+    startTransition(() => {
+      root.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
+    });
+  });
+};
+
+const prepareApp = () => {
+  hydrate();
+  scheduleIdleTask(warmRuntimeCaches, 1500);
+};
+
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  scheduleIdleTask(prepareApp, 1);
+} else {
+  document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      scheduleIdleTask(prepareApp, 1);
+    },
+    { once: true },
+  );
+}
+
+registerServiceWorker();

--- a/web/src/pwa/cacheManifest.ts
+++ b/web/src/pwa/cacheManifest.ts
@@ -1,0 +1,3 @@
+export const SHELL_ASSETS: string[] = ['/', '/index.html', '/manifest.webmanifest'];
+
+export const PREFETCH_URLS: string[] = ['/locales/en.json'];

--- a/web/src/pwa/cacheWarmup.ts
+++ b/web/src/pwa/cacheWarmup.ts
@@ -1,0 +1,31 @@
+import { PREFETCH_URLS, SHELL_ASSETS } from './cacheManifest';
+
+export const warmRuntimeCaches = (): void => {
+  if (typeof window === 'undefined' || !('caches' in window) || !('fetch' in window)) {
+    return;
+  }
+
+  const urls = Array.from(new Set([...SHELL_ASSETS, ...PREFETCH_URLS]));
+
+  void (async () => {
+    try {
+      const cache = await caches.open('bo-prewarm');
+      await Promise.all(
+        urls.map(async (url) => {
+          try {
+            const response = await fetch(new Request(url, { cache: 'reload' }));
+            if (response.ok) {
+              await cache.put(url, response.clone());
+            }
+          } catch {
+            // Ignore network failures – offline mode will fall back to existing cache.
+          }
+        }),
+      );
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Cache warmup failed', error);
+      }
+    }
+  })();
+};

--- a/web/src/pwa/registerServiceWorker.ts
+++ b/web/src/pwa/registerServiceWorker.ts
@@ -1,0 +1,49 @@
+const SW_PATH = '/service-worker.js';
+
+const shouldRegister = () =>
+  process.env.NODE_ENV === 'production' && typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+
+const handleUpdate = (registration: ServiceWorkerRegistration) => {
+  if (!registration.waiting) {
+    return;
+  }
+  registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+};
+
+export function registerServiceWorker(): void {
+  if (!shouldRegister()) {
+    return;
+  }
+
+  const register = () => {
+    navigator.serviceWorker
+      .register(SW_PATH)
+      .then((registration) => {
+        if (registration.waiting) {
+          handleUpdate(registration);
+        }
+        registration.addEventListener('updatefound', () => {
+          const installing = registration.installing;
+          if (!installing) {
+            return;
+          }
+          installing.addEventListener('statechange', () => {
+            if (registration.waiting && installing.state === 'installed') {
+              handleUpdate(registration);
+            }
+          });
+        });
+      })
+      .catch((error) => {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('Service worker registration failed', error);
+        }
+      });
+  };
+
+  if (document.readyState === 'complete') {
+    register();
+  } else {
+    window.addEventListener('load', register, { once: true });
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,616 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #020617;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #0f172a, #020617 60%);
+  color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+}
+
+#root {
+  width: 100%;
+}
+
+.boot-splash {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100vh;
+  color: #cbd5f5;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.boot-splash__pulse {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #38bdf8, #8b5cf6);
+  animation: pulse 1.4s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+}
+
+.gadget-lab-shell {
+  width: min(1160px, 100%);
+  margin: 0 auto;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(8, 11, 19, 0.8));
+  border: 1px solid rgba(56, 189, 248, 0.08);
+  border-radius: 28px;
+  backdrop-filter: blur(22px);
+  padding: 28px 32px 36px;
+  box-shadow: 0 20px 70px rgba(3, 7, 18, 0.55);
+}
+
+.lab-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.lab-header__subtitle {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.lab-header__title {
+  margin: 6px 0 0;
+  font-size: clamp(2rem, 2.6vw, 2.6rem);
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.lab-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.lab-hero {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.lab-hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.lab-content {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.lab-main {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.lab-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+@media (min-width: 980px) {
+  .lab-content {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+}
+
+.gadget-tile {
+  position: relative;
+  border-radius: 24px;
+  padding: 24px;
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.25), rgba(15, 23, 42, 0.7));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  min-height: 200px;
+  transition: transform 180ms ease, border 240ms ease;
+  overflow: hidden;
+}
+
+.gadget-tile:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.75);
+  outline-offset: 3px;
+}
+
+.gadget-tile__shine {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 0%, rgba(255, 255, 255, 0.22), transparent 55%);
+  pointer-events: none;
+}
+
+.gadget-tile__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.gadget-tile__status {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 999px;
+  padding: 4px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.gadget-tile__status--online {
+  color: #4ade80;
+}
+
+.gadget-tile__status--standby {
+  color: #facc15;
+}
+
+.gadget-tile__status--degraded {
+  color: #fb7185;
+}
+
+.gadget-tile__tag {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.gadget-tile__title {
+  margin: 18px 0 8px;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.gadget-tile__body {
+  margin: 0 0 18px;
+  color: rgba(203, 213, 225, 0.85);
+  line-height: 1.4;
+}
+
+.gadget-tile__footer {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(148, 163, 184, 0.88);
+  font-size: 0.85rem;
+}
+
+.gadget-tile__footer-accent {
+  color: #f8fafc;
+}
+
+.lab-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.metric-card {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.75));
+  border-radius: 20px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.28);
+}
+
+.metric-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  color: rgba(148, 163, 184, 0.86);
+  font-size: 0.8rem;
+}
+
+.metric-card__value {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 10px 0;
+  color: #f8fafc;
+}
+
+.metric-card__delta {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.metric-card__delta--up {
+  color: #4ade80;
+}
+
+.metric-card__delta--down {
+  color: #f97316;
+}
+
+.metric-card__spark {
+  width: 100%;
+  height: 56px;
+}
+
+.metric-card__spark-area {
+  fill: rgba(56, 189, 248, 0.12);
+}
+
+.metric-card__spark-line {
+  fill: none;
+  stroke: #38bdf8;
+  stroke-width: 1.8;
+}
+
+.metric-card__footer {
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.8rem;
+}
+
+.quick-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.quick-actions__item {
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  color: #bae6fd;
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.quick-actions__item:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 2px;
+}
+
+.quick-actions__item:hover {
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-1px);
+}
+
+.quick-actions__hint {
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.75rem;
+}
+
+.lab-activity {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(9, 13, 25, 0.75));
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 22px;
+}
+
+.activity-feed__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.activity-feed__item {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.activity-feed__marker {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-top: 8px;
+  background: #38bdf8;
+  box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.08);
+}
+
+.activity-feed__marker--warning {
+  background: #f97316;
+  box-shadow: 0 0 0 6px rgba(249, 115, 22, 0.15);
+}
+
+.activity-feed__marker--critical {
+  background: #fb7185;
+  box-shadow: 0 0 0 6px rgba(251, 113, 133, 0.12);
+}
+
+.activity-feed__marker--success {
+  background: #4ade80;
+  box-shadow: 0 0 0 6px rgba(74, 222, 128, 0.12);
+}
+
+.activity-feed__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.activity-feed__timestamp {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.activity-feed__description {
+  margin: 8px 0 6px;
+  color: rgba(203, 213, 225, 0.82);
+  line-height: 1.45;
+}
+
+.activity-feed__meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.insight-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.insight-grid__item {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.72), rgba(15, 23, 42, 0.78));
+  border-radius: 20px;
+  padding: 18px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.insight-grid__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.insight-grid__badge {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.insight-grid__badge--alert {
+  background: rgba(251, 113, 133, 0.18);
+  color: #fecaca;
+}
+
+.insight-grid__badge--upgrade {
+  background: rgba(192, 132, 252, 0.18);
+  color: #e9d5ff;
+}
+
+.insight-grid__badge--success {
+  background: rgba(74, 222, 128, 0.18);
+  color: #bbf7d0;
+}
+
+.insight-grid__timestamp {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.72);
+}
+
+.insight-grid__title {
+  margin: 12px 0 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.insight-grid__summary {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.82);
+  line-height: 1.4;
+}
+
+.insight-grid__confidence {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.insight-grid__confidence-track {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.insight-grid__confidence-fill {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8, #8b5cf6);
+}
+
+.insight-grid__confidence-label {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.88);
+}
+
+.install-banner {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.94));
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  border-radius: 20px;
+  padding: 16px 22px;
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.45);
+  color: #e0f2fe;
+  max-width: 560px;
+  width: calc(100% - 32px);
+  z-index: 40;
+}
+
+.install-banner__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.install-banner__cta {
+  background: linear-gradient(135deg, #38bdf8, #8b5cf6);
+  color: #0f172a;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.install-banner__cta:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.install-banner__dismiss {
+  background: transparent;
+  border: none;
+  color: rgba(148, 163, 184, 0.9);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.offline-toast {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  padding: 10px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.4);
+  color: rgba(226, 232, 240, 0.95);
+  z-index: 30;
+}
+
+.offline-toast__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #f97316;
+  animation: blink 1.2s infinite;
+}
+
+.offline-toast--restored .offline-toast__dot {
+  background: #4ade80;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.deferred-fallback {
+  display: grid;
+  gap: 10px;
+}
+
+.deferred-fallback__line {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.08));
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-10%);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translateX(10%);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-10%);
+    opacity: 0.6;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .quick-actions__item,
+  .gadget-tile {
+    transition: none;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 16px;
+  }
+
+  .gadget-lab-shell {
+    padding: 20px;
+  }
+
+  .lab-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .install-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/web/src/utils/scheduler.ts
+++ b/web/src/utils/scheduler.ts
@@ -1,0 +1,13 @@
+export type IdleTask = (deadline?: IdleDeadline) => void;
+
+export const scheduleIdleTask = (task: IdleTask, timeout = 1000): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const idleCallback = (window as Window & { requestIdleCallback?: any }).requestIdleCallback;
+  if (typeof idleCallback === 'function') {
+    idleCallback((deadline: IdleDeadline) => task(deadline), { timeout });
+    return;
+  }
+  window.setTimeout(() => task(undefined), timeout);
+};

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,7 +1,60 @@
+const path = require('path');
+const webpack = require('webpack');
+
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
 module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
-  config.output.publicPath = "./"; // Use relative URLs for IPFS
+  const mode = argv.mode || 'development';
+
+  config.entry = {
+    main: path.resolve(__dirname, 'src/index.tsx'),
+  };
+
+  config.output = {
+    ...config.output,
+    filename: mode === 'production' ? 'static/js/[name].[contenthash:8].js' : 'static/js/[name].js',
+    chunkFilename:
+      mode === 'production' ? 'static/js/[name].[contenthash:8].chunk.js' : 'static/js/[name].chunk.js',
+    publicPath: './',
+  };
+
+  config.optimization = {
+    ...config.optimization,
+    runtimeChunk: 'single',
+    moduleIds: 'deterministic',
+    chunkIds: 'deterministic',
+    splitChunks: {
+      chunks: 'all',
+      maxInitialRequests: 30,
+      maxAsyncRequests: 30,
+      cacheGroups: {
+        react: {
+          test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+          name: 'react-vendors',
+          chunks: 'all',
+          priority: -5,
+        },
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          priority: -10,
+        },
+      },
+    },
+  };
+
+  config.performance = {
+    ...config.performance,
+    hints: false,
+  };
+
+  config.plugins = config.plugins || [];
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      __PWA_BUILD__: JSON.stringify(mode === 'production'),
+    }),
+  );
   return config;
 };


### PR DESCRIPTION
## Summary
- add a standalone Gadget Lab PWA entry that lazy-loads the dashboard and primes caches after first paint
- implement tactile dashboard components with reduced-motion awareness and persistent data hooks for offline use
- refresh service worker, manifest, and webpack optimizations to keep bundles lean and resilient offline

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser in the workspace)*
- yarn typecheck *(fails: missing type definition packages and expo/tsconfig.base.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c881af71108326a831e0729fdd7524