### PR TITLE
Add throttled search bar using local index service

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 // TOUCHPOINT: app/index.tsx renders in production — Fix Pack v2
-import React, { Suspense, useCallback, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -24,6 +24,7 @@ import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
 import ProductGrid from '@/features/home/components/ProductGrid';
 import CategoryCard from '@/features/home/components/CategoryCard';
+import SearchBar from '@/features/home/components/SearchBar';
 import { Spinner, Heading } from '@/ui/primitives';
 import EmptyState from '@/shared/ui/EmptyState';
 import { CartModal } from '@/features/cart';
@@ -38,6 +39,7 @@ import ErrorBoundary from 'src/shared/ErrorBoundary';
 import HomeError from '@/features/home/screens/HomeError';
 import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 import { useAppRouter } from '@/services/useAppRouter';
+import { localIndex } from '@/services/localIndex';
 
 function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
@@ -75,6 +77,8 @@ function HomeScreenContent() {
   const {
     filteredProducts,
     searchQuery,
+    setSearchQuery,
+    applySearchResults,
     selectedCategory,
     setSelectedCategory,
     minPrice,
@@ -86,6 +90,62 @@ function HomeScreenContent() {
     showSortModal,
     setShowSortModal,
   } = useHomeFilters(products);
+
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSearchRunRef = useRef(0);
+  const latestSearchValueRef = useRef(searchQuery);
+
+  useEffect(() => {
+    latestSearchValueRef.current = searchQuery;
+  }, [searchQuery]);
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchQuery(value);
+      latestSearchValueRef.current = value;
+
+      const invoke = async () => {
+        const queryText = latestSearchValueRef.current;
+        try {
+          const result = await localIndex.query(queryText);
+          applySearchResults(queryText, result);
+        } catch {
+          applySearchResults(queryText, {
+            products: [...products],
+            total: products.length,
+          });
+        }
+      };
+
+      const now = Date.now();
+      const elapsed = now - lastSearchRunRef.current;
+      const wait = 150;
+
+      if (elapsed >= wait) {
+        lastSearchRunRef.current = now;
+        if (searchTimeoutRef.current) {
+          clearTimeout(searchTimeoutRef.current);
+          searchTimeoutRef.current = null;
+        }
+        void invoke();
+      } else if (!searchTimeoutRef.current) {
+        searchTimeoutRef.current = setTimeout(() => {
+          lastSearchRunRef.current = Date.now();
+          searchTimeoutRef.current = null;
+          void invoke();
+        }, wait - elapsed);
+      }
+    },
+    [applySearchResults, products, setSearchQuery],
+  );
 
   const getProductItemWidth = () => {
     if (windowWidth >= 1024) {
@@ -326,6 +386,11 @@ function HomeScreenContent() {
               )}
             </Stack>
           </Stack>
+
+          <SearchBar
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+          />
 
           <Suspense fallback={<Spinner />}>
             <ProductGrid

--- a/services/localIndex.ts
+++ b/services/localIndex.ts
@@ -1,0 +1,62 @@
+import Fuse from 'fuse.js';
+import type { Product } from '@/types';
+
+export interface ResultSet {
+  products: Product[];
+  total: number;
+}
+
+class LocalIndex {
+  private fuse: Fuse<Product> | null = null;
+
+  private products: Product[] = [];
+
+  setProducts(products: Product[]) {
+    this.products = products;
+    if (products.length === 0) {
+      this.fuse = null;
+      return;
+    }
+
+    this.fuse = new Fuse(products, {
+      keys: [
+        'name',
+        'name_en',
+        'name_he',
+        'description',
+        'description_en',
+        'description_he',
+        'category',
+      ],
+      threshold: 0.3,
+      ignoreLocation: true,
+    });
+  }
+
+  async query(text: string): Promise<ResultSet> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return {
+        products: [...this.products],
+        total: this.products.length,
+      };
+    }
+
+    if (!this.fuse) {
+      return {
+        products: [],
+        total: 0,
+      };
+    }
+
+    const matches = this.fuse.search(trimmed);
+    const products = matches.map((match) => match.item);
+
+    return {
+      products,
+      total: products.length,
+    };
+  }
+}
+
+export const localIndex = new LocalIndex();

--- a/src/features/home/hooks/useHomeFilters.ts
+++ b/src/features/home/hooks/useHomeFilters.ts
@@ -1,27 +1,56 @@
-import { useState, useMemo } from 'react';
-import { Product } from '@/types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Product } from '@/types';
+import { localIndex, type ResultSet } from '@/services/localIndex';
 
 export type SortOption = 'newest' | 'price-low' | 'price-high' | 'rating';
 
 export function useHomeFilters(products: Product[]) {
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Product[]>(products);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
   const [sortBy, setSortBy] = useState<SortOption>('newest');
   const [showSortModal, setShowSortModal] = useState(false);
 
-  const filteredProducts = useMemo(() => {
-    let filtered = products;
+  const queryRef = useRef(searchQuery);
 
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (product) =>
-          product.name.toLowerCase().includes(q) ||
-          product.category.toLowerCase().includes(q),
-      );
-    }
+  useEffect(() => {
+    queryRef.current = searchQuery;
+  }, [searchQuery]);
+
+  useEffect(() => {
+    localIndex.setProducts(products);
+
+    let active = true;
+    const syncResults = async () => {
+      try {
+        const { products: results } = await localIndex.query(queryRef.current);
+        if (!active) return;
+        setSearchResults(results);
+      } catch {
+        if (!active) return;
+        setSearchResults([...products]);
+      }
+    };
+
+    void syncResults();
+
+    return () => {
+      active = false;
+    };
+  }, [products]);
+
+  const applySearchResults = useCallback(
+    (query: string, resultSet: ResultSet) => {
+      setSearchQuery(query);
+      setSearchResults(resultSet.products);
+    },
+    [],
+  );
+
+  const filteredProducts = useMemo(() => {
+    let filtered = searchResults;
 
     if (selectedCategory) {
       filtered = filtered.filter((p) => p.category === selectedCategory);
@@ -29,14 +58,14 @@ export function useHomeFilters(products: Product[]) {
 
     const min = parseFloat(minPrice);
     const max = parseFloat(maxPrice);
-    if (!isNaN(min)) {
+    if (!Number.isNaN(min)) {
       filtered = filtered.filter((p) => p.price >= min);
     }
-    if (!isNaN(max)) {
+    if (!Number.isNaN(max)) {
       filtered = filtered.filter((p) => p.price <= max);
     }
 
-    filtered = [...filtered].sort((a, b) => {
+    return [...filtered].sort((a, b) => {
       switch (sortBy) {
         case 'price-low':
           return a.price - b.price;
@@ -52,14 +81,13 @@ export function useHomeFilters(products: Product[]) {
           );
       }
     });
-
-    return filtered;
-  }, [products, searchQuery, selectedCategory, minPrice, maxPrice, sortBy]);
+  }, [searchResults, selectedCategory, minPrice, maxPrice, sortBy]);
 
   return {
     filteredProducts,
     searchQuery,
     setSearchQuery,
+    applySearchResults,
     selectedCategory,
     setSelectedCategory,
     minPrice,

--- a/tests/homeErrorBoundary.test.tsx
+++ b/tests/homeErrorBoundary.test.tsx
@@ -96,6 +96,7 @@ jest.mock('@features/home/hooks/useHomeFilters', () => ({
     filteredProducts: [],
     searchQuery: '',
     setSearchQuery: jest.fn(),
+    applySearchResults: jest.fn(),
     selectedCategory: null,
     setSelectedCategory: jest.fn(),
     minPrice: '',

--- a/tests/homeFallbackVisibility.test.tsx
+++ b/tests/homeFallbackVisibility.test.tsx
@@ -109,6 +109,7 @@ jest.mock('@/features/home/hooks/useHomeFilters', () => ({
     filteredProducts: [],
     searchQuery: '',
     setSearchQuery: jest.fn(),
+    applySearchResults: jest.fn(),
     selectedCategory: null,
     setSelectedCategory: jest.fn(),
     minPrice: '',

--- a/tests/homeScreenRender.test.tsx
+++ b/tests/homeScreenRender.test.tsx
@@ -88,6 +88,7 @@ jest.mock('@/features/home/hooks/useHomeFilters', () => ({
     filteredProducts: [],
     searchQuery: '',
     setSearchQuery: jest.fn(),
+    applySearchResults: jest.fn(),
     selectedCategory: null,
     setSelectedCategory: jest.fn(),
     minPrice: '',


### PR DESCRIPTION
## Summary
- add a Fuse-powered local index service that returns query result sets
- update the home filters hook to consume local index search results and expose an applySearchResults helper
- render a throttled home SearchBar that uses the local index to drive filtered products

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser in environment)*
- yarn typecheck *(fails: missing type definition packages and expo tsconfig base in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ca2efc5c832692e4be61a25dd76c