### PR TITLE
Fix module resolution for auth wallet and schema imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -96,6 +96,7 @@ const cfg = {
     '^@/ui$': '<rootDir>/src/ui/index',
     '^@/layout/(.*)$': '<rootDir>/src/layout/$1',
     '^@/core/(.*)$': '<rootDir>/src/core/$1',
+    '^@/auth/(.*)$': '<rootDir>/src/auth/$1',
     '^@/services$': '<rootDir>/src/services/index',
     '^@/services/(.*)$': ['<rootDir>/src/services/$1', '<rootDir>/services/$1'],
     '^@/billing$': '<rootDir>/src/billing/index',
@@ -104,6 +105,7 @@ const cfg = {
     '^@/providers/(.*)$': '<rootDir>/src/providers/$1',
     '^@/providers$': '<rootDir>/src/providers/index',
     '^@/i18n$': '<rootDir>/src/i18n',
+    '^@/schemas/(.*)$': '<rootDir>/schemas/$1',
     '^@/(.*)$': '<rootDir>/$1',
     '^src/(.*)$': '<rootDir>/src/$1',
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -16,6 +16,12 @@ config.resolver.extraNodeModules = {
     ),
 };
 
+config.resolver.alias = {
+  ...(config.resolver.alias || {}),
+  '@/auth': path.resolve(__dirname, 'src/auth'),
+  '@/schemas': path.resolve(__dirname, 'schemas'),
+};
+
 if (!config.resolver.sourceExts.includes('mjs'))
   config.resolver.sourceExts.push('mjs');
 if (!config.resolver.sourceExts.includes('cjs'))

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -14,6 +14,7 @@
 
       "@/*": ["*"],
 
+      "@/auth/*": ["src/auth/*"],
       "@/features/*": ["src/features/*"],
       "@/shared/*": ["src/shared/*"],
       "@/ui/*": ["src/ui/*"],
@@ -28,6 +29,7 @@
       "@/providers/*": ["src/providers/*"],
       "@/providers": ["src/providers/index"],
       "@/i18n": ["src/i18n"],
+      "@/schemas/*": ["schemas/*"],
       "@/constants/*": ["constants/*"],
       "src/*": ["src/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,9 @@
       "@providers/*": [
         "src/providers/*"
       ],
+      "@/auth/*": [
+        "src/auth/*"
+      ],
       "@/features/*": [
         "src/features/*"
       ],
@@ -74,6 +77,9 @@
       ],
       "@/providers/*": [
         "src/providers/*"
+      ],
+      "@/schemas/*": [
+        "schemas/*"
       ],
       "@/i18n": [
         "src/i18n.ts"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,8 @@ module.exports = async function (env, argv) {
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     '@': path.resolve(__dirname),
+    '@/auth': path.resolve(__dirname, 'src/auth'),
+    '@/schemas': path.resolve(__dirname, 'schemas'),
     'expo-router/_ctx': path.resolve(__dirname, 'router-ctx.web.js'),
     'expo-router/_ctx.web': path.resolve(__dirname, 'router-ctx.web.js'),
     'expo-router/_ctx.web.js': path.resolve(__dirname, 'router-ctx.web.js'),


### PR DESCRIPTION
## Summary
- add TypeScript path aliases for the auth wallet helper and cache schemas
- teach Metro and Webpack to resolve the new aliases so bundling can load the modules
- align Jest configuration with the new alias mappings

## Testing
- yarn typecheck *(fails: missing React/Jest/Node type packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a83ba9908326ad120afead671fb8