### PR TITLE
Add pseudonymous billing service and tenant fee dashboard

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -18,6 +18,7 @@ import {
 } from '@/services/nearContract';
 import productsAgent from './products-agent';
 import { getSellerPublicKey } from '@/features/stores/services/sellerRegistry';
+import meteredBilling from '@/billing';
 
 assertNearChain();
 import { encryptShippingInfo } from '../utils/shippingCrypto';
@@ -324,6 +325,21 @@ class OrdersAgent {
         status: normalized.status,
       });
       if (normalized.status === 'released') {
+        if (sid) {
+          void meteredBilling
+            .recordUsage({
+              tenantId: sid,
+              meterId: 'orders.released',
+              quantity: 1,
+              unitPrice: normalized.total || 0,
+              walletAddress: normalized.sellerAddress || undefined,
+              metadata: {
+                orderId: normalized.id,
+                status: normalized.status,
+              },
+            })
+            .catch((err) => errorLog('Failed to record billing usage', err));
+        }
         await this.recordSellerMetric(normalized.sellerAddress, 'completed');
       } else if (normalized.status === 'refunded') {
         await this.recordSellerMetric(normalized.sellerAddress, 'refunded');

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -5,6 +5,7 @@ import { useAppRouter } from '@/services';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
+import FeeDashboard from '@/features/billing/components/FeeDashboard';
 import { useAuth } from '@/features/auth/AuthContext';
 import { getStore as getNearStore } from '@/features/stores/services/nearStores';
 import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
@@ -79,6 +80,7 @@ export default function StoreDashboardScreen() {
         </Text>
         {storeId && <OrderRevenueMetrics storeId={storeId} />}
       </View>
+      {storeId && <FeeDashboard tenantId={storeId} />}
       <View style={styles.nav}>
         <TouchableOpacity
           style={[styles.navButton, { borderColor: colors.border.primary }]}

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -7,6 +7,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { useAuth } from '@/features/auth/AuthContext';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
+import FeeDashboard from '@/features/billing/components/FeeDashboard';
 import { routes } from '@/utils/routes';
 import { getStore as getNearStore } from '@/features/stores/services/nearStores';
 import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
@@ -53,6 +54,7 @@ export default function DashboardRoute(props: any) {
         <View>
           <Text>{`מוצרים: ${count}`}</Text>
           {storeId ? <OrderRevenueMetrics storeId={storeId as string} /> : null}
+          {storeId ? <FeeDashboard tenantId={storeId as string} /> : null}
         </View>
       );
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -97,6 +97,8 @@ const cfg = {
     '^@/core/(.*)$': '<rootDir>/src/core/$1',
     '^@/services$': '<rootDir>/src/services/index',
     '^@/services/(.*)$': ['<rootDir>/src/services/$1', '<rootDir>/services/$1'],
+    '^@/billing$': '<rootDir>/src/billing/index',
+    '^@/billing/(.*)$': '<rootDir>/src/billing/$1',
     '^@/utils/(.*)$': ['<rootDir>/src/utils/$1', '<rootDir>/utils/$1'],
     '^@/providers/(.*)$': '<rootDir>/src/providers/$1',
     '^@/providers$': '<rootDir>/src/providers/index',

--- a/src/billing/MeteredBillingService.ts
+++ b/src/billing/MeteredBillingService.ts
@@ -1,0 +1,343 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { sha256 } from '@noble/hashes/sha256';
+import { chainAdapter } from '@/services/chain';
+import eventBus from '@/services/eventBus';
+import { getFeeSettings } from '@/constants/tenant';
+import { canonicalJson } from '@/utils/serialization';
+import ensureNearWallet from '@/utils/ensureNearWallet';
+import { uuid } from '@/utils/uuid';
+import { errorLog } from '@/utils/logger';
+import type {
+  BillingPayment,
+  BillingSummary,
+  MeteredUsageEvent,
+  RecordUsageInput,
+  SettleUsageOptions,
+} from './types';
+
+const BILLING_TOPIC = '/blue-ocean/billing/1';
+const STORAGE_USAGE_PREFIX = 'billing:usage:';
+const STORAGE_PAYMENT_PREFIX = 'billing:payments:';
+
+function round(value: number, decimals = 6): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function toUtf8(value: string): Uint8Array {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value);
+  }
+  const arr = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i += 1) {
+    arr[i] = value.charCodeAt(i);
+  }
+  return arr;
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function pseudonymizeWallet(address: string, tenantId: string): string {
+  const normalizedAddress = address.trim().toLowerCase();
+  const normalizedTenant = tenantId.trim().toLowerCase();
+  const input = `${normalizedTenant}:${normalizedAddress}`;
+  const hash = sha256(toUtf8(input));
+  return toHex(hash);
+}
+
+function sanitizeMetadata(metadata?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!metadata) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(metadata));
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneUsage(events: MeteredUsageEvent[]): MeteredUsageEvent[] {
+  return events.map((event) => ({ ...event, metadata: sanitizeMetadata(event.metadata) }));
+}
+
+function clonePayments(payments: BillingPayment[]): BillingPayment[] {
+  return payments.map((payment) => ({ ...payment, usageIds: [...payment.usageIds] }));
+}
+
+export default class MeteredBillingService {
+  private static instance: MeteredBillingService | null = null;
+
+  private usageCache: Map<string, MeteredUsageEvent[]> = new Map();
+
+  private paymentCache: Map<string, BillingPayment[]> = new Map();
+
+  private listeners: Map<string, Set<() => void>> = new Map();
+
+  static getInstance(): MeteredBillingService {
+    if (!MeteredBillingService.instance) {
+      MeteredBillingService.instance = new MeteredBillingService();
+    }
+    return MeteredBillingService.instance;
+  }
+
+  private constructor() {}
+
+  private getUsageKey(tenantId: string): string {
+    return `${STORAGE_USAGE_PREFIX}${tenantId}`;
+  }
+
+  private getPaymentKey(tenantId: string): string {
+    return `${STORAGE_PAYMENT_PREFIX}${tenantId}`;
+  }
+
+  private async loadUsage(tenantId: string): Promise<MeteredUsageEvent[]> {
+    if (this.usageCache.has(tenantId)) {
+      return this.usageCache.get(tenantId) as MeteredUsageEvent[];
+    }
+    try {
+      const raw = await AsyncStorage.getItem(this.getUsageKey(tenantId));
+      if (!raw) {
+        this.usageCache.set(tenantId, []);
+        return [];
+      }
+      const parsed = JSON.parse(raw) as MeteredUsageEvent[];
+      this.usageCache.set(tenantId, parsed);
+      return parsed;
+    } catch (err) {
+      errorLog('Failed to load metered usage', err);
+      this.usageCache.set(tenantId, []);
+      return [];
+    }
+  }
+
+  private async loadPayments(tenantId: string): Promise<BillingPayment[]> {
+    if (this.paymentCache.has(tenantId)) {
+      return this.paymentCache.get(tenantId) as BillingPayment[];
+    }
+    try {
+      const raw = await AsyncStorage.getItem(this.getPaymentKey(tenantId));
+      if (!raw) {
+        this.paymentCache.set(tenantId, []);
+        return [];
+      }
+      const parsed = JSON.parse(raw) as BillingPayment[];
+      this.paymentCache.set(tenantId, parsed);
+      return parsed;
+    } catch (err) {
+      errorLog('Failed to load billing payments', err);
+      this.paymentCache.set(tenantId, []);
+      return [];
+    }
+  }
+
+  private async persistUsage(tenantId: string, events: MeteredUsageEvent[]): Promise<void> {
+    const sorted = [...events].sort((a, b) => (a.recordedAt < b.recordedAt ? 1 : -1));
+    this.usageCache.set(tenantId, sorted);
+    try {
+      await AsyncStorage.setItem(this.getUsageKey(tenantId), JSON.stringify(sorted));
+    } catch (err) {
+      errorLog('Failed to persist metered usage', err);
+    }
+  }
+
+  private async persistPayments(tenantId: string, payments: BillingPayment[]): Promise<void> {
+    const sorted = [...payments].sort((a, b) => (a.recordedAt < b.recordedAt ? 1 : -1));
+    this.paymentCache.set(tenantId, sorted);
+    try {
+      await AsyncStorage.setItem(this.getPaymentKey(tenantId), JSON.stringify(sorted));
+    } catch (err) {
+      errorLog('Failed to persist billing payments', err);
+    }
+  }
+
+  private notify(tenantId: string): void {
+    const listeners = this.listeners.get(tenantId);
+    if (!listeners) return;
+    listeners.forEach((listener) => {
+      try {
+        listener();
+      } catch (err) {
+        errorLog('MeteredBilling listener error', err);
+      }
+    });
+  }
+
+  subscribe(tenantId: string, callback: () => void): () => void {
+    if (!this.listeners.has(tenantId)) {
+      this.listeners.set(tenantId, new Set());
+    }
+    const set = this.listeners.get(tenantId) as Set<() => void>;
+    set.add(callback);
+    return () => {
+      set.delete(callback);
+      if (set.size === 0) {
+        this.listeners.delete(tenantId);
+      }
+    };
+  }
+
+  async recordUsage(input: RecordUsageInput): Promise<MeteredUsageEvent> {
+    const tenantId = input.tenantId?.trim();
+    if (!tenantId) {
+      throw new Error('Tenant identifier required for billing usage');
+    }
+    const meterId = input.meterId?.trim();
+    if (!meterId) {
+      throw new Error('Meter identifier required for billing usage');
+    }
+    const quantity = Number.isFinite(input.quantity) ? Number(input.quantity) : 1;
+    const unitPrice = Number.isFinite(input.unitPrice) ? Number(input.unitPrice) : 0;
+    const safeQuantity = quantity > 0 ? quantity : 0;
+    const safeUnitPrice = unitPrice >= 0 ? unitPrice : 0;
+    const subtotal = round(safeQuantity * safeUnitPrice);
+    const { feeBps } = await getFeeSettings();
+    const fee = round((subtotal * (feeBps ?? 0)) / 10000);
+    const total = round(subtotal + fee);
+    const walletHash = input.walletAddress
+      ? pseudonymizeWallet(input.walletAddress, tenantId)
+      : 'anonymous';
+    const usage: MeteredUsageEvent = {
+      id: uuid(),
+      tenantId,
+      meterId,
+      quantity: safeQuantity,
+      unitPrice: safeUnitPrice,
+      subtotal,
+      fee,
+      total,
+      recordedAt: new Date().toISOString(),
+      walletHash,
+      metadata: sanitizeMetadata(input.metadata),
+      settledAt: null,
+    };
+
+    const existing = await this.loadUsage(tenantId);
+    await this.persistUsage(tenantId, [usage, ...existing]);
+
+    await eventBus.publish(BILLING_TOPIC, 'billing.usage', {
+      tenantId,
+      meterId,
+      eventId: usage.id,
+      quantity: safeQuantity,
+      subtotal,
+      fee,
+      walletHash,
+    });
+
+    this.notify(tenantId);
+    return usage;
+  }
+
+  async listUsageEvents(tenantId: string): Promise<MeteredUsageEvent[]> {
+    const usage = await this.loadUsage(tenantId);
+    return cloneUsage(usage);
+  }
+
+  async listPayments(tenantId: string): Promise<BillingPayment[]> {
+    const payments = await this.loadPayments(tenantId);
+    return clonePayments(payments);
+  }
+
+  async getSummary(tenantId: string): Promise<BillingSummary> {
+    const usage = await this.loadUsage(tenantId);
+    const payments = await this.loadPayments(tenantId);
+    const totalUsage = round(usage.reduce((sum, event) => sum + event.subtotal, 0));
+    const totalFees = round(usage.reduce((sum, event) => sum + event.fee, 0));
+    const outstanding = round(
+      usage.filter((event) => !event.settledAt).reduce((sum, event) => sum + event.fee, 0),
+    );
+    const lastPayment = payments[0] ?? null;
+    const walletAlias = lastPayment?.walletHash || usage[0]?.walletHash || null;
+
+    return {
+      tenantId,
+      totalUsage,
+      totalFees,
+      outstanding,
+      updatedAt: new Date().toISOString(),
+      usage: cloneUsage(usage),
+      payments: clonePayments(payments),
+      lastPayment,
+      walletAlias,
+    };
+  }
+
+  async settleUsage(tenantId: string, options: SettleUsageOptions = {}): Promise<BillingPayment> {
+    const id = tenantId?.trim();
+    if (!id) {
+      throw new Error('Tenant identifier required to settle usage');
+    }
+    const usage = await this.loadUsage(id);
+    const unsettled = usage.filter((event) => !event.settledAt);
+    if (unsettled.length === 0) {
+      throw new Error('No outstanding usage to settle');
+    }
+    const selectedIds = options.usageIds?.length
+      ? options.usageIds.filter((usageId) => unsettled.some((event) => event.id === usageId))
+      : unsettled.map((event) => event.id);
+    const selectedEvents = unsettled.filter((event) => selectedIds.includes(event.id));
+    if (selectedEvents.length === 0) {
+      throw new Error('Selected usage events are already settled');
+    }
+    const calculatedAmount = round(selectedEvents.reduce((sum, event) => sum + event.fee, 0));
+    const amount = Number.isFinite(options.amount) && (options.amount ?? 0) > 0
+      ? round(options.amount as number)
+      : calculatedAmount;
+    if (amount <= 0) {
+      throw new Error('Payment amount must be greater than zero');
+    }
+
+    const { address } = await ensureNearWallet('Connect wallet to settle network fees.');
+    if (!chainAdapter.signMessage) {
+      throw new Error('Wallet does not support private billing settlements');
+    }
+    const walletHash = pseudonymizeWallet(address, id);
+    const paymentId = uuid();
+    const recordedAt = new Date().toISOString();
+    const payload = {
+      type: 'billing.payment',
+      paymentId,
+      tenantId: id,
+      walletHash,
+      amount: amount.toFixed(6),
+      usageIds: selectedIds,
+      timestamp: recordedAt,
+      note: options.note ?? undefined,
+    };
+    const signature = await chainAdapter.signMessage(canonicalJson(payload));
+
+    const payment: BillingPayment = {
+      id: paymentId,
+      tenantId: id,
+      walletHash,
+      amount,
+      currency: 'NEAR',
+      usageIds: selectedIds,
+      recordedAt,
+      signature,
+      note: options.note,
+    };
+
+    const payments = await this.loadPayments(id);
+    await this.persistPayments(id, [payment, ...payments]);
+
+    const updatedUsage = usage.map((event) =>
+      selectedIds.includes(event.id) ? { ...event, settledAt: recordedAt } : event,
+    );
+    await this.persistUsage(id, updatedUsage);
+
+    await eventBus.publish(BILLING_TOPIC, 'billing.payment', {
+      tenantId: id,
+      paymentId,
+      amount,
+      usageIds: selectedIds,
+      walletHash,
+    });
+
+    this.notify(id);
+    return payment;
+  }
+}

--- a/src/billing/hooks.ts
+++ b/src/billing/hooks.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import MeteredBillingService from './MeteredBillingService';
+import type { BillingSummary } from './types';
+
+const service = MeteredBillingService.getInstance();
+
+type LoadMode = 'initial' | 'refresh';
+
+interface UseBillingSummaryResult {
+  data: BillingSummary | null;
+  error: Error | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  refetch: () => Promise<BillingSummary | null>;
+}
+
+export function useBillingSummary(tenantId: string | null): UseBillingSummaryResult {
+  const [data, setData] = useState<BillingSummary | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(!!tenantId);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+
+  const load = useCallback(
+    async (mode: LoadMode = 'initial'): Promise<BillingSummary | null> => {
+      if (!tenantId) {
+        setData(null);
+        setError(null);
+        setIsLoading(false);
+        setIsFetching(false);
+        return null;
+      }
+      if (mode === 'initial') {
+        setIsLoading(true);
+      } else {
+        setIsFetching(true);
+      }
+      try {
+        const summary = await service.getSummary(tenantId);
+        setData(summary);
+        setError(null);
+        return summary;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error('Failed to load billing summary');
+        setError(e);
+        return null;
+      } finally {
+        if (mode === 'initial') {
+          setIsLoading(false);
+        } else {
+          setIsFetching(false);
+        }
+      }
+    },
+    [tenantId],
+  );
+
+  useEffect(() => {
+    void load('initial');
+  }, [load]);
+
+  useEffect(() => {
+    if (!tenantId) return;
+    return service.subscribe(tenantId, () => {
+      void load('refresh');
+    });
+  }, [tenantId, load]);
+
+  const refetch = useCallback(() => load('refresh'), [load]);
+
+  return useMemo(
+    () => ({ data, error, isLoading, isFetching, refetch }),
+    [data, error, isLoading, isFetching, refetch],
+  );
+}
+
+export default useBillingSummary;

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,0 +1,9 @@
+import MeteredBillingService from './MeteredBillingService';
+
+const meteredBilling = MeteredBillingService.getInstance();
+
+export * from './types';
+export { useBillingSummary } from './hooks';
+export { MeteredBillingService };
+export { meteredBilling };
+export default meteredBilling;

--- a/src/billing/types.ts
+++ b/src/billing/types.ts
@@ -1,0 +1,53 @@
+export interface MeteredUsageEvent {
+  id: string;
+  tenantId: string;
+  meterId: string;
+  quantity: number;
+  unitPrice: number;
+  subtotal: number;
+  fee: number;
+  total: number;
+  recordedAt: string;
+  walletHash: string;
+  metadata?: Record<string, unknown>;
+  settledAt?: string | null;
+}
+
+export interface RecordUsageInput {
+  tenantId: string;
+  meterId: string;
+  quantity?: number;
+  unitPrice?: number;
+  walletAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BillingPayment {
+  id: string;
+  tenantId: string;
+  walletHash: string;
+  amount: number;
+  currency: string;
+  usageIds: string[];
+  recordedAt: string;
+  signature: string;
+  note?: string;
+}
+
+export interface BillingSummary {
+  tenantId: string;
+  totalUsage: number;
+  totalFees: number;
+  outstanding: number;
+  updatedAt: string;
+  usage: MeteredUsageEvent[];
+  payments: BillingPayment[];
+  lastPayment: BillingPayment | null;
+  walletAlias: string | null;
+}
+
+export interface SettleUsageOptions {
+  usageIds?: string[];
+  amount?: number;
+  note?: string;
+}

--- a/src/features/billing/components/FeeDashboard.tsx
+++ b/src/features/billing/components/FeeDashboard.tsx
@@ -1,0 +1,319 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Card, Heading, Text, Button, Spinner } from '@/ui/primitives';
+import { Stack } from '@/ui/layout';
+import { useLanguage, useTheme } from '@/ui/ThemeProvider';
+import { spacing, radius } from '@/ui/tokens';
+import meteredBilling, { useBillingSummary } from '@/billing';
+
+interface FeeDashboardProps {
+  tenantId: string | null;
+  usagePreviewLimit?: number;
+}
+
+function formatAmount(value: number): string {
+  if (!Number.isFinite(value)) return '0.000';
+  return value.toFixed(3);
+}
+
+function formatAlias(alias: string | null): string {
+  if (!alias) return '—';
+  if (alias.length <= 12) return alias;
+  return `${alias.slice(0, 6)}…${alias.slice(-4)}`;
+}
+
+function formatTimestamp(value?: string | null): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString().replace('T', ' ').slice(0, 16);
+}
+
+export default function FeeDashboard({ tenantId, usagePreviewLimit = 4 }: FeeDashboardProps) {
+  const { t } = useLanguage();
+  const { colors } = useTheme();
+  const { data, error, isLoading, isFetching, refetch } = useBillingSummary(tenantId);
+  const [settling, setSettling] = useState(false);
+  const [settleError, setSettleError] = useState<string | null>(null);
+
+  const outstanding = data?.outstanding ?? 0;
+  const usagePreview = useMemo(() => {
+    const items = data?.usage ?? [];
+    return items.slice(0, usagePreviewLimit);
+  }, [data?.usage, usagePreviewLimit]);
+
+  const unsettledCount = useMemo(() => {
+    return (data?.usage ?? []).filter((event) => !event.settledAt).length;
+  }, [data?.usage]);
+
+  const handleSettle = useCallback(async () => {
+    if (!tenantId || settling || outstanding <= 0) return;
+    setSettleError(null);
+    try {
+      setSettling(true);
+      await meteredBilling.settleUsage(tenantId);
+      await refetch();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to settle balance';
+      setSettleError(message);
+    } finally {
+      setSettling(false);
+    }
+  }, [tenantId, outstanding, settling, refetch]);
+
+  if (!tenantId) {
+    return null;
+  }
+
+  return (
+    <Card style={styles.card}>
+      <Stack gap="spacer16">
+        <Stack direction="horizontal" align="center" style={styles.header}>
+          <Heading size="md">
+            {t('billing.title', 'Network fees & usage')}
+          </Heading>
+          <View style={styles.headerActions}>
+            <Button
+              onPress={() => void refetch()}
+              disabled={isFetching || settling}
+              loading={isFetching && !isLoading}
+              style={[
+                styles.secondaryButton,
+                {
+                  backgroundColor: colors.surface.secondary,
+                  borderColor: colors.border.primary,
+                },
+              ]}
+              textStyle={{ color: colors.text.primary }}
+            >
+              {t('common.refresh', 'Refresh')}
+            </Button>
+            <Button
+              onPress={handleSettle}
+              disabled={settling || outstanding <= 0}
+              loading={settling}
+              tooltip={
+                outstanding > 0
+                  ? t('billing.settleTooltip', 'Sign with your wallet to clear fees')
+                  : t('billing.settleDisabled', 'No outstanding fees')
+              }
+            >
+              {t('billing.settleCta', 'Settle balance')}
+            </Button>
+          </View>
+        </Stack>
+
+        {isLoading ? (
+          <View style={styles.loadingRow}>
+            <Spinner />
+          </View>
+        ) : (
+          <Stack gap="spacer12">
+            <View style={styles.metricsRow}>
+              <View style={[styles.metricBox, { borderColor: colors.border.primary }]}>
+                <Text style={[styles.metricLabel, { color: colors.text.secondary }]}>
+                  {t('billing.totalVolume', 'Billed volume')}
+                </Text>
+                <Text style={[styles.metricValue, { color: colors.text.primary }]}>
+                  {formatAmount(data?.totalUsage ?? 0)} NEAR
+                </Text>
+              </View>
+              <View style={[styles.metricBox, { borderColor: colors.border.primary }]}>
+                <Text style={[styles.metricLabel, { color: colors.text.secondary }]}>
+                  {t('billing.totalFees', 'Accrued fees')}
+                </Text>
+                <Text style={[styles.metricValue, { color: colors.text.primary }]}>
+                  {formatAmount(data?.totalFees ?? 0)} NEAR
+                </Text>
+              </View>
+              <View
+                style={[
+                  styles.metricBox,
+                  styles.outstanding,
+                  {
+                    borderColor: colors.border.focus,
+                    backgroundColor: colors.surface.secondary,
+                  },
+                ]}
+              >
+                <Text style={[styles.metricLabel, { color: colors.text.secondary }]}>
+                  {t('billing.outstanding', 'Outstanding')}
+                </Text>
+                <Text style={[styles.metricValue, { color: colors.text.primary }]}>
+                  {formatAmount(outstanding)} NEAR
+                </Text>
+                <Text style={[styles.metricMeta, { color: colors.text.secondary }]}>
+                  {`${t('billing.unsettledCount', 'Unsettled records')}: ${unsettledCount}`}
+                </Text>
+              </View>
+            </View>
+
+            {error && (
+              <Text style={[styles.errorText, { color: colors.status.error }]}>
+                {error.message}
+              </Text>
+            )}
+            {settleError && (
+              <Text style={[styles.errorText, { color: colors.status.error }]}>
+                {settleError}
+              </Text>
+            )}
+
+            <Stack gap="spacer8">
+              <Text style={[styles.sectionTitle, { color: colors.text.secondary }]}>
+                {t('billing.recentActivity', 'Recent usage')}
+              </Text>
+              {usagePreview.length === 0 ? (
+                <Text style={{ color: colors.text.secondary }}>
+                  {t('billing.noUsage', 'No billable activity yet.')}
+                </Text>
+              ) : (
+                usagePreview.map((event) => {
+                  const settled = Boolean(event.settledAt);
+                  return (
+                    <View
+                      key={event.id}
+                      style={[
+                        styles.usageRow,
+                        { borderColor: colors.border.secondary },
+                        settled && styles.settledRow,
+                      ]}
+                    >
+                      <Stack gap="spacer4" style={{ flex: 1 }}>
+                        <Text style={[styles.usageTitle, { color: colors.text.primary }]}>
+                          {event.meterId}
+                        </Text>
+                        <Text style={{ color: colors.text.secondary }}>
+                          {t('billing.orderReference', 'Reference')}: {event.metadata?.orderId ?? event.id}
+                        </Text>
+                      </Stack>
+                      <Stack gap="spacer4" style={styles.usageDetails}>
+                        <Text style={[styles.usageAmount, { color: colors.text.primary }]}>
+                          {formatAmount(event.fee)} NEAR
+                        </Text>
+                        <Text style={{ color: colors.text.secondary, textAlign: 'right' }}>
+                          {settled
+                            ? `${t('billing.settledAt', 'Settled at')}: ${formatTimestamp(event.settledAt)}`
+                            : `${t('billing.recordedAt', 'Recorded')}: ${formatTimestamp(event.recordedAt)}`}
+                        </Text>
+                      </Stack>
+                    </View>
+                  );
+                })
+              )}
+            </Stack>
+
+            <View style={[styles.noticeBox, { borderColor: colors.border.secondary }]}>
+              <Text style={{ color: colors.text.secondary }}>
+                {t(
+                  'billing.pseudonymousNotice',
+                  'Wallet aliases are hashed per tenant. Raw addresses never leave your device.'
+                )}
+              </Text>
+              <Text style={{ color: colors.text.secondary }}>
+                {t('billing.activeAlias', 'Active alias')}: {formatAlias(data?.walletAlias ?? null)}
+              </Text>
+            </View>
+
+            {data?.lastPayment && (
+              <View style={[styles.noticeBox, { borderColor: colors.border.secondary }]}>
+                <Text style={{ color: colors.text.secondary }}>
+                  {t('billing.lastPayment', 'Last payment')}: {formatTimestamp(data.lastPayment.recordedAt)}
+                </Text>
+                <Text style={{ color: colors.text.secondary }}>
+                  {t('billing.lastPaymentAmount', 'Amount')}: {formatAmount(data.lastPayment.amount)} NEAR
+                </Text>
+              </View>
+            )}
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginTop: spacing.spacer16,
+  },
+  header: {
+    justifyContent: 'space-between',
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: spacing.spacer8,
+    alignItems: 'center',
+  },
+  secondaryButton: {
+    backgroundColor: 'transparent',
+    borderColor: 'transparent',
+  },
+  loadingRow: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.spacer16,
+  },
+  metricsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.spacer16,
+  },
+  metricBox: {
+    minWidth: 140,
+    flexGrow: 1,
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.spacer12,
+    gap: spacing.spacer4,
+  },
+  outstanding: {
+    minWidth: 160,
+  },
+  metricLabel: {
+    fontSize: 12,
+    opacity: 0.9,
+  },
+  metricValue: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  metricMeta: {
+    fontSize: 12,
+    opacity: 0.8,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  usageRow: {
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.spacer12,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.spacer12,
+  },
+  settledRow: {
+    opacity: 0.7,
+  },
+  usageTitle: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  usageAmount: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  usageDetails: {
+    alignItems: 'flex-end',
+  },
+  noticeBox: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    padding: spacing.spacer12,
+    gap: spacing.spacer4,
+  },
+  errorText: {
+    fontSize: 13,
+  },
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -22,6 +22,8 @@
       "@/core/*": ["src/core/*"],
       "@/services": ["src/services/index"],
       "@/services/*": ["src/services/*", "services/*"],
+      "@/billing": ["src/billing/index"],
+      "@/billing/*": ["src/billing/*"],
       "@/utils/*": ["src/utils/*", "utils/*"],
       "@/providers/*": ["src/providers/*"],
       "@/providers": ["src/providers/index"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,12 @@
         "src/services/*",
         "services/*"
       ],
+      "@/billing": [
+        "src/billing/index.ts"
+      ],
+      "@/billing/*": [
+        "src/billing/*"
+      ],
       "@/utils/*": [
         "src/utils/*",
         "utils/*"


### PR DESCRIPTION
## Summary
- add a metered billing service that stores pseudonymous usage, persists payments, and signs wallet settlements
- expose a billing summary hook and fee dashboard UI so tenants can review usage and settle balances
- record billing usage whenever orders are released to keep the dashboard metrics up to date

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser in the environment)*
- yarn jest tests/storeDashboard.test.tsx *(fails: jest command unavailable without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c898dcd7408326b8263548abf976e7