### PR TITLE
Normalize Hebrew search matching

### DIFF
--- a/services/localIndex.ts
+++ b/services/localIndex.ts
@@ -1,12 +1,33 @@
 import Fuse from 'fuse.js';
 import type { Product } from '@/types';
+import { normalizeHebrew } from '@/utils/strings';
 
 export interface ResultSet {
   products: Product[];
   total: number;
 }
 
-class LocalIndex {
+const normalizeSearchValue = (
+  value: unknown,
+): string | readonly string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? normalizeHebrew(entry) : null))
+      .filter((entry): entry is string => entry !== null);
+  }
+
+  if (typeof value === 'string') {
+    return normalizeHebrew(value);
+  }
+
+  if (value == null) {
+    return '';
+  }
+
+  return String(value);
+};
+
+export class LocalIndex {
   private fuse: Fuse<Product> | null = null;
 
   private products: Product[] = [];
@@ -30,6 +51,10 @@ class LocalIndex {
       ],
       threshold: 0.3,
       ignoreLocation: true,
+      getFn: (obj, path) => {
+        const value = Fuse.config.getFn(obj, path);
+        return normalizeSearchValue(value);
+      },
     });
   }
 
@@ -49,7 +74,8 @@ class LocalIndex {
       };
     }
 
-    const matches = this.fuse.search(trimmed);
+    const normalizedQuery = normalizeHebrew(trimmed);
+    const matches = this.fuse.search(normalizedQuery);
     const products = matches.map((match) => match.item);
 
     return {

--- a/tests/integration/localIndex.test.ts
+++ b/tests/integration/localIndex.test.ts
@@ -1,0 +1,76 @@
+import { LocalIndex } from '@/services/localIndex';
+import type { Product } from '@/types';
+import { normalizeHebrew } from '@/utils/strings';
+
+describe('normalizeHebrew', () => {
+  it('removes niqqud characters while preserving base letters', () => {
+    expect(normalizeHebrew('חָלָב')).toBe('חלב');
+  });
+
+  it('returns the original string when no niqqud characters are present', () => {
+    expect(normalizeHebrew('שוקו')).toBe('שוקו');
+  });
+});
+
+const createProduct = (overrides: Partial<Product> = {}): Product => ({
+  id: overrides.id ?? 'product-1',
+  name: overrides.name ?? 'Product',
+  price: overrides.price ?? 10,
+  description: overrides.description ?? 'תיאור מוצר',
+  category: overrides.category ?? 'קטגוריה',
+  images: overrides.images ?? [],
+  rating: overrides.rating ?? 0,
+  reviews: overrides.reviews ?? 0,
+  storeId: overrides.storeId ?? 'store-1',
+  stock: overrides.stock ?? 1,
+  name_en: overrides.name_en,
+  name_he: overrides.name_he,
+  description_en: overrides.description_en,
+  description_he: overrides.description_he,
+  originalPrice: overrides.originalPrice,
+  subcategory: overrides.subcategory,
+  videos: overrides.videos,
+  colors: overrides.colors,
+  variants: overrides.variants,
+  badges: overrides.badges,
+  pricingTier: overrides.pricingTier,
+  mixGroupId: overrides.mixGroupId,
+  createdAt: overrides.createdAt,
+  updatedAt: overrides.updatedAt,
+});
+
+describe('LocalIndex query normalization', () => {
+  it('matches products whose stored values contain niqqud when the query does not', async () => {
+    const index = new LocalIndex();
+    const product = createProduct({
+      id: 'milk',
+      name: 'חָלָב טרי',
+      description: 'חלב באיכות גבוהה',
+      category: 'מוצרי חלב',
+    });
+
+    index.setProducts([product]);
+
+    const result = await index.query('חלב טרי');
+
+    expect(result.products).toEqual([product]);
+    expect(result.total).toBe(1);
+  });
+
+  it('matches products when the query includes niqqud but the stored values do not', async () => {
+    const index = new LocalIndex();
+    const product = createProduct({
+      id: 'bread',
+      name: 'לחם טרי',
+      description: 'לחם חם מהתנור',
+      category: 'מאפים',
+    });
+
+    index.setProducts([product]);
+
+    const result = await index.query('לֶחֶם טרי');
+
+    expect(result.products).toEqual([product]);
+    expect(result.total).toBe(1);
+  });
+});

--- a/utils/strings.ts
+++ b/utils/strings.ts
@@ -1,0 +1,5 @@
+const HEBREW_NIQQUD_PATTERN = /[\u0591-\u05C7]/g;
+
+export function normalizeHebrew(input: string): string {
+  return input.normalize('NFKD').replace(HEBREW_NIQQUD_PATTERN, '');
+}


### PR DESCRIPTION
## Summary
- add a normalizeHebrew helper to strip niqqud from strings
- normalize product fields and search queries inside the local index before matching
- cover niqqud-insensitive matching with new integration tests

## Testing
- yarn jest tests/integration/localIndex.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c8cf50299c8326b311a38bd351a66b