### PR TITLE
Add accessibility label to ProductCard

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -151,6 +151,7 @@ const cfg = {
     '<rootDir>/tests/homeScreenRender.test.tsx',
     '<rootDir>/tests/homeFallbackVisibility.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
+    '<rootDir>/tests/productCardAccessibility.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',
     '<rootDir>/tests/wallet/**/*.test.ts',

--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -22,10 +22,17 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
     price,
     originalPrice,
   } = useProductCard(product);
+  const accessibilityLabel = React.useMemo(() => {
+    if (!price) {
+      return product.name;
+    }
+    return `${product.name}, ${price}`;
+  }, [price, product.name]);
 
   return (
     <Pressable
       accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
       onPress={onPress}
       style={[styles.card, { backgroundColor: colors.surface.primary }, style]}
     >

--- a/tests/productCardAccessibility.test.tsx
+++ b/tests/productCardAccessibility.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Pressable } from 'react-native';
+import ProductCard from '@/features/products/ProductCard';
+import type { Product } from '@/types';
+
+const mockUseProductCard = jest.fn();
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useTheme: () => ({
+    colors: {
+      surface: { primary: '#ffffff' },
+      muted: '#f0f0f0',
+      text: { primary: '#111111', secondary: '#666666' },
+      status: { error: '#ff0000' },
+      gold: '#ffcc00',
+    },
+  }),
+}));
+
+jest.mock('@/ui', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text,
+    Button: ({ title, onPress, style }: any) =>
+      React.createElement('Button', { title, onPress, style }),
+    Skeleton: (props: any) => React.createElement('Skeleton', props),
+  };
+});
+
+jest.mock('lucide-react-native', () => {
+  const React = require('react');
+  return {
+    Star: (props: any) => React.createElement('Star', props),
+    Heart: (props: any) => React.createElement('Heart', props),
+  };
+});
+
+jest.mock('@/features/products/hooks/useProductCard', () => ({
+  __esModule: true,
+  useProductCard: (product: Product) => mockUseProductCard(product),
+  default: (product: Product) => mockUseProductCard(product),
+}));
+
+describe('ProductCard accessibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses product name and price in accessibility label', () => {
+    const product: Product = {
+      id: '1',
+      name: 'Test Product',
+      price: 9.99,
+      description: 'A product for testing',
+      category: 'category',
+      images: [],
+      rating: 4.5,
+      reviews: 10,
+      storeId: 'store',
+      stock: 5,
+    };
+    const onPress = jest.fn();
+
+    mockUseProductCard.mockReturnValue({
+      isInWishlist: false,
+      pricingTier: null,
+      toggleWishlist: jest.fn(),
+      handleWishlistPress: jest.fn(),
+      price: '$9.99',
+      originalPrice: undefined,
+    });
+
+    const tree = renderer.create(
+      <ProductCard product={product} onPress={onPress} />,
+    );
+
+    const pressables = tree.root.findAllByType(Pressable);
+    const outerPressable = pressables.find(
+      pressable => pressable.props.onPress === onPress,
+    );
+
+    expect(outerPressable).toBeDefined();
+    expect(outerPressable?.props.accessibilityLabel).toBe(
+      'Test Product, $9.99',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- compute the product card accessibility label from the name and formatted price and wire it to the outer Pressable
- cover the accessibility label with a dedicated test and register it with the Jest suite

## Testing
- `yarn install --no-progress --silent` *(fails: @waku/core@0.0.38 requires node >= 22)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d468cb4483269d61bd826823ce03