### PR TITLE
feat: enhance commerce flows with new UI screens

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -36,6 +36,8 @@ import { spacing, typography, radius, shadows } from '@/ui/tokens';
 import HeroCallout from '@/features/home/components/HeroCallout';
 import ErrorBoundary from 'src/shared/ErrorBoundary';
 import HomeError from '@/features/home/screens/HomeError';
+import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
+import { useAppRouter } from '@/services/useAppRouter';
 
 function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
@@ -43,6 +45,7 @@ function HomeScreenContent() {
   const { colors: themeColors } = useTheme();
   const { appName, logoCid } = useAppInfo();
   const { width: windowWidth } = useWindowDimensions();
+  const appRouter = useAppRouter();
 
   const home = useHome(tenantId);
 
@@ -69,17 +72,39 @@ function HomeScreenContent() {
   const { fallbackCategories, fallbackBanners } = useHomeData();
   const categoriesToShow = categories.length ? categories : fallbackCategories;
 
-    const { filteredProducts, searchQuery, selectedCategory, setSelectedCategory, minPrice, setMinPrice, maxPrice, setMaxPrice, sortBy, setSortBy, showSortModal, setShowSortModal } = useHomeFilters(products);
-    const [showCategorySelector, setShowCategorySelector] = useState(false);
+  const {
+    filteredProducts,
+    searchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    sortBy,
+    setSortBy,
+    showSortModal,
+    setShowSortModal,
+  } = useHomeFilters(products);
 
-    const getProductItemWidth = () => {
-      if (windowWidth >= 1024) {
-        return '23.5%';
-      } else if (windowWidth >= 768) {
-        return '32%';
-      }
-      return '48%';
-    };
+  const getProductItemWidth = () => {
+    if (windowWidth >= 1024) {
+      return '23.5%';
+    }
+    if (windowWidth >= 768) {
+      return '32%';
+    }
+    return '48%';
+  };
+
+  const handleProductPress = useCallback(
+    (product: Product) => {
+      const store = product.storeId || tenantId;
+      if (!store) return;
+      appRouter.push(`/store/${store}/product/${product.id}`);
+    },
+    [appRouter, tenantId],
+  );
 
   const getSortLabel = () => {
     switch (sortBy) {
@@ -133,6 +158,8 @@ function HomeScreenContent() {
           <HeroCallout />
           <View style={{ height: spacing.spacer16 }} />
           <HomeOptions />
+          <View style={{ height: spacing.spacer16 }} />
+          <AdminOnboardingChecklist onAddProduct={() => openProductForm()} />
         </Container>
       </ScrollArea>
     );
@@ -205,6 +232,9 @@ function HomeScreenContent() {
           maxPrice={maxPrice}
           setMaxPrice={setMaxPrice}
         />
+        <View style={{ height: spacing.spacer16 }} />
+        <AdminOnboardingChecklist onAddProduct={() => openProductForm()} />
+        <View style={{ height: spacing.spacer16 }} />
         {/* Categories Section */}
         <Container
           style={[
@@ -217,7 +247,7 @@ function HomeScreenContent() {
             <Heading size="lg" style={{ color: themeColors.text.primary }}>
               {t('home.categories')}
             </Heading>
-            <TouchableOpacity onPress={() => setShowCategorySelector(true)}>
+            <TouchableOpacity onPress={() => setSelectedCategory(null)}>
               <Text style={[styles.seeAll, { color: themeColors.gold }]}>
                 {t('common.viewAll')}
               </Text>
@@ -307,6 +337,7 @@ function HomeScreenContent() {
               searchQuery={searchQuery}
               onAddProduct={openProductForm}
               loading={productsLoading}
+              onProductPress={handleProductPress}
             />
           </Suspense>
         </Container>

--- a/app/orders/index.tsx
+++ b/app/orders/index.tsx
@@ -1,0 +1,237 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshControl, StyleSheet, View } from 'react-native';
+import { ScrollArea, Container, Stack } from '@/ui/layout';
+import { Heading, Skeleton } from '@/ui/primitives';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import EmptyState from '@/shared/ui/EmptyState';
+import { useWallet } from '@/contexts/WalletProvider';
+import { chainAdapter } from '@/services/chain';
+import { Order } from '@/types';
+import { errorLog } from '@/utils/logger';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import { AlertTriangle, RefreshCw, ShoppingCart } from 'lucide-react-native';
+
+function OrderSkeletonRow() {
+  return (
+    <Stack gap="spacer12" style={{ marginBottom: 16 }}>
+      <Skeleton height={16} width="60%" />
+      <Skeleton height={12} width="40%" />
+      <Skeleton height={12} width="80%" />
+    </Stack>
+  );
+}
+
+interface OrderListItemProps {
+  order: Order;
+  color: string;
+  subtle: string;
+  currencyPrefix: string;
+  borderColor: string;
+  background: string;
+}
+
+function OrderListItem({
+  order,
+  color,
+  subtle,
+  currencyPrefix,
+  borderColor,
+  background,
+}: OrderListItemProps) {
+  const createdAtLabel = useMemo(() => {
+    if (!order.createdAt) return '—';
+    const date = new Date(order.createdAt);
+    if (Number.isNaN(date.getTime())) return order.createdAt;
+    return date.toLocaleString();
+  }, [order.createdAt]);
+
+  return (
+    <View
+      style={[styles.row, { borderColor, backgroundColor: background }]}
+      accessibilityRole="summary"
+    >
+      <Text style={[styles.rowId, { color }]} numberOfLines={1}>
+        #{order.id}
+      </Text>
+      <Text style={[styles.rowMeta, { color: subtle }]}>{createdAtLabel}</Text>
+      <Stack direction="horizontal" justify="space-between" align="center">
+        <Text style={[styles.rowStatus, { color }]}>{order.status}</Text>
+        <Text style={[styles.rowTotal, { color }]}>
+          {currencyPrefix}
+          {order.total?.toFixed?.(2) ?? order.total}
+        </Text>
+      </Stack>
+    </View>
+  );
+}
+
+export default function OrdersScreen() {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const { address, connect } = useWallet();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { currencySymbol } = useCurrency();
+
+  const supportsBuyerOrders = typeof chainAdapter.listOrdersByBuyer === 'function';
+
+  const fetchOrders = useCallback(
+    async (mode: 'initial' | 'refresh' = 'initial') => {
+      if (!address || !supportsBuyerOrders) return;
+      if (mode === 'initial') {
+        setLoading(true);
+      } else {
+        setRefreshing(true);
+      }
+      setError(null);
+      try {
+        const list = await chainAdapter.listOrdersByBuyer!(address);
+        const sorted = [...list].sort((a, b) => {
+          const aTime = new Date(a.createdAt || 0).getTime();
+          const bTime = new Date(b.createdAt || 0).getTime();
+          return bTime - aTime;
+        });
+        setOrders(sorted);
+      } catch (err) {
+        errorLog('Failed to load buyer orders', err);
+        setError(t('orders.loadError', 'Unable to load your orders. Please try again.'));
+      } finally {
+        if (mode === 'initial') {
+          setLoading(false);
+        } else {
+          setRefreshing(false);
+        }
+      }
+    },
+    [address, supportsBuyerOrders, t],
+  );
+
+  useEffect(() => {
+    if (!address || !supportsBuyerOrders) {
+      setOrders([]);
+      return;
+    }
+    fetchOrders('initial').catch(() => {});
+  }, [address, supportsBuyerOrders, fetchOrders]);
+
+  const handleRefresh = useCallback(() => {
+    void fetchOrders('refresh');
+  }, [fetchOrders]);
+
+  if (!supportsBuyerOrders) {
+    return (
+      <ScrollArea backgroundColor={colors.canvas}>
+        <Container>
+          <EmptyState
+            icon={AlertTriangle}
+            title={t('orders.unsupportedTitle', 'Orders unavailable')}
+            message={t(
+              'orders.unsupportedDescription',
+              'Your current network does not expose buyer order history yet.'
+            )}
+          />
+        </Container>
+      </ScrollArea>
+    );
+  }
+
+  if (!address) {
+    return (
+      <ScrollArea backgroundColor={colors.canvas}>
+        <Container>
+          <Heading size="xl">{t('navigation.orders', 'Orders')}</Heading>
+          <View style={{ height: 16 }} />
+          <EmptyState
+            icon={ShoppingCart}
+            title={t('orders.connectTitle', 'Connect to view orders')}
+            message={t(
+              'orders.connectDescription',
+              'Link your wallet to follow purchases and delivery updates.'
+            )}
+            actionText={t('auth.login', 'Login')}
+            onAction={connect}
+          />
+        </Container>
+      </ScrollArea>
+    );
+  }
+
+  return (
+    <ScrollArea
+      backgroundColor={colors.canvas}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.gold} />
+      }
+    >
+      <Container>
+        <Heading size="xl">{t('navigation.orders', 'Orders')}</Heading>
+        <View style={{ height: 16 }} />
+        {loading ? (
+          <View>
+            {Array.from({ length: 3 }).map((_, idx) => (
+              <OrderSkeletonRow key={`skeleton-${idx}`} />
+            ))}
+          </View>
+        ) : error ? (
+          <EmptyState
+            icon={RefreshCw}
+            title={t('orders.loadErrorTitle', 'Something went wrong')}
+            message={error}
+            actionText={t('common.reload', 'Reload')}
+            onAction={() => fetchOrders('initial')}
+          />
+        ) : orders.length === 0 ? (
+          <EmptyState
+            icon={ShoppingCart}
+            title={t('orders.emptyTitle', 'No orders yet')}
+            message={t(
+              'orders.emptyDescription',
+              'Start by adding an item to your cart and completing checkout.'
+            )}
+          />
+        ) : (
+          <Stack gap="spacer16">
+            {orders.map((order) => (
+              <OrderListItem
+                key={order.id}
+                order={order}
+                color={colors.text.primary}
+                subtle={colors.text.secondary}
+                currencyPrefix={currencySymbol}
+                borderColor={colors.border.primary}
+                background={colors.surface.primary}
+              />
+            ))}
+          </Stack>
+        )}
+      </Container>
+    </ScrollArea>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+  },
+  rowId: {
+    fontWeight: '600',
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  rowMeta: {
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  rowStatus: {
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  rowTotal: {
+    fontWeight: '700',
+  },
+});
+

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,20 +1,136 @@
 import React from 'react';
-import { View } from 'react-native';
-import { ScrollArea, Container } from '@/ui/layout';
-import { Heading, Text } from '@/ui/primitives';
+import { View, Switch, StyleSheet } from 'react-native';
+import { ScrollArea, Container, Stack } from '@/ui/layout';
+import { Heading, Text, Card, Button } from '@/ui/primitives';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import { spacing } from '@/ui/tokens';
 
 export default function SettingsScreen() {
-  const { colors } = useTheme();
-  const { t } = useLanguage();
+  const { colors, theme, setTheme } = useTheme();
+  const { t, currentLanguage, setLanguage } = useLanguage();
+  const { currencySymbol, setCurrencySymbol } = useCurrency();
+
+  const handleThemeToggle = (value: boolean) => {
+    void setTheme(value ? 'dark' : 'light');
+  };
+
+  const handleLanguageChange = (lang: 'en' | 'he') => {
+    void setLanguage(lang);
+  };
+
+  const handleCurrencyChange = (symbol: string) => {
+    void setCurrencySymbol(symbol);
+  };
+
   return (
     <ScrollArea backgroundColor={colors.canvas}>
       <Container>
         <Heading size="xl">{t('navigation.settings', 'Settings')}</Heading>
-        <View style={{ height: 8 }} />
-        <Text>{t('common.comingSoon', 'Coming Soon')}</Text>
+        <View style={{ height: spacing.spacer12 }} />
+        <Stack gap="spacer20">
+          <Card>
+            <Stack gap="spacer12">
+              <Heading size="md" style={{ color: colors.text.primary }}>
+                {t('settings.appearance', 'Appearance')}
+              </Heading>
+              <View style={styles.row}>
+                <Text style={{ color: colors.text.primary }}>{t('settings.darkMode', 'Dark mode')}</Text>
+                <Switch
+                  value={theme === 'dark'}
+                  onValueChange={handleThemeToggle}
+                  thumbColor={theme === 'dark' ? colors.gold : colors.surface.secondary}
+                  accessibilityLabel={t('settings.darkModeToggle', 'Toggle dark mode')}
+                />
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                {t(
+                  'settings.accessibilityHint',
+                  'Dark mode is optimised for WCAG 2.2 AA contrast across the entire experience.',
+                )}
+              </Text>
+            </Stack>
+          </Card>
+
+          <Card>
+            <Stack gap="spacer12">
+              <Heading size="md" style={{ color: colors.text.primary }}>
+                {t('settings.language', 'Language')}
+              </Heading>
+              <Text style={{ color: colors.text.secondary }}>
+                {t('settings.languageHint', 'Choose your default interface language.')}
+              </Text>
+              <View style={styles.buttonRow}>
+                <Button
+                  title="English"
+                  onPress={() => handleLanguageChange('en')}
+                  disabled={currentLanguage === 'en'}
+                />
+                <Button
+                  title="עברית"
+                  onPress={() => handleLanguageChange('he')}
+                  disabled={currentLanguage === 'he'}
+                />
+              </View>
+            </Stack>
+          </Card>
+
+          <Card>
+            <Stack gap="spacer12">
+              <Heading size="md" style={{ color: colors.text.primary }}>
+                {t('settings.currency', 'Currency')}
+              </Heading>
+              <Text style={{ color: colors.text.secondary }}>
+                {t(
+                  'settings.currencyHint',
+                  'All totals are shown using your preferred currency symbol.',
+                )}
+              </Text>
+              <View style={styles.buttonRow}>
+                {['₪', '$', '€'].map((symbol) => (
+                  <Button
+                    key={symbol}
+                    title={`${symbol} ${t('settings.useSymbol', 'Use symbol')}`}
+                    onPress={() => handleCurrencyChange(symbol)}
+                    disabled={currencySymbol === symbol}
+                  />
+                ))}
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                {t('settings.currentCurrency', 'Current currency')}: {currencySymbol}
+              </Text>
+            </Stack>
+          </Card>
+
+          <Card>
+            <Stack gap="spacer12">
+              <Heading size="md" style={{ color: colors.text.primary }}>
+                {t('settings.accessibility', 'Accessibility & privacy')}
+              </Heading>
+              <Text style={{ color: colors.text.secondary }}>
+                {t(
+                  'settings.accessibilityDescription',
+                  'Anonymous browsing is supported. We only store preferences like theme and currency locally on your device.',
+                )}
+              </Text>
+            </Stack>
+          </Card>
+        </Stack>
       </Container>
     </ScrollArea>
   );
 }
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.spacer12,
+  },
+});
 

--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -1,5 +1,5 @@
 // TOUCHPOINT: app/store/[storeId]/_StoreScreen.tsx renders in production — Fix Pack v2
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
@@ -9,11 +9,12 @@ import { ProductGrid, ProductCardSkeleton } from '@/features/products';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import { useProducts, useCategories, useStoreReviews } from '@/services';
 import { selectStore } from '@/agents/stores-agent';
-import type { Store } from '@/types';
+import type { Store, Product } from '@/types';
 import { spacing } from '@/shared/ui/tokens';
 import EmptyState from '@/shared/ui/EmptyState';
 import Button from '@/ui/primitives/Button';
 import { useAppRouter } from '@/services/useAppRouter';
+import { AlertTriangle } from 'lucide-react-native';
 
 export default function StoreScreen() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
@@ -25,14 +26,42 @@ export default function StoreScreen() {
   const {
     data: products = [],
     isLoading: productsLoading,
+    refetch: refetchProducts,
+    isRefetching: productsRefetching,
+    error: productsError,
   } = useProducts(storeId);
   const {
     data: categories = [],
     isLoading: categoriesLoading,
+    refetch: refetchCategories,
+    isRefetching: categoriesRefetching,
+    error: categoriesError,
   } = useCategories(storeId);
   const { data: { score } = { score: 0 } } = useStoreReviews(storeId);
   const [tab, setTab] = useState<'products' | 'about' | 'reviews'>('products');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const refreshing = productsRefetching || categoriesRefetching;
+
+  const handleRefresh = useCallback(() => {
+    void Promise.all([refetchProducts(), refetchCategories()]);
+  }, [refetchProducts, refetchCategories]);
+
+  const handleProductPress = useCallback(
+    (product: Product) => {
+      const targetStore = product.storeId || storeId;
+      if (!targetStore) return;
+      push(`/store/${targetStore}/product/${product.id}`);
+    },
+    [push, storeId],
+  );
+
+  const loadError = productsError || categoriesError;
+  const loadErrorMessage = loadError
+    ? loadError instanceof Error
+      ? loadError.message
+      : String(loadError)
+    : null;
 
   const filteredProducts = useMemo(
     () =>
@@ -102,8 +131,21 @@ export default function StoreScreen() {
                 </View>
               ))}
             </View>
+          ) : loadErrorMessage ? (
+            <EmptyState
+              icon={AlertTriangle}
+              title={t('home.loadErrorTitle', 'Unable to load products')}
+              message={loadErrorMessage}
+              actionText={t('common.reload', 'Reload')}
+              onAction={handleRefresh}
+            />
           ) : (
-            <ProductGrid products={filteredProducts} />
+            <ProductGrid
+              products={filteredProducts}
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              onProductPress={handleProductPress}
+            />
           )}
         </>
       )}

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
@@ -11,6 +11,7 @@ import { getStore as getNearStore } from '@/features/stores/services/nearStores'
 import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
 import { routes } from '@/utils/routes';
 import { Spinner } from '@/ui/primitives';
+import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 
 export default function StoreDashboardScreen() {
   console.debug('SD: mount');
@@ -24,6 +25,11 @@ export default function StoreDashboardScreen() {
   const [store, setStore] = useState<any>(null);
   const [products, setProducts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const handleOpenProducts = useCallback(() => {
+    if (!storeId) return;
+    push(`/store/${storeId}/admin/products`);
+  }, [push, storeId]);
 
   useEffect(() => {
     let active = true;
@@ -74,6 +80,8 @@ export default function StoreDashboardScreen() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
+      <AdminOnboardingChecklist onAddProduct={handleOpenProducts} />
+      <View style={{ height: 16 }} />
       <View style={styles.stats}>
         <Text style={[styles.statText, { color: colors.text.primary }]}>
           {t('admin.productCount', { count: productCount })}

--- a/app/store/[storeId]/product/[productId].tsx
+++ b/app/store/[storeId]/product/[productId].tsx
@@ -1,0 +1,16 @@
+import React, { Suspense } from 'react';
+import { Spinner } from '@/ui/primitives';
+import ErrorBoundary from '@/shared/ErrorBoundary';
+
+const ProductScreen = React.lazy(() => import('./_ProductScreen'));
+
+export default function ProductRoute(props: any) {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <ErrorBoundary>
+        <ProductScreen {...props} />
+      </ErrorBoundary>
+    </Suspense>
+  );
+}
+

--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -1,0 +1,325 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  TouchableOpacity,
+} from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { Heading, Text, Button, Skeleton } from '@/ui/primitives';
+import { spacing, typography, radius } from '@/ui/tokens';
+import SmartImage from '@/components/SmartImage';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import CartService from '@/features/cart/services/cart';
+import { useNotificationActions } from '@/components/NotificationContext';
+import EmptyState from '@/shared/ui/EmptyState';
+import { useAppRouter } from '@/services/useAppRouter';
+import { useProductDetail } from '@/features/products/hooks/useProductDetail';
+import { AlertTriangle, Heart, Minus, Plus, ShoppingCart } from 'lucide-react-native';
+
+export default function ProductDetailScreen() {
+  const { storeId, productId } = useLocalSearchParams<{ storeId: string; productId: string }>();
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const { currencySymbol } = useCurrency();
+  const { showNotification } = useNotificationActions();
+  const appRouter = useAppRouter();
+
+  const {
+    product,
+    isLoading,
+    refreshing,
+    refresh,
+    error,
+    quantity,
+    incrementQuantity,
+    decrementQuantity,
+    effectivePrice,
+    totalPrice,
+    currentPricingTier,
+    showTieredPricing,
+    media,
+    mainImageUri,
+    isFavorite,
+    toggleFavorite,
+    notFound,
+  } = useProductDetail(productId ?? '', typeof storeId === 'string' ? storeId : undefined);
+
+  const [adding, setAdding] = useState(false);
+
+  const handleAddToCart = useCallback(async () => {
+    if (!product) return;
+    setAdding(true);
+    try {
+      await CartService.getInstance().addToCart(product, quantity);
+      showNotification(
+        t('cart.addedTitle', 'Added to cart'),
+        t('cart.addedMessage', 'The item was added to your cart.'),
+        'success',
+      );
+    } catch (err) {
+      showNotification(
+        t('common.error', 'Error'),
+        err instanceof Error ? err.message : t('cart.addError', 'Could not add to cart.'),
+        'error',
+      );
+    } finally {
+      setAdding(false);
+    }
+  }, [product, quantity, showNotification, t]);
+
+  const handleBack = useCallback(() => {
+    if (storeId) {
+      appRouter.push(`/store/${storeId}`);
+    } else {
+      appRouter.back();
+    }
+  }, [appRouter, storeId]);
+
+  const priceLabel = useMemo(() => {
+    if (!product) return '';
+    return `${currencySymbol}${effectivePrice.toFixed(2)}`;
+  }, [product, currencySymbol, effectivePrice]);
+
+  if (!productId) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title={t('productDetail.missing', 'Product unavailable')}
+        message={t('productDetail.missingDescription', 'This product identifier is invalid.')}
+        actionText={t('common.back', 'Back')}
+        onAction={handleBack}
+      />
+    );
+  }
+
+  if (notFound) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title={t('productDetail.notFound', 'Product not found')}
+        message={t(
+          'productDetail.notFoundDescription',
+          'The item may have been removed or is unavailable in this store.',
+        )}
+        actionText={t('common.back', 'Back')}
+        onAction={handleBack}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title={t('productDetail.errorTitle', 'Unable to load product')}
+        message={error.message}
+        actionText={t('common.reload', 'Reload')}
+        onAction={async () => {
+          await refresh();
+        }}
+      />
+    );
+  }
+
+  const renderSkeleton = () => (
+    <View style={styles.skeletonCard}>
+      <Skeleton height={220} borderRadius={radius.lg} />
+      <View style={{ marginTop: spacing.spacer16, gap: spacing.spacer12 }}>
+        <Skeleton height={24} width="60%" />
+        <Skeleton height={16} width="80%" />
+        <Skeleton height={48} width="100%" />
+      </View>
+    </View>
+  );
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: colors.canvas }}
+      contentContainerStyle={{ padding: spacing.spacer16 }}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} tintColor={colors.gold} />}
+    >
+      {isLoading || !product ? (
+        renderSkeleton()
+      ) : (
+        <View style={[styles.card, { backgroundColor: colors.surface.primary, borderColor: colors.border.primary }] }>
+          <SmartImage
+            uri={mainImageUri || product.images?.[0]}
+            width={360}
+            height={220}
+            style={[styles.heroImage, { borderRadius: radius.lg }]}
+            contentFit="cover"
+          />
+          <View style={{ marginTop: spacing.spacer16, gap: spacing.spacer12 }}>
+            <Heading size="lg" style={{ color: colors.text.primary }}>
+              {product.name}
+            </Heading>
+            <Text style={{ color: colors.text.secondary }}>{product.description}</Text>
+            <View style={styles.priceRow}>
+              <Text style={[styles.price, { color: colors.text.primary }]}>{priceLabel}</Text>
+              <TouchableOpacity
+                onPress={toggleFavorite}
+                accessibilityRole="button"
+                style={styles.favoriteButton}
+              >
+                <Heart
+                  size={20}
+                  color={isFavorite ? colors.status.error : colors.text.secondary}
+                  fill={isFavorite ? colors.status.error : 'transparent'}
+                />
+              </TouchableOpacity>
+            </View>
+            {showTieredPricing && currentPricingTier ? (
+              <View style={[styles.tierNotice, { backgroundColor: colors.surface.secondary }] }>
+                <Text style={{ color: colors.text.secondary }}>
+                  {t('productDetail.tiered', 'Tier pricing')} · {currentPricingTier.name}
+                </Text>
+              </View>
+            ) : null}
+            <View style={styles.quantityRow}>
+              <Text style={{ color: colors.text.primary, fontWeight: '600' }}>
+                {t('productDetail.quantity', 'Quantity')}
+              </Text>
+              <View style={styles.quantityControls}>
+                <TouchableOpacity
+                  onPress={decrementQuantity}
+                  accessibilityLabel={t('productDetail.decrease', 'Decrease quantity')}
+                  style={[styles.quantityButton, { borderColor: colors.border.primary }]}
+                  disabled={quantity <= 1}
+                >
+                  <Minus size={16} color={colors.text.primary} />
+                </TouchableOpacity>
+                <Text style={[styles.quantityValue, { color: colors.text.primary }]}>{quantity}</Text>
+                <TouchableOpacity
+                  onPress={incrementQuantity}
+                  accessibilityLabel={t('productDetail.increase', 'Increase quantity')}
+                  style={[styles.quantityButton, { borderColor: colors.border.primary }]}
+                  disabled={product.stock !== undefined && quantity >= product.stock}
+                >
+                  <Plus size={16} color={colors.text.primary} />
+                </TouchableOpacity>
+              </View>
+            </View>
+            <Text style={{ color: colors.text.secondary }}>
+              {t('productDetail.subtotal', 'Subtotal')}: {currencySymbol}
+              {totalPrice.toFixed(2)}
+            </Text>
+            <View style={styles.stockRow}>
+              <Text style={{ color: colors.text.secondary }}>
+                {t('productDetail.stock', 'In stock')}: {product.stock ?? t('common.unknown', 'Unknown')}
+              </Text>
+            </View>
+            <Button
+              onPress={handleAddToCart}
+              loading={adding}
+              disabled={!product.stock || product.stock === 0}
+              accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
+            >
+              <View style={styles.buttonContent}>
+                <ShoppingCart size={18} color={colors.text.inverse} />
+                <Text style={[styles.buttonText, { color: colors.text.inverse }]}>
+                  {t('productDetail.addToCart', 'Add to cart')}
+                </Text>
+              </View>
+            </Button>
+          </View>
+        </View>
+      )}
+      {media?.length ? (
+        <View style={{ marginTop: spacing.spacer24 }}>
+          <Heading size="md" style={{ color: colors.text.primary }}>
+            {t('productDetail.gallery', 'Gallery')}
+          </Heading>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ gap: spacing.spacer12, paddingVertical: spacing.spacer12 }}
+          >
+            {media.map((item) => (
+              <SmartImage
+                key={item.uri}
+                uri={item.uri}
+                width={120}
+                height={120}
+                style={{ borderRadius: radius.md }}
+                contentFit="cover"
+              />
+            ))}
+          </ScrollView>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radius.xl,
+    padding: spacing.spacer16,
+  },
+  skeletonCard: {
+    borderRadius: radius.xl,
+    padding: spacing.spacer16,
+    borderWidth: 1,
+    borderColor: 'transparent',
+    backgroundColor: 'rgba(255,255,255,0.04)',
+  },
+  heroImage: {
+    width: '100%',
+    height: 220,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.spacer16,
+  },
+  price: {
+    ...typography.xl,
+    fontWeight: '700',
+  },
+  favoriteButton: {
+    padding: spacing.spacer8,
+  },
+  tierNotice: {
+    padding: spacing.spacer12,
+    borderRadius: radius.md,
+  },
+  quantityRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  quantityControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.spacer12,
+  },
+  quantityButton: {
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.spacer8,
+  },
+  quantityValue: {
+    minWidth: 32,
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+  stockRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  buttonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.spacer8,
+  },
+  buttonText: {
+    ...typography.md,
+    fontWeight: '600',
+  },
+});
+

--- a/services/nearOrders.ts
+++ b/services/nearOrders.ts
@@ -28,6 +28,19 @@ function matchesStore(order: Order | undefined, sid: string): boolean {
   return !!inferred && inferred === sid;
 }
 
+function normalizeAddress(value?: string | null): string {
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function matchesBuyer(order: Order | undefined, buyer: string): boolean {
+  if (!order || !buyer) return false;
+  const normalized = normalizeAddress(buyer);
+  if (!normalized) return false;
+  const buyerAddress = normalizeAddress(order.buyerAddress);
+  const userId = normalizeAddress(order.userId);
+  return buyerAddress === normalized || userId === normalized;
+}
+
 async function hydrateOrderLake(): Promise<Array<DiffMessage<Order>>> {
   try {
     const entries = await listValues(ADDRESS);
@@ -124,6 +137,28 @@ export async function listOrdersBySeller(
     .filter((i) => i.key.startsWith(`${ADDRESS}:${sid}:`))
     .map((i) => JSON.parse(i.value) as Order)
     .filter((o) => o.sellerAddress === sellerAddress);
+}
+
+export async function listOrdersByBuyer(buyerAddress: string): Promise<Order[]> {
+  const normalized = normalizeAddress(buyerAddress);
+  if (!normalized) return [];
+  const sortByCreatedAtDesc = (a: Order, b: Order) => {
+    const aTime = new Date(a.createdAt || 0).getTime();
+    const bTime = new Date(b.createdAt || 0).getTime();
+    return bTime - aTime;
+  };
+  try {
+    const cached = orderCache
+      .values()
+      .filter((order) => matchesBuyer(order, normalized))
+      .sort(sortByCreatedAtDesc);
+    if (cached.length > 0) return cached;
+  } catch {}
+  const items = await listValues(ADDRESS);
+  return items
+    .map((i) => JSON.parse(i.value) as Order)
+    .filter((o) => matchesBuyer(o, normalized))
+    .sort(sortByCreatedAtDesc);
 }
 
 export { E_STALE_DATA, E_SYNC_LAG } from '@/services/warmCache';

--- a/src/features/home/components/AdminOnboardingChecklist.tsx
+++ b/src/features/home/components/AdminOnboardingChecklist.tsx
@@ -1,0 +1,315 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Card, Heading, Text, Button, Skeleton } from '@/ui/primitives';
+import { Stack } from '@/ui/layout';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { useWallet } from '@/contexts/WalletProvider';
+import { useAuth } from '@/features/auth/AuthContext';
+import { useStores } from '@/services/useStores';
+import { useProducts } from '@/services';
+import { useTenant } from '@/contexts/TenantContext';
+import { useAppRouter } from '@/services/useAppRouter';
+import { useNotificationActions } from '@/components/NotificationContext';
+import { chainAdapter } from '@/services/chain';
+import { routes } from '@/utils/routes';
+import { Order, Store } from '@/types';
+import { errorLog } from '@/utils/logger';
+import {
+  CheckCircle2,
+  Circle,
+  PackagePlus,
+  ShoppingCart,
+  Store as StoreIcon,
+} from 'lucide-react-native';
+
+interface AdminOnboardingChecklistProps {
+  onAddProduct?: () => void;
+}
+
+interface StepConfig {
+  key: string;
+  title: string;
+  description: string;
+  completed: boolean;
+  actionLabel?: string;
+  onAction?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  helperText?: string | null;
+  Icon: React.ComponentType<{ size: number; color: string }>;
+}
+
+const StepRow: React.FC<{ step: StepConfig; colors: any }> = ({ step, colors }) => {
+  const StatusIcon = step.completed ? CheckCircle2 : step.Icon;
+  return (
+    <View style={styles.stepRow} accessibilityRole="summary">
+      <StatusIcon
+        size={22}
+        color={step.completed ? colors.gold : colors.text.secondary}
+        accessibilityElementsHidden
+      />
+      <View style={styles.stepBody}>
+        <Heading size="sm" style={{ color: colors.text.primary }}>
+          {step.title}
+        </Heading>
+        {step.loading && !step.completed ? (
+          <Skeleton height={12} width="80%" style={{ marginTop: 4 }} />
+        ) : (
+          <Text style={[styles.stepDescription, { color: colors.text.secondary }]}>
+            {step.description}
+          </Text>
+        )}
+        {step.helperText && !step.completed ? (
+          <Text style={[styles.helperText, { color: colors.status.warning }]}>
+            {step.helperText}
+          </Text>
+        ) : null}
+      </View>
+      {step.actionLabel ? (
+        <Button
+          title={step.actionLabel}
+          onPress={step.onAction}
+          disabled={step.disabled}
+          loading={step.loading}
+          style={styles.stepButton}
+        />
+      ) : null}
+    </View>
+  );
+};
+
+export default function AdminOnboardingChecklist({ onAddProduct }: AdminOnboardingChecklistProps) {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const { address, connect } = useWallet();
+  const { isStoreOwner } = useAuth();
+  const { tenantId } = useTenant();
+  const { push } = useAppRouter();
+  const { showNotification } = useNotificationActions();
+
+  const { data: stores = [], isLoading: storesLoading, refetch: refetchStores, isRefetching: storesRefetching } =
+    useStores('default');
+
+  const ownedStores = useMemo(() => {
+    if (!address) return [] as Store[];
+    const lower = address.toLowerCase();
+    return stores.filter((s) => s.owner?.toLowerCase() === lower);
+  }, [stores, address]);
+
+  const primaryStore = useMemo(() => {
+    if (tenantId) {
+      const match = ownedStores.find((s) => s.id === tenantId);
+      if (match) return match;
+    }
+    return ownedStores[0] ?? null;
+  }, [ownedStores, tenantId]);
+
+  const {
+    data: products = [],
+    isLoading: productsLoading,
+    refetch: refetchProducts,
+    isRefetching: productsRefetching,
+  } = useProducts(primaryStore?.id ?? null);
+
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [ordersLoading, setOrdersLoading] = useState(false);
+  const [ordersError, setOrdersError] = useState<string | null>(null);
+
+  const loadOrders = useCallback(async (): Promise<boolean> => {
+    if (!primaryStore?.id || !chainAdapter.listOrdersBySeller) {
+      setOrders([]);
+      return true;
+    }
+    setOrdersLoading(true);
+    setOrdersError(null);
+    try {
+      const list = await chainAdapter.listOrdersBySeller(
+        primaryStore.id,
+        primaryStore.owner || address || primaryStore.id,
+      );
+      setOrders(list);
+      return true;
+    } catch (err) {
+      errorLog('Failed to load onboarding order progress', err);
+      setOrdersError(
+        t('home.adminChecklistOrderError', 'Order history is temporarily unavailable. Try again shortly.'),
+      );
+      return false;
+    } finally {
+      setOrdersLoading(false);
+    }
+  }, [address, primaryStore, t]);
+
+  useEffect(() => {
+    void loadOrders();
+  }, [loadOrders]);
+
+  const isConnected = !!address;
+  const hasStore = ownedStores.length > 0;
+  const hasProduct = products.length > 0;
+  const hasCheckout = orders.length > 0;
+
+  const handleCreateStore = useCallback(() => {
+    if (!isConnected) {
+      connect();
+      return;
+    }
+    push(routes.createStore());
+  }, [connect, isConnected, push]);
+
+  const handleManageStore = useCallback(() => {
+    if (!primaryStore) return;
+    push(`/store/${primaryStore.id}/admin`);
+  }, [primaryStore, push]);
+
+  const handleManageProducts = useCallback(() => {
+    if (onAddProduct) {
+      onAddProduct();
+      return;
+    }
+    if (!primaryStore) return;
+    push(`/store/${primaryStore.id}/admin/products`);
+  }, [onAddProduct, primaryStore, push]);
+
+  const handleTestCheckout = useCallback(() => {
+    if (!primaryStore) return;
+    push(`/store/${primaryStore.id}`);
+  }, [primaryStore, push]);
+
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([refetchStores(), primaryStore?.id ? refetchProducts() : Promise.resolve()]);
+    const success = await loadOrders();
+    showNotification(
+      success ? t('common.updated', 'Updated') : t('common.warning', 'Warning'),
+      success
+        ? t('home.adminChecklistRefreshed', 'Progress refreshed successfully.')
+        : t('home.adminChecklistRefreshFailed', 'Some checklist data could not be refreshed.'),
+      success ? 'success' : 'warning',
+    );
+  }, [loadOrders, primaryStore?.id, refetchProducts, refetchStores, showNotification, t]);
+
+  const steps: StepConfig[] = [
+    {
+      key: 'connect',
+      title: t('home.adminChecklistConnectTitle', 'Connect your wallet'),
+      description: t(
+        'home.adminChecklistConnectDescription',
+        'Link your wallet to unlock store management tools.',
+      ),
+      completed: isConnected,
+      actionLabel: isConnected ? undefined : t('auth.login', 'Login'),
+      onAction: isConnected ? undefined : connect,
+      Icon: Circle,
+    },
+    {
+      key: 'store',
+      title: t('home.adminChecklistStoreTitle', 'Create your store'),
+      description: t(
+        'home.adminChecklistStoreDescription',
+        'Set your branding, fulfillment preferences and payout details.',
+      ),
+      completed: hasStore,
+      actionLabel: hasStore ? t('home.manageStore', 'Manage store') : t('home.create_store', 'Create Store'),
+      onAction: hasStore ? handleManageStore : handleCreateStore,
+      disabled: !isConnected,
+      loading: storesLoading || storesRefetching,
+      Icon: StoreIcon,
+    },
+    {
+      key: 'product',
+      title: t('home.adminChecklistProductTitle', 'Add your first product'),
+      description: t(
+        'home.adminChecklistProductDescription',
+        'Add pricing, inventory and rich media so shoppers can browse.',
+      ),
+      completed: hasProduct,
+      actionLabel: hasProduct
+        ? t('home.manageProducts', 'Manage products')
+        : t('home.addProduct', 'Add product'),
+      onAction: handleManageProducts,
+      disabled: !hasStore,
+      loading: productsLoading || productsRefetching,
+      Icon: PackagePlus,
+    },
+    {
+      key: 'checkout',
+      title: t('home.adminChecklistCheckoutTitle', 'Place a test order'),
+      description: t(
+        'home.adminChecklistCheckoutDescription',
+        'Verify that checkout, notifications and fulfillment work end-to-end.',
+      ),
+      completed: hasCheckout,
+      actionLabel: hasCheckout
+        ? t('navigation.orders', 'Orders')
+        : t('home.testCheckout', 'Open storefront'),
+      onAction: hasCheckout ? handleManageStore : handleTestCheckout,
+      disabled: !hasProduct,
+      loading: ordersLoading,
+      helperText: ordersError,
+      Icon: ShoppingCart,
+    },
+  ];
+
+  const shouldShow = isConnected || isStoreOwner || hasStore || onAddProduct;
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <Card style={styles.card}>
+      <Stack gap="spacer12">
+        <Stack gap="spacer4">
+          <Heading size="md" style={{ color: colors.text.primary }}>
+            {t('home.adminChecklistTitle', 'Store owner quickstart')}
+          </Heading>
+          <Text style={{ color: colors.text.secondary }}>
+            {t(
+              'home.adminChecklistSubtitle',
+              'Complete the guided steps below to go from configuration to first checkout.',
+            )}
+          </Text>
+        </Stack>
+        <Stack gap="spacer12">
+          {steps.map((step) => (
+            <StepRow key={step.key} step={step} colors={colors} />
+          ))}
+        </Stack>
+        <Button
+          title={t('common.reload', 'Reload')}
+          onPress={handleRefresh}
+          loading={storesRefetching || productsRefetching || ordersLoading}
+          style={styles.refreshButton}
+        />
+      </Stack>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: '100%',
+  },
+  stepRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  stepBody: {
+    flex: 1,
+    gap: 4,
+  },
+  stepDescription: {
+    fontSize: 12,
+  },
+  helperText: {
+    marginTop: 4,
+    fontSize: 12,
+  },
+  stepButton: {
+    marginTop: 4,
+  },
+  refreshButton: {
+    alignSelf: 'flex-start',
+  },
+});
+

--- a/src/features/home/components/ProductGrid.tsx
+++ b/src/features/home/components/ProductGrid.tsx
@@ -16,6 +16,9 @@ interface ProductGridProps {
   searchQuery: string;
   onAddProduct: () => void;
   loading?: boolean;
+  onProductPress?: (product: Product) => void;
+  refreshing?: boolean;
+  onRefresh?: () => void;
 }
 
 const rowStyles = StyleSheet.create({
@@ -23,11 +26,17 @@ const rowStyles = StyleSheet.create({
   card: { marginBottom: spacing.spacer12 },
 });
 
-const ProductRow = React.memo(({ item }: { item: Product }) => (
-  <View style={rowStyles.flex}>
-    <ProductCard product={item} style={rowStyles.card} />
-  </View>
-));
+const ProductRow = React.memo(
+  ({ item, onProductPress }: { item: Product; onProductPress?: (product: Product) => void }) => (
+    <View style={rowStyles.flex}>
+      <ProductCard
+        product={item}
+        onPress={onProductPress ? () => onProductPress(item) : undefined}
+        style={rowStyles.card}
+      />
+    </View>
+  ),
+);
 
 function ProductGrid({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,11 +48,16 @@ function ProductGrid({
   searchQuery,
   onAddProduct,
   loading,
+  onProductPress,
+  refreshing,
+  onRefresh,
 }: ProductGridProps) {
   const { t } = useLanguage();
   const renderItem = useCallback(
-    ({ item }: { item: Product }) => <ProductRow item={item} />,
-    []
+    ({ item }: { item: Product }) => (
+      <ProductRow item={item} onProductPress={onProductPress} />
+    ),
+    [onProductPress],
   );
 
   const keyExtractor = useCallback((item: Product) => item.id, []);
@@ -95,6 +109,8 @@ function ProductGrid({
       columnWrapperStyle={columnWrapperStyle}
       contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}
+      refreshing={refreshing}
+      onRefresh={onRefresh}
     />
   );
 }

--- a/src/features/home/screens/HomeProducts.tsx
+++ b/src/features/home/screens/HomeProducts.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useCallback } from 'react';
 import { Text, TouchableOpacity, useWindowDimensions } from 'react-native';
 import { ArrowUpDown, Plus } from 'lucide-react-native';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
@@ -8,6 +8,7 @@ import ProductGrid from '@/features/home/components/ProductGrid';
 import HomeServices from '@/features/home/components/HomeServices';
 import { Product } from '@/types';
 import { styles } from './HomeProducts.styles';
+import { useAppRouter } from '@/services/useAppRouter';
 
 type Props = {
   products: Product[];
@@ -33,6 +34,7 @@ export default function HomeProducts({
   const { width: windowWidth } = useWindowDimensions();
   const { t } = useLanguage();
   const { colors: themeColors } = useTheme();
+  const appRouter = useAppRouter();
 
   const getProductItemWidth = () => {
     if (windowWidth >= 1024) {
@@ -42,6 +44,14 @@ export default function HomeProducts({
     }
     return '48%';
   };
+
+  const handleProductPress = useCallback(
+    (product: Product) => {
+      if (!product.storeId) return;
+      appRouter.push(`/store/${product.storeId}/product/${product.id}`);
+    },
+    [appRouter],
+  );
 
   const getSortLabel = () => {
     switch (sortBy) {
@@ -104,6 +114,7 @@ export default function HomeProducts({
             searchQuery={searchQuery}
             onAddProduct={onAddProduct}
             loading={loading}
+            onProductPress={handleProductPress}
           />
         </Suspense>
       </Container>

--- a/src/features/products/components/ProductGrid.tsx
+++ b/src/features/products/components/ProductGrid.tsx
@@ -10,27 +10,39 @@ import { spacing } from '@/shared/ui/tokens';
 const rowStyles = StyleSheet.create({ flex: { flex: 1 } });
 
 const ProductRow = React.memo(
-  ({ item, borderColor }: { item: Product; borderColor: string }) => (
+  ({
+    item,
+    borderColor,
+    onProductPress,
+  }: { item: Product; borderColor: string; onProductPress?: (product: Product) => void }) => (
     <View style={rowStyles.flex}>
       <ProductCard
         key={item.id}
         product={item}
         style={{ marginBottom: spacing.spacer12, borderColor }}
+        onPress={onProductPress ? () => onProductPress(item) : undefined}
       />
     </View>
   )
 );
 
-function ProductGrid({ products }: { products: Product[] }) {
+interface ProductGridProps {
+  products: Product[];
+  refreshing?: boolean;
+  onRefresh?: () => void;
+  onProductPress?: (product: Product) => void;
+}
+
+function ProductGrid({ products, refreshing, onRefresh, onProductPress }: ProductGridProps) {
   const { colors } = useTheme();
   const { t } = useLanguage();
 
   const borderColor = colors.border.primary;
   const renderItem = useCallback(
     ({ item }: { item: Product }) => (
-      <ProductRow item={item} borderColor={borderColor} />
+      <ProductRow item={item} borderColor={borderColor} onProductPress={onProductPress} />
     ),
-    [borderColor]
+    [borderColor, onProductPress]
   );
 
   const keyExtractor = useCallback((item: Product) => item.id, []);
@@ -62,6 +74,8 @@ function ProductGrid({ products }: { products: Product[] }) {
       columnWrapperStyle={columnWrapperStyle}
       contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}
+      refreshing={refreshing}
+      onRefresh={onRefresh}
     />
   );
 }

--- a/src/features/products/hooks/useProductDetail.ts
+++ b/src/features/products/hooks/useProductDetail.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import CartService from '@/features/cart/services/cart';
 import { Product, PricingTier } from '@/types';
-import { chainAdapter } from '@/services/chain';
 import { useProduct } from './useProduct';
 import { useProductPricing } from '@/services/useProductPricing';
 import { useProductMedia } from '@/services/useProductMedia';
@@ -10,6 +9,9 @@ import eventBus from '@/services/eventBus';
 interface ProductDetailResult {
   product: Product | null;
   isLoading: boolean;
+  refreshing: boolean;
+  refresh: () => Promise<void>;
+  error: Error | null;
   quantity: number;
   incrementQuantity: () => void;
   decrementQuantity: () => void;
@@ -26,9 +28,14 @@ interface ProductDetailResult {
   notFound: boolean;
 }
 
-export function useProductDetail(id: string): ProductDetailResult {
-  const { data: fetchedProduct, isLoading } = useProduct(id);
-  const address = chainAdapter.useAccountId();
+export function useProductDetail(id: string, storeId?: string): ProductDetailResult {
+  const {
+    data: fetchedProduct,
+    isLoading,
+    refetch,
+    isRefetching,
+    error,
+  } = useProduct(id, storeId ?? 'default');
 
   const [product, setProduct] = useState<Product | null>(null);
   const [quantity, setQuantity] = useState(1);
@@ -39,19 +46,24 @@ export function useProductDetail(id: string): ProductDetailResult {
     useProductPricing(product, quantity);
   const { media, mainImageUri } = useProductMedia(product);
 
+  const fetchError = error instanceof Error ? error : error ? new Error(String(error)) : null;
+
   useEffect(() => {
     if (isLoading) return;
-    if (address && fetchedProduct && fetchedProduct.storeId !== address) {
-      setNotFound(true);
+    if (!fetchedProduct) {
       setProduct(null);
+      setNotFound(true);
       return;
     }
-    if (fetchedProduct) {
-      setProduct(fetchedProduct);
-      setNotFound(false);
-      eventBus.track('catalog.product_view', { productId: fetchedProduct.id });
+    if (storeId && fetchedProduct.storeId !== storeId) {
+      setProduct(null);
+      setNotFound(true);
+      return;
     }
-  }, [fetchedProduct, isLoading, address]);
+    setProduct(fetchedProduct);
+    setNotFound(false);
+    eventBus.track('catalog.product_view', { productId: fetchedProduct.id });
+  }, [fetchedProduct, isLoading, storeId]);
 
   useEffect(() => {
     if (!product) return;
@@ -95,6 +107,11 @@ export function useProductDetail(id: string): ProductDetailResult {
   return {
     product,
     isLoading,
+    refreshing: isRefetching,
+    refresh: async () => {
+      await refetch();
+    },
+    error: fetchError,
     quantity,
     incrementQuantity,
     decrementQuantity,

--- a/src/features/profile/components/ProfileOverview.tsx
+++ b/src/features/profile/components/ProfileOverview.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/ui/ThemeProvider';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useWallet } from '@/contexts/WalletProvider';
 import { chainAdapter } from '@/services/chain';
-import { Heading, Text, Card } from '@/ui/primitives';
+import { Heading, Text, Card, Button } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
 import { routes } from '@/utils/routes';
 import { listStores } from '@/features/stores/services/nearStores';
@@ -182,6 +182,16 @@ export default function ProfileOverview() {
               </Text>
             </TouchableOpacity>
           )}
+        </Stack>
+      </Card>
+      <Card>
+        <Stack gap="spacer8">
+          <Heading size="md">{t('profile.quickActions', 'Quick actions')}</Heading>
+          <Button title={t('navigation.orders', 'Orders')} onPress={handleViewOrders} />
+          <Button title={t('navigation.settings', 'Settings')} onPress={handleOpenSettings} />
+          {primaryStore ? (
+            <Button title={t('admin.dashboard', 'Store admin')} onPress={handleManageStore} />
+          ) : null}
         </Stack>
       </Card>
     </Stack>

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -38,6 +38,12 @@ const NAV_ITEMS: readonly NavItemConfig[] = [
     requiresAuth: true,
   },
   {
+    href: '/orders',
+    title: 'navigation.orders',
+    icon: 'Receipt',
+    requiresAuth: true,
+  },
+  {
     href: '/me',
     title: 'navigation.profile',
     icon: 'User',

--- a/src/services/chain/ChainAdapter.ts
+++ b/src/services/chain/ChainAdapter.ts
@@ -21,6 +21,8 @@ export interface ChainAdapter {
   signMessage?(message: Uint8Array | string): Promise<string>;
   /** List orders for a given seller */
   listOrdersBySeller?(storeId: string, sellerId: string): Promise<Order[]>;
+  /** List orders for a buyer across stores */
+  listOrdersByBuyer?(buyerId: string): Promise<Order[]>;
   /** Optional chain specific payment helper */
   payPrivately?(args: any): Promise<any>;
 }

--- a/src/services/chain/index.ts
+++ b/src/services/chain/index.ts
@@ -13,6 +13,7 @@ const unsupported: ChainAdapter = {
   async getBalance() { return '0'; },
   async signMessage() { throw new Error('Unsupported chain'); },
   async listOrdersBySeller() { throw new Error('Unsupported chain'); },
+  async listOrdersByBuyer() { throw new Error('Unsupported chain'); },
   async payPrivately() { throw new Error('Unsupported chain'); },
 };
 

--- a/src/services/chain/near.ts
+++ b/src/services/chain/near.ts
@@ -1,6 +1,6 @@
 import { init, signIn, signMessage, useAccount, useAccountId, getAccountId, getPublicKey, getSelector } from '@/services/walletSelector';
 import { payPrivately as nearPayPrivately } from '@blue-ocean/sdk-near';
-import { listOrdersBySeller as nearListOrdersBySeller } from '@/services/nearOrders';
+import { listOrdersBySeller as nearListOrdersBySeller, listOrdersByBuyer as nearListOrdersByBuyer } from '@/services/nearOrders';
 import { getNetworkId } from '@/services/config';
 import config from '@/config';
 import type { ChainAdapter } from './ChainAdapter';
@@ -43,6 +43,7 @@ export const nearAdapter: ChainAdapter = {
   getBalance,
   signMessage,
   listOrdersBySeller: nearListOrdersBySeller,
+  listOrdersByBuyer: nearListOrdersByBuyer,
   payPrivately: nearPayPrivately,
 };
 


### PR DESCRIPTION
## Summary
- add a buyer-facing orders screen with skeleton, empty, and refresh states backed by new chain adapter helpers
- introduce an admin onboarding checklist component and surface it on home and admin dashboards for guided setup
- add a product detail route with add-to-cart support while enhancing product grids, settings, profile, and navigation for the connect→store→product→checkout journey

## Testing
- yarn lint *(fails: Cannot find module '@typescript-eslint/parser')*
- yarn typecheck *(fails: missing type definition files and expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b06b4f2c83269d332e35232d4f24