### PR TITLE
Implement role-aware admin bootstrap approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const { tokens, colors } = useTheme();
 
 5. **Admin onboarding**
 
-   - Enable `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2=1` to roll out the canary join-request flow.
+   - Enable `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2=1` to roll out the join-request flow, or stage specific wallets with `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_CANARY=<wallet1,wallet2>` while the flag stays off. Flip `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK=1` for an instant kill switch if a regression appears.
    - The first signed `admin.joinRequested` message seeds the admin list; subsequent wallets must be approved from **Admin → Requests**.
 
 All data is ephemeral and synchronized between peers over Waku and written to NEAR smart contracts when needed; no external services or local database are required. All state is held in memory and hydrated from the Waku message history on boot. No database setup or SQL migrations are required, and all prior SQLite migration files have been removed from this repository.
@@ -149,6 +149,8 @@ Common variables include:
 | `EXPO_PUBLIC_PINATA_SECRET_API_KEY` | no | Pinata API secret for authenticated uploads. |
 | `EXPO_PUBLIC_PINATA_JWT` | no | Pinata JWT used by the app and `scripts/pinata-upload.ts`. |
 | `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2` | no | Feature flag for canarying role-aware admin bootstrap. |
+| `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_CANARY` | no | Comma-separated NEAR accounts that should opt into the admin join-request flow while the global flag is off. |
+| `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK` | no | Set to `1` to disable the role-aware bootstrap logic immediately (feature kill switch). |
 
 The OrderPayment factory contract address is configured by admins through the
 **Admin → Settings** dashboard and does not require an environment variable.
@@ -156,6 +158,8 @@ The OrderPayment factory contract address is configured by admins through the
 `NEAR_STRICT` remains permissive in development, so local runs skip strict NEAR validation.
 
 - `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2` – enables the role-aware admin bootstrap canary (optional)
+- `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_CANARY` – comma-separated allowlist for staged rollouts (optional)
+- `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK` – emergency kill-switch for the bootstrap flow (optional)
 - `NEAR_RPC_URL` – primary NEAR RPC endpoint used for blockchain calls (optional; overrides tenant setting)
 - `EXPO_PUBLIC_CONTRACT_ID` – marketplace contract account the app interacts with (required)
 - `EXPO_PUBLIC_DEBUG_LOGS` – enable verbose logging (`true`/`false`, default `false`)

--- a/agents/admin-agent.ts
+++ b/agents/admin-agent.ts
@@ -41,6 +41,7 @@ export class AdminAgent extends EventEmitter {
 
   private seenSignatures = new Map<string, number>();
   private unauthorizedAttemptTimestamps: number[] = [];
+  private lastUnauthorizedAlertAt = 0;
 
   async getAdmins(): Promise<AdminRecord[]> {
     return await readRecords(ADMINS_KEY);
@@ -79,8 +80,11 @@ export class AdminAgent extends EventEmitter {
       (ts) => ts >= cutoff,
     );
     if (
-      this.unauthorizedAttemptTimestamps.length ===
-      AdminAgent.UNAUTHORIZED_ALERT_THRESHOLD + 1
+      this.unauthorizedAttemptTimestamps.length >
+        AdminAgent.UNAUTHORIZED_ALERT_THRESHOLD &&
+      (this.lastUnauthorizedAlertAt === 0 ||
+        now - this.lastUnauthorizedAlertAt >=
+          AdminAgent.UNAUTHORIZED_ALERT_WINDOW_MS)
     ) {
       monitoringLogger.warn(
         {
@@ -89,6 +93,7 @@ export class AdminAgent extends EventEmitter {
         },
         'admin unauthorized attempts threshold exceeded',
       );
+      this.lastUnauthorizedAlertAt = now;
     }
   }
 
@@ -137,7 +142,12 @@ export class AdminAgent extends EventEmitter {
           : Date.now(),
     };
     const admins = await this.getAdmins();
-    if (!flags.ADMIN_BOOTSTRAP_V2) {
+    const bootstrapFlag = flags.ADMIN_BOOTSTRAP_V2;
+    const normalizedAddress = record.address.toLowerCase();
+    const shouldUseV2 =
+      !bootstrapFlag.rollback &&
+      (bootstrapFlag.enabled || bootstrapFlag.canary.includes(normalizedAddress));
+    if (!shouldUseV2) {
       if (!admins.some((a) => a.address === record.address)) {
         await this.addAdmin(record);
       }

--- a/constants/tenant.ts
+++ b/constants/tenant.ts
@@ -13,7 +13,6 @@ export interface TenantSettings {
   fiatKey?: string;
   feeAddress?: string;
   feeBps?: number;
-  admins?: string[];
   rpcUrl: string;
   rpcFallbackUrls?: string[];
   paymentFactoryAddress?: string;
@@ -25,7 +24,6 @@ export let AppConfig: TenantSettings = {
   logoCid: '',
   feeAddress: '',
   feeBps: 0,
-  admins: [],
   rpcUrl: '',
   rpcFallbackUrls: [],
   paymentFactoryAddress: '',
@@ -39,7 +37,6 @@ export async function loadTenantSettings(): Promise<void> {
   const FIAT_KEY = 'app_fiat_key';
   const FEE_ADDR_KEY = 'app_fee_address';
   const FEE_BPS_KEY = 'app_fee_bps';
-  const ADMINS_KEY = 'app_admins';
   const RPC_URL_KEY = 'app_rpc_url';
   const RPC_FALLBACK_KEY = 'app_rpc_fallback_urls';
   const PAYMENT_FACTORY_KEY = 'app_payment_factory_address';
@@ -53,7 +50,6 @@ export async function loadTenantSettings(): Promise<void> {
       fiat,
       feeAddr,
       feeBps,
-      admins,
       rpc,
       rpcFallback,
       paymentFactory,
@@ -65,7 +61,6 @@ export async function loadTenantSettings(): Promise<void> {
       FIAT_KEY,
       FEE_ADDR_KEY,
       FEE_BPS_KEY,
-      ADMINS_KEY,
       RPC_URL_KEY,
       RPC_FALLBACK_KEY,
       PAYMENT_FACTORY_KEY,
@@ -79,7 +74,6 @@ export async function loadTenantSettings(): Promise<void> {
       fiatKey: fiat?.[1] || undefined,
       feeAddress: feeAddr?.[1] || '',
       feeBps: feeBps?.[1] ? parseInt(feeBps[1]) : 0,
-      admins: admins?.[1] ? JSON.parse(admins[1]) : [],
       rpcUrl: rpc?.[1] || '',
       rpcFallbackUrls: rpcFallback?.[1] ? JSON.parse(rpcFallback[1]) : [],
       paymentFactoryAddress: paymentFactory?.[1] || '',
@@ -94,7 +88,6 @@ export async function loadTenantSettings(): Promise<void> {
       fiatKey: remote.fiatKey,
       feeAddress: remote.feeAddress ?? '',
       feeBps: remote.feeBps ?? 0,
-      admins: remote.admins ?? [],
       rpcUrl: remote.rpcUrl,
       rpcFallbackUrls: remote.rpcFallbackUrls ?? [],
       paymentFactoryAddress: remote.paymentFactoryAddress ?? '',
@@ -108,7 +101,6 @@ export async function loadTenantSettings(): Promise<void> {
       [FIAT_KEY, remote.fiatKey ?? ''],
       [FEE_ADDR_KEY, remote.feeAddress ?? ''],
       [FEE_BPS_KEY, String(remote.feeBps ?? 0)],
-      [ADMINS_KEY, JSON.stringify(remote.admins ?? [])],
       [RPC_URL_KEY, remote.rpcUrl],
       [RPC_FALLBACK_KEY, JSON.stringify(remote.rpcFallbackUrls ?? [])],
       [PAYMENT_FACTORY_KEY, remote.paymentFactoryAddress ?? ''],
@@ -143,11 +135,4 @@ export async function getFeeSettings(): Promise<{
     feeAddress: AppConfig.feeAddress || '',
     feeBps: AppConfig.feeBps || 0,
   };
-}
-
-export async function getAdmins(): Promise<string[]> {
-  if (!AppConfig.admins || AppConfig.admins.length === 0) {
-    await loadTenantSettings();
-  }
-  return AppConfig.admins || [];
 }

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -17,7 +17,7 @@ This playbook is intended for tenant administrators who manage their own NEAR ac
 1. **Choose a wallet.** We recommend [MyNearWallet](https://my.near.org) or another NEAR Wallet Selector compatible provider.
 2. **Secure your seed phrase.** Store the recovery phrase offline before proceeding. Require hardware-backed authentication where possible.
 3. **Fund the account.** Keep at least 3 Ⓝ available for contract deployment fees, storage staking, and initial listings.
-4. **Enable admin bootstrap canary.** Set `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2=1` once your canary wallet has tested the join request flow end-to-end.
+4. **Enable admin bootstrap canary.** Set `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2=1` once your canary wallet has tested the join request flow end-to-end. To stage the rollout, supply `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_CANARY=<wallet1,wallet2>` while the global flag remains off, and keep `EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK=1` ready as an instant kill switch.
 5. **Sign in through the app.** Launch Blue Ocean (`yarn dev` or `yarn dev:web`) and use the Profile → **Connect Wallet** action to link your account. Confirm the `Admin` tab is visible before moving forward.
 
 > Tip: enable verbose logs during onboarding by setting `EXPO_PUBLIC_DEBUG_LOGS=true` so you can watch Waku agent events in the console.

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -166,14 +166,62 @@ export function isDataV2Enabled(): boolean {
   );
 }
 
-export function isAdminBootstrapV2Enabled(): boolean {
-  const raw =
+export interface AdminBootstrapFlagConfig {
+  enabled: boolean;
+  canary: string[];
+  rollback: boolean;
+}
+
+function parseAddressList(raw: string | undefined): string[] {
+  return (raw || '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function toBoolean(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'on';
+}
+
+export function getAdminBootstrapFlag(): AdminBootstrapFlagConfig {
+  const rawFlag =
     process.env.EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2 ??
     process.env.FEATURE_ADMIN_BOOTSTRAP_V2 ??
     '';
-  if (raw === '0') return false;
-  if (raw === '1') return true;
-  return true;
+  const canaryRaw =
+    process.env.EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_CANARY ??
+    process.env.FEATURE_ADMIN_BOOTSTRAP_V2_CANARY ??
+    '';
+  const rollbackRaw =
+    process.env.EXPO_PUBLIC_FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK ??
+    process.env.FEATURE_ADMIN_BOOTSTRAP_V2_ROLLBACK ??
+    '';
+
+  const canary = parseAddressList(canaryRaw);
+  const rollback = toBoolean(rollbackRaw);
+
+  if (rollback) {
+    return { enabled: false, canary: [], rollback: true };
+  }
+
+  const normalized = rawFlag.trim().toLowerCase();
+
+  if (normalized === '0' || normalized === 'off' || normalized === 'false') {
+    return { enabled: false, canary, rollback: false };
+  }
+
+  if (normalized === 'canary') {
+    return { enabled: false, canary, rollback: false };
+  }
+
+  if (normalized === '1' || normalized === 'on' || normalized === 'true') {
+    return { enabled: true, canary, rollback: false };
+  }
+
+  // Default behaviour keeps the v2 bootstrap enabled unless explicitly disabled.
+  return { enabled: true, canary, rollback: false };
 }
 
 export default requireEnv;

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -6,6 +6,7 @@ import type { WakuMessage } from '@/types/waku';
 import {
   adminCountGauge,
   adminUnauthorizedAttempts,
+  logger as monitoringLogger,
 } from '@/services/monitoring';
 import '@/polyfills.web';
 
@@ -225,5 +226,65 @@ describe('AdminAgent', () => {
     await expect(agent.requestAdmin(replay)).rejects.toMatchObject({
       code: 'E_DUPLICATE',
     });
+  });
+
+  it('alerts when unauthorized approvals exceed the threshold inside a minute', async () => {
+    jest.useFakeTimers();
+    const warnSpy = jest
+      .spyOn(monitoringLogger, 'warn')
+      .mockImplementation(() => undefined);
+
+    try {
+      jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+
+      const seedPriv = utils.randomPrivateKey();
+      const seedPub = await getPublicKey(seedPriv);
+      await agent.requestAdmin(
+        await createJoinRequest(seedPriv, seedPub, 'seed-admin'),
+      );
+
+      const roguePriv = utils.randomPrivateKey();
+      const roguePub = await getPublicKey(roguePriv);
+
+      for (let i = 0; i < 4; i++) {
+        const attempt = await createSignedMessage(
+          'admin.approve',
+          { address: `rogue-${i}` },
+          roguePriv,
+          roguePub,
+        );
+        await expect(agent.approveAdmin(attempt)).rejects.toMatchObject({
+          code: 'E_UNAUTHORIZED',
+        });
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        {
+          attempts: 4,
+          windowMs: 60_000,
+        },
+        'admin unauthorized attempts threshold exceeded',
+      );
+
+      jest.setSystemTime(new Date('2024-01-01T00:02:00.000Z'));
+
+      for (let i = 0; i < 4; i++) {
+        const attempt = await createSignedMessage(
+          'admin.approve',
+          { address: `later-${i}` },
+          roguePriv,
+          roguePub,
+        );
+        await expect(agent.approveAdmin(attempt)).rejects.toMatchObject({
+          code: 'E_UNAUTHORIZED',
+        });
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });

--- a/tests/bulkProductUploader.test.ts
+++ b/tests/bulkProductUploader.test.ts
@@ -1,6 +1,6 @@
 import { Product } from '../types';
 import { insertConfig } from './testUtils';
-import { loadTenantSettings, getAdmins } from '@/constants/tenant';
+import { loadTenantSettings } from '@/constants/tenant';
 
 jest.mock('expo-document-picker', () => ({}));
 
@@ -35,8 +35,6 @@ describe('BulkProductUploader processRecords', () => {
   });
 
   it('uploads 100 products in ≤4 batches', async () => {
-    const admins = await getAdmins();
-    expect(admins).toEqual([]);
     const { processRecords } = await import('@/features/products');
     const products: Product[] = Array.from({ length: 100 }, (_, i) => ({
       id: `p${i}`,

--- a/tests/pinataService.test.ts
+++ b/tests/pinataService.test.ts
@@ -1,5 +1,5 @@
 import { insertConfig } from './testUtils';
-import { loadTenantSettings, getAdmins } from '@/constants/tenant';
+import { loadTenantSettings } from '@/constants/tenant';
 import PinataService from '@/services/pinata';
 import fs from 'fs';
 import path from 'path';
@@ -20,8 +20,6 @@ describe('PinataService', () => {
   });
 
   it('returns URI unchanged when already CID or URL', async () => {
-    const admins = await getAdmins();
-    expect(admins).toEqual([]);
     const svc = PinataService.getInstance();
     const cid = 'ipfs://bafybeigdyrzt5u2r6sxcv5a3dyhv6aipjfiv6t5bygbw4s3z6';
     const url = 'https://example.com/file.png';

--- a/utils/flags.ts
+++ b/utils/flags.ts
@@ -1,13 +1,13 @@
 import {
   isUiV2Enabled,
   isDataV2Enabled,
-  isAdminBootstrapV2Enabled,
+  getAdminBootstrapFlag,
 } from '@/services/config';
 
 export const flags = {
   UI_V2: isUiV2Enabled(),
   DATA_V2: isDataV2Enabled(),
-  ADMIN_BOOTSTRAP_V2: isAdminBootstrapV2Enabled(),
+  ADMIN_BOOTSTRAP_V2: getAdminBootstrapFlag(),
 };
 
 export default flags;


### PR DESCRIPTION
## Summary
- restructure the admin bootstrap feature flag to expose canary allow lists and an emergency rollback switch
- apply the new flag in the admin agent, add throttled unauthorized alerts, and extend unit coverage for approval flows
- remove the legacy tenant admin cache and document the staged rollout options for the join-request flow

## Testing
- npx jest tests/adminAgent.test.ts tests/pinataService.test.ts tests/bulkProductUploader.test.ts
- yarn typecheck *(fails: repository already contains unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a8cbdc8483269c53647e262106a1