### PR TITLE
Implement warm cache data layer capabilities

### DIFF
--- a/services/nearOrders.ts
+++ b/services/nearOrders.ts
@@ -4,7 +4,7 @@ import { assertNearChain } from './chain';
 import { requireStoreId } from '@blue-ocean/utils';
 import { canonicalJson } from '@/utils/serialization';
 import { createWarmCache } from '@/services/warmCache';
-import type { DiffMessage } from '@/services/warmCache';
+import type { CacheMutation, DiffMessage } from '@/services/warmCache';
 import { errorLog } from '@/utils/logger';
 
 assertNearChain();
@@ -67,13 +67,19 @@ export const ordersWarmCache = {
   getById(id: string) {
     return orderCache.getById(id);
   },
+  list(filter?: (id: string, value: Order) => boolean) {
+    return orderCache.list(filter);
+  },
   subscribe(
     filter: (id: string, value: Order | undefined) => boolean,
     cb: (id: string, value: Order | undefined) => void,
   ) {
     return orderCache.subscribe(filter, cb);
   },
-  onSynced(cb: () => void) {
+  mutate(cmd: CacheMutation<Order>) {
+    return orderCache.mutate(cmd);
+  },
+  onSynced(cb: (event?: { cache: string }) => void) {
     return orderCache.onSynced(cb);
   },
 };
@@ -100,7 +106,7 @@ export async function removeOrder(storeId: string, id: string) {
 export async function listOrders(storeId: string): Promise<Order[]> {
   const sid = requireStoreId(storeId);
   try {
-    const cached = orderCache.values().filter((order) => matchesStore(order, sid));
+    const cached = orderCache.list((id, order) => matchesStore(order, sid));
     if (cached.length > 0) return cached;
   } catch {}
   const items = await listValues(ADDRESS);
@@ -114,9 +120,9 @@ export async function listOrdersBySeller(
 ): Promise<Order[]> {
   const sid = requireStoreId(storeId);
   try {
-    const cached = orderCache
-      .values()
-      .filter((order) => matchesStore(order, sid) && order.sellerAddress === sellerAddress);
+    const cached = orderCache.list(
+      (id, order) => matchesStore(order, sid) && order.sellerAddress === sellerAddress,
+    );
     if (cached.length > 0) return cached;
   } catch {}
   const items = await listValues(ADDRESS);

--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -9,22 +9,34 @@ import { fetchHistory, subscribeWithAck } from '@/services/waku';
 import { isWarmCacheEnabled } from '@/config/featureFlags';
 import { E_STALE_DATA, E_SYNC_LAG } from '@/services/cache';
 
+export type DiffOp = 'set' | 'delete' | 'merge';
+
 export interface DiffMessage<T> {
   id: string;
   rev: number;
-  op: 'set' | 'delete';
-  value?: T;
+  op: DiffOp;
+  value?: T | Partial<T>;
+  ts?: number;
+}
+
+export interface CacheMutation<T> {
+  id: string;
+  rev?: number;
+  op?: DiffOp;
+  value?: T | Partial<T>;
   ts?: number;
 }
 
 export interface WarmCache<T> {
   getById(id: string): T | undefined;
+  list(filter?: (id: string, value: T) => boolean): T[];
   values(): T[];
   subscribe(
     filter: (id: string, value: T | undefined) => boolean,
     cb: (id: string, value: T | undefined) => void,
   ): () => void;
-  onSynced(cb: () => void): () => void;
+  onSynced(cb: (event?: { cache: string }) => void): () => void;
+  mutate(cmd: CacheMutation<T>): DiffMessage<T> | null;
   registerReconciler(
     address: string,
     fn: (id: string, value: T | undefined) => void,
@@ -36,12 +48,17 @@ export interface WarmCacheOptions<T> {
   lagThresholdMs?: number;
 }
 
-type MessageSource = 'lake' | 'history' | 'live';
+type MessageSource = 'lake' | 'history' | 'live' | 'local';
 
 const DEFAULT_LAG_THRESHOLD = 3000;
+const CLOCK_SKEW_GUARD_MS = 60_000;
 
-function normalizeMessage<T>(msg: DiffMessage<T>): DiffMessage<T> {
-  const ts = typeof msg.ts === 'number' ? msg.ts : Date.now();
+function normalizeMessage<T>(msg: DiffMessage<T>, source: MessageSource): DiffMessage<T> {
+  const now = Date.now();
+  let ts = typeof msg.ts === 'number' ? msg.ts : now;
+  if ((source === 'live' || source === 'local') && ts > now + CLOCK_SKEW_GUARD_MS) {
+    ts = now;
+  }
   return { ...msg, ts };
 }
 
@@ -65,8 +82,8 @@ export function createWarmCache<T>(
   const metricLabels = { cache: topic } as const;
   cacheLagGauge.set(metricLabels, 0);
 
-  function apply(raw: DiffMessage<T>, source: MessageSource): void {
-    const msg = normalizeMessage(raw);
+  function apply(raw: DiffMessage<T>, source: MessageSource): DiffMessage<T> | null {
+    const msg = normalizeMessage(raw, source);
     const currentRev = revisions.get(msg.id) ?? 0;
     const expected = currentRev === 0 ? msg.rev : currentRev + 1;
     if (currentRev !== 0) {
@@ -80,7 +97,7 @@ export function createWarmCache<T>(
             actual: msg.rev,
           });
         }
-        return;
+        return null;
       }
       if (msg.rev < currentRev) {
         if (source === 'live') {
@@ -92,7 +109,7 @@ export function createWarmCache<T>(
             actual: msg.rev,
           });
         }
-        return;
+        return null;
       }
     }
     if (currentRev !== 0 && msg.rev !== expected) {
@@ -103,13 +120,31 @@ export function createWarmCache<T>(
         expected,
         actual: msg.rev,
       });
-      return;
+      return null;
     }
     revisions.set(msg.id, msg.rev);
+    let appliedValue: T | undefined;
     if (msg.op === 'delete') {
       store.delete(msg.id);
+    } else if (msg.op === 'merge') {
+      const base = store.get(msg.id)?.value;
+      const patch =
+        msg.value && typeof msg.value === 'object'
+          ? (msg.value as Partial<T>)
+          : ({} as Partial<T>);
+      const merged = {
+        ...(typeof base === 'object' && base !== null ? (base as Record<string, unknown>) : {}),
+        ...(patch as Record<string, unknown>),
+      } as T;
+      store.set(msg.id, { value: merged, rev: msg.rev });
+      appliedValue = merged;
     } else if (msg.value !== undefined) {
-      store.set(msg.id, { value: msg.value, rev: msg.rev });
+      store.set(msg.id, { value: msg.value as T, rev: msg.rev });
+      appliedValue = msg.value as T;
+    }
+    if (msg.op !== 'delete' && appliedValue === undefined) {
+      // Nothing to merge or set; do not emit updates but keep revision for idempotency
+      return msg;
     }
     if (synced && source === 'live') {
       const now = Date.now();
@@ -134,13 +169,14 @@ export function createWarmCache<T>(
     reconcilers.forEach((fn, addr) => {
       if (isWarmCacheEnabled(addr)) fn(msg.id, value);
     });
+    return msg;
   }
 
   (async () => {
     let unsub: (() => void) | null = null;
     try {
       unsub = await subscribeWithAck(topic, (msg: DiffMessage<T>) => {
-        const normalized = normalizeMessage(msg);
+        const normalized = normalizeMessage(msg, 'live');
         if (!synced) buffer.push({ msg: normalized, source: 'live' });
         else apply(normalized, 'live');
       });
@@ -166,7 +202,7 @@ export function createWarmCache<T>(
       synced = true;
       endHydration();
       cacheLagGauge.set(metricLabels, 0);
-      emitter.emit('cache.synced');
+      emitter.emit('cache.synced', { cache: topic });
       if (unsub) (emitter as any).unsub = unsub;
     } catch (err) {
       stale = true;
@@ -186,12 +222,18 @@ export function createWarmCache<T>(
       cacheHitRatioGauge.set({ cache: topic }, stats.total ? stats.hits / stats.total : 0);
       return value;
     },
-    values() {
+    list(filter) {
       if (stale || !isWarmCacheEnabled()) throw { code: E_STALE_DATA };
       if (lagging) throw { code: E_SYNC_LAG, lagMs: lastLagMs };
-      return Array.from(store.values())
-        .map((v) => v.value)
-        .filter((value): value is T => value !== undefined);
+      const res: T[] = [];
+      store.forEach(({ value }, id) => {
+        if (value === undefined) return;
+        if (!filter || filter(id, value)) res.push(value);
+      });
+      return res;
+    },
+    values() {
+      return this.list();
     },
     subscribe(filter, cb) {
       const handler = (id: string, value: T | undefined) => {
@@ -200,10 +242,24 @@ export function createWarmCache<T>(
       emitter.on('update', handler);
       return () => emitter.off('update', handler);
     },
-    onSynced(cb: () => void) {
-      if (synced) cb();
-      emitter.on('cache.synced', cb);
-      return () => emitter.off('cache.synced', cb);
+    onSynced(cb: (event?: { cache: string }) => void) {
+      if (synced) cb({ cache: topic });
+      const handler = (evt: { cache: string }) => cb(evt);
+      emitter.on('cache.synced', handler);
+      return () => emitter.off('cache.synced', handler);
+    },
+    mutate(cmd: CacheMutation<T>) {
+      if (stale || !isWarmCacheEnabled()) throw { code: E_STALE_DATA };
+      const currentRev = revisions.get(cmd.id) ?? 0;
+      const rev = cmd.rev ?? currentRev + 1;
+      const op: DiffOp = cmd.op ?? (cmd.value === undefined ? 'delete' : 'set');
+      return apply({
+        id: cmd.id,
+        rev,
+        op,
+        value: cmd.value,
+        ts: cmd.ts,
+      }, 'local');
     },
     registerReconciler(address, fn) {
       const key = address.toLowerCase();

--- a/src/features/auth/services/nearUsers.ts
+++ b/src/features/auth/services/nearUsers.ts
@@ -8,7 +8,7 @@ import { User } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { canonicalJson } from '@/utils/serialization';
 import { createWarmCache } from '@/services/warmCache';
-import type { DiffMessage } from '@/services/warmCache';
+import type { CacheMutation, DiffMessage } from '@/services/warmCache';
 import { errorLog } from '@/utils/logger';
 
 if (typeof assertNearChain === 'function') {
@@ -56,13 +56,19 @@ export const usersWarmCache = {
   getById(id: string) {
     return userCache.getById(id);
   },
+  list(filter?: (id: string, value: User) => boolean) {
+    return userCache.list(filter);
+  },
   subscribe(
     filter: (id: string, value: User | undefined) => boolean,
     cb: (id: string, value: User | undefined) => void,
   ) {
     return userCache.subscribe(filter, cb);
   },
-  onSynced(cb: () => void) {
+  mutate(cmd: CacheMutation<User>) {
+    return userCache.mutate(cmd);
+  },
+  onSynced(cb: (event?: { cache: string }) => void) {
     return userCache.onSynced(cb);
   },
 };
@@ -86,7 +92,7 @@ export async function removeUser(id: string) {
 
 export async function listUsers(): Promise<User[]> {
   try {
-    return userCache.values();
+    return userCache.list();
   } catch {}
   const items = await listValues(ADDRESS);
   return items.map((i) => JSON.parse(i.value) as User);

--- a/src/features/products/services/nearProducts.ts
+++ b/src/features/products/services/nearProducts.ts
@@ -6,7 +6,7 @@ import { errorLog } from '@/utils/logger';
 import { productSchema } from '@/schemas/waku';
 import { canonicalJson } from '@/utils/serialization';
 import { createWarmCache } from '@/services/warmCache';
-import type { DiffMessage } from '@/services/warmCache';
+import type { CacheMutation, DiffMessage } from '@/services/warmCache';
 
 assertNearChain();
 
@@ -53,6 +53,27 @@ async function hydrateProductLake(): Promise<Array<DiffMessage<Product>>> {
 const productCache = createWarmCache<Product>(PRODUCT_CACHE_TOPIC, {
   hydrateLake: hydrateProductLake,
 });
+
+export const productsWarmCache = {
+  getById(id: string) {
+    return productCache.getById(id);
+  },
+  list(filter?: (id: string, value: Product) => boolean) {
+    return productCache.list(filter);
+  },
+  subscribe(
+    filter: (id: string, value: Product | undefined) => boolean,
+    cb: (id: string, value: Product | undefined) => void,
+  ) {
+    return productCache.subscribe(filter, cb);
+  },
+  mutate(cmd: CacheMutation<Product>) {
+    return productCache.mutate(cmd);
+  },
+  onSynced(cb: (event?: { cache: string }) => void) {
+    return productCache.onSynced(cb);
+  },
+};
 const DISABLED = false;
 let SEEDED = false;
 
@@ -121,7 +142,7 @@ export async function listProducts(storeId: string): Promise<Product[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);
   try {
-    const cached = productCache.values().filter((p) => p.storeId === sid);
+    const cached = productCache.list((id, p) => p.storeId === sid);
     if (cached.length > 0) return cached;
   } catch {}
   const items = await listValues(ADDRESS);

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -15,7 +15,7 @@ import {
 import { errorLog } from '@/utils/logger';
 import config from '@/config';
 import { createWarmCache } from '@/services/warmCache';
-import type { DiffMessage } from '@/services/warmCache';
+import type { CacheMutation, DiffMessage } from '@/services/warmCache';
 
 assertNearChain();
 
@@ -66,13 +66,19 @@ export const storesWarmCache = {
   getById(id: string) {
     return storeCache.getById(id);
   },
+  list(filter?: (id: string, value: Store) => boolean) {
+    return storeCache.list(filter);
+  },
   subscribe(
     filter: (id: string, value: Store | undefined) => boolean,
     cb: (id: string, value: Store | undefined) => void,
   ) {
     return storeCache.subscribe(filter, cb);
   },
-  onSynced(cb: () => void) {
+  mutate(cmd: CacheMutation<Store>) {
+    return storeCache.mutate(cmd);
+  },
+  onSynced(cb: (event?: { cache: string }) => void) {
     return storeCache.onSynced(cb);
   },
 };
@@ -199,7 +205,7 @@ export async function listStores(storeId: string): Promise<Store[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);
   try {
-    const values = storeCache.values();
+    const values = storeCache.list();
     if (sid === 'default') return values;
     const filtered = values.filter((store) => requireStoreId(store.id) === sid);
     if (filtered.length > 0) return filtered;

--- a/tests/services/warmCache.test.ts
+++ b/tests/services/warmCache.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 
 describe('warmCache', () => {
   it('warm boot matches cold boot results', async () => {
-    const warm = createWarmCache<any>('topic', { hydrateLake });
+    const warm = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => warm.onSynced(res));
     // apply live diff
     liveHandler &&
@@ -57,14 +57,14 @@ describe('warmCache', () => {
       { id: '1', rev: 2, op: 'set', value: { name: 'a2' } },
       { id: '2', rev: 1, op: 'set', value: { name: 'b' } },
     ];
-    const cold = createWarmCache<any>('topic', { hydrateLake });
+    const cold = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cold.onSynced(res));
     expect(cold.getById('1')).toEqual({ name: 'a2' });
     expect(cold.getById('2')).toEqual({ name: 'b' });
   });
 
   it('detects conflicting diffs', async () => {
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     liveHandler &&
       liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'a2' } });
@@ -72,28 +72,31 @@ describe('warmCache', () => {
     // duplicate revision triggers stale state
     liveHandler &&
       liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'bad' } });
+    // @ts-expect-error - matcher provided by jest-extended typings
     expect(() => cache.getById('1')).toThrowErrorMatchingObject({
       code: E_STALE_DATA,
     });
   });
 
   it('throws on out-of-order diff', async () => {
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     liveHandler &&
       liveHandler({ id: '1', rev: 4, op: 'set', value: { name: 'bad' } });
+    // @ts-expect-error - matcher provided by jest-extended typings
     expect(() => cache.getById('1')).toThrowErrorMatchingObject({
       code: E_STALE_DATA,
     });
   });
 
   it('tracks revision numbers after deletes to catch stale updates', async () => {
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     liveHandler && liveHandler({ id: '1', rev: 2, op: 'delete' });
     expect(cache.getById('1')).toBeUndefined();
     liveHandler &&
       liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'bad' } });
+    // @ts-expect-error - matcher provided by jest-extended typings
     expect(() => cache.getById('1')).toThrowErrorMatchingObject({
       code: E_STALE_DATA,
     });
@@ -101,7 +104,7 @@ describe('warmCache', () => {
 
   it('falls back when history fails', async () => {
     failHistory = true;
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     expect(cache.getById('1')).toEqual({ name: 'a' });
     liveHandler &&
@@ -112,7 +115,7 @@ describe('warmCache', () => {
   it('processes canary reconcilers only for allowed admins', async () => {
     const flags = require('@/config/featureFlags');
     flags.default.canaryAdmins = ['0xabc'];
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     const hitsA: any[] = [];
     const hitsB: any[] = [];
@@ -125,7 +128,7 @@ describe('warmCache', () => {
   });
 
   it('tracks hit ratio', async () => {
-    const cache = createWarmCache<any>('topic', { hydrateLake });
+    const cache = createWarmCache('topic', { hydrateLake });
     await new Promise((res) => cache.onSynced(res));
     cache.getById('1');
     cache.getById('missing');
@@ -135,12 +138,13 @@ describe('warmCache', () => {
   it('throws sync lag error when updates fall behind', async () => {
     jest.useFakeTimers();
     try {
-      const cache = createWarmCache<any>('topic', { hydrateLake, lagThresholdMs: 1000 });
+      const cache = createWarmCache('topic', { hydrateLake, lagThresholdMs: 1000 });
       await new Promise((res) => cache.onSynced(res));
       jest.setSystemTime(0);
       liveHandler &&
         liveHandler({ id: '1', rev: 2, op: 'set', value: { name: 'late' }, ts: 0 });
       jest.setSystemTime(2005);
+      // @ts-expect-error - matcher provided by jest-extended typings
       expect(() => cache.getById('1')).toThrowErrorMatchingObject({ code: E_SYNC_LAG });
     } finally {
       jest.useRealTimers();
@@ -150,7 +154,7 @@ describe('warmCache', () => {
   it('uses a 3s default lag threshold before raising sync alerts', async () => {
     jest.useFakeTimers();
     try {
-      const cache = createWarmCache<any>('topic', { hydrateLake });
+      const cache = createWarmCache('topic', { hydrateLake });
       await new Promise((res) => cache.onSynced(res));
       jest.setSystemTime(0);
       liveHandler &&
@@ -158,7 +162,48 @@ describe('warmCache', () => {
       jest.setSystemTime(2800);
       expect(cache.getById('2')).toEqual({ name: 'slow' });
       jest.setSystemTime(3300);
+      // @ts-expect-error - matcher provided by jest-extended typings
       expect(() => cache.getById('2')).toThrowErrorMatchingObject({ code: E_SYNC_LAG });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('lists cached entries with optional filtering', async () => {
+    const cache = createWarmCache('topic', { hydrateLake });
+    await new Promise((res) => cache.onSynced(res));
+    expect(cache.list()).toHaveLength(2);
+    const filtered = cache.list((id) => id === '1');
+    expect(filtered).toEqual([{ name: 'a' }]);
+  });
+
+  it('mutates entries with merge semantics and idempotent revs', async () => {
+    const cache = createWarmCache('topic', { hydrateLake });
+    await new Promise((res) => cache.onSynced(res));
+    const created = cache.mutate({ id: '3', rev: 1, op: 'set', value: { name: 'c', stock: 1 } });
+    expect(created).toMatchObject({ id: '3', rev: 1, op: 'set' });
+    expect(cache.getById('3')).toEqual({ name: 'c', stock: 1 });
+    const merged = cache.mutate({ id: '3', rev: 2, op: 'merge', value: { stock: 5 } });
+    expect(merged).toMatchObject({ id: '3', rev: 2, op: 'merge' });
+    expect(cache.getById('3')).toEqual({ name: 'c', stock: 5 });
+    const duplicate = cache.mutate({ id: '3', rev: 2, op: 'merge', value: { stock: 5 } });
+    expect(duplicate).toBeNull();
+  });
+
+  it('clamps future timestamps when mutating locally', async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(1_000);
+      const cache = createWarmCache('topic', { hydrateLake });
+      await new Promise((res) => cache.onSynced(res));
+      const diff = cache.mutate({
+        id: '4',
+        rev: 1,
+        op: 'set',
+        value: { name: 'future' },
+        ts: 1_000 + 10 * 60_000,
+      });
+      expect(diff?.ts).toBe(1_000);
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## Summary
- extend the warm cache core to support diff merge ops, a list API, local mutations, and clock-skew guards while emitting cache.synced payloads
- surface the richer cache interface for orders, users, products, and stores so callers can list and mutate domain data from hydrated caches
- broaden warm cache unit coverage to exercise list filtering, merge mutation idempotency, and timestamp guards

## Testing
- yarn jest --testMatch '<rootDir>/tests/services/warmCache.test.ts' *(fails: ts-jest type checks raise @waku encoder typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b01c9e048326b7de6f1276acd45f