### PR TITLE
Bind session tokens to device fingerprint

### DIFF
--- a/services/session.ts
+++ b/services/session.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { uuid } from '@/utils/uuid';
+import { getDeviceHash } from '@/utils/getDeviceHash';
 import { saveSession, loadSessions, removeSession } from '@/services/tokenCache';
 import { requestConsent } from '@/services/consent';
 import {
@@ -29,6 +30,7 @@ export interface SessionToken {
   token: string;
   scopes: string[];
   exp: number;
+  deviceHash: string;
   sealed?: EncryptedScopePayload;
 }
 
@@ -96,14 +98,15 @@ export function requestScopes(
   const now = Date.now();
   const exp = ttlMs < 0 ? now - CLOCK_TOLERANCE_MS - 1 : now + ttlMs;
   const payload = JSON.stringify({ scopes, exp });
+  const deviceHash = getDeviceHash();
 
   const persist = (maybeToken: string | undefined): SessionToken => {
     const token = maybeToken || uuid();
     const sealed =
       typeof options.sealed === 'function' ? options.sealed() : options.sealed;
     const record: SessionToken = sealed
-      ? { token, scopes, exp, sealed }
-      : { token, scopes, exp };
+      ? { token, scopes, exp, sealed, deviceHash }
+      : { token, scopes, exp, deviceHash };
     store.set(token, record);
     void saveSession(record);
     return record;
@@ -133,6 +136,10 @@ export async function initSessionTokens(): Promise<void> {
   const records = await loadSessions();
   const now = Date.now();
   for (const r of records) {
+    if (typeof r.deviceHash !== 'string' || r.deviceHash.length === 0) {
+      void removeSession(r.token);
+      continue;
+    }
     if (now > r.exp + CLOCK_TOLERANCE_MS) {
       void removeSession(r.token);
       continue;
@@ -153,6 +160,12 @@ export function validateToken(token: string, requiredScopes: string[]): void {
   if (Date.now() > rec.exp + CLOCK_TOLERANCE_MS) {
     store.delete(token);
     throw new Error('{E_EXPIRED}');
+  }
+  const deviceHash = getDeviceHash();
+  if (rec.deviceHash !== deviceHash) {
+    store.delete(token);
+    void removeSession(token);
+    throw new Error('{E_DEVICE_MISMATCH}');
   }
   validateScopes(requiredScopes);
   const missing = requiredScopes.find((s) => !rec.scopes.includes(s));
@@ -198,6 +211,12 @@ export function refreshToken(
   if (Date.now() > rec.exp + CLOCK_TOLERANCE_MS) {
     store.delete(token);
     throw new Error('{E_EXPIRED}');
+  }
+  const deviceHash = getDeviceHash();
+  if (rec.deviceHash !== deviceHash) {
+    store.delete(token);
+    void removeSession(token);
+    throw new Error('{E_DEVICE_MISMATCH}');
   }
 
   const handleNext = (next: SessionToken): SessionToken => {

--- a/services/tokenCache.ts
+++ b/services/tokenCache.ts
@@ -20,9 +20,16 @@ async function writeIndex(list: string[]): Promise<void> {
 
 export async function saveSession(record: SessionToken): Promise<void> {
   try {
+    const payload = {
+      token: record.token,
+      scopes: record.scopes,
+      exp: record.exp,
+      deviceHash: record.deviceHash,
+      ...(record.sealed ? { sealed: record.sealed } : {}),
+    } satisfies SessionToken;
     await SecureStore.setItemAsync(
       `session-${record.token}`,
-      JSON.stringify(record),
+      JSON.stringify(payload),
     );
     const idx = await readIndex();
     if (!idx.includes(record.token)) {
@@ -38,7 +45,52 @@ export async function loadSessions(): Promise<SessionToken[]> {
   for (const token of idx) {
     try {
       const raw = await SecureStore.getItemAsync(`session-${token}`);
-      if (raw) out.push(JSON.parse(raw));
+      if (!raw) continue;
+      const parsed = JSON.parse(raw) as Partial<SessionToken> & {
+        token?: unknown;
+        scopes?: unknown;
+        exp?: unknown;
+        deviceHash?: unknown;
+        sealed?: unknown;
+      };
+      if (
+        parsed &&
+        typeof parsed.token === 'string' &&
+        typeof parsed.deviceHash === 'string' &&
+        parsed.deviceHash.length > 0 &&
+        Array.isArray(parsed.scopes) &&
+        parsed.scopes.every((s) => typeof s === 'string') &&
+        typeof parsed.exp === 'number'
+      ) {
+        const sealed = parsed.sealed as SessionToken['sealed'];
+        if (
+          sealed !== undefined &&
+          (
+            !sealed ||
+            typeof sealed !== 'object' ||
+            typeof sealed.cipher !== 'string' ||
+            typeof sealed.walletPublicKey !== 'string' ||
+            typeof sealed.identityPublicKey !== 'string'
+          )
+        ) {
+          continue;
+        }
+        const record: SessionToken = sealed
+          ? {
+              token: parsed.token,
+              scopes: parsed.scopes as string[],
+              exp: parsed.exp,
+              deviceHash: parsed.deviceHash,
+              sealed,
+            }
+          : {
+              token: parsed.token,
+              scopes: parsed.scopes as string[],
+              exp: parsed.exp,
+              deviceHash: parsed.deviceHash,
+            };
+        out.push(record);
+      }
     } catch {}
   }
   return out;

--- a/tests/auth/session.spec.ts
+++ b/tests/auth/session.spec.ts
@@ -6,6 +6,7 @@ describe('session scope validation', () => {
 
   afterEach(() => {
     scopedTokensFlag.rollback = false;
+    delete (globalThis as any).__DEVICE_INFO__;
   });
 
   it('rejects invalid scope requests', () => {
@@ -58,5 +59,12 @@ describe('session scope validation', () => {
     jest.setSystemTime(exp + 120_000);
     expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
     jest.useRealTimers();
+  });
+
+  it('rejects tokens when device hash changes', () => {
+    (globalThis as any).__DEVICE_INFO__ = 'device-a';
+    const { token } = requestScopes(['read'], signer);
+    (globalThis as any).__DEVICE_INFO__ = 'device-b';
+    expect(() => validateToken(token, ['read'])).toThrow('{E_DEVICE_MISMATCH}');
   });
 });

--- a/tests/auth/session.test.ts
+++ b/tests/auth/session.test.ts
@@ -3,6 +3,10 @@ import { requestScopes, validateToken, refreshToken, sessionEvents } from '@/ser
 describe('session token lifecycle', () => {
   const signer = (msg: string) => `sig:${msg}`;
 
+  afterEach(() => {
+    delete (globalThis as any).__DEVICE_INFO__;
+  });
+
   it('refreshToken rotates token and extends expiry', async () => {
     const { token, exp } = requestScopes(['checkout'], signer, 50);
     const events: any[] = [];
@@ -25,5 +29,12 @@ describe('session token lifecycle', () => {
     expect(next.token).not.toBe(token);
     expect(() => validateToken(next.token, ['read'])).not.toThrow();
     expect(() => validateToken(token, ['read'])).toThrow('{E_EXPIRED}');
+  });
+
+  it('prevents refresh when device hash differs', () => {
+    (globalThis as any).__DEVICE_INFO__ = 'device-a';
+    const { token } = requestScopes(['read'], signer, 1000);
+    (globalThis as any).__DEVICE_INFO__ = 'device-b';
+    expect(() => refreshToken(token, signer, 1000)).toThrow('{E_DEVICE_MISMATCH}');
   });
 });

--- a/utils/getDeviceHash.ts
+++ b/utils/getDeviceHash.ts
@@ -1,0 +1,40 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils';
+
+function resolveDeviceInfo(): string {
+  const globalObject: any = typeof globalThis === 'undefined' ? undefined : globalThis;
+
+  const override = globalObject?.__DEVICE_INFO__;
+  if (override !== undefined && override !== null) {
+    if (typeof override === 'string') return override;
+    try {
+      return JSON.stringify(override);
+    } catch {
+      return String(override);
+    }
+  }
+
+  const navigatorInfo: any = globalObject?.navigator;
+  if (navigatorInfo?.userAgent) {
+    return navigatorInfo.userAgent;
+  }
+
+  if (typeof navigator !== 'undefined' && navigator?.userAgent) {
+    return navigator.userAgent;
+  }
+
+  if (typeof process !== 'undefined' && process && typeof process === 'object') {
+    const platform = (process as NodeJS.Process).platform ?? 'unknown';
+    const arch = (process as NodeJS.Process).arch ?? 'unknown';
+    return `${platform}-${arch}`;
+  }
+
+  return 'unknown-device';
+}
+
+export function getDeviceHash(): string {
+  const info = resolveDeviceInfo();
+  return bytesToHex(sha256(utf8ToBytes(info)));
+}
+
+export default getDeviceHash;


### PR DESCRIPTION
## Summary
- add a device hash utility and include the hash on issued session tokens
- validate and refresh session tokens only when the device hash matches
- persist the device hash in secure storage and cover device mismatch behaviour in unit tests

## Testing
- yarn install --frozen-lockfile --no-progress *(fails: @waku/core requires Node >=22 while the environment provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d0cd4e9c8326b4e7c264b0c7d170