### PR TITLE
Track home view and search analytics

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -40,6 +40,7 @@ import ErrorBoundary from 'src/shared/ErrorBoundary';
 import HomeError from '@/features/home/screens/HomeError';
 import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 import { useAppRouter } from '@/services/useAppRouter';
+import eventBus from '@/services/eventBus';
 import { localIndex } from '@/services/localIndex';
 
 function HomeScreenContent() {
@@ -97,6 +98,10 @@ function HomeScreenContent() {
   const latestSearchValueRef = useRef(searchQuery);
 
   useEffect(() => {
+    void eventBus.track('view.home');
+  }, []);
+
+  useEffect(() => {
     latestSearchValueRef.current = searchQuery;
   }, [searchQuery]);
 
@@ -115,6 +120,7 @@ function HomeScreenContent() {
 
       const invoke = async () => {
         const queryText = latestSearchValueRef.current;
+        void eventBus.track('search.query', { query: queryText });
         try {
           const result = await localIndex.query(queryText);
           applySearchResults(queryText, result);

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -28,8 +28,10 @@ Events published on `/blue-ocean/{tenantId}/analytics/1` follow this structure:
 
 | Type | Payload |
 |------|---------|
+| `view.home` | `{}` |
 | `catalog.view` | `{ category: string | null }` |
 | `catalog.product_view` | `{ productId: string }` |
+| `search.query` | `{ query: string }` |
 | `cart.add` | `{ productId: string, quantity: number }` |
 | `cart.remove` | `{ itemId: string }` |
 | `cart.update` | `{ itemId: string, quantity: number }` |


### PR DESCRIPTION
## Summary
- track the home screen view when the app index mounts
- record analytics events whenever the throttled search runs
- document the new `view.home` and `search.query` events in the analytics guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8da10c8d48326815c9d1698c55a5f