### PR TITLE
Add secure checkout session guards and scope enforcement

### DIFF
--- a/services/checkoutGuard.ts
+++ b/services/checkoutGuard.ts
@@ -1,0 +1,124 @@
+import { Buffer } from 'buffer';
+import { verify } from '@noble/ed25519';
+import { utils as nearUtils } from 'near-api-js';
+import { chainAdapter } from '@/services/chain';
+import { getUser } from '@/features/auth/services/nearUsers';
+import { getSession, validateToken, SessionToken } from '@/services/session';
+import type { User, UserRole } from '@/types';
+
+const ALLOWED_ROLES: ReadonlySet<UserRole> = new Set([
+  'user',
+  'driver',
+  'store-owner',
+  'admin',
+  'platform-admin',
+]);
+
+function normalizePublicKey(value?: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.startsWith('ed25519:') ? trimmed.slice(8) : trimmed;
+}
+
+function decodeSignature(signature: string): Uint8Array {
+  const trimmed = signature.trim();
+  if (!trimmed) throw new Error('{E_SESSION_PROOF}');
+  const withoutPrefix = trimmed.startsWith('0x') ? trimmed.slice(2) : trimmed;
+  if (/^[0-9a-fA-F]+$/.test(withoutPrefix) && withoutPrefix.length % 2 === 0) {
+    return Uint8Array.from(Buffer.from(withoutPrefix, 'hex'));
+  }
+  if (/^[A-Za-z0-9+/=]+$/.test(trimmed) && trimmed.length >= 8) {
+    try {
+      const buf = Buffer.from(trimmed, 'base64');
+      if (buf.length) return Uint8Array.from(buf);
+    } catch {}
+  }
+  try {
+    return nearUtils.serialize.base_decode(trimmed);
+  } catch {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+}
+
+async function ensureSignature(record: SessionToken, publicKey: string): Promise<void> {
+  const sealed = record.sealed;
+  if (!sealed) throw new Error('{E_SESSION_PROOF}');
+  const message = Buffer.from(sealed.cipher, 'utf8');
+  const signature = decodeSignature(record.token);
+  if (signature.length !== 64) throw new Error('{E_SESSION_PROOF}');
+  let publicKeyBytes: Uint8Array;
+  try {
+    publicKeyBytes = nearUtils.serialize.base_decode(publicKey);
+  } catch {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+  if (publicKeyBytes.length !== 32) throw new Error('{E_SESSION_PROOF}');
+  const ok = await verify(signature, message, publicKeyBytes);
+  if (!ok) throw new Error('{E_SESSION_PROOF}');
+}
+
+function ensureRole(user: User | null, userId: string): User {
+  if (!user) throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  if (user.address && user.address !== userId) {
+    throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  }
+  if (user.customerTier === 'banned') {
+    throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  }
+  const role = user.role ?? 'user';
+  if (!ALLOWED_ROLES.has(role)) {
+    throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  }
+  return user;
+}
+
+export interface CheckoutSessionContext {
+  token: string;
+  user: User;
+  walletPublicKey: string;
+}
+
+interface CheckoutSessionOptions {
+  user?: User | null;
+}
+
+export async function assertCheckoutSession(
+  userId: string,
+  token: string,
+  options: CheckoutSessionOptions = {},
+): Promise<CheckoutSessionContext> {
+  if (!userId) throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  validateToken(token, ['checkout']);
+  const record = getSession(token);
+  if (!record || !record.sealed) {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+
+  const normalizedKey = normalizePublicKey(record.sealed.walletPublicKey);
+  if (!normalizedKey) {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+  await ensureSignature(record, normalizedKey);
+
+  const adapterKey = normalizePublicKey(chainAdapter.getPublicKey?.());
+  if (adapterKey && adapterKey !== normalizedKey) {
+    throw new Error('{E_SESSION_PROOF}');
+  }
+
+  const currentAccount = chainAdapter.getAccountId?.();
+  if (currentAccount && currentAccount !== userId) {
+    throw new Error('{E_CHECKOUT_FORBIDDEN}');
+  }
+
+  let profile = options.user ?? null;
+  if (profile && profile.id !== userId) {
+    profile = null;
+  }
+  if (!profile) {
+    profile = await getUser(userId);
+  }
+  const user = ensureRole(profile, userId);
+
+  return { token, user, walletPublicKey: normalizedKey };
+}

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -17,9 +17,12 @@ import { chainAdapter } from '@/services/chain';
 import { adminResolve, deployOrderPayment } from './nearContract';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
-import { validateToken } from '@/services/session';
 import { checkoutTokenIntegrity } from '@/services/monitoring';
 import SettingsAgent from '@/agents/settings-agent';
+import {
+  assertCheckoutSession,
+  type CheckoutSessionContext,
+} from '@/services/checkoutGuard';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
@@ -127,8 +130,15 @@ class OrderService {
       sellerAddress?: string;
     },
     sessionToken: string,
+    checkout?: CheckoutSessionContext,
   ): Promise<Order> {
-    validateToken(sessionToken, ['write']);
+    const guard =
+      checkout && checkout.token === sessionToken
+        ? checkout
+        : await assertCheckoutSession(userId, sessionToken, {
+            user: checkout?.user,
+          });
+    const buyerHint = guard.user.address || guard.user.id;
     const total = items.reduce((sum, item) => {
       const price = item.unitPrice ?? item.product.price;
       return sum + price * item.quantity;
@@ -144,7 +154,11 @@ class OrderService {
     }
 
     if (!pay?.buyerAddress) {
-      pay = { ...pay, buyerAddress: chainAdapter.getAccountId() || undefined };
+      const account = chainAdapter.getAccountId();
+      pay = {
+        ...pay,
+        buyerAddress: account || buyerHint || undefined,
+      };
     }
 
     const orderId = uuid();
@@ -162,7 +176,7 @@ class OrderService {
       total,
       status: 'order_received',
       shippingAddress,
-       itemsHash,
+      itemsHash,
       paymentMethod: pay?.method ?? 'cash_on_delivery',
       buyerAddress: pay?.buyerAddress,
       sellerAddress: pay?.sellerAddress,
@@ -190,13 +204,10 @@ class OrderService {
     paymentMethod: 'cash_on_delivery' | 'near' | 'card' = 'cash_on_delivery',
     sessionToken: string,
   ): Promise<Order[]> {
+    let checkoutGuard: CheckoutSessionContext;
     try {
-      validateToken(sessionToken, ['write']);
+      checkoutGuard = await assertCheckoutSession(userId, sessionToken);
     } catch (err) {
-      void eventBus.track('checkout.token_integrity', {
-        tokenValid: false,
-        success: false,
-      });
       checkoutTokenIntegrity.inc({ token_valid: 'false', success: 'false' });
       throw err;
     }
@@ -215,18 +226,30 @@ class OrderService {
           paymentMethod === 'near'
             ? {
                 method: 'near' as const,
-                buyerAddress: chainAdapter.getAccountId() || undefined,
+                buyerAddress:
+                  chainAdapter.getAccountId() ||
+                  checkoutGuard.user.address ||
+                  checkoutGuard.user.id ||
+                  undefined,
                 sellerAddress: store?.owner,
               }
             : paymentMethod === 'card'
             ? {
                 method: 'card' as const,
-                buyerAddress: chainAdapter.getAccountId() || undefined,
+                buyerAddress:
+                  chainAdapter.getAccountId() ||
+                  checkoutGuard.user.address ||
+                  checkoutGuard.user.id ||
+                  undefined,
                 sellerAddress: store?.owner,
               }
             : {
                 method: 'cash_on_delivery' as const,
-                buyerAddress: chainAdapter.getAccountId() || undefined,
+                buyerAddress:
+                  chainAdapter.getAccountId() ||
+                  checkoutGuard.user.address ||
+                  checkoutGuard.user.id ||
+                  undefined,
                 sellerAddress: store?.owner,
               };
         const order = await this.createOrder(
@@ -235,21 +258,14 @@ class OrderService {
           shippingAddress,
           payment,
           sessionToken,
+          checkoutGuard,
         );
         await emitOrderEvents(order, storeId, sessionToken);
         orders.push(order);
       }
-      void eventBus.track('checkout.token_integrity', {
-        tokenValid: true,
-        success: true,
-      });
       checkoutTokenIntegrity.inc({ token_valid: 'true', success: 'true' });
       return orders;
     } catch (err) {
-      void eventBus.track('checkout.token_integrity', {
-        tokenValid: true,
-        success: false,
-      });
       checkoutTokenIntegrity.inc({ token_valid: 'true', success: 'false' });
       throw err;
     }

--- a/services/session.ts
+++ b/services/session.ts
@@ -10,7 +10,7 @@ import {
 
 export const sessionEvents = new EventEmitter();
 
-const POLICY = new Set<string>(['read', 'write']);
+const POLICY = new Set<string>(['read', 'write', 'checkout']);
 
 // Allow a small amount of clock skew when validating expirations
 const CLOCK_TOLERANCE_MS = 60 * 1000; // 1 minute
@@ -88,11 +88,15 @@ export function requestScopes(
   const now = Date.now();
   const exp = ttlMs < 0 ? now - CLOCK_TOLERANCE_MS - 1 : now + ttlMs;
   const payload = JSON.stringify({ scopes, exp });
+  const requiresProof = scopes.includes('checkout');
 
   const persist = (maybeToken: string | undefined): SessionToken => {
     const token = maybeToken || uuid();
     const sealed =
       typeof options.sealed === 'function' ? options.sealed() : options.sealed;
+    if (requiresProof && (!sealed || !sealed.walletPublicKey || !sealed.identityPublicKey)) {
+      throw new Error('{E_SESSION_PROOF}');
+    }
     const record: SessionToken = sealed
       ? { token, scopes, exp, sealed }
       : { token, scopes, exp };
@@ -149,6 +153,12 @@ export function validateToken(token: string, requiredScopes: string[]): void {
   validateScopes(requiredScopes);
   const missing = requiredScopes.find((s) => !rec.scopes.includes(s));
   if (missing) throw new Error('{E_SCOPE}');
+  if (requiredScopes.includes('checkout')) {
+    const sealed = rec.sealed;
+    if (!sealed || !sealed.cipher || !sealed.walletPublicKey || !sealed.identityPublicKey) {
+      throw new Error('{E_SESSION_PROOF}');
+    }
+  }
 }
 
 export function refreshToken(

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -164,7 +164,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const login = async () => {
     try {
       await connect();
-      const session = await loginWithWallet(['write']);
+      const session = await loginWithWallet(['checkout']);
       setSessionToken(session.token);
     } catch (err: unknown) {
       errorLog(

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -36,9 +36,7 @@ if (chain === 'near') {
 }
 
 import OrderService from '@/services/orders';
-import eventBus from '@/services/eventBus';
 import { Spinner } from '@/ui/primitives';
-import { getCacheHitRatio } from '@/services/warmCache';
 const MoonPayButton = require('@/features/payments').MoonPayButton;
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '@/ui/ThemeProvider';
@@ -49,11 +47,7 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
-import { requestTokenWithConsent } from '@/services/session';
-import { uuid } from '@/utils/uuid';
-import NotificationService from '@/services/notification';
-
-const PRODUCT_CACHE_TOPIC = '/blue-ocean/products/1';
+import { useWalletSessions } from '@/auth/wallet';
 
 interface CartModalProps {
   visible: boolean;
@@ -77,7 +71,8 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const [loading, setLoading] = useState(false);
   const [orderPlaced, setOrderPlaced] = useState(false);
   const [orderIds, setOrderIds] = useState<string[]>([]);
-  const { isLoggedIn, user } = useAuth();
+  const { isLoggedIn, user, sessionToken: authSessionToken, refreshSession } = useAuth();
+  const { useToken } = useWalletSessions();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
   const { showNotification } = useNotifications();
@@ -101,13 +96,29 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     action: () => {},
   });
 
-  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [checkoutToken, setCheckoutToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authSessionToken) {
+      setCheckoutToken(authSessionToken);
+    }
+  }, [authSessionToken]);
 
   const ensureSessionToken = async (): Promise<string> => {
-    if (sessionToken) return sessionToken;
-    const { token } = await requestTokenWithConsent(['write'], () => uuid());
-    setSessionToken(token);
-    return token;
+    const base = authSessionToken || checkoutToken;
+    if (!base) {
+      throw new Error('{E_EXPIRED}');
+    }
+    try {
+      const next = await useToken(base, ['checkout']);
+      setCheckoutToken(next.token);
+      return next.token;
+    } catch (err: any) {
+      if (err?.message === '{E_EXPIRED}') {
+        await refreshSession();
+      }
+      throw err;
+    }
   };
 
 
@@ -215,7 +226,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       return;
     }
 
-    eventBus.track('checkout.start', { items: cartItems.length, total: getTotal() });
     setCheckoutStep('shipping');
   };
 
@@ -295,12 +305,6 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         'near',
         token,
       );
-      eventBus.track('checkout.complete', {
-        orderIds: orders.map((o) => o.id),
-        total: getTotal(),
-        cacheHitRatio: getCacheHitRatio(PRODUCT_CACHE_TOPIC),
-        sourceNotificationId: NotificationService.getInstance().getLastOpenedNotificationId(),
-      });
       setOrderIds(orders.map((o) => o.id));
       setOrderPlaced(true);
       await clearCart();
@@ -313,7 +317,12 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
 
       setTimeout(() => onClose(), 5000);
     } catch (error: any) {
-      if (error?.message === '{E_EXPIRED}' || error?.message === '{E_SCOPE}') {
+      if (
+        error?.message === '{E_EXPIRED}' ||
+        error?.message === '{E_SCOPE}' ||
+        error?.message === '{E_SESSION_PROOF}' ||
+        error?.message === '{E_CHECKOUT_FORBIDDEN}'
+      ) {
         setInfoModal({
           visible: true,
           title: t('common.error'),

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -1,15 +1,38 @@
+import { Buffer } from 'buffer';
+import { getPublicKey, sign } from '@noble/ed25519';
+import { utils as nearUtils } from 'near-api-js';
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { AuthProvider, useAuth } from '@/features/auth/AuthContext';
 import OrderService from '@/services/orders';
 import { CartItem, ShippingAddress } from '@/types';
 
+const walletSecretKey = Uint8Array.from({ length: 32 }, (_, i) => 7 + i);
+let walletPublicKeyStr = 'ed25519:';
+
 jest.mock('@/contexts/WalletProvider', () => ({
   useWallet: () => ({
     address: 'buyer.near',
     connect: jest.fn().mockResolvedValue(undefined),
     disconnect: jest.fn().mockResolvedValue(undefined),
+    sign: jest.fn(async (message: Uint8Array | string) => {
+      const bytes = typeof message === 'string' ? Buffer.from(message) : Buffer.from(message);
+      const sig = await sign(bytes, walletSecretKey);
+      return Buffer.from(sig).toString('base64');
+    }),
   }),
+}));
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    init: jest.fn(async () => ({})),
+    useAccount: jest.fn(() => 'buyer.near'),
+    openModal: jest.fn(),
+    getSelector: jest.fn(() => ({ wallet: async () => ({ signOut: jest.fn() }) })),
+    getAccountId: jest.fn(() => 'buyer.near'),
+    getPublicKey: jest.fn(() => walletPublicKeyStr),
+    signMessage: jest.fn(),
+  },
 }));
 
 const store: Record<string, any> = {};
@@ -23,9 +46,18 @@ jest.mock('@/services/nearOrders', () => ({
 
 jest.mock('@/services/eventBus', () => ({ publish: jest.fn(), track: jest.fn() }));
 
-jest.mock('@/features/auth/services/nearAuth', () => ({
-  getAccountId: jest.fn().mockReturnValue('buyer.near'),
-  signIn: jest.fn(),
+jest.mock('@/features/auth/services/nearUsers', () => ({
+  getUser: jest.fn(async (id: string) => ({
+    id,
+    username: id,
+    displayName: id,
+    isAdmin: false,
+    role: 'user',
+    address: id,
+    chatPublicKey: '',
+    customerTier: 'regular' as const,
+  })),
+  setUser: jest.fn(),
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => ({
@@ -51,6 +83,11 @@ jest.mock('../../agents/orders-agent', () => ({
     update: jest.fn(),
   },
 }));
+
+beforeAll(async () => {
+  const publicKey = await getPublicKey(walletSecretKey);
+  walletPublicKeyStr = `ed25519:${nearUtils.serialize.base_encode(publicKey)}`;
+});
 
 function Grab() {
   (Grab as any).ctx = useAuth();
@@ -99,7 +136,7 @@ describe('login issues session token used in checkout', () => {
       postalCode: 'p',
     };
 
-    await svc.createOrdersFromCart('user1', [item], shipping, 'cash_on_delivery', ctx.sessionToken!);
+    await svc.createOrdersFromCart('buyer.near', [item], shipping, 'cash_on_delivery', ctx.sessionToken!);
 
     expect(addMock).toHaveBeenCalled();
     const passedOrder = addMock.mock.calls[0][0];

--- a/tests/auth/session.spec.ts
+++ b/tests/auth/session.spec.ts
@@ -7,6 +7,10 @@ describe('session scope validation', () => {
     expect(() => requestScopes(['foo'], signer)).toThrow('{E_SCOPE}');
   });
 
+  it('requires sealed payload for checkout scope', () => {
+    expect(() => requestScopes(['checkout'], signer)).toThrow('{E_SESSION_PROOF}');
+  });
+
   it('throws on validating with unknown scopes', () => {
     const { token } = requestScopes(['read'], signer);
     expect(() => validateToken(token, ['foo'])).toThrow('{E_SCOPE}');

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -1,9 +1,24 @@
+import { Buffer } from 'buffer';
+import { getPublicKey, sign } from '@noble/ed25519';
+import { utils as nearUtils } from 'near-api-js';
 import OrderService from '@/services/orders';
 import { CartItem, ShippingAddress } from '../types';
 import { requestScopes } from '@/services/session';
 
+const walletSecretKey = Uint8Array.from({ length: 32 }, (_, i) => i + 1);
+let walletPublicKeyStr = 'ed25519:';
+
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    getAccountId: jest.fn(() => 'buyer.near'),
+    openModal: jest.fn(),
+    getPublicKey: jest.fn(() => walletPublicKeyStr),
+    signMessage: jest.fn(),
+  },
+}));
 
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
@@ -19,6 +34,19 @@ jest.mock('@/services/nearContract', () => ({
   deployOrderPayment: jest.fn(),
   releasePayment: jest.fn(),
   refundPayment: jest.fn(),
+}));
+
+jest.mock('@/features/auth/services/nearUsers', () => ({
+  getUser: jest.fn(async (id: string) => ({
+    id,
+    username: id,
+    displayName: id,
+    isAdmin: false,
+    role: 'user',
+    address: id,
+    chatPublicKey: '',
+    customerTier: 'regular' as const,
+  })),
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => ({
@@ -42,14 +70,51 @@ jest.mock('../agents/orders-agent', () => ({
   update: jest.fn(),
 }));
 
-jest.mock('@/features/auth/services/nearAuth', () => ({
-  getAccountId: jest.fn().mockReturnValue('buyer_address'),
-  signIn: jest.fn(),
-}));
-
 jest.mock('@/constants/tenant', () => ({
   getFeeSettings: jest.fn().mockResolvedValue({ feeAddress: 'fee_addr', feeBps: 250 }),
 }));
+
+beforeAll(async () => {
+  const publicKey = await getPublicKey(walletSecretKey);
+  walletPublicKeyStr = `ed25519:${nearUtils.serialize.base_encode(publicKey)}`;
+});
+
+async function issueCheckoutToken(): Promise<string> {
+  let sealed: { cipher: string; walletPublicKey: string; identityPublicKey: string } | undefined;
+  const session = await requestScopes(
+    ['checkout'],
+    async (payload) => {
+      sealed = {
+        cipher: payload,
+        walletPublicKey: walletPublicKeyStr,
+        identityPublicKey: 'identity',
+      };
+      const sig = await sign(Buffer.from(sealed.cipher), walletSecretKey);
+      return Buffer.from(sig).toString('base64');
+    },
+    undefined,
+    { sealed: () => sealed },
+  );
+  return session.token;
+}
+
+async function issueInvalidCheckoutToken(): Promise<string> {
+  let sealed: { cipher: string; walletPublicKey: string; identityPublicKey: string } | undefined;
+  const session = await requestScopes(
+    ['checkout'],
+    async (payload) => {
+      sealed = {
+        cipher: payload,
+        walletPublicKey: walletPublicKeyStr,
+        identityPublicKey: 'identity',
+      };
+      return 'deadbeef';
+    },
+    undefined,
+    { sealed: () => sealed },
+  );
+  return session.token;
+}
 
 describe('card checkout fee deduction', () => {
   it('deducts platform fee for card payments', async () => {
@@ -90,13 +155,57 @@ describe('card checkout fee deduction', () => {
       postalCode: 'p',
     };
 
-    const { token } = requestScopes(['write'], () => 'sig');
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'card', token);
+    const token = await issueCheckoutToken();
+    const orders = await svc.createOrdersFromCart('buyer.near', items, shipping, 'card', token);
     expect(orders).toHaveLength(1);
     const order = orders[0];
     expect(order.total).toBe(100);
     expect(order.platformFee).toBeCloseTo(2.5);
     expect(order.sellerPayout).toBeCloseTo(97.5);
+  });
+
+  it('rejects card payments when checkout signature is invalid', async () => {
+    jest
+      .spyOn<any, any>(OrderService.prototype as any, 'simulateOrderProgress')
+      .mockImplementation(() => {});
+
+    const svc = OrderService.getInstance();
+
+    const items: CartItem[] = [
+      {
+        id: 'i1',
+        productId: 'p1',
+        product: {
+          id: 'p1',
+          name: 'P1',
+          price: 100,
+          description: 'd',
+          category: 'c',
+          images: [],
+          rating: 0,
+          reviews: 0,
+          storeId: 's1',
+          stock: 10,
+        },
+        quantity: 1,
+        addedAt: '',
+      },
+    ];
+
+    mockProducts['p1'] = { ...items[0].product };
+
+    const shipping: ShippingAddress = {
+      name: 'A',
+      phone: '1',
+      street: 'st',
+      city: 'c',
+      postalCode: 'p',
+    };
+
+    const token = await issueInvalidCheckoutToken();
+    await expect(
+      svc.createOrdersFromCart('buyer.near', items, shipping, 'card', token),
+    ).rejects.toThrow('{E_SESSION_PROOF}');
   });
 });
 

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -1,10 +1,25 @@
+import { Buffer } from 'buffer';
+import { getPublicKey, sign } from '@noble/ed25519';
+import { utils as nearUtils } from 'near-api-js';
 import OrderService from '@/services/orders';
 import { deployOrderPayment } from '@/services/nearContract';
 import { CartItem, ShippingAddress } from '../types';
 import { requestScopes } from '@/services/session';
 
+const walletSecretKey = Uint8Array.from({ length: 32 }, (_, i) => 32 - i);
+let walletPublicKeyStr = 'ed25519:';
+
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    getAccountId: jest.fn(() => 'buyer.near'),
+    openModal: jest.fn(),
+    getPublicKey: jest.fn(() => walletPublicKeyStr),
+    signMessage: jest.fn(),
+  },
+}));
 
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
@@ -28,7 +43,16 @@ jest.mock('@/services/nearContract', () => ({
 }));
 
 jest.mock('@/features/auth/services/nearUsers', () => ({
-  getUser: jest.fn().mockResolvedValue({ publicKey: 'a'.repeat(64) }),
+  getUser: jest.fn(async (id: string) => ({
+    id,
+    username: id,
+    displayName: id,
+    isAdmin: false,
+    role: 'user',
+    address: id,
+    chatPublicKey: '',
+    customerTier: 'regular' as const,
+  })),
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => ({
@@ -52,10 +76,29 @@ jest.mock('../agents/orders-agent', () => ({
   update: jest.fn(),
 }));
 
-jest.mock('@/features/auth/services/nearAuth', () => ({
-  getAccountId: jest.fn().mockReturnValue('buyer_address'),
-  signIn: jest.fn(),
-}));
+beforeAll(async () => {
+  const publicKey = await getPublicKey(walletSecretKey);
+  walletPublicKeyStr = `ed25519:${nearUtils.serialize.base_encode(publicKey)}`;
+});
+
+async function issueCheckoutToken(): Promise<string> {
+  let sealed: { cipher: string; walletPublicKey: string; identityPublicKey: string } | undefined;
+  const session = await requestScopes(
+    ['checkout'],
+    async (payload) => {
+      sealed = {
+        cipher: payload,
+        walletPublicKey: walletPublicKeyStr,
+        identityPublicKey: 'identity',
+      };
+      const sig = await sign(Buffer.from(sealed.cipher), walletSecretKey);
+      return Buffer.from(sig).toString('base64');
+    },
+    undefined,
+    { sealed: () => sealed },
+  );
+  return session.token;
+}
 
 describe('multi-seller checkout flow', () => {
   it('creates separate orders per seller with near payment', async () => {
@@ -115,8 +158,8 @@ describe('multi-seller checkout flow', () => {
       postalCode: 'p',
     };
 
-    const { token } = requestScopes(['write'], () => 'sig');
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'near', token);
+    const token = await issueCheckoutToken();
+    const orders = await svc.createOrdersFromCart('buyer.near', items, shipping, 'near', token);
     expect(orders).toHaveLength(2);
     expect(deployOrderPayment).toHaveBeenCalledTimes(2);
     const totals = orders.map((o) => o.total).sort();
@@ -141,7 +184,7 @@ describe('multi-seller checkout flow', () => {
     const firstPayload = eventBus.publish.mock.calls[0][2];
     expect(firstPayload.orderId).toBe(orders[0].id);
     expect(firstPayload.storeId).toBe('s1');
-    expect(firstPayload.buyerAddress).toBe('buyer_address');
+    expect(firstPayload.buyerAddress).toBe('buyer.near');
     expect(firstPayload.sellerAddress).toBe('seller_s1');
     expect(firstPayload.payment.method).toBe('near');
     expect(firstPayload.payment.contractAddress).toBe('escrow_5');


### PR DESCRIPTION
## Summary
- add a checkout session guard that validates signed wallet scopes and user roles
- require checkout scope proof storage and update orders service to enforce the guard while removing telemetry calls
- request checkout tokens during auth/login and rotate them in the cart flow while updating related tests to use real signatures

## Testing
- npx jest tests/auth/session.spec.ts *(fails: missing ts-jest preset because dependencies require Node >=22)*
- YARN_IGNORE_NODE=1 yarn install --no-progress --silent --ignore-engines *(fails: @waku/core requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b03f55d0832681f9d070994688e8