### PR TITLE
Limit HomeServices create-store card to empty admin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -150,6 +150,7 @@ const cfg = {
     '<rootDir>/tests/nearKvPersistence.test.ts',
     '<rootDir>/tests/homeScreenRender.test.tsx',
     '<rootDir>/tests/homeFallbackVisibility.test.tsx',
+    '<rootDir>/tests/homeServices.test.tsx',
     '<rootDir>/tests/featuredStoresCarousel.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',

--- a/src/features/home/components/HomeServices.tsx
+++ b/src/features/home/components/HomeServices.tsx
@@ -1,17 +1,31 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, Alert } from 'react-native';
 import { Stack } from '@/ui/layout';
 import { spacing } from '@/ui/tokens';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
-import { Store, Truck } from 'lucide-react-native';
+import { Store as StoreIcon, Truck } from 'lucide-react-native';
 import { useAppRouter } from '@/services/useAppRouter';
 import { routes } from '@/utils/routes';
+import { useAuth } from '@/features/auth/AuthContext';
+import { useStores } from '@/services/useStores';
 import ServiceCard from './ServiceCard';
 
 export default function HomeServices() {
   const { t } = useLanguage();
   const { colors } = useTheme();
   const appRouter = useAppRouter();
+  const { isAdmin, user } = useAuth();
+  const { data: stores = [] } = useStores('default');
+
+  const userAddress = user?.address ?? user?.id ?? null;
+
+  const ownedStores = useMemo(() => {
+    if (!userAddress) return [];
+    const lower = userAddress.toLowerCase();
+    return stores.filter((store) => store.owner?.toLowerCase() === lower);
+  }, [stores, userAddress]);
+
+  const shouldShowCreateStore = isAdmin === true && ownedStores.length === 0;
 
   const handleCreateStore = () => {
     appRouter.push(routes.createStore());
@@ -23,13 +37,15 @@ export default function HomeServices() {
 
   return (
     <Stack direction="horizontal" gap="spacer16" style={styles.container}>
-      <ServiceCard
-        title={t('cta.create_store')}
-        icon={<Store size={32} color={colors.gold} />}
-        onPress={handleCreateStore}
-        accessibilityRole="link"
-        testID="create-store-link"
-      />
+      {shouldShowCreateStore ? (
+        <ServiceCard
+          title={t('cta.create_store')}
+          icon={<StoreIcon size={32} color={colors.gold} />}
+          onPress={handleCreateStore}
+          accessibilityRole="link"
+          testID="create-store-link"
+        />
+      ) : null}
       <ServiceCard
         title={t('cta.become_driver')}
         icon={<Truck size={32} color={colors.gold} />}

--- a/tests/homeServices.test.tsx
+++ b/tests/homeServices.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import HomeServices from '@/features/home/components/HomeServices';
+
+const mockServiceCard = jest.fn(() => null);
+jest.mock('@/features/home/components/ServiceCard', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockServiceCard(props);
+    return null;
+  },
+}));
+
+const mockUseLanguage = { t: (key: string, defaultText?: string) => defaultText ?? key };
+const mockUseTheme = {
+  colors: {
+    gold: '#FFD700',
+    text: { primary: '#000', secondary: '#333' },
+  },
+};
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useLanguage: () => mockUseLanguage,
+  useTheme: () => mockUseTheme,
+}));
+
+const mockAppRouter = { push: jest.fn() };
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => mockAppRouter,
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockUseStores = jest.fn();
+jest.mock('@/services/useStores', () => ({
+  useStores: () => mockUseStores(),
+}));
+
+describe('HomeServices create store visibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      isAdmin: true,
+      user: { id: '0xabc', address: '0xabc' },
+    });
+    mockUseStores.mockReturnValue({ data: [] });
+  });
+
+  it('renders create store card when admin owns no stores', () => {
+    renderer.create(<HomeServices />);
+    const createStoreCards = (mockServiceCard.mock.calls as any[]).filter(
+      (args) => args?.[0]?.testID === 'create-store-link',
+    );
+    expect(createStoreCards).toHaveLength(1);
+  });
+
+  it('hides create store card when admin already owns a store', () => {
+    mockUseStores.mockReturnValue({
+      data: [
+        {
+          id: '1',
+          name: 'Storefront',
+          owner: '0xabc',
+        },
+      ],
+    });
+    renderer.create(<HomeServices />);
+    const createStoreCards = (mockServiceCard.mock.calls as any[]).filter(
+      (args) => args?.[0]?.testID === 'create-store-link',
+    );
+    expect(createStoreCards).toHaveLength(0);
+  });
+});

--- a/types/lucide-react-native.d.ts
+++ b/types/lucide-react-native.d.ts
@@ -63,6 +63,7 @@ declare module 'lucide-react-native' {
   export const Shield: FC<LucideProps>;
   export const ShoppingBag: FC<LucideProps>;
   export const ShoppingCart: FC<LucideProps>;
+  export const Store: FC<LucideProps>;
   export const Smile: FC<LucideProps>;
   export const Star: FC<LucideProps>;
   export const Sun: FC<LucideProps>;


### PR DESCRIPTION
## Summary
- show the HomeServices create-store card only for admin users who do not own any stores
- add a focused HomeServices test suite covering the visible and hidden card scenarios and wire it into Jest
- extend lucide-react-native typings so the Store icon import remains type-safe

## Testing
- yarn jest --runTestsByPath tests/homeServices.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8d62b453483268478f1e13ca4688d