### PR TITLE
Add warm-start caches for users, stores, and orders

### DIFF
--- a/docs/cache-invalidation.md
+++ b/docs/cache-invalidation.md
@@ -1,6 +1,9 @@
 # Cache Invalidation
 
-Guidelines for keeping cache entries fresh across peers.
+Guidelines for keeping cache entries fresh across peers. The warm-start caches
+for **users**, **stores**, and **orders** hydrate from encrypted NEAR Lake
+snapshots and replay Waku history at boot, so the same invalidation rules apply
+across every device.
 
 ## When to Invalidate
 

--- a/services/nearOrders.ts
+++ b/services/nearOrders.ts
@@ -3,13 +3,87 @@ import { Order } from '../types';
 import { assertNearChain } from './chain';
 import { requireStoreId } from '@blue-ocean/utils';
 import { canonicalJson } from '@/utils/serialization';
+import { createWarmCache } from '@/services/warmCache';
+import type { DiffMessage } from '@/services/warmCache';
+import { errorLog } from '@/utils/logger';
 
 assertNearChain();
 
 const ADDRESS = 'orders';
+const ORDER_CACHE_TOPIC = '/blue-ocean/orders/1';
+
+function inferStoreId(order: Order | undefined): string | null {
+  if (!order || !Array.isArray(order.items) || order.items.length === 0) return null;
+  const storeId = order.items[0]?.product?.storeId;
+  if (!storeId) return null;
+  try {
+    return requireStoreId(storeId);
+  } catch {
+    return storeId;
+  }
+}
+
+function matchesStore(order: Order | undefined, sid: string): boolean {
+  const inferred = inferStoreId(order);
+  return !!inferred && inferred === sid;
+}
+
+async function hydrateOrderLake(): Promise<Array<DiffMessage<Order>>> {
+  try {
+    const entries = await listValues(ADDRESS);
+    const diffs: Array<DiffMessage<Order>> = [];
+    for (const entry of entries) {
+      try {
+        const parsed = JSON.parse(entry.value) as Order & { rev?: number; version?: number };
+        const parts = entry.key.split(':');
+        const id = parsed.id || parts[parts.length - 1] || entry.key;
+        if (!id) continue;
+        const tsSource =
+          (parsed.updatedAt && new Date(parsed.updatedAt).getTime()) ||
+          (parsed.createdAt && new Date(parsed.createdAt).getTime()) ||
+          Date.now();
+        const ts = Number.isFinite(tsSource) ? tsSource : Date.now();
+        const rev =
+          (typeof parsed.rev === 'number' && parsed.rev) ||
+          (typeof parsed.version === 'number' && parsed.version) ||
+          1;
+        diffs.push({ id, rev, op: 'set', value: parsed, ts });
+      } catch (err) {
+        errorLog('Invalid order snapshot', err);
+      }
+    }
+    return diffs;
+  } catch (err) {
+    errorLog('Failed to hydrate orders from NEAR Lake', err);
+    return [];
+  }
+}
+
+const orderCache = createWarmCache<Order>(ORDER_CACHE_TOPIC, {
+  hydrateLake: hydrateOrderLake,
+});
+
+export const ordersWarmCache = {
+  getById(id: string) {
+    return orderCache.getById(id);
+  },
+  subscribe(
+    filter: (id: string, value: Order | undefined) => boolean,
+    cb: (id: string, value: Order | undefined) => void,
+  ) {
+    return orderCache.subscribe(filter, cb);
+  },
+  onSynced(cb: () => void) {
+    return orderCache.onSynced(cb);
+  },
+};
 
 export async function getOrder(storeId: string, id: string): Promise<Order | null> {
   const sid = requireStoreId(storeId);
+  try {
+    const cached = ordersWarmCache.getById(id);
+    if (cached && matchesStore(cached, sid)) return cached;
+  } catch {}
   const res = await getValue(ADDRESS, `${ADDRESS}:${sid}:${id}`);
   return res ? (JSON.parse(res) as Order) : null;
 }
@@ -25,6 +99,10 @@ export async function removeOrder(storeId: string, id: string) {
 }
 export async function listOrders(storeId: string): Promise<Order[]> {
   const sid = requireStoreId(storeId);
+  try {
+    const cached = orderCache.values().filter((order) => matchesStore(order, sid));
+    if (cached.length > 0) return cached;
+  } catch {}
   const items = await listValues(ADDRESS);
   return items
     .filter((i) => i.key.startsWith(`${ADDRESS}:${sid}:`))
@@ -35,9 +113,17 @@ export async function listOrdersBySeller(
   sellerAddress: string,
 ): Promise<Order[]> {
   const sid = requireStoreId(storeId);
+  try {
+    const cached = orderCache
+      .values()
+      .filter((order) => matchesStore(order, sid) && order.sellerAddress === sellerAddress);
+    if (cached.length > 0) return cached;
+  } catch {}
   const items = await listValues(ADDRESS);
   return items
     .filter((i) => i.key.startsWith(`${ADDRESS}:${sid}:`))
     .map((i) => JSON.parse(i.value) as Order)
     .filter((o) => o.sellerAddress === sellerAddress);
 }
+
+export { E_STALE_DATA, E_SYNC_LAG } from '@/services/warmCache';

--- a/src/features/auth/services/nearUsers.ts
+++ b/src/features/auth/services/nearUsers.ts
@@ -7,14 +7,71 @@ import {
 import { User } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { canonicalJson } from '@/utils/serialization';
+import { createWarmCache } from '@/services/warmCache';
+import type { DiffMessage } from '@/services/warmCache';
+import { errorLog } from '@/utils/logger';
 
 if (typeof assertNearChain === 'function') {
   try { assertNearChain(); } catch {}
 }
 
 const ADDRESS = 'users';
+const USER_CACHE_TOPIC = '/blue-ocean/users/1';
+
+async function hydrateUserLake(): Promise<Array<DiffMessage<User>>> {
+  try {
+    const entries = await listValues(ADDRESS);
+    const diffs: Array<DiffMessage<User>> = [];
+    for (const entry of entries) {
+      try {
+        const parsed = JSON.parse(entry.value) as User & { rev?: number; version?: number };
+        const id = parsed.id || entry.key;
+        if (!id) continue;
+        const tsSource =
+          (parsed.updatedAt && new Date(parsed.updatedAt).getTime()) ||
+          (parsed.createdAt && new Date(parsed.createdAt).getTime()) ||
+          Date.now();
+        const ts = Number.isFinite(tsSource) ? tsSource : Date.now();
+        const rev =
+          (typeof parsed.rev === 'number' && parsed.rev) ||
+          (typeof parsed.version === 'number' && parsed.version) ||
+          1;
+        diffs.push({ id, rev, op: 'set', value: parsed, ts });
+      } catch (err) {
+        errorLog('Invalid user snapshot', err);
+      }
+    }
+    return diffs;
+  } catch (err) {
+    errorLog('Failed to hydrate users from NEAR Lake', err);
+    return [];
+  }
+}
+
+const userCache = createWarmCache<User>(USER_CACHE_TOPIC, {
+  hydrateLake: hydrateUserLake,
+});
+
+export const usersWarmCache = {
+  getById(id: string) {
+    return userCache.getById(id);
+  },
+  subscribe(
+    filter: (id: string, value: User | undefined) => boolean,
+    cb: (id: string, value: User | undefined) => void,
+  ) {
+    return userCache.subscribe(filter, cb);
+  },
+  onSynced(cb: () => void) {
+    return userCache.onSynced(cb);
+  },
+};
 
 export async function getUser(id: string): Promise<User | null> {
+  try {
+    const cached = usersWarmCache.getById(id);
+    if (cached) return cached;
+  } catch {}
   const res = await getValue(ADDRESS, id);
   return res ? (JSON.parse(res) as User) : null;
 }
@@ -28,6 +85,11 @@ export async function removeUser(id: string) {
 }
 
 export async function listUsers(): Promise<User[]> {
+  try {
+    return userCache.values();
+  } catch {}
   const items = await listValues(ADDRESS);
   return items.map((i) => JSON.parse(i.value) as User);
 }
+
+export { E_STALE_DATA, E_SYNC_LAG } from '@/services/warmCache';

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -14,12 +14,68 @@ import {
 } from '@/services/nearKvStore';
 import { errorLog } from '@/utils/logger';
 import config from '@/config';
+import { createWarmCache } from '@/services/warmCache';
+import type { DiffMessage } from '@/services/warmCache';
 
 assertNearChain();
 
 const ADDRESS = 'stores';
+const STORE_CACHE_TOPIC = '/blue-ocean/stores/1';
 const DISABLED = false;
 let SEEDED = false;
+
+async function hydrateStoreLake(): Promise<Array<DiffMessage<Store>>> {
+  try {
+    const entries = await listValues(ADDRESS);
+    const seen = new Map<string, DiffMessage<Store>>();
+    for (const entry of entries) {
+      try {
+        const parsed = JSON.parse(entry.value) as Store & { rev?: number; version?: number };
+        const keyParts = entry.key.split(':');
+        const id = parsed.id || keyParts[keyParts.length - 1] || entry.key;
+        if (!id) continue;
+        const tsSource =
+          (parsed.updatedAt && new Date(parsed.updatedAt).getTime()) ||
+          (parsed.createdAt && new Date(parsed.createdAt).getTime()) ||
+          Date.now();
+        const ts = Number.isFinite(tsSource) ? tsSource : Date.now();
+        const rev =
+          (typeof parsed.rev === 'number' && parsed.rev) ||
+          (typeof parsed.version === 'number' && parsed.version) ||
+          1;
+        const diff: DiffMessage<Store> = { id, rev, op: 'set', value: parsed, ts };
+        if (!seen.has(id) || entry.key.includes(`:${id}`)) {
+          seen.set(id, diff);
+        }
+      } catch (err) {
+        errorLog('Invalid store snapshot', err);
+      }
+    }
+    return Array.from(seen.values());
+  } catch (err) {
+    errorLog('Failed to hydrate stores from NEAR Lake', err);
+    return [];
+  }
+}
+
+const storeCache = createWarmCache<Store>(STORE_CACHE_TOPIC, {
+  hydrateLake: hydrateStoreLake,
+});
+
+export const storesWarmCache = {
+  getById(id: string) {
+    return storeCache.getById(id);
+  },
+  subscribe(
+    filter: (id: string, value: Store | undefined) => boolean,
+    cb: (id: string, value: Store | undefined) => void,
+  ) {
+    return storeCache.subscribe(filter, cb);
+  },
+  onSynced(cb: () => void) {
+    return storeCache.onSynced(cb);
+  },
+};
 
 function ensureSeed() {
   if (!DISABLED || SEEDED) return;
@@ -125,6 +181,10 @@ export async function selectStore(
 ): Promise<Store | null> {
   ensureSeed();
   const id = arg2 ?? arg1;
+  try {
+    const cached = storesWarmCache.getById(id);
+    if (cached) return cached;
+  } catch {}
   const key = arg2 ? storeKey(id, requireStoreId(arg1)) : indexKey(id);
   const res = await getValue(ADDRESS, key);
   if (!res) return null;
@@ -138,6 +198,12 @@ export async function selectStore(
 export async function listStores(storeId: string): Promise<Store[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);
+  try {
+    const values = storeCache.values();
+    if (sid === 'default') return values;
+    const filtered = values.filter((store) => requireStoreId(store.id) === sid);
+    if (filtered.length > 0) return filtered;
+  } catch {}
   const items = await listValues(ADDRESS);
   const res: Store[] = [];
   for (const i of items) {
@@ -229,3 +295,5 @@ export async function createStoreOnChain(args: {
   if (json?.error) throw new Error(String(json.error));
   return json?.tx || '';
 }
+
+export { E_STALE_DATA, E_SYNC_LAG } from '@/services/warmCache';

--- a/tests/services/warmCache.test.ts
+++ b/tests/services/warmCache.test.ts
@@ -146,4 +146,21 @@ describe('warmCache', () => {
       jest.useRealTimers();
     }
   });
+
+  it('uses a 3s default lag threshold before raising sync alerts', async () => {
+    jest.useFakeTimers();
+    try {
+      const cache = createWarmCache<any>('topic', { hydrateLake });
+      await new Promise((res) => cache.onSynced(res));
+      jest.setSystemTime(0);
+      liveHandler &&
+        liveHandler({ id: '2', rev: 2, op: 'set', value: { name: 'slow' }, ts: 0 });
+      jest.setSystemTime(2800);
+      expect(cache.getById('2')).toEqual({ name: 'slow' });
+      jest.setSystemTime(3300);
+      expect(() => cache.getById('2')).toThrowErrorMatchingObject({ code: E_SYNC_LAG });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- hydrate user, store, and order caches from NEAR Lake snapshots and Waku history with warm-cache accessors
- update cache invalidation guidance to cover the new warm-started caches
- extend warm cache tests to assert the default 3s sync lag threshold

## Testing
- ⚠️ `yarn jest tests/services/warmCache.test.ts` *(fails: yarn install cannot proceed because @waku/core requires Node >=22 and the environment provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ac42157c8326beb429e84d9eefa3