### PR TITLE
Add wallet connect helper and tests

### DIFF
--- a/src/auth/wallet.ts
+++ b/src/auth/wallet.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { Buffer } from 'buffer';
 import { useWallet } from '@/contexts/WalletProvider';
-import { chainAdapter } from '@/services/chain';
+import { signIn, getAccountId, getPublicKey } from '@/features/auth/services/nearAuth';
 import {
   requestScopes,
   refreshToken,
@@ -15,13 +15,27 @@ import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from '@/utils
 
 const SESSION_ENCRYPTION_INFO = 'wallet.session';
 
-function requireWalletPublicKey(): string {
-  const getter = chainAdapter.getPublicKey;
-  const publicKey = typeof getter === 'function' ? getter.call(chainAdapter) : null;
-  if (!publicKey) {
+export async function connectWallet(): Promise<{ address: string; publicKey: string }> {
+  const readAccount = typeof getAccountId === 'function' ? getAccountId : () => null;
+  const readPublicKey = typeof getPublicKey === 'function' ? getPublicKey : () => null;
+
+  let address = readAccount();
+  let publicKey = readPublicKey();
+
+  if (!address || !publicKey) {
+    if (typeof signIn !== 'function') {
+      throw new Error('Wallet public key unavailable');
+    }
+    await signIn();
+    address = readAccount();
+    publicKey = readPublicKey();
+  }
+
+  if (!address || !publicKey) {
     throw new Error('Wallet public key unavailable');
   }
-  return publicKey;
+
+  return { address, publicKey };
 }
 
 async function sealPayload(
@@ -94,7 +108,7 @@ export function useWalletSessions(): {
       if (!Array.isArray(scopes) || scopes.length === 0) {
         throw new Error('{E_SCOPE}');
       }
-      const walletPublicKey = requireWalletPublicKey();
+      const { publicKey: walletPublicKey } = await connectWallet();
       let sealed: EncryptedScopePayload | undefined;
       const session = await requestScopes(
         scopes,
@@ -126,7 +140,8 @@ export function useWalletSessions(): {
       await verifySealedPayload(record);
       validateToken(token, scopes);
 
-      const walletPublicKey = record.sealed?.walletPublicKey ?? requireWalletPublicKey();
+      const { publicKey: connectedPublicKey } = await connectWallet();
+      const walletPublicKey = record.sealed?.walletPublicKey ?? connectedPublicKey;
       let sealed: EncryptedScopePayload | undefined;
       const refreshed = await refreshToken(
         token,

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
 import { signMessage, getPublicKey } from '@/features/auth/services/nearAuth';
+import { connectWallet } from '@/auth/wallet';
 import { publish, subscribeWithAck } from '@/services/waku';
 import { requestScopes, validateToken, refreshToken, SessionToken } from '@/services/session';
 import { canonicalJson } from '@/utils/serialization';
@@ -86,6 +87,7 @@ export async function createWorkspace(
   ttlMs = DEFAULT_WORKSPACE_SESSION_TTL_MS,
 ): Promise<WorkspaceSession> {
   const workspaceId = generateWorkspaceId();
+  await connectWallet();
   const session = await requestScopes(
     Array.from(WORKSPACE_SCOPES),
     (payload) => signWorkspacePayload(workspaceId, payload),
@@ -107,6 +109,7 @@ export async function refreshWorkspaceSession(
   ttlMs = DEFAULT_WORKSPACE_SESSION_TTL_MS,
 ): Promise<WorkspaceSession> {
   const meta = requireWorkspaceMeta(token);
+  await connectWallet();
   const session = await refreshToken(
     token,
     (payload) => signWorkspacePayload(meta.workspaceId, payload),

--- a/tests/admin-disputes.test.tsx
+++ b/tests/admin-disputes.test.tsx
@@ -15,7 +15,8 @@ jest.mock('@/services/nearContract', () => ({
 jest.mock('@/services/eventLog', () => ({ logOrderEvent: jest.fn() }));
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('testadmin.near'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:testadmin'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('OrderService.resolveDispute', () => {

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -63,7 +63,8 @@ jest.mock('@/services/eventBus', () => ({ publish: jest.fn(), track: jest.fn() }
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('buyer.near'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:buyer'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => ({

--- a/tests/auth/workspaceSession.test.ts
+++ b/tests/auth/workspaceSession.test.ts
@@ -5,6 +5,8 @@ import { signMessage } from '@/features/auth/services/nearAuth';
 jest.mock('@/features/auth/services/nearAuth', () => ({
   signMessage: jest.fn((msg: string) => Promise.resolve(`sig:${msg}`)),
   getPublicKey: jest.fn(() => 'wallet:test'),
+  signIn: jest.fn().mockResolvedValue(undefined),
+  getAccountId: jest.fn(() => 'wallet.test'),
 }));
 
 const mockSignMessage = signMessage as jest.MockedFunction<typeof signMessage>;

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -44,7 +44,8 @@ jest.mock('../agents/orders-agent', () => ({
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('buyer_address'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:buyer_address'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/constants/tenant', () => ({

--- a/tests/cartService.test.ts
+++ b/tests/cartService.test.ts
@@ -26,12 +26,17 @@ jest.mock('@/services/database', () => ({
 }));
 
 const getAccountIdMock = jest.fn();
+const mockSignIn = jest.fn().mockResolvedValue(undefined);
+const mockGetPublicKey = jest.fn(() => 'pub:test');
 jest.mock('@/services/chain', () => ({
   chainAdapter: { getAccountId: () => getAccountIdMock() },
 }));
 jest.mock('@/features/auth/services/nearAuth', () => ({
   __esModule: true,
   default: { getAccountId: getAccountIdMock },
+  getAccountId: getAccountIdMock,
+  getPublicKey: mockGetPublicKey,
+  signIn: mockSignIn,
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () => ({

--- a/tests/moonPayButton.test.ts
+++ b/tests/moonPayButton.test.ts
@@ -12,8 +12,11 @@ jest.mock('../contexts/AppInfoContext', () => ({
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   __esModule: true,
-  default: { signIn: jest.fn() },
+  default: { signIn: jest.fn().mockResolvedValue(undefined) },
   useAccountId: jest.fn(() => 'addr'),
+  getAccountId: jest.fn(() => 'addr'),
+  getPublicKey: jest.fn(() => 'pub:addr'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/contexts/WalletProvider', () => ({

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -54,7 +54,8 @@ jest.mock('../agents/orders-agent', () => ({
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('buyer_address'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:buyer_address'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('multi-seller checkout flow', () => {

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -46,7 +46,8 @@ jest.mock('@/services/eventBus', () => ({ publish: jest.fn() }));
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('seller'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:seller'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 const sellerKey = nacl.sign.keyPair();

--- a/tests/reviewAgent.test.ts
+++ b/tests/reviewAgent.test.ts
@@ -34,7 +34,8 @@ jest.mock('../agents/stores-agent', () => ({
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: jest.fn().mockReturnValue('user1'),
-  signIn: jest.fn(),
+  getPublicKey: jest.fn().mockReturnValue('pub:user1'),
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 import reviewAgent from '../agents/review-agent';

--- a/tests/settingsAgent.test.ts
+++ b/tests/settingsAgent.test.ts
@@ -1,6 +1,7 @@
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: () => 'addr_admin',
-  signIn: jest.fn(),
+  getPublicKey: () => 'pub:addr_admin',
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('@/services/nearKvStore', () => require('./nearKvMock'));
 jest.mock('@/services/nearSettings');

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -9,7 +9,8 @@ import validateNearAddress from '../utils/validateNearAddress';
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   getAccountId: () => 'addr_admin',
-  signIn: jest.fn(),
+  getPublicKey: () => 'pub:addr_admin',
+  signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/services/localIdentity', () => ({

--- a/tests/waku/workspaceProvision.test.ts
+++ b/tests/waku/workspaceProvision.test.ts
@@ -10,10 +10,14 @@ const mockSignMessage = jest.fn<Promise<string>, [string | Uint8Array]>((message
   Promise.resolve(typeof message === 'string' ? `sig:${message}` : 'sig:bytes'),
 );
 const mockGetPublicKey = jest.fn(() => 'wallet:test');
+const mockSignIn = jest.fn().mockResolvedValue(undefined);
+const mockGetAccountId = jest.fn(() => 'wallet.test');
 
 jest.mock('@/features/auth/services/nearAuth', () => ({
   signMessage: mockSignMessage,
   getPublicKey: mockGetPublicKey,
+  signIn: mockSignIn,
+  getAccountId: mockGetAccountId,
 }));
 
 describe('workspace provisioning handshake', () => {
@@ -29,6 +33,10 @@ describe('workspace provisioning handshake', () => {
     );
     mockGetPublicKey.mockReset();
     mockGetPublicKey.mockReturnValue('wallet:test');
+    mockSignIn.mockClear();
+    mockSignIn.mockResolvedValue(undefined);
+    mockGetAccountId.mockReset();
+    mockGetAccountId.mockReturnValue('wallet.test');
   });
 
   afterEach(() => {

--- a/tests/wallet/connectWallet.test.ts
+++ b/tests/wallet/connectWallet.test.ts
@@ -1,0 +1,52 @@
+const mockSignIn = jest.fn();
+const mockGetAccountId = jest.fn();
+const mockGetPublicKey = jest.fn();
+
+jest.mock('@/features/auth/services/nearAuth', () => ({
+  signIn: mockSignIn,
+  getAccountId: mockGetAccountId,
+  getPublicKey: mockGetPublicKey,
+}));
+
+import { connectWallet } from '@/auth/wallet';
+
+describe('connectWallet', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset();
+    mockSignIn.mockResolvedValue(undefined);
+    mockGetAccountId.mockReset();
+    mockGetPublicKey.mockReset();
+  });
+
+  it('returns existing wallet connection without prompting sign-in', async () => {
+    mockGetAccountId.mockReturnValue('alice.testnet');
+    mockGetPublicKey.mockReturnValue('ed25519:alice');
+
+    const result = await connectWallet();
+
+    expect(result).toEqual({ address: 'alice.testnet', publicKey: 'ed25519:alice' });
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+
+  it('triggers sign-in when wallet details missing', async () => {
+    mockGetAccountId
+      .mockReturnValueOnce(null)
+      .mockReturnValue('bob.testnet');
+    mockGetPublicKey
+      .mockReturnValueOnce(null)
+      .mockReturnValue('ed25519:bob');
+
+    const result = await connectWallet();
+
+    expect(mockSignIn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ address: 'bob.testnet', publicKey: 'ed25519:bob' });
+  });
+
+  it('throws when wallet remains unavailable after sign-in', async () => {
+    mockGetAccountId.mockReturnValue(null);
+    mockGetPublicKey.mockReturnValue(null);
+
+    await expect(connectWallet()).rejects.toThrow('Wallet public key unavailable');
+    expect(mockSignIn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `connectWallet` helper that ensures a wallet sign-in and return values before signing scope requests
- invoke the helper from wallet session hooks and workspace session helpers so scope issuance always has an active wallet
- cover the helper with unit tests and update existing nearAuth mocks to provide wallet details

## Testing
- ⚠️ `yarn install --no-progress` *(fails: @waku/core requires Node >=22 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d61fd2d88326a7a4310165dd18f7