### PR TITLE
Add featured stores carousel to home screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -23,6 +23,7 @@ import PriceRange from '@/features/home/components/PriceRange';
 import CategoryChips from '@/features/home/components/CategoryChips';
 import HomeOptions from '@/features/home/components/HomeOptions';
 import ProductGrid from '@/features/home/components/ProductGrid';
+import FeaturedStoresCarousel from '@/features/home/components/FeaturedStoresCarousel';
 import CategoryCard from '@/features/home/components/CategoryCard';
 import SearchBar from '@/features/home/components/SearchBar';
 import { Spinner, Heading } from '@/ui/primitives';
@@ -339,6 +340,8 @@ function HomeScreenContent() {
             />
           )}
         </Container>
+
+        <FeaturedStoresCarousel />
 
         {/* Products Section */}
         <Container

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,6 +150,7 @@ const cfg = {
     '<rootDir>/tests/nearKvPersistence.test.ts',
     '<rootDir>/tests/homeScreenRender.test.tsx',
     '<rootDir>/tests/homeFallbackVisibility.test.tsx',
+    '<rootDir>/tests/featuredStoresCarousel.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',

--- a/src/features/home/components/FeaturedStoresCarousel.tsx
+++ b/src/features/home/components/FeaturedStoresCarousel.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ShoppingBag } from 'lucide-react-native';
+import { useStores } from '@/services/useStores';
+import { useAppRouter } from '@/services/useAppRouter';
+import { useLanguage, useTheme } from '@/ui/ThemeProvider';
+import { Container, ScrollArea, Stack } from '@/ui/layout';
+import { Spinner } from '@/ui/primitives';
+import EmptyState from '@/shared/ui/EmptyState';
+import { radius, spacing, typography } from '@/ui/tokens';
+
+const MAX_FEATURED_STORES = 8;
+
+export default function FeaturedStoresCarousel() {
+  const { data: stores = [], isLoading } = useStores('default');
+  const { push } = useAppRouter();
+  const { t } = useLanguage();
+  const { colors } = useTheme();
+
+  const featuredStores = useMemo(() => {
+    const seen = new Map<string, typeof stores[number]>();
+    for (const store of stores) {
+      if (!store || !store.id) continue;
+      if (!seen.has(store.id)) {
+        seen.set(store.id, store);
+      }
+    }
+    return Array.from(seen.values())
+      .sort((a, b) => (b.reputation ?? 0) - (a.reputation ?? 0))
+      .slice(0, MAX_FEATURED_STORES);
+  }, [stores]);
+
+  const openStore = useCallback(
+    (id: string) => {
+      if (!id) return;
+      push(`/store/${id}`);
+    },
+    [push],
+  );
+
+  const loading = isLoading && featuredStores.length === 0;
+
+  if (loading) {
+    return (
+      <Container style={styles.section}>
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
+      </Container>
+    );
+  }
+
+  if (featuredStores.length === 0) {
+    return (
+      <Container style={styles.section}>
+        <EmptyState
+          icon={ShoppingBag}
+          title={t('home.featuredStoresEmptyTitle', 'No featured stores yet')}
+          message={t(
+            'home.featuredStoresEmptyMessage',
+            'Featured stores will appear here soon.',
+          )}
+        />
+      </Container>
+    );
+  }
+
+  return (
+    <Container style={styles.section}>
+      <Stack direction="horizontal" style={styles.header}>
+        <Text style={[styles.title, { color: colors.text.primary }]}>
+          {t('home.featuredStores', 'Featured Stores')}
+        </Text>
+      </Stack>
+      <ScrollArea
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.carouselContent}
+      >
+        {featuredStores.map((store) => (
+          <TouchableOpacity
+            key={store.id}
+            style={[
+              styles.card,
+              {
+                backgroundColor: colors.surface.elevated,
+                borderColor: colors.border.primary,
+              },
+            ]}
+            onPress={() => openStore(store.id)}
+            accessibilityRole="button"
+            testID={`featured-store-${store.id}`}
+          >
+            <Stack gap="spacer8">
+              <View
+                style={[
+                  styles.iconWrapper,
+                  { backgroundColor: colors.surface.primary },
+                ]}
+              >
+                <ShoppingBag size={20} color={colors.gold} />
+              </View>
+              <Text
+                style={[styles.storeName, { color: colors.text.primary }]}
+                numberOfLines={1}
+              >
+                {store.name || t('home.unnamedStore', 'Unnamed Store')}
+              </Text>
+              {store.owner ? (
+                <Text
+                  style={[styles.storeOwner, { color: colors.text.secondary }]}
+                  numberOfLines={1}
+                >
+                  {store.owner}
+                </Text>
+              ) : null}
+            </Stack>
+          </TouchableOpacity>
+        ))}
+      </ScrollArea>
+    </Container>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    paddingHorizontal: spacing.spacer16,
+    marginBottom: spacing.spacer24,
+  },
+  header: {
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.spacer12,
+  },
+  title: {
+    ...typography.lg,
+    fontWeight: '600',
+  },
+  carouselContent: {
+    paddingRight: spacing.spacer16,
+  },
+  card: {
+    width: 180,
+    padding: spacing.spacer12,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    marginRight: spacing.spacer12,
+  },
+  iconWrapper: {
+    width: 40,
+    height: 40,
+    borderRadius: radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  storeName: {
+    ...typography.md,
+    fontWeight: '600',
+  },
+  storeOwner: {
+    ...typography.xs,
+  },
+  centered: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+

--- a/src/features/home/screens/HomeProducts.tsx
+++ b/src/features/home/screens/HomeProducts.tsx
@@ -6,6 +6,7 @@ import { Container, Stack } from '@/ui/layout';
 import { Spinner } from '@/ui/primitives';
 import ProductGrid from '@/features/home/components/ProductGrid';
 import HomeServices from '@/features/home/components/HomeServices';
+import FeaturedStoresCarousel from '@/features/home/components/FeaturedStoresCarousel';
 import { Product } from '@/types';
 import { styles } from './HomeProducts.styles';
 import { useAppRouter } from '@/services/useAppRouter';
@@ -70,6 +71,7 @@ export default function HomeProducts({
   return (
     <>
       <HomeServices />
+      <FeaturedStoresCarousel />
       <Container style={styles.section}>
         <Stack direction="horizontal" style={styles.sectionHeader}>
           <Text style={[styles.sectionTitle, { color: themeColors.text.primary }]}> 

--- a/tests/featuredStoresCarousel.test.tsx
+++ b/tests/featuredStoresCarousel.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import FeaturedStoresCarousel from '@/features/home/components/FeaturedStoresCarousel';
+import EmptyState from '@/shared/ui/EmptyState';
+
+const mockPush = jest.fn();
+const mockUseStores = jest.fn();
+
+jest.mock('@/services/useStores', () => ({
+  useStores: () => mockUseStores(),
+}));
+
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => ({ push: mockPush }),
+}));
+
+const colors = {
+  text: { primary: '#111111', secondary: '#555555' },
+  surface: { primary: '#ffffff', elevated: '#f4f4f4' },
+  border: { primary: '#dddddd' },
+  gold: '#FFD700',
+  interactive: { disabled: '#999999' },
+};
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => ({ t: (key: string, defaultText?: string) => defaultText ?? key }),
+  useTheme: () => ({
+    colors,
+    getColor: (path: string) =>
+      path.split('.').reduce((acc: any, key) => (acc ? acc[key] : undefined), colors),
+  }),
+}));
+
+describe('FeaturedStoresCarousel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStores.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('renders an empty state when there are no featured stores', () => {
+    const tree = renderer.create(<FeaturedStoresCarousel />);
+    const emptyState = tree.root.findByType(EmptyState);
+    expect(emptyState.props.title).toBe('No featured stores yet');
+  });
+
+  it('renders store cards and opens stores on press', () => {
+    mockUseStores.mockReturnValue({
+      data: [
+        { id: '1', name: 'Alpha Market', owner: '0xabc', reputation: 5 },
+        { id: '2', name: 'Beta Shop', owner: '0xdef', reputation: 2 },
+      ],
+      isLoading: false,
+    });
+
+    const tree = renderer.create(<FeaturedStoresCarousel />);
+    const cards = tree.root.findAll(
+      (node) => node.props?.testID && node.props.testID.startsWith('featured-store-'),
+    );
+    expect(cards).toHaveLength(2);
+
+    cards[0].props.onPress();
+    expect(mockPush).toHaveBeenCalledWith('/store/1');
+  });
+});
+

--- a/translations/en.json
+++ b/translations/en.json
@@ -132,7 +132,11 @@
     "connectWalletToContinue": "Connect wallet to continue",
     "create_store_prompt_title": "Create your store",
     "create_store_prompt_message": "You have no store yet. Create one to start selling.",
-    "create_store_prompt_action": "Create Store"
+    "create_store_prompt_action": "Create Store",
+    "featuredStores": "Featured Stores",
+    "featuredStoresEmptyTitle": "No featured stores yet",
+    "featuredStoresEmptyMessage": "Featured stores will appear here soon.",
+    "unnamedStore": "Unnamed Store"
   },
   "cta": {
     "create_store": "Create a Store",

--- a/translations/he.json
+++ b/translations/he.json
@@ -132,7 +132,11 @@
     "connectWalletToContinue": "חבר ארנק כדי להמשיך",
     "create_store_prompt_title": "צור את החנות שלך",
     "create_store_prompt_message": "אין לך עדיין חנות. צור אחת כדי להתחיל למכור.",
-    "create_store_prompt_action": "צור חנות"
+    "create_store_prompt_action": "צור חנות",
+    "featuredStores": "חנויות מובילות",
+    "featuredStoresEmptyTitle": "אין עדיין חנויות מובילות",
+    "featuredStoresEmptyMessage": "חנויות נבחרות יופיעו כאן בקרוב.",
+    "unnamedStore": "חנות ללא שם"
   },
   "cta": {
     "create_store": "צור חנות",


### PR DESCRIPTION
## Summary
- create a featured stores carousel that surfaces locally indexed stores and supports opening storefronts
- surface the carousel on the home screen and shared HomeProducts view, along with localized copy for the section
- add unit coverage for empty and populated states and register the suite with the jest config

## Testing
- `./node_modules/.bin/jest featuredStoresCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c8d0ad2c7083269ff3e0f9e6fbb15c