### PR TITLE
feat: add Waku delivery notifications pipeline

### DIFF
--- a/agents/delivery-agent.ts
+++ b/agents/delivery-agent.ts
@@ -1,0 +1,166 @@
+import AgentError from '@/types/AgentError';
+import { publish, isWakuDisabled } from '@/services/waku';
+import { buildTopic } from '@/utils/wakuTopics';
+import { isDeliveryNotificationsEnabled } from '@/config/featureFlags';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import { errorLog } from '@/utils/logger';
+import { deliveryBacklog } from '@/utils/observability';
+import { onBacklog, onDrained } from '@/utils/wakuStore';
+import type { DeliveryJobStatus } from '@/types';
+
+export const E_BACKLOG = 'E_BACKLOG';
+
+const DELIVERY_TOPIC_DOMAIN = 'delivery';
+type PauseReason = 'queue' | 'waku';
+
+type OrderCreatedPayload = {
+  orderId: string;
+  storeId?: string;
+};
+
+type DeliveryAssignedPayload = {
+  jobId: string;
+  orderId: string;
+  driverId?: string;
+  status: DeliveryJobStatus;
+  storeId?: string;
+};
+
+type QueueItem =
+  | { type: 'order.created'; payload: OrderCreatedPayload; storeId: string; queuedAt: number }
+  | { type: 'delivery.assigned'; payload: DeliveryAssignedPayload; storeId: string; queuedAt: number };
+
+class DeliveryAgent {
+  private backlog: QueueItem[] = [];
+  private draining = false;
+  private backlogLimit = 100;
+  private pauseReasons = new Set<PauseReason>();
+
+  constructor() {
+    onBacklog(() => this.pause('waku'));
+    onDrained(() => this.resume('waku'));
+  }
+
+  async handleOrderEvent(
+    type: 'order.created',
+    payload: OrderCreatedPayload,
+  ): Promise<void> {
+    this.enqueue(type, payload);
+  }
+
+  async handleDeliveryEvent(
+    type: 'delivery.assigned',
+    payload: DeliveryAssignedPayload,
+  ): Promise<void> {
+    this.enqueue(type, payload);
+  }
+
+  private enqueue(type: QueueItem['type'], payload: QueueItem['payload']): void {
+    if (isWakuDisabled()) return;
+    const storeId = payload.storeId || '1';
+    if (!isDeliveryNotificationsEnabled(storeId)) return;
+    if (this.backlog.length >= this.backlogLimit) {
+      deliveryBacklog.set(this.backlog.length);
+      this.pause('queue');
+      errorLog('Delivery backlog limit exceeded', {
+        size: this.backlog.length,
+        limit: this.backlogLimit,
+      });
+      throw new AgentError(E_BACKLOG, 'Delivery backlog limit exceeded', 'delivery-agent');
+    }
+    const queuedAt = Date.now();
+    let job: QueueItem;
+    if (type === 'order.created') {
+      const data: OrderCreatedPayload = { ...(payload as OrderCreatedPayload), storeId };
+      job = { type, payload: data, storeId, queuedAt };
+    } else {
+      const data: DeliveryAssignedPayload = { ...(payload as DeliveryAssignedPayload), storeId };
+      job = { type, payload: data, storeId, queuedAt };
+    }
+    this.backlog.push(job);
+    deliveryBacklog.set(this.backlog.length);
+    if (!this.draining && !this.shouldHaltProcessing()) {
+      void this.drain();
+    }
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining || this.shouldHaltProcessing()) return;
+    this.draining = true;
+    while (this.backlog.length) {
+      if (this.shouldHaltProcessing()) break;
+      const job = this.backlog.shift()!;
+      deliveryBacklog.set(this.backlog.length);
+      try {
+        await this.broadcast(job);
+        if (this.pauseReasons.has('queue') && this.backlog.length < this.backlogLimit) {
+          this.resume('queue');
+        }
+      } catch (err) {
+        errorLog('Failed to broadcast delivery update', err);
+      }
+    }
+    this.draining = false;
+    if (!this.backlog.length) {
+      this.resume('queue');
+    }
+  }
+
+  private async broadcast(job: QueueItem): Promise<void> {
+    const { type, payload, storeId } = job;
+    const topic = buildTopic(DELIVERY_TOPIC_DOMAIN, storeId);
+    const timestamp = Date.now();
+    if (type === 'order.created') {
+      const message = await makeSignedWakuMessage(
+        'notify.deliveryUpdate',
+        {
+          event: type,
+          orderId: payload.orderId,
+          storeId,
+          status: 'pending',
+          timestamp,
+        },
+        'deliveries',
+      );
+      await publish(topic, message);
+      return;
+    }
+    const assigned = payload as DeliveryAssignedPayload;
+    const message = await makeSignedWakuMessage(
+      'notify.deliveryUpdate',
+      {
+        event: type,
+        orderId: assigned.orderId,
+        storeId,
+        jobId: assigned.jobId,
+        driverId: assigned.driverId,
+        status: assigned.status,
+        timestamp,
+      },
+      'deliveries',
+    );
+    await publish(topic, message);
+  }
+
+  private pause(reason: PauseReason): void {
+    this.pauseReasons.add(reason);
+  }
+
+  private resume(reason: PauseReason): void {
+    if (!this.pauseReasons.has(reason)) return;
+    this.pauseReasons.delete(reason);
+    if (!this.shouldHaltProcessing() && this.backlog.length && !this.draining) {
+      void this.drain();
+    }
+  }
+
+  isPaused(): boolean {
+    return this.pauseReasons.size > 0;
+  }
+
+  private shouldHaltProcessing(): boolean {
+    return this.pauseReasons.size > 0 || this.backlog.length >= this.backlogLimit;
+  }
+}
+
+export default new DeliveryAgent();

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -24,9 +24,8 @@ import { onBacklog, onDrained } from '@/utils/wakuStore';
 import {
   isNotificationsPipelineEnabled,
 } from '@/config/featureFlags';
-import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
 import { canonicalJson } from '@/utils/serialization';
-import { sign } from '@noble/ed25519';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 
 export const E_BACKLOG = 'E_BACKLOG';
 
@@ -34,28 +33,6 @@ const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
 const MESSAGE_TYPE = 'notification.broadcast';
 type PauseReason = 'queue' | 'latency' | 'waku';
 type NotificationBroadcastPayload = NotificationWakuPayload & { storeId?: string };
-
-const textEncoder = new TextEncoder();
-
-async function makeSignedNotificationMessage(
-  payload: NotificationBroadcastPayload,
-): Promise<WakuMessage<string>> {
-  const priv = await getPrivateKey();
-  const pub = await getPublicKeyHex();
-  const serializedPayload = canonicalJson(payload);
-  const message: WakuMessage<string> = {
-    type: MESSAGE_TYPE,
-    payload: serializedPayload,
-    sender: { publicKey: pub, role: 'notifications' },
-    signature: '',
-  };
-  const toSign = textEncoder.encode(
-    canonicalJson({ type: message.type, payload: message.payload, sender: message.sender }),
-  );
-  const sig = await sign(toSign, priv);
-  message.signature = Buffer.from(sig).toString('hex');
-  return message;
-}
 
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
@@ -308,7 +285,11 @@ class NotificationsAgent {
         notification: item,
         storeId,
       };
-      const message = await makeSignedNotificationMessage(payload);
+      const message = await makeSignedWakuMessage(
+        MESSAGE_TYPE,
+        canonicalJson(payload),
+        'notifications',
+      );
       await publish(NOTIFICATION_TOPIC, message);
     } catch (err) {
       errorLog('Failed to broadcast notification', err);

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -1,6 +1,7 @@
 import { Order, OrderStatus, OrderTrackingStep } from '../types';
 import nearAuth from '@/features/auth/services/nearAuth';
 import notificationsAgent from './notifications-agent';
+import deliveryAgent from './delivery-agent';
 import { assertNearChain } from '@/services/chain';
 import {
   setOrder,
@@ -269,6 +270,10 @@ class OrdersAgent {
     await notificationsAgent.handleOrderEvent('order.created', {
       orderId: enriched.id,
       userId: enriched.userId,
+      storeId: sid,
+    });
+    await deliveryAgent.handleOrderEvent('order.created', {
+      orderId: enriched.id,
       storeId: sid,
     });
   }

--- a/app/store/[storeId]/admin/_DeliveriesScreen.tsx
+++ b/app/store/[storeId]/admin/_DeliveriesScreen.tsx
@@ -36,9 +36,6 @@ export default function AdminDeliveriesScreen() {
   >([]);
   const [viewerVisible, setViewerVisible] = useState(false);
   const { replace, back } = useAppRouter();
-  // Matrix integration is currently disabled and tracked separately.
-  // const matrixService = MatrixService.getInstance(); // TODO: re-enable Matrix later
-
   useEffect(() => {
     if (!isStoreOwner) {
       replace('/');
@@ -87,8 +84,6 @@ export default function AdminDeliveriesScreen() {
     try {
       const db = DatabaseService.getInstance();
       await db.updateDeliveryJobStatus(jobId, status);
-      // Matrix notifications via Matrix are disabled and tracked separately.
-      // TODO: re-enable Matrix later
       loadData();
     } catch (error) {
       errorLog('Error updating job:', error);

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -156,9 +156,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
   };
 
   const contactSupport = () => {
-    // Matrix chat integration is currently disabled and tracked separately.
-    // TODO: re-enable Matrix later
-    Alert.alert('Support', 'Contact support via chat is disabled');
+    Alert.alert('Support', 'Delivery support over Waku is rolling out soon.');
   };
 
   const cancelOrder = async () => {

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -19,6 +19,15 @@ const envSchema = z.object({
     .optional()
     .default(''),
   EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_ROLLBACK: z.string().optional().default('false'),
+  EXPO_PUBLIC_DELIVERY_NOTIFICATIONS: z.string().optional().default('false'),
+  EXPO_PUBLIC_DELIVERY_NOTIFICATIONS_CANARY_STORES: z
+    .string()
+    .optional()
+    .default(''),
+  EXPO_PUBLIC_DELIVERY_NOTIFICATIONS_ROLLBACK: z
+    .string()
+    .optional()
+    .default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -68,6 +77,21 @@ const notificationsPipelineFlag: NotificationsPipelineFeatureFlag = {
   rollback: env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE_ROLLBACK === 'true',
 };
 
+export interface DeliveryNotificationsFeatureFlag {
+  enabled: boolean;
+  canaryStores: string[];
+  rollback: boolean;
+}
+
+const deliveryNotificationsFlag: DeliveryNotificationsFeatureFlag = {
+  enabled: env.EXPO_PUBLIC_DELIVERY_NOTIFICATIONS === 'true',
+  canaryStores: env.EXPO_PUBLIC_DELIVERY_NOTIFICATIONS_CANARY_STORES
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+  rollback: env.EXPO_PUBLIC_DELIVERY_NOTIFICATIONS_ROLLBACK === 'true',
+};
+
 export function isWarmCacheEnabled(address?: string): boolean {
   if (warmCacheFlag.rollback) return false;
   if (warmCacheFlag.enabled) return true;
@@ -102,5 +126,17 @@ export function triggerNotificationsPipelineRollback(): void {
   notificationsPipelineFlag.rollback = true;
 }
 export { notificationsPipelineFlag };
+
+export function isDeliveryNotificationsEnabled(storeId?: string): boolean {
+  if (deliveryNotificationsFlag.rollback) return false;
+  if (deliveryNotificationsFlag.enabled) return true;
+  if (!storeId) return false;
+  return deliveryNotificationsFlag.canaryStores.includes(storeId.toLowerCase());
+}
+
+export function triggerDeliveryNotificationsRollback(): void {
+  deliveryNotificationsFlag.rollback = true;
+}
+export { deliveryNotificationsFlag };
 
 export default warmCacheFlag;

--- a/docs/notifications-topics.md
+++ b/docs/notifications-topics.md
@@ -13,6 +13,7 @@ Reference of Waku topics used by the notifications pipeline.
 |-------|---------|
 | `/blue-ocean/orders/1` | Order events published by the orders agent. |
 | `/blue-ocean/notifications/1` | User-facing notifications broadcast by the notifications agent. |
+| `/blue-ocean/delivery/<storeId>` | Delivery updates broadcast by the delivery agent for each store. |
 
 ## Usage
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,6 +21,16 @@ Emitted when an order cannot be processed.
   - `code` (`string`): error code describing the failure.
   - `reason` (`string`): human readable explanation.
 
+### `{delivery.assigned}`
+Emitted when a delivery job is assigned or its status changes.
+
+- **Payload**
+  - `jobId` (`string`): delivery job identifier.
+  - `orderId` (`string`): related order identifier.
+  - `driverId` (`string`): identifier of the assigned driver.
+  - `status` (`'pending' | 'in_progress' | 'completed' | 'cancelled'`): delivery status.
+  - `storeId` (`string`): store scope for the delivery topic.
+
 ### Output Payloads
 
 #### `{notify.orderCreated}`
@@ -34,6 +44,18 @@ Broadcast when an order fails.
 
 - **Payload** (`notifyOrderFailedSchema`)
   - `notification` (`Notification`): localized title and message.
+
+#### `{notify.deliveryUpdate}`
+Broadcast delivery progress updates over Waku.
+
+- **Payload** (`deliveryUpdatePayloadSchema`)
+  - `event` (`'order.created' | 'delivery.assigned'`): source event driving the update.
+  - `orderId` (`string`): related order identifier.
+  - `jobId` (`string`, optional): delivery job identifier when available.
+  - `driverId` (`string`, optional): assigned driver identifier.
+  - `status` (`'pending' | 'in_progress' | 'completed' | 'cancelled'`): delivery status.
+  - `timestamp` (`number`): milliseconds since epoch when the update was published.
+  - `storeId` (`string`): store topic scope for subscribers.
 
 ## API Reference
 
@@ -49,7 +71,7 @@ Subscribes to notification outputs.
 Producers send order events to the network.
 
 - **Parameters**
-  - `event` (`'order.created' | 'order.failed'`)
+  - `event` (`'order.created' | 'order.failed' | 'delivery.assigned'`)
   - `payload` (matching event schema)
 - **Errors**: may reject with `{ code: 'E_BACKLOG', retryAfter: number }` when the node backlog is full.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,6 +23,7 @@ Key metrics:
 - `auth_rate_limit_total` – Counter of auth requests rejected by rate limiting.
 - `auth_scope_requests_total` – Counter of auth scope checks.
 - `auth_invalid_scope_total` – Counter of auth scope checks with invalid scopes.
+- `delivery_notifications_backlog` – Gauge tracking queued delivery updates (alerts when > 100).
 
 Use `withMonitoring` from [`services/monitoring.ts`](../services/monitoring.ts) to
 wrap asynchronous service calls. The helper records latency, increments the

--- a/schemas/waku/delivery.update.ts
+++ b/schemas/waku/delivery.update.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+const deliveryStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'cancelled']);
+
+export const deliveryUpdatePayloadSchema = z.object({
+  event: z.enum(['order.created', 'delivery.assigned']),
+  orderId: z.string(),
+  storeId: z.string(),
+  jobId: z.string().optional(),
+  driverId: z.string().optional(),
+  status: deliveryStatusSchema,
+  timestamp: z.number(),
+});
+
+export const deliveryUpdateMessageSchema = wakuMessageSchema.extend({
+  type: z.literal('notify.deliveryUpdate'),
+  payload: deliveryUpdatePayloadSchema,
+});
+
+export type DeliveryUpdateMessage = z.infer<typeof deliveryUpdateMessageSchema>;

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -6,3 +6,4 @@ export * from './order.status';
 export * from './admin.requested';
 export * from './store.created';
 export * from './workspace.created';
+export * from './delivery.update';

--- a/services/database.ts
+++ b/services/database.ts
@@ -11,6 +11,7 @@ import productsAgent, {
   selectProduct as fetchProduct,
 } from '../agents/products-agent';
 import ordersAgent from '../agents/orders-agent';
+import deliveryAgent from '../agents/delivery-agent';
 import SettingsAgent from '../agents/settings-agent';
 import reviewAgent from '../agents/review-agent';
 import chain, { chainAdapter } from '@/services/chain';
@@ -526,6 +527,15 @@ class DatabaseService {
       createdAt: now,
       updatedAt: now,
     });
+    const order = await ordersAgent.get(orderId);
+    const storeId = order?.items?.[0]?.product?.storeId;
+    await deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+      jobId: id,
+      orderId,
+      driverId,
+      status: 'pending',
+      storeId,
+    });
     return id;
   }
 
@@ -538,6 +548,15 @@ class DatabaseService {
     job.status = status;
     job.updatedAt = new Date().toISOString();
     this.deliveryJobs.set(id, job);
+    const order = await ordersAgent.get(job.orderId);
+    const storeId = order?.items?.[0]?.product?.storeId;
+    await deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+      jobId: job.id,
+      orderId: job.orderId,
+      driverId: job.driverId,
+      status,
+      storeId,
+    });
   }
 
   async updateDeliveryJobProof(id: string, uri: string): Promise<void> {

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -19,6 +19,12 @@ jest.mock('@/services/nearOrders', () => ({
 
 jest.mock('../agents/stores-agent', () => ({ updateReputationByOwner: jest.fn() }));
 
+const deliveryAgentMock = { handleOrderEvent: jest.fn(), handleDeliveryEvent: jest.fn() };
+jest.mock('../agents/delivery-agent', () => ({
+  __esModule: true,
+  default: deliveryAgentMock,
+}));
+
 const getAdminsWithScopeMock = jest.fn().mockResolvedValue(['admin']);
 jest.mock('../agents/settings-agent', () => ({
   __esModule: true,

--- a/tests/waku/deliveryAgent.test.ts
+++ b/tests/waku/deliveryAgent.test.ts
@@ -1,0 +1,167 @@
+jest.mock('@/services/waku', () => ({
+  publish: jest.fn().mockResolvedValue('id'),
+  isWakuDisabled: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/utils/wakuSigning', () => ({
+  makeSignedWakuMessage: jest
+    .fn()
+    .mockImplementation(async (type: string, payload: any, role: string) => ({
+      type,
+      payload,
+      sender: { publicKey: 'mock-pub', role },
+      signature: 'deadbeef',
+    })),
+}));
+
+const backlogCallbacks: Array<(code: string) => void> = [];
+const drainedCallbacks: Array<() => void> = [];
+
+jest.mock('@/utils/wakuStore', () => ({
+  onBacklog: jest.fn((cb: (code: string) => void) => backlogCallbacks.push(cb)),
+  onDrained: jest.fn((cb: () => void) => drainedCallbacks.push(cb)),
+  E_BACKLOG: 'E_BACKLOG',
+  __backlogCallbacks: backlogCallbacks,
+  __drainedCallbacks: drainedCallbacks,
+}));
+
+jest.mock('@/config/featureFlags', () => ({
+  isDeliveryNotificationsEnabled: jest.fn(() => true),
+}));
+
+jest.mock('@/services/localIdentity', () => ({
+  getPrivateKey: jest.fn(async () => new Uint8Array(32).fill(1)),
+  getPublicKeyHex: jest.fn(async () => '11'.repeat(32)),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  errorLog: jest.fn(),
+}));
+
+if (typeof (globalThis as any).setImmediate !== 'function') {
+  (globalThis as any).setImmediate = (fn: (...args: any[]) => void, ...args: any[]) =>
+    setTimeout(fn, 0, ...args);
+}
+
+const deliveryAgent = require('../../agents/delivery-agent').default;
+const { publish } = require('@/services/waku');
+const featureFlags = require('@/config/featureFlags');
+const { E_BACKLOG } = require('../../agents/delivery-agent');
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('deliveryAgent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    publish.mockResolvedValue('id');
+    featureFlags.isDeliveryNotificationsEnabled.mockReturnValue(true);
+    (deliveryAgent as any).backlog = [];
+    (deliveryAgent as any).draining = false;
+    (deliveryAgent as any).pauseReasons = new Set();
+    (deliveryAgent as any).backlogLimit = 100;
+  });
+
+  it('broadcasts delivery assignments over Waku', async () => {
+    await deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+      jobId: 'job1',
+      orderId: 'order1',
+      driverId: 'driver1',
+      status: 'in_progress',
+      storeId: 's1',
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(featureFlags.isDeliveryNotificationsEnabled).toHaveBeenCalledWith('s1');
+    expect((deliveryAgent as any).backlog.length).toBe(0);
+    expect(require('@/services/waku').publish).toBe(publish);
+    expect(require('@/utils/logger').errorLog).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledWith(
+      '/blue-ocean/delivery/s1',
+      expect.objectContaining({
+        type: 'notify.deliveryUpdate',
+        payload: expect.objectContaining({
+          event: 'delivery.assigned',
+          jobId: 'job1',
+          driverId: 'driver1',
+          status: 'in_progress',
+          storeId: 's1',
+        }),
+      }),
+    );
+  });
+
+  it('broadcasts pending update on order creation', async () => {
+    await deliveryAgent.handleOrderEvent('order.created', {
+      orderId: 'order-new',
+      storeId: 'tenant',
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(publish).toHaveBeenCalledWith(
+      '/blue-ocean/delivery/tenant',
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          event: 'order.created',
+          orderId: 'order-new',
+          status: 'pending',
+        }),
+      }),
+    );
+    expect(featureFlags.isDeliveryNotificationsEnabled).toHaveBeenCalledWith('tenant');
+    expect((deliveryAgent as any).backlog.length).toBe(0);
+    expect(require('@/utils/logger').errorLog).not.toHaveBeenCalled();
+  });
+
+  it('throws E_BACKLOG when queue is full', async () => {
+    (deliveryAgent as any).backlogLimit = 1;
+    let resolvePublish: ((value: string) => void) | undefined;
+    publish.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePublish = resolve;
+        }),
+    );
+    await deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+      jobId: 'job1',
+      orderId: 'order1',
+      driverId: 'driver1',
+      status: 'pending',
+      storeId: 's1',
+    });
+    await expect(
+      deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+        jobId: 'job2',
+        orderId: 'order2',
+        driverId: 'driver2',
+        status: 'pending',
+        storeId: 's1',
+      }),
+    ).rejects.toMatchObject({ code: E_BACKLOG });
+    resolvePublish?.('ok');
+    await flushMicrotasks();
+  });
+
+  it('pauses on Waku store backlog and resumes on drain', async () => {
+    expect(deliveryAgent.isPaused()).toBe(false);
+    backlogCallbacks.forEach((cb) => cb('E_BACKLOG'));
+    expect(deliveryAgent.isPaused()).toBe(true);
+    drainedCallbacks.forEach((cb) => cb());
+    await flushMicrotasks();
+    expect(deliveryAgent.isPaused()).toBe(false);
+  });
+
+  it('skips broadcasting when feature flag is disabled', async () => {
+    featureFlags.isDeliveryNotificationsEnabled.mockReturnValue(false);
+    await deliveryAgent.handleDeliveryEvent('delivery.assigned', {
+      jobId: 'job1',
+      orderId: 'order1',
+      driverId: 'driver1',
+      status: 'pending',
+      storeId: 's1',
+    });
+    await flushMicrotasks();
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -7,4 +7,5 @@ export {
   type OrderStatusMessage,
   type WorkspaceCreatedMessage,
   type WorkspaceCreatedPayload,
+  type DeliveryUpdateMessage,
 } from '../schemas/waku';

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -36,6 +36,11 @@ export const notificationDeliveryLatency = registry.createHistogram({
   labelNames: ['event'],
 });
 
+export const deliveryBacklog = registry.createGauge({
+  name: 'delivery_notifications_backlog',
+  help: 'Number of delivery updates pending broadcast',
+});
+
 export function startMetricsServer(): void {
   logger.debug('Central metrics server disabled; metrics stay local.');
 }

--- a/utils/wakuSigning.ts
+++ b/utils/wakuSigning.ts
@@ -1,0 +1,27 @@
+import { canonicalJson } from '@/utils/serialization';
+import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
+import type { WakuMessage } from '@/types/waku';
+import { sign } from '@noble/ed25519';
+
+const textEncoder = new TextEncoder();
+
+export async function makeSignedWakuMessage<T>(
+  type: string,
+  payload: T,
+  role: string,
+): Promise<WakuMessage<T>> {
+  const priv = await getPrivateKey();
+  const pub = await getPublicKeyHex();
+  const message: WakuMessage<T> = {
+    type,
+    payload,
+    sender: { publicKey: pub, role },
+    signature: '',
+  };
+  const toSign = textEncoder.encode(
+    canonicalJson({ type: message.type, payload: message.payload, sender: message.sender }),
+  );
+  const sig = await sign(toSign, priv);
+  message.signature = Buffer.from(sig).toString('hex');
+  return message;
+}


### PR DESCRIPTION
## Summary
- introduce a delivery notifications agent that back-pressures Waku broadcasts and signs delivery updates
- wire delivery job creation and status changes to publish notify.deliveryUpdate messages under a new feature flag
- document the delivery topic, schema, and observability metric while covering the workflow with Jest tests

## Testing
- npx jest --coverage=false tests/waku/deliveryAgent.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8a0005f6c8326ab9d59c786169326