### PR TITLE
Implement StoreAdmin dashboards and admin tooling

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -38,10 +38,10 @@ import AgentError from '@/types/AgentError';
 import { canonicalJson } from '@/utils/serialization';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  order_received: ['courier_found'],
-  courier_found: ['courier_picked_up'],
-  courier_picked_up: ['courier_on_way'],
-  courier_on_way: ['delivered'],
+  order_received: ['courier_found', 'refunded'],
+  courier_found: ['courier_picked_up', 'refunded'],
+  courier_picked_up: ['courier_on_way', 'refunded'],
+  courier_on_way: ['delivered', 'refunded'],
   delivered: ['released', 'refunded', 'disputed'],
   disputed: ['released', 'refunded'],
   released: [],

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -33,7 +33,8 @@ type SettingKey =
   | 'paymentFactoryAddress'
   | 'rpcUrl'
   | 'rpcFallbackUrls'
-  | 'paymentFactoryAddress';
+  | 'paymentFactoryAddress'
+  | 'kyc.required';
 
 class SettingsAgent {
   private static instance: SettingsAgent;

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -1,124 +1,338 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  RefreshControl,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
 import { useAppRouter } from '@/services';
-import { useTheme } from '@/ui/ThemeProvider';
-import { useLanguage } from '@/ui/ThemeProvider';
+import type { Order, Product, User } from '@/types';
+import { ordersWarmCache } from '@/services/nearOrders';
+import { productsWarmCache } from '@/features/products/services/nearProducts';
+import { usersWarmCache } from '@/features/auth/services/nearUsers';
+import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
 import FeeDashboard from '@/features/billing/components/FeeDashboard';
-import { useAuth } from '@/features/auth/AuthContext';
-import { getStore as getNearStore } from '@/features/stores/services/nearStores';
-import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
-import { routes } from '@/utils/routes';
-import { Spinner } from '@/ui/primitives';
-import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 
-export default function StoreDashboardScreen() {
-  console.debug('SD: mount');
-  const { replace, push } = useAppRouter();
-  const { storeId, impersonate } = useLocalSearchParams<{ storeId: string; impersonate?: string }>();
+const LOW_STOCK_THRESHOLD = 5;
+
+function isToday(date: string | undefined): boolean {
+  if (!date) return false;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return false;
+  const now = new Date();
+  return (
+    parsed.getFullYear() === now.getFullYear() &&
+    parsed.getMonth() === now.getMonth() &&
+    parsed.getDate() === now.getDate()
+  );
+}
+
+function isOrderForStore(order: Order | undefined, storeId: string): order is Order {
+  if (!order) return false;
+  return order.items?.some((item) => item.product?.storeId === storeId) ?? false;
+}
+
+function getOrderAttentionScore(order: Order): number {
+  const updated = order.updatedAt ? new Date(order.updatedAt).getTime() : 0;
+  const created = order.createdAt ? new Date(order.createdAt).getTime() : 0;
+  return Math.max(updated, created);
+}
+
+interface Kpis {
+  ordersToday: number;
+  pendingKyc: number;
+  lowStock: number;
+}
+
+const initialKpis: Kpis = { ordersToday: 0, pendingKyc: 0, lowStock: 0 };
+
+export default function StoreDashboardScreen(): React.ReactElement {
+  const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
   const { t } = useLanguage();
-  const { user } = useAuth();
-  const [productCount, setProductCount] = useState(0);
-  const [authorized, setAuthorized] = useState(false);
-  const [store, setStore] = useState<any>(null);
-  const [products, setProducts] = useState<any[]>([]);
+  const { push } = useAppRouter();
+  const [kpis, setKpis] = useState<Kpis>(initialKpis);
+  const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const handleOpenProducts = useCallback(() => {
-    if (!storeId) return;
-    push(`/store/${storeId}/admin/products`);
-  }, [push, storeId]);
+  const computeKpis = useCallback(
+    (nextOrders: Order[], nextProducts: Product[], nextUsers: User[]) => {
+      const ordersToday = nextOrders.filter((order) => isToday(order.createdAt)).length;
+      const pendingKyc = nextUsers.filter((user) => user.kycStatus === 'pending').length;
+      const lowStock = nextProducts.filter(
+        (product) => product.storeId === storeId && (product.stock ?? 0) <= LOW_STOCK_THRESHOLD,
+      ).length;
+      setKpis({ ordersToday, pendingKyc, lowStock });
+    },
+    [storeId],
+  );
 
-  useEffect(() => {
-    let active = true;
-    (async () => {
-      if (!storeId) return;
-      try {
-        console.debug('SD: fetch store', storeId);
-        const s = await getNearStore(storeId, storeId);
-        if (active) setStore(s);
-      } catch {
-        // ignore
-      }
-      try {
-        console.debug('SD: fetch products', storeId);
-        const ps = await listNearProducts(storeId);
-        if (active) setProducts(ps || []);
-      } catch {
-        // ignore
-      }
-      if (active) setLoading(false);
-    })();
-    return () => {
-      active = false;
-    };
+  const loadFromCaches = useCallback(() => {
+    if (!storeId) return { orders: [], products: [], users: [] };
+    let cachedOrders: Order[] = [];
+    let cachedProducts: Product[] = [];
+    let cachedUsers: User[] = [];
+    try {
+      cachedOrders = ordersWarmCache.list((_, order) => isOrderForStore(order, storeId));
+    } catch {}
+    try {
+      cachedProducts = productsWarmCache.list((_, product) => product.storeId === storeId);
+    } catch {}
+    try {
+      cachedUsers = usersWarmCache.list();
+    } catch {}
+    return { orders: cachedOrders, products: cachedProducts, users: cachedUsers };
   }, [storeId]);
 
   useEffect(() => {
-    if (!storeId || !store) return;
-    const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
-    if (store.owner !== user?.address && !isAdmin) {
-      replace(routes.store(storeId));
-      return;
-    }
-    setAuthorized(true);
-    setProductCount(products.filter((p) => p.storeId === storeId).length);
-  }, [storeId, store, user?.address, products, impersonate]);
-  
+    if (!storeId) return;
+    let cancelled = false;
+    const hydrate = () => {
+      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+        loadFromCaches();
+      if (cancelled) return;
+      setOrders(
+        cachedOrders
+          .slice()
+          .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+      );
+      computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      setLoading(false);
+    };
 
-  if (!authorized) {
-    console.debug('SD: not authorized yet');
+    hydrate();
+
+    const unsubOrders = ordersWarmCache.subscribe((_, order) => {
+      if (!storeId || !isOrderForStore(order, storeId)) return;
+      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+        loadFromCaches();
+      if (cancelled) return;
+      setOrders(
+        cachedOrders
+          .slice()
+          .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+      );
+      computeKpis(cachedOrders, cachedProducts, cachedUsers);
+    });
+
+    const unsubProducts = productsWarmCache.subscribe((_, product) => {
+      if (!storeId || !product || product.storeId !== storeId) return;
+      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+        loadFromCaches();
+      if (cancelled) return;
+      computeKpis(cachedOrders, cachedProducts, cachedUsers);
+    });
+
+    const unsubUsers = usersWarmCache.subscribe(() => {
+      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+        loadFromCaches();
+      if (cancelled) return;
+      computeKpis(cachedOrders, cachedProducts, cachedUsers);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubOrders?.();
+      unsubProducts?.();
+      unsubUsers?.();
+    };
+  }, [storeId, loadFromCaches, computeKpis]);
+
+  const onRefresh = useCallback(() => {
+    if (!storeId) return;
+    setRefreshing(true);
+    const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+      loadFromCaches();
+    setOrders(
+      cachedOrders
+        .slice()
+        .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+    );
+    computeKpis(cachedOrders, cachedProducts, cachedUsers);
+    setRefreshing(false);
+  }, [computeKpis, loadFromCaches, storeId]);
+
+  const actionableOrders = useMemo(
+    () =>
+      orders
+        .filter(
+          (order) =>
+            !['delivered', 'released', 'refunded'].includes(order.status) &&
+            order.items?.length,
+        )
+        .slice(0, 3),
+    [orders],
+  );
+
+  const addProduct = useCallback(() => {
+    if (!storeId) return;
+    push(`/store/${storeId}/admin/products?create=1`);
+  }, [push, storeId]);
+
+  const openOrder = useCallback(
+    (orderId: string) => {
+      if (!storeId || !orderId) return;
+      push(`/store/${storeId}/admin/orders?orderId=${orderId}`);
+    },
+    [push, storeId],
+  );
+
+  if (loading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
         <Spinner />
       </View>
     );
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
-      <AdminOnboardingChecklist onAddProduct={handleOpenProducts} />
-      <View style={{ height: 16 }} />
-      <View style={styles.stats}>
-        <Text style={[styles.statText, { color: colors.text.primary }]}>
-          {t('admin.productCount', { count: productCount })}
-        </Text>
-        {storeId && <OrderRevenueMetrics storeId={storeId} />}
-      </View>
-      {storeId && <FeeDashboard tenantId={storeId} />}
-      <View style={styles.nav}>
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
         <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/products`)}
-        >
-          <Text style={{ color: colors.text.primary }}>{t('admin.manageProducts')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/orders`)}
-        >
-          <Text style={{ color: colors.text.primary }}>{t('admin.viewOrders')}</Text>
+          accessibilityRole="button"
+          style={[styles.addButton, { borderColor: colors.border.primary }]}
+          onPress={addProduct}>
+          <Text style={[styles.addButtonText, { color: colors.text.primary }]}>הוסף מוצר מהיר</Text>
         </TouchableOpacity>
       </View>
+
+      <View style={styles.kpiRow}>
+        <KpiCard
+          label="הזמנות היום"
+          value={kpis.ordersToday}
+          colors={colors}
+        />
+        <KpiCard
+          label="בקשות KYC ממתינות"
+          value={kpis.pendingKyc}
+          colors={colors}
+        />
+        <KpiCard
+          label={`מלאי נמוך (<${LOW_STOCK_THRESHOLD})`}
+          value={kpis.lowStock}
+          colors={colors}
+        />
+      </View>
+
+      {storeId ? (
+        <View style={styles.metricsSection}>
+          <OrderRevenueMetrics storeId={storeId} />
+          <View style={styles.metricSpacer} />
+          <FeeDashboard tenantId={storeId} />
+        </View>
+      ) : null}
+
+      <AdminOnboardingChecklist onAddProduct={addProduct} />
+
+      <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>הזמנות לטיפול</Text>
+      {actionableOrders.length === 0 ? (
+        <Text style={{ color: colors.text.secondary }}>אין הזמנות הדורשות פעולה.</Text>
+      ) : (
+        <View style={styles.bannerColumn}>
+          {actionableOrders.map((order) => (
+            <TouchableOpacity
+              key={order.id}
+              style={[styles.orderBanner, { borderColor: colors.border.primary }]}
+              onPress={() => openOrder(order.id)}>
+              <View style={styles.bannerText}>
+                <Text style={[styles.orderId, { color: colors.text.primary }]}>#{order.id}</Text>
+                <Text style={{ color: colors.text.secondary }}>{order.status}</Text>
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                {new Date(order.createdAt || order.updatedAt || Date.now()).toLocaleString('he-IL')}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+interface KpiCardProps {
+  label: string;
+  value: number;
+  colors: any;
+}
+
+function KpiCard({ label, value, colors }: KpiCardProps) {
+  return (
+    <View
+      style={[
+        styles.kpiCard,
+        {
+          backgroundColor: colors.surface.primary,
+          borderColor: colors.border.primary,
+        },
+      ]}>
+      <Text style={[styles.kpiValue, { color: colors.text.primary }]}>{value}</Text>
+      <Text style={[styles.kpiLabel, { color: colors.text.secondary }]}>{label}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 24, textAlign: 'right' },
-  stats: { marginBottom: 24, gap: 8, alignItems: 'flex-end' },
-  statText: { fontSize: 16 },
-  nav: { gap: 12 },
-  navButton: {
-    paddingVertical: 12,
+  container: { flex: 1 },
+  content: {
+    padding: 16,
+    gap: 16,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 22, fontWeight: '700' },
+  addButton: {
+    paddingVertical: 10,
     paddingHorizontal: 16,
     borderWidth: 1,
-    borderRadius: 8,
+    borderRadius: 10,
+  },
+  addButtonText: { fontSize: 14, fontWeight: '600' },
+  kpiRow: {
+    flexDirection: 'row',
+    gap: 12,
+    justifyContent: 'space-between',
+  },
+  kpiCard: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+  },
+  kpiValue: { fontSize: 28, fontWeight: '700', textAlign: 'center' },
+  kpiLabel: { fontSize: 14, textAlign: 'center', marginTop: 4 },
+  metricsSection: {
+    gap: 12,
+  },
+  metricSpacer: { height: 8 },
+  sectionTitle: { fontSize: 18, fontWeight: '600' },
+  bannerColumn: { gap: 12 },
+  orderBanner: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
   },
+  bannerText: { gap: 4 },
+  orderId: { fontSize: 16, fontWeight: '600' },
 });
-

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -39,9 +39,12 @@ function isOrderForStore(order: Order | undefined, storeId: string): order is Or
 }
 
 function getOrderAttentionScore(order: Order): number {
-  const updated = order.updatedAt ? new Date(order.updatedAt).getTime() : 0;
-  const created = order.createdAt ? new Date(order.createdAt).getTime() : 0;
-  return Math.max(updated, created);
+  const toTime = (value?: string | null) => {
+    if (!value) return 0;
+    const parsed = new Date(value).getTime();
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  return Math.max(toTime(order.updatedAt), toTime(order.createdAt));
 }
 
 interface Kpis {
@@ -109,33 +112,47 @@ export default function StoreDashboardScreen(): React.ReactElement {
 
     hydrate();
 
-    const unsubOrders = ordersWarmCache.subscribe((_, order) => {
-      if (!storeId || !isOrderForStore(order, storeId)) return;
-      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
-        loadFromCaches();
-      if (cancelled) return;
-      setOrders(
-        cachedOrders
-          .slice()
-          .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
-      );
-      computeKpis(cachedOrders, cachedProducts, cachedUsers);
-    });
+    const unsubOrders = ordersWarmCache.subscribe(
+      (_, order) => {
+        if (!storeId) return false;
+        if (!order) return false;
+        return isOrderForStore(order, storeId);
+      },
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        setOrders(
+          cachedOrders
+            .slice()
+            .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+        );
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
 
-    const unsubProducts = productsWarmCache.subscribe((_, product) => {
-      if (!storeId || !product || product.storeId !== storeId) return;
-      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
-        loadFromCaches();
-      if (cancelled) return;
-      computeKpis(cachedOrders, cachedProducts, cachedUsers);
-    });
+    const unsubProducts = productsWarmCache.subscribe(
+      (_, product) => {
+        if (!storeId) return false;
+        return !!product && product.storeId === storeId;
+      },
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
 
-    const unsubUsers = usersWarmCache.subscribe(() => {
-      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
-        loadFromCaches();
-      if (cancelled) return;
-      computeKpis(cachedOrders, cachedProducts, cachedUsers);
-    });
+    const unsubUsers = usersWarmCache.subscribe(
+      (_id, _user) => true,
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -1,233 +1,236 @@
-import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ScrollView,
   Alert,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useAppRouter } from '@/services';
-import { ArrowLeft, CircleCheck as CheckCircle, Circle as XCircle, Clock, User, Mail, FileText, Calendar } from 'lucide-react-native';
-import { useAuth } from '@/features/auth/AuthContext';
+import { ArrowLeft, FileText, ShieldCheck, XCircle } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
-import DatabaseService from '@/services/database';
-import { User as UserType } from '../../../../types';
+import { useAppRouter } from '@/services';
+import SettingsAgent from '@/agents/settings-agent';
+import usersAgent from '@/agents/users-agent';
+import type { User } from '@/types';
 import { Spinner } from '@/ui/primitives';
-import commonStyles from '@/constants/styles';
-import SmartImage from '../../../../components/SmartImage';
+import { issueKycReceipt, loadKycReceipt } from '@/services/kycReceipts';
 
+const POLICY_SETTING_KEY = 'kyc.required';
 
-
-export default function KycApprovalsScreen() {
-  const [pendingRequests, setPendingRequests] = useState<UserType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const { isAdmin, isDriver, user } = useAuth();
+export default function KycApprovalsScreen(): React.ReactElement {
   const { colors } = useTheme();
-  const { replace, back } = useAppRouter();
+  const { back } = useAppRouter();
+  const [policyRequired, setPolicyRequired] = useState(false);
+  const [pending, setPending] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [policySaving, setPolicySaving] = useState(false);
+  const [processingId, setProcessingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => replace('/') }
-      ]);
-      return;
-    }
-
-    loadPendingRequests();
-  }, [isAdmin, isDriver]);
-
-  const loadPendingRequests = async () => {
+  const refreshData = useCallback(async () => {
     setLoading(true);
     try {
-      const db = DatabaseService.getInstance();
-      const requests = await db.getPendingKycRequests();
-      setPendingRequests(requests);
+      const [policyValue, users] = await Promise.all([
+        SettingsAgent.getInstance().getSettingValue(POLICY_SETTING_KEY),
+        usersAgent.getAll(),
+      ]);
+      setPolicyRequired((policyValue || '').toLowerCase() === 'on');
+      setPending(users.filter((user) => user.kycStatus === 'pending'));
     } catch (error) {
-      errorLog('Error loading pending KYC requests:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה בטעינת בקשות האימות');
+      Alert.alert('שגיאה', 'טעינת בקשות KYC נכשלה');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const approveRequest = async (userId: string) => {
-    if (!user) return;
-    
+  useEffect(() => {
+    void refreshData();
+  }, [refreshData]);
+
+  const togglePolicy = useCallback(async () => {
+    const next = !policyRequired;
+    setPolicySaving(true);
     try {
-      const db = DatabaseService.getInstance();
-      const success = await db.updateUserKycStatus(userId, 'verified', user.id);
-      
-      if (success) {
-        // Update local state
-        setPendingRequests(prev => prev.filter(req => req.id !== userId));
-        Alert.alert('הצלחה', 'אימות KYC אושר בהצלחה');
-      } else {
-        Alert.alert('שגיאה', 'אירעה שגיאה באישור האימות');
-      }
+      await SettingsAgent.getInstance().updateSettingValue(
+        POLICY_SETTING_KEY,
+        next ? 'on' : 'off',
+      );
+      setPolicyRequired(next);
     } catch (error) {
-      errorLog('Error approving KYC request:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה באישור האימות');
+      Alert.alert('שגיאה', 'עדכון מדיניות KYC נכשל');
+    } finally {
+      setPolicySaving(false);
     }
-  };
+  }, [policyRequired]);
 
-  const rejectRequest = async (userId: string) => {
-    if (!user) return;
-    
+  const handlePreview = useCallback((user: User) => {
+    if (user.kycDocumentUri) {
+      Linking.openURL(user.kycDocumentUri).catch(() =>
+        Alert.alert('שגיאה', 'לא ניתן לפתוח את מסמך ה-KYC'),
+      );
+    } else if (user.kycRequestNotes) {
+      Alert.alert('הערות משתמש', user.kycRequestNotes);
+    } else {
+      Alert.alert('מידע חסר', 'לא נמצאו מסמכי אימות עבור משתמש זה.');
+    }
+  }, []);
+
+  const approveRequest = useCallback(
+    async (user: User) => {
+      setProcessingId(user.id);
+      try {
+        await usersAgent.updateKyc(user.id, 'verified');
+        if (user.publicKey) {
+          const existingReceipt = await loadKycReceipt(user.publicKey);
+          if (!existingReceipt) {
+            await issueKycReceipt(user.publicKey, { userId: user.id });
+          }
+        }
+        setPending((prev) => prev.filter((item) => item.id !== user.id));
+        Alert.alert('הצלחה', 'האימות אושר ונשלחה קבלה חתומה');
+      } catch (error) {
+        Alert.alert('שגיאה', 'אישור הבקשה נכשל');
+      } finally {
+        setProcessingId(null);
+      }
+    },
+    [],
+  );
+
+  const declineRequest = useCallback(async (user: User) => {
+    setProcessingId(user.id);
     try {
-      const db = DatabaseService.getInstance();
-      const success = await db.updateUserKycStatus(userId, 'rejected', user.id);
-      
-      if (success) {
-        // Update local state
-        setPendingRequests(prev => prev.filter(req => req.id !== userId));
-        Alert.alert('הצלחה', 'אימות KYC נדחה');
-      } else {
-        Alert.alert('שגיאה', 'אירעה שגיאה בדחיית האימות');
-      }
+      await usersAgent.updateKyc(user.id, 'rejected');
+      setPending((prev) => prev.filter((item) => item.id !== user.id));
+      Alert.alert('עודכן', 'הבקשה נדחתה והמשתמש עודכן.');
     } catch (error) {
-      errorLog('Error rejecting KYC request:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה בדחיית האימות');
+      Alert.alert('שגיאה', 'דחיית הבקשה נכשלה');
+    } finally {
+      setProcessingId(null);
     }
-  };
+  }, []);
 
-  const formatDate = (dateString?: string) => {
-    if (!dateString) return 'לא זמין';
-    return new Date(dateString).toLocaleDateString('he-IL', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
+  const policyDescription = useMemo(
+    () =>
+      policyRequired
+        ? 'לקוחות ללא קבלה חתומה ייחסמו בקופה.'
+        : 'הקופה תתאפשר ללא אימות מוקדם.',
+    [policyRequired],
+  );
 
   if (loading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
-        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => back()}>
+        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
+          <TouchableOpacity onPress={back} accessibilityRole="button">
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>
-          <View style={commonStyles.spacer24} />
+          <Text style={[styles.title, { color: colors.text.primary }]}>אישורי KYC</Text>
+          <View style={{ width: 24 }} />
         </View>
-        <Spinner />
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => back()}>
-          <ArrowLeft size={24} color={colors.text.primary} />
-        </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>
-        <View style={commonStyles.spacer24} />
-      </View>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
+      <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
+        <TouchableOpacity onPress={back} accessibilityRole="button"> 
+          <ArrowLeft size={24} color={colors.text.primary} /> 
+        </TouchableOpacity> 
+        <Text style={[styles.title, { color: colors.text.primary }]}>אישורי KYC</Text> 
+        <View style={{ width: 24 }} /> 
+      </View> 
 
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.titleContainer}>
-          <Clock size={24} color={colors.gold} />
-          <Text style={[styles.title, { color: colors.text.primary }]}>בקשות אימות KYC ממתינות</Text>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}> 
+        <View style={[styles.policyCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
+          <View style={styles.policyHeader}> 
+            <ShieldCheck size={20} color={colors.gold} /> 
+            <Text style={[styles.policyTitle, { color: colors.text.primary }]}>מדיניות אימות</Text> 
+          </View> 
+          <View style={styles.policyToggle}> 
+            <Text style={{ color: colors.text.primary }}>דרוש KYC לפני רכישה</Text> 
+            <Switch
+              value={policyRequired}
+              onValueChange={togglePolicy}
+              thumbColor={policyRequired ? colors.gold : colors.border.primary}
+              disabled={policySaving}
+            />
+          </View>
+          <Text style={{ color: colors.text.secondary }}>{policyDescription}</Text>
         </View>
 
-        {pendingRequests.length > 0 ? (
-          <View style={styles.requestsList}>
-            {pendingRequests.map((request) => (
-              <View key={request.id} style={[styles.requestCard, { 
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary 
-              }]}>
-                <View style={styles.userInfo}>
-                  <View style={styles.avatarContainer}>
-                    {request.avatar ? (
-                      <SmartImage
-                        uri={request.avatar}
-                        width={60}
-                        height={60}
-                        style={[styles.avatar, { borderColor: colors.gold }]}
-                      />
-                    ) : (
-                      <View style={[styles.avatarPlaceholder, { 
-                        backgroundColor: colors.surface.secondary,
-                        borderColor: colors.border.primary 
-                      }]}>
-                        <User size={24} color={colors.interactive.disabled} />
-                      </View>
-                    )}
-                  </View>
-                  
-                  <View style={styles.userDetails}>
-                    <Text style={[styles.userName, { color: colors.text.primary }]}>{request.displayName}</Text>
-                    <View style={styles.userDetailRow}>
-                      <User size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>@{request.username}</Text>
-                    </View>
-                    <View style={styles.userDetailRow}>
-                      <Mail size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>{request.email}</Text>
-                    </View>
-                    <View style={styles.userDetailRow}>
-                      <Calendar size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>
-                        בקשה מ: {formatDate(request.kycRequestedAt)}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-
-                {request.kycRequestNotes && (
-                  <View style={[styles.notesContainer, { backgroundColor: colors.surface.secondary }]}>
-                    <View style={styles.notesHeader}>
-                      <FileText size={16} color={colors.gold} />
-                      <Text style={[styles.notesTitle, { color: colors.text.primary }]}>הערות המשתמש:</Text>
-                    </View>
-                    <Text style={[styles.notesText, { color: colors.text.secondary }]}>{request.kycRequestNotes}</Text>
-                  </View>
-                )}
-
-                <View style={styles.actionButtons}>
-                  <TouchableOpacity 
-                    style={[styles.approveButton, { backgroundColor: colors.status.success }]}
-                    onPress={() => approveRequest(request.id)}
-                  >
-                    <CheckCircle size={20} color={colors.text.inverse} />
-                    <Text style={[styles.approveButtonText, { color: colors.text.inverse }]}>אשר</Text>
-                  </TouchableOpacity>
-                  
-                  <TouchableOpacity 
-                    style={[styles.rejectButton, { backgroundColor: colors.status.error }]}
-                    onPress={() => rejectRequest(request.id)}
-                  >
-                    <XCircle size={20} color={colors.text.inverse} />
-                    <Text style={[styles.rejectButtonText, { color: colors.text.inverse }]}>דחה</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            ))}
+        <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>בקשות ממתינות</Text>
+        {pending.length === 0 ? (
+          <View style={styles.emptyState}>
+            <ShieldCheck size={48} color={colors.interactive.disabled} />
+            <Text style={{ color: colors.text.secondary }}>אין בקשות חדשות</Text>
           </View>
         ) : (
-          <View style={styles.emptyContainer}>
-            <CheckCircle size={80} color={colors.interactive.disabled} />
-            <Text style={[styles.emptyTitle, { color: colors.text.primary }]}>אין בקשות אימות ממתינות</Text>
-            <Text style={[styles.emptyMessage, { color: colors.text.secondary }]}>
-              כל בקשות האימות טופלו. בדוק שוב מאוחר יותר.
-            </Text>
-          </View>
+          pending.map((user) => (
+            <View
+              key={user.id}
+              style={[styles.requestCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
+              <View style={styles.requestHeader}> 
+                <View> 
+                  <Text style={[styles.requestName, { color: colors.text.primary }]}>{user.displayName || user.username}</Text> 
+                  <Text style={{ color: colors.text.secondary }}>{user.email}</Text> 
+                </View> 
+                <TouchableOpacity
+                  style={styles.previewButton}
+                  onPress={() => handlePreview(user)}
+                  accessibilityRole="button">
+                  <FileText size={18} color={colors.text.primary} />
+                  <Text style={{ color: colors.text.primary }}>תצוגה</Text>
+                </TouchableOpacity>
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                בקשה: {formatDate(user.kycRequestedAt)}
+              </Text>
+              {user.kycRequestNotes ? (
+                <Text style={[styles.notes, { color: colors.text.secondary }]}>{user.kycRequestNotes}</Text>
+              ) : null}
+              <View style={styles.actionsRow}>
+                <TouchableOpacity
+                  style={[styles.approveButton, { borderColor: colors.status.success }]}
+                  onPress={() => approveRequest(user)}
+                  disabled={processingId === user.id}>
+                  <ShieldCheck size={18} color={colors.status.success} />
+                  <Text style={{ color: colors.status.success }}>אשר</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.rejectButton, { borderColor: colors.status.error }]}
+                  onPress={() => declineRequest(user)}
+                  disabled={processingId === user.id}>
+                  <XCircle size={18} color={colors.status.error} />
+                  <Text style={{ color: colors.status.error }}>דחה</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ))
         )}
       </ScrollView>
     </SafeAreaView>
   );
 }
 
+function formatDate(value?: string): string {
+  if (!value) return 'לא זמין';
+  try {
+    return new Date(value).toLocaleString('he-IL');
+  } catch {
+    return value;
+  }
+}
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -236,137 +239,26 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     borderBottomWidth: 1,
   },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  content: {
-    flex: 1,
-    padding: 16,
-  },
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginLeft: 8,
-  },
-  requestsList: {
-    gap: 16,
-  },
-  requestCard: {
-    borderRadius: 16,
-    padding: 16,
+  title: { fontSize: 18, fontWeight: 'bold' },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  content: { padding: 16, gap: 16, paddingBottom: 40 },
+  policyCard: {
     borderWidth: 1,
-  },
-  userInfo: {
-    flexDirection: 'row',
-    marginBottom: 16,
-  },
-  avatarContainer: {
-    marginRight: 16,
-  },
-  avatar: {
-    borderRadius: 30,
-    borderWidth: 2,
-  },
-  avatarPlaceholder: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-  },
-  userDetails: {
-    flex: 1,
-  },
-  userName: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 8,
-    textAlign: 'right',
-  },
-  userDetailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-    justifyContent: 'flex-end',
-  },
-  userDetailText: {
-    fontSize: 14,
-    marginRight: 6,
-  },
-  notesContainer: {
     borderRadius: 12,
-    padding: 12,
-    marginBottom: 16,
-  },
-  notesHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-    justifyContent: 'flex-end',
-  },
-  notesTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginRight: 8,
-  },
-  notesText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'right',
-  },
-  actionButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    padding: 16,
     gap: 12,
   },
-  approveButton: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  approveButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  rejectButton: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  rejectButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 60,
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 16,
-    marginBottom: 8,
-  },
-  emptyMessage: {
-    fontSize: 16,
-    textAlign: 'center',
-    lineHeight: 24,
-  },
+  policyHeader: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  policyTitle: { fontSize: 16, fontWeight: '600' },
+  policyToggle: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  sectionTitle: { fontSize: 18, fontWeight: '600' },
+  emptyState: { alignItems: 'center', gap: 12, paddingVertical: 40 },
+  requestCard: { borderWidth: 1, borderRadius: 12, padding: 16, gap: 12 },
+  requestHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  requestName: { fontSize: 16, fontWeight: '600' },
+  previewButton: { flexDirection: 'row', gap: 6, alignItems: 'center' },
+  notes: { fontStyle: 'italic' },
+  actionsRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  approveButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
+  rejectButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
 });

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -1,86 +1,322 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
-import { debugLog } from '@/utils/logger';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import { useTheme } from '@/ui/ThemeProvider';
-import { chainAdapter } from '@/services/chain';
-import { useWallet } from '@/contexts/WalletProvider';
-import type { Order } from '../../../../types';
-import { useLanguage } from '@/ui/ThemeProvider';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import type { Order, OrderStatus } from '@/types';
+import { useOrders } from '@/services/useOrders';
+import { ordersWarmCache } from '@/services/nearOrders';
+import ordersAgent, { ALLOWED_STATUS_TRANSITIONS } from '@/agents/orders-agent';
+import { Spinner } from '@/ui/primitives';
+import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
 
-export default function StoreOrdersScreen() {
+const SHIPPING_SEQUENCE: OrderStatus[] = [
+  'order_received',
+  'courier_found',
+  'courier_picked_up',
+  'courier_on_way',
+];
+
+const FILTERS = [
+  { id: 'open', label: 'פתוחות' },
+  { id: 'completed', label: 'הושלמו' },
+  { id: 'refunded', label: 'בוטלו' },
+  { id: 'all', label: 'הכל' },
+] as const;
+
+type FilterKey = typeof FILTERS[number]['id'];
+
+function formatDate(value?: string): string {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString('he-IL');
+  } catch {
+    return value;
+  }
+}
+
+function getFilterPredicate(filter: FilterKey): (order: Order) => boolean {
+  switch (filter) {
+    case 'open':
+      return (order) => !['delivered', 'released', 'refunded'].includes(order.status);
+    case 'completed':
+      return (order) => ['delivered', 'released'].includes(order.status);
+    case 'refunded':
+      return (order) => order.status === 'refunded';
+    default:
+      return () => true;
+  }
+}
+
+async function advanceStatus(order: Order, target: OrderStatus): Promise<Order> {
+  let current = order;
+  const visited = new Set<OrderStatus>();
+  while (current.status !== target) {
+    visited.add(current.status);
+    const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
+    if (allowed.length === 0) break;
+    const next = allowed.includes(target) ? target : allowed[0];
+    if (visited.has(next)) break;
+    const updated: Order = {
+      ...current,
+      status: next,
+      updatedAt: new Date().toISOString(),
+    };
+    await ordersAgent.update(updated);
+    ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
+    current = updated;
+  }
+  return current;
+}
+
+export default function StoreOrdersScreen(): React.ReactElement {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
-  const [orders, setOrders] = useState<Order[]>([]);
-  const { address } = useWallet();
   const { t } = useLanguage();
-
-  const handlePress = (order: Order) => {
-    debugLog('Pressed order', order.id);
-  };
-
-  const handleLongPress = (order: Order) => {
-    debugLog('Long pressed order', order.id);
-  };
+  const { requireUnlock } = useLaunchGate();
+  const [filter, setFilter] = useState<FilterKey>('open');
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const {
+    data: fetchedOrders = [],
+    isLoading,
+    isRefetching,
+    refetch,
+  } = useOrders(storeId ?? null);
 
   useEffect(() => {
-    const load = async () => {
-      if (!storeId || address !== storeId || !chainAdapter.listOrdersBySeller) return;
-      const all = await chainAdapter.listOrdersBySeller(storeId, storeId);
-      setOrders(all);
-    };
-    load();
-  }, [storeId, address]);
+    if (!storeId) return;
+    const sorted = fetchedOrders
+      .filter((order) => order.items?.[0]?.product?.storeId === storeId)
+      .slice()
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    setOrders(sorted);
+  }, [fetchedOrders, storeId]);
 
-  if (address !== storeId) {
+  useEffect(() => {
+    if (!storeId) return;
+    const unsub = ordersWarmCache.subscribe((_, value) => {
+      if (!value || value.items?.[0]?.product?.storeId !== storeId) return;
+      setOrders((prev) => {
+        const next = prev.some((order) => order.id === value.id)
+          ? prev.map((order) => (order.id === value.id ? value : order))
+          : [value, ...prev];
+        return next
+          .slice()
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      });
+    });
+    return () => unsub?.();
+  }, [storeId]);
+
+  const filtered = useMemo(() => orders.filter(getFilterPredicate(filter)), [orders, filter]);
+
+  const handleMarkShipped = useCallback(
+    async (order: Order) => {
+      setPendingId(order.id);
+      try {
+        const target = order.status === 'courier_on_way' ? 'delivered' : 'courier_on_way';
+        const pathIndex = SHIPPING_SEQUENCE.indexOf(order.status);
+        if (target === 'courier_on_way' && pathIndex === -1) {
+          throw new Error('לא ניתן לסמן הזמנה זו כנשלחה');
+        }
+        let updated = order;
+        if (target === 'courier_on_way' && pathIndex >= 0) {
+          for (const step of SHIPPING_SEQUENCE.slice(pathIndex + 1)) {
+            updated = await advanceStatus(updated, step);
+            if (step === 'courier_on_way') break;
+          }
+        } else {
+          updated = await advanceStatus(updated, target);
+        }
+        setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      } catch (error) {
+        Alert.alert('שגיאה', 'עדכון סטטוס ההזמנה נכשל');
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [],
+  );
+
+  const handleCancel = useCallback(
+    (order: Order) => {
+      Alert.alert('ביטול הזמנה', 'האם לבטל את ההזמנה?', [
+        { text: 'לא', style: 'cancel' },
+        {
+          text: 'כן, בטל',
+          style: 'destructive',
+          onPress: async () => {
+            setPendingId(order.id);
+            try {
+              await requireUnlock('order.cancel');
+              const updated: Order = {
+                ...order,
+                status: 'refunded',
+                updatedAt: new Date().toISOString(),
+              };
+              await ordersAgent.update(updated);
+              ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
+              setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+            } catch (error) {
+              Alert.alert('שגיאה', 'ביטול ההזמנה נכשל');
+            } finally {
+              setPendingId(null);
+            }
+          },
+        },
+      ]);
+    },
+    [requireUnlock],
+  );
+
+  const refreshing = isLoading || isRefetching;
+
+  if (!storeId) {
     return (
-      <View
-        style={[
-          styles.container,
-          styles.content,
-          { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>{t('orders.connectWallet')}</Text>
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>בחר חנות להצגת הזמנות.</Text>
       </View>
     );
   }
 
   return (
-    <FlatList
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={styles.content}
-      data={orders}
-      keyExtractor={(order) => order.id}
-      renderItem={({ item: o }) => (
-        <TouchableOpacity
-          style={[styles.orderItem, { borderColor: colors.border.primary }]}
-          onPress={() => handlePress(o)}
-          onLongPress={() => handleLongPress(o)}
-        >
-          <Text style={{ color: colors.text.primary }}>#{o.id}</Text>
-          <Text style={{ color: colors.text.primary }}>{o.status}</Text>
-          <Text style={{ color: colors.text.primary }}>{o.total}</Text>
-        </TouchableOpacity>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={styles.filterRow}>
+        {FILTERS.map((item) => {
+          const active = filter === item.id;
+          return (
+            <TouchableOpacity
+              key={item.id}
+              style={[
+                styles.filterButton,
+                {
+                  borderColor: active ? colors.gold : colors.border.primary,
+                  backgroundColor: active ? colors.surface.secondary : 'transparent',
+                },
+              ]}
+              onPress={() => setFilter(item.id)}
+              accessibilityRole="button">
+              <Text style={{ color: active ? colors.gold : colors.text.primary }}>{item.label}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {isLoading && orders.length === 0 ? (
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(order) => order.id}
+          renderItem={({ item }) => (
+            <OrderRow
+              order={item}
+              colors={colors}
+              busy={pendingId === item.id}
+              onMarkShipped={handleMarkShipped}
+              onCancel={handleCancel}
+            />
+          )}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refetch} />}
+          ListEmptyComponent={
+            <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+              {t('orders.emptyTitle', 'אין הזמנות להצגה')}
+            </Text>
+          }
+          contentContainerStyle={styles.listContent}
+        />
       )}
-      ListEmptyComponent={
-        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
-          {t('orders.emptyTitle')}
+    </View>
+  );
+}
+
+interface OrderRowProps {
+  order: Order;
+  colors: any;
+  busy: boolean;
+  onMarkShipped: (order: Order) => void;
+  onCancel: (order: Order) => void;
+}
+
+function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProps) {
+  const actionable = !['released', 'refunded'].includes(order.status);
+  return (
+    <View
+      style={[
+        styles.orderCard,
+        { borderColor: colors.border.primary, backgroundColor: colors.surface.primary, opacity: busy ? 0.6 : 1 },
+      ]}>
+      <View style={styles.orderHeader}>
+        <Text style={[styles.orderTitle, { color: colors.text.primary }]}>#{order.id}</Text>
+        <Text style={{ color: colors.text.secondary }}>{formatDate(order.createdAt)}</Text>
+      </View>
+      <View style={styles.orderMeta}>
+        <Text style={{ color: colors.text.secondary }}>סטטוס: {order.status}</Text>
+        <Text style={{ color: colors.text.secondary }}>
+          סכום: ₪{order.total.toLocaleString('he-IL')}
         </Text>
-      }
-      ListHeaderComponent={
-        <Text style={[styles.title, { color: colors.text.primary }]}>
-          {t('navigation.orders')}
-        </Text>
-      }
-    />
+      </View>
+      <View style={styles.actionRow}>
+        <TouchableOpacity
+          style={[styles.secondaryButton, { borderColor: colors.border.primary }]}
+          onPress={() => onMarkShipped(order)}
+          disabled={!actionable || busy}>
+          <Text style={{ color: colors.text.primary }}>
+            {order.status === 'courier_on_way' ? 'סמן נמסר' : 'סמן נשלח'}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.dangerButton, { borderColor: colors.status.error }]}
+          onPress={() => onCancel(order)}
+          disabled={order.status === 'refunded' || busy}>
+          <Text style={{ color: colors.status.error }}>בטל</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  content: { padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 16, textAlign: 'right' },
-  orderItem: { padding: 12, borderWidth: 1, borderRadius: 8, marginBottom: 12 },
+  container: { flex: 1, padding: 16 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  filterRow: { flexDirection: 'row', gap: 12, marginBottom: 16 },
+  filterButton: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+  },
+  listContent: { gap: 12, paddingBottom: 48 },
+  orderCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  orderHeader: { flexDirection: 'row', justifyContent: 'space-between' },
+  orderTitle: { fontSize: 16, fontWeight: '600' },
+  orderMeta: { flexDirection: 'row', justifyContent: 'space-between' },
+  actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  dangerButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
 });
-

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -16,6 +16,8 @@ import { ordersWarmCache } from '@/services/nearOrders';
 import ordersAgent, { ALLOWED_STATUS_TRANSITIONS } from '@/agents/orders-agent';
 import { Spinner } from '@/ui/primitives';
 import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
+import OrderTrackingModal from '@/components/OrderTrackingModal';
+import { useAppRouter } from '@/services';
 
 const SHIPPING_SEQUENCE: OrderStatus[] = [
   'order_received',
@@ -32,6 +34,11 @@ const FILTERS = [
 ] as const;
 
 type FilterKey = typeof FILTERS[number]['id'];
+
+function getCreatedAt(order: Order): number {
+  const ts = order.createdAt ? new Date(order.createdAt).getTime() : 0;
+  return Number.isFinite(ts) ? ts : 0;
+}
 
 function formatDate(value?: string): string {
   if (!value) return '';
@@ -77,13 +84,18 @@ async function advanceStatus(order: Order, target: OrderStatus): Promise<Order> 
 }
 
 export default function StoreOrdersScreen(): React.ReactElement {
-  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+  const params = useLocalSearchParams<{ storeId: string; orderId?: string | string[] }>();
+  const storeId = params.storeId;
+  const orderIdParam = Array.isArray(params.orderId) ? params.orderId[0] : params.orderId;
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { requireUnlock } = useLaunchGate();
+  const { replace } = useAppRouter();
   const [filter, setFilter] = useState<FilterKey>('open');
   const [orders, setOrders] = useState<Order[]>([]);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [detailsVisible, setDetailsVisible] = useState(false);
   const {
     data: fetchedOrders = [],
     isLoading,
@@ -96,25 +108,54 @@ export default function StoreOrdersScreen(): React.ReactElement {
     const sorted = fetchedOrders
       .filter((order) => order.items?.[0]?.product?.storeId === storeId)
       .slice()
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      .sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
     setOrders(sorted);
   }, [fetchedOrders, storeId]);
 
   useEffect(() => {
     if (!storeId) return;
-    const unsub = ordersWarmCache.subscribe((_, value) => {
-      if (!value || value.items?.[0]?.product?.storeId !== storeId) return;
-      setOrders((prev) => {
-        const next = prev.some((order) => order.id === value.id)
-          ? prev.map((order) => (order.id === value.id ? value : order))
-          : [value, ...prev];
-        return next
-          .slice()
-          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-      });
-    });
-    return () => unsub?.();
+    const unsubscribe = ordersWarmCache.subscribe(
+      (_, value) => {
+        if (!storeId) return false;
+        if (!value) return true;
+        return value.items?.[0]?.product?.storeId === storeId;
+      },
+      (id, value) => {
+        setOrders((prev) => {
+          if (!value) {
+            return prev.filter((order) => order.id !== id);
+          }
+          if (value.items?.[0]?.product?.storeId !== storeId) return prev;
+          const next = prev.some((order) => order.id === value.id)
+            ? prev.map((order) => (order.id === value.id ? value : order))
+            : [value, ...prev];
+          return next
+            .slice()
+            .sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
+        });
+      },
+    );
+    return () => unsubscribe?.();
   }, [storeId]);
+
+  useEffect(() => {
+    if (!orderIdParam) {
+      setDetailsVisible(false);
+      setSelectedOrder(null);
+      return;
+    }
+    const match = orders.find((order) => order.id === orderIdParam);
+    if (match) {
+      setSelectedOrder(match);
+      setDetailsVisible(true);
+    }
+  }, [orderIdParam, orders]);
+
+  useEffect(() => {
+    if (!detailsVisible || !selectedOrder) return;
+    const updated = orders.find((order) => order.id === selectedOrder.id);
+    if (updated) setSelectedOrder(updated);
+  }, [detailsVisible, orders, selectedOrder?.id]);
 
   const filtered = useMemo(() => orders.filter(getFilterPredicate(filter)), [orders, filter]);
 
@@ -122,11 +163,16 @@ export default function StoreOrdersScreen(): React.ReactElement {
     async (order: Order) => {
       setPendingId(order.id);
       try {
-        const target = order.status === 'courier_on_way' ? 'delivered' : 'courier_on_way';
-        const pathIndex = SHIPPING_SEQUENCE.indexOf(order.status);
-        if (target === 'courier_on_way' && pathIndex === -1) {
+        let target: OrderStatus | null = null;
+        if (order.status === 'courier_on_way') {
+          target = 'delivered';
+        } else if (SHIPPING_SEQUENCE.includes(order.status)) {
+          target = 'courier_on_way';
+        }
+        if (!target) {
           throw new Error('לא ניתן לסמן הזמנה זו כנשלחה');
         }
+        const pathIndex = SHIPPING_SEQUENCE.indexOf(order.status);
         let updated = order;
         if (target === 'courier_on_way' && pathIndex >= 0) {
           for (const step of SHIPPING_SEQUENCE.slice(pathIndex + 1)) {
@@ -176,6 +222,14 @@ export default function StoreOrdersScreen(): React.ReactElement {
     },
     [requireUnlock],
   );
+
+  const closeDetails = useCallback(() => {
+    setDetailsVisible(false);
+    setSelectedOrder(null);
+    if (storeId) {
+      replace(`/store/${storeId}/admin/orders`);
+    }
+  }, [replace, storeId]);
 
   const refreshing = isLoading || isRefetching;
 
@@ -236,6 +290,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
           contentContainerStyle={styles.listContent}
         />
       )}
+      <OrderTrackingModal visible={detailsVisible} order={selectedOrder} onClose={closeDetails} />
     </View>
   );
 }
@@ -249,7 +304,14 @@ interface OrderRowProps {
 }
 
 function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProps) {
-  const actionable = !['released', 'refunded'].includes(order.status);
+  const actionableStatuses: OrderStatus[] = [
+    'order_received',
+    'courier_found',
+    'courier_picked_up',
+    'courier_on_way',
+  ];
+  const actionable = actionableStatuses.includes(order.status);
+  const cancellable = ['order_received', 'courier_found'].includes(order.status);
   return (
     <View
       style={[
@@ -278,7 +340,7 @@ function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProp
         <TouchableOpacity
           style={[styles.dangerButton, { borderColor: colors.status.error }]}
           onPress={() => onCancel(order)}
-          disabled={order.status === 'refunded' || busy}>
+          disabled={!cancellable || busy}>
           <Text style={{ color: colors.status.error }}>בטל</Text>
         </TouchableOpacity>
       </View>

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -31,6 +31,8 @@ const LOW_STOCK_THRESHOLD = 5;
 
 function ProductRow({ product, colors, busy, onEdit, onToggle, onDelete }: ProductRowProps) {
   const isActive = product.isActive !== false;
+  const stock = product.stock ?? 0;
+  const price = Number.isFinite(product.price) ? product.price : Number(product.price ?? 0);
   return (
     <View
       style={[
@@ -44,12 +46,12 @@ function ProductRow({ product, colors, busy, onEdit, onToggle, onDelete }: Produ
       <View style={styles.rowInfo}>
         <Text style={[styles.productName, { color: colors.text.primary }]}>{product.name}</Text>
         <Text style={{ color: colors.text.secondary }}>
-          ₪{product.price.toLocaleString('he-IL')} · מלאי {product.stock}
+          ₪{price.toLocaleString('he-IL')} · מלאי {stock}
         </Text>
         {!isActive && (
           <Text style={[styles.statusBadge, { color: colors.status.error }]}>מושבת</Text>
         )}
-        {product.stock <= LOW_STOCK_THRESHOLD && isActive ? (
+        {stock <= LOW_STOCK_THRESHOLD && isActive ? (
           <Text style={[styles.statusBadge, { color: colors.status.warning }]}>מלאי נמוך</Text>
         ) : null}
       </View>
@@ -105,6 +107,33 @@ export default function StoreProductsScreen(): React.ReactElement {
         .sort((a, b) => a.name.localeCompare(b.name)),
     );
   }, [fetchedProducts, storeId]);
+
+  useEffect(() => {
+    if (!storeId) return;
+    const unsubscribe = productsWarmCache.subscribe(
+      (_, product) => {
+        if (!storeId) return false;
+        if (!product) return true;
+        return product.storeId === storeId;
+      },
+      (id, product) => {
+        setProducts((prev) => {
+          if (!product) {
+            return prev.filter((item) => item.id !== id);
+          }
+          if (product.storeId !== storeId) return prev;
+          const next = prev.some((item) => item.id === id)
+            ? prev.map((item) => (item.id === id ? product : item))
+            : [...prev, product];
+          return next
+            .filter((item) => item.storeId === storeId)
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
+      },
+    );
+    return () => unsubscribe?.();
+  }, [storeId]);
 
   const openForm = useCallback(
     (product?: Product) => {

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -1,113 +1,246 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '@/ui/ThemeProvider';
-import { Product } from '../../../../types';
-import { spacing, radius } from '@/shared/ui/tokens';
+import type { Product } from '@/types';
 import { useProducts } from '@/services/useProducts';
-import { ProductCard, ProductFormModal } from '@/features/products';
-import { useWallet } from '@/contexts/WalletProvider';
-import { useAuth } from '@/features/auth/AuthContext';
+import { productsWarmCache } from '@/features/products/services/nearProducts';
+import { useLanguage } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
+import DatabaseService from '@/services/database';
+import { ProductFormModal } from '@/features/products';
 
-const ITEM_HEIGHT = 200;
-
-interface ProductItemProps {
+interface ProductRowProps {
   product: Product;
-  onEdit: (p: Product) => void;
+  colors: any;
+  busy: boolean;
+  onEdit: (product: Product) => void;
+  onToggle: (product: Product) => void;
+  onDelete: (product: Product) => void;
 }
 
-const ProductItem = React.memo(({ product, onEdit }: ProductItemProps) => (
-  <TouchableOpacity
-    style={{ marginBottom: spacing.spacer12 }}
-    onPress={() => onEdit(product)}
-  >
-    <ProductCard key={product.id} product={product} />
-  </TouchableOpacity>
-));
+const LOW_STOCK_THRESHOLD = 5;
 
-export default function StoreProductsScreen() {
+function ProductRow({ product, colors, busy, onEdit, onToggle, onDelete }: ProductRowProps) {
+  const isActive = product.isActive !== false;
+  return (
+    <View
+      style={[
+        styles.row,
+        {
+          borderColor: colors.border.primary,
+          backgroundColor: colors.surface.primary,
+          opacity: busy ? 0.5 : 1,
+        },
+      ]}>
+      <View style={styles.rowInfo}>
+        <Text style={[styles.productName, { color: colors.text.primary }]}>{product.name}</Text>
+        <Text style={{ color: colors.text.secondary }}>
+          ₪{product.price.toLocaleString('he-IL')} · מלאי {product.stock}
+        </Text>
+        {!isActive && (
+          <Text style={[styles.statusBadge, { color: colors.status.error }]}>מושבת</Text>
+        )}
+        {product.stock <= LOW_STOCK_THRESHOLD && isActive ? (
+          <Text style={[styles.statusBadge, { color: colors.status.warning }]}>מלאי נמוך</Text>
+        ) : null}
+      </View>
+      <View style={styles.rowActions}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.actionButton, { borderColor: colors.border.primary }]}
+          onPress={() => onEdit(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.text.primary }}>עריכה</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.actionButton, { borderColor: colors.border.primary }]}
+          onPress={() => onToggle(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.text.primary }}>{isActive ? 'השהה' : 'הפעל'}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.deleteButton, { borderColor: colors.status.error }]}
+          onPress={() => onDelete(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.status.error }}>מחק</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+export default function StoreProductsScreen(): React.ReactElement {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
+  const { t } = useLanguage();
+  const db = useMemo(() => DatabaseService.getInstance(), []);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [formVisible, setFormVisible] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null);
   const {
-    data: initialProducts = [],
+    data: fetchedProducts = [],
     isLoading,
+    isRefetching,
     refetch,
   } = useProducts(storeId ?? null);
-  const [products, setProducts] = useState<Product[]>(initialProducts);
-  const [formVisible, setFormVisible] = useState(false);
-  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
-  const { address } = useWallet();
-  const { isStoreOwner } = useAuth();
 
   useEffect(() => {
-    setProducts(initialProducts.filter((p) => p.storeId === storeId));
-  }, [initialProducts, storeId]);
+    if (!storeId) return;
+    setProducts(
+      fetchedProducts
+        .filter((product) => product.storeId === storeId)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    );
+  }, [fetchedProducts, storeId]);
 
-  const openForm = useCallback((p?: Product) => {
-    setEditingProduct(p || null);
-    setFormVisible(true);
-  }, []);
-
-  const handleSaved = useCallback((p: Product, isNew: boolean) => {
-    if (isNew) {
-      setProducts((prev) => [...prev, p]);
-    } else {
-      setProducts((prev) => prev.map((prod) => (prod.id === p.id ? p : prod)));
-    }
-  }, []);
-
-  const handleDeleted = useCallback((productId: string) => {
-    setProducts((prev) => prev.filter((p) => p.id !== productId));
-  }, []);
-
-  const renderItem = useCallback(
-    ({ item }: { item: Product }) => (
-      <ProductItem product={item} onEdit={openForm} />
-    ),
-    [openForm]
+  const openForm = useCallback(
+    (product?: Product) => {
+      setSelectedProduct(product ?? null);
+      setFormVisible(true);
+    },
+    [],
   );
 
-  if (!isStoreOwner || address !== storeId) {
-    return (
-      <View
-        style={[
-          styles.container,
-          {
-            backgroundColor: colors.background,
-            justifyContent: 'center',
-            alignItems: 'center',
+  const handleToggle = useCallback(
+    async (product: Product) => {
+      if (!storeId) return;
+      const nextActive = product.isActive === false;
+      setPendingActionId(product.id);
+      const original = product;
+      setProducts((prev) =>
+        prev.map((item) =>
+          item.id === product.id ? { ...item, isActive: nextActive } : item,
+        ),
+      );
+      try {
+        await db.updateProduct(product.id, { isActive: nextActive });
+        productsWarmCache.mutate({
+          id: product.id,
+          value: { ...original, isActive: nextActive },
+          ts: Date.now(),
+        });
+        await refetch();
+      } catch (error) {
+        setProducts((prev) =>
+          prev.map((item) => (item.id === original.id ? original : item)),
+        );
+        Alert.alert('שגיאה', 'עדכון סטטוס המוצר נכשל');
+      } finally {
+        setPendingActionId(null);
+      }
+    },
+    [db, refetch, storeId],
+  );
+
+  const confirmDelete = useCallback(
+    (product: Product) => {
+      Alert.alert('מחיקת מוצר', `האם למחוק את "${product.name}"?`, [
+        { text: 'בטל', style: 'cancel' },
+        {
+          text: 'מחק',
+          style: 'destructive',
+          onPress: async () => {
+            setPendingActionId(product.id);
+            try {
+              await db.deleteProduct(product.id);
+              setProducts((prev) => prev.filter((item) => item.id !== product.id));
+              productsWarmCache.mutate({ id: product.id, op: 'delete', ts: Date.now() });
+              await refetch();
+            } catch (error) {
+              Alert.alert('שגיאה', 'מחיקת המוצר נכשלה');
+            } finally {
+              setPendingActionId(null);
+            }
           },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>יש להתחבר לארנק המתאים</Text>
+        },
+      ]);
+    },
+    [db, refetch],
+  );
+
+  const handleSaved = useCallback((saved: Product, isNew: boolean) => {
+    setProducts((prev) => {
+      const next = isNew
+        ? [...prev, saved]
+        : prev.map((item) => (item.id === saved.id ? saved : item));
+      return next
+        .filter((item) => item.storeId === saved.storeId)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
+    });
+    productsWarmCache.mutate({ id: saved.id, value: saved, ts: Date.now() });
+  }, []);
+
+  const handleDeleted = useCallback((id: string) => {
+    setProducts((prev) => prev.filter((item) => item.id !== id));
+    productsWarmCache.mutate({ id, op: 'delete', ts: Date.now() });
+  }, []);
+
+  const refreshing = isLoading || isRefetching;
+
+  if (!storeId) {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>יש לבחור חנות לניהול מוצרים.</Text>
       </View>
     );
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       <TouchableOpacity
-        style={[styles.addButton, { borderColor: colors.border.primary }]}
+        style={[styles.primaryButton, { borderColor: colors.border.primary }]}
         onPress={() => openForm()}
-      >
-        <Text style={{ color: colors.text.primary }}>הוסף מוצר</Text>
+        accessibilityRole="button">
+        <Text style={{ color: colors.text.primary }}>הוסף מוצר חדש</Text>
       </TouchableOpacity>
-      <FlatList
-        data={products}
-        keyExtractor={(p) => p.id}
-        renderItem={renderItem}
-        ListEmptyComponent={
-          <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>אין מוצרים</Text>
-        }
-        contentContainerStyle={styles.list}
-        getItemLayout={(_, index) => ({ length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index })}
-        removeClippedSubviews
-        refreshing={isLoading}
-        onRefresh={refetch}
-      />
+
+      {isLoading && products.length === 0 ? (
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
+      ) : (
+        <FlatList
+          data={products}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <ProductRow
+              product={item}
+              colors={colors}
+              busy={pendingActionId === item.id}
+              onEdit={openForm}
+              onToggle={handleToggle}
+              onDelete={confirmDelete}
+            />
+          )}
+          ListEmptyComponent={
+            <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+              {t('products.empty', 'אין מוצרים להצגה')}
+            </Text>
+          }
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={colors.text.primary} />
+          }
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+
       <ProductFormModal
         visible={formVisible}
-        product={editingProduct}
+        product={selectedProduct}
         onClose={() => setFormVisible(false)}
         onSaved={handleSaved}
         onDeleted={handleDeleted}
@@ -117,17 +250,36 @@ export default function StoreProductsScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: spacing.spacer16 },
-  addButton: {
-    paddingVertical: spacing.spacer12,
-    paddingHorizontal: spacing.spacer16,
+  container: { flex: 1, padding: 16 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  primaryButton: {
     borderWidth: 1,
-    borderRadius: radius.md,
+    borderRadius: 12,
+    paddingVertical: 12,
     alignItems: 'center',
-    marginBottom: spacing.spacer16,
+    marginBottom: 16,
   },
-  list: {
-    paddingBottom: spacing.spacer24,
+  listContent: { paddingBottom: 32, gap: 12 },
+  row: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  rowInfo: { gap: 4 },
+  productName: { fontSize: 16, fontWeight: '600' },
+  statusBadge: { fontSize: 12, fontWeight: '600' },
+  rowActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  actionButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  deleteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
 });
-

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { errorLog } from '@/utils/logger';
 import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
@@ -26,6 +27,8 @@ import { isMoonPayEnabled } from '@/config/featureFlags';
 
 export default function SettingsScreen() {
   const { replace, back } = useAppRouter();
+  const params = useLocalSearchParams<{ storeId: string }>();
+  const storeId = Array.isArray(params.storeId) ? params.storeId[0] : params.storeId;
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
   const [name, setName] = useState('');
   const [logoCidInput, setLogoCidInput] = useState('');
@@ -53,6 +56,7 @@ export default function SettingsScreen() {
   const [pendingInvites, setPendingInvites] = useState<string[]>([]);
   const [inviteLoading, setInviteLoading] = useState(false);
   const moonPayEnabled = useMemo(() => isMoonPayEnabled(), []);
+  const storeTopic = useMemo(() => `/blue-ocean/stores/${storeId ?? '1'}`, [storeId]);
 
   const [infoModal, setInfoModal] = useState({
     visible: false,
@@ -120,6 +124,14 @@ export default function SettingsScreen() {
         'paymentFactoryAddress',
         paymentFactoryAddress.trim(),
       );
+      await eventBus.publish(storeTopic, 'store.updated', {
+        profile: {
+          name,
+          logoCid: logoUri,
+          themeColor,
+          currencySymbol,
+        },
+      });
       setInfoModal({
         visible: true,
         title: 'הצלחה',
@@ -147,7 +159,7 @@ export default function SettingsScreen() {
     }
     setInviteLoading(true);
     try {
-      await eventBus.publish('/blue-ocean/stores/1', 'admin.joinRequested', {
+      await eventBus.publish(storeTopic, 'admin.joinRequested', {
         address,
       });
       setPendingInvites((prev) =>
@@ -171,7 +183,7 @@ export default function SettingsScreen() {
   const approveInvite = async (address: string) => {
     setInviteLoading(true);
     try {
-      await eventBus.publish('/blue-ocean/stores/1', 'admin.registered', {
+      await eventBus.publish(storeTopic, 'admin.registered', {
         address,
       });
       const nextAdmins = Array.from(new Set([...admins, address]));

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import React, { useState, useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppRouter } from '@/services';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
@@ -21,6 +21,8 @@ import NotificationSettings from '../../../../components/settings/NotificationSe
 import RpcSettings from '../../../../components/settings/RpcSettings';
 import MoonPaySettings from '../../../../components/settings/MoonPaySettings';
 import PaymentFactorySettings from '../../../../components/settings/PaymentFactorySettings';
+import eventBus from '@/services/eventBus';
+import { isMoonPayEnabled } from '@/config/featureFlags';
 
 export default function SettingsScreen() {
   const { replace, back } = useAppRouter();
@@ -47,6 +49,10 @@ export default function SettingsScreen() {
     setFiatKey,
   } = useAppInfo();
   const [admins, setAdmins] = useState<string[]>([]);
+  const [inviteAddress, setInviteAddress] = useState('');
+  const [pendingInvites, setPendingInvites] = useState<string[]>([]);
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const moonPayEnabled = useMemo(() => isMoonPayEnabled(), []);
 
   const [infoModal, setInfoModal] = useState({
     visible: false,
@@ -133,6 +139,53 @@ export default function SettingsScreen() {
     }
   };
 
+  const sendInvite = async () => {
+    const address = inviteAddress.trim();
+    if (!address) {
+      Alert.alert('שגיאה', 'נא להזין כתובת ארנק להזמנה');
+      return;
+    }
+    setInviteLoading(true);
+    try {
+      await eventBus.publish('/blue-ocean/stores/1', 'admin.joinRequested', {
+        address,
+      });
+      setPendingInvites((prev) =>
+        prev.includes(address) ? prev : [...prev, address],
+      );
+      setInviteAddress('');
+      setInfoModal({
+        visible: true,
+        title: 'הזמנה נשלחה',
+        message: 'המנהל החדש יקבל בקשת הצטרפות.',
+        type: 'success',
+      });
+    } catch (error) {
+      errorLog('Failed to publish admin invitation', error);
+      Alert.alert('שגיאה', 'שליחת ההזמנה נכשלה');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const approveInvite = async (address: string) => {
+    setInviteLoading(true);
+    try {
+      await eventBus.publish('/blue-ocean/stores/1', 'admin.registered', {
+        address,
+      });
+      const nextAdmins = Array.from(new Set([...admins, address]));
+      await SettingsAgent.getInstance().setAdmins(nextAdmins);
+      setAdmins(nextAdmins);
+      setPendingInvites((prev) => prev.filter((item) => item !== address));
+    } catch (error) {
+      errorLog('Failed to approve admin invite', error);
+      Alert.alert('שגיאה', 'אישור ההזמנה נכשל');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
@@ -186,12 +239,73 @@ export default function SettingsScreen() {
           fiatKeyInput={fiatKeyInput}
           setFiatKeyInput={setFiatKeyInput}
           colors={colors}
+          disabled={!moonPayEnabled}
         />
         <PaymentFactorySettings
           paymentFactoryAddress={paymentFactoryAddress}
           setPaymentFactoryAddress={setPaymentFactoryAddress}
           colors={colors}
         />
+        <View style={styles.sectionHeader}>
+          <SettingsIcon size={24} color={colors.gold} />
+          <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>ניהול מנהלים</Text>
+        </View>
+        <View
+          style={[styles.adminCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}
+        >
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>הזמנת מנהל חדש</Text>
+          <View style={styles.inviteRow}>
+            <TextInput
+              style={[styles.inviteInput, { borderColor: colors.border.primary, color: colors.text.primary }]}
+              value={inviteAddress}
+              onChangeText={setInviteAddress}
+              placeholder="wallet.near"
+              placeholderTextColor={colors.text.tertiary}
+              textAlign="right"
+            />
+            <TouchableOpacity
+              style={[styles.inviteButton, { borderColor: colors.border.primary }]}
+              onPress={sendInvite}
+              disabled={inviteLoading}
+              accessibilityRole="button"
+            >
+              <Text style={{ color: colors.text.primary }}>שליחת הזמנה</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={{ color: colors.text.secondary }}>
+            הזמנה חדשה דורשת אישור מנהל קיים לפני כניסה למערכת.
+          </Text>
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>הזמנות בהמתנה</Text>
+          {pendingInvites.length === 0 ? (
+            <Text style={{ color: colors.text.secondary }}>אין הזמנות ממתינות.</Text>
+          ) : (
+            pendingInvites.map((address) => (
+              <View
+                key={address}
+                style={[styles.inviteItem, { borderColor: colors.border.primary }]}
+              >
+                <Text style={{ color: colors.text.primary }}>{address}</Text>
+                <TouchableOpacity
+                  style={[styles.approveInviteButton, { borderColor: colors.status.success }]}
+                  onPress={() => approveInvite(address)}
+                  disabled={inviteLoading}
+                >
+                  <Text style={{ color: colors.status.success }}>אשר</Text>
+                </TouchableOpacity>
+              </View>
+            ))
+          )}
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>מנהלים פעילים</Text>
+          {admins.length === 0 ? (
+            <Text style={{ color: colors.text.secondary }}>עדיין לא הוגדרו מנהלים נוספים.</Text>
+          ) : (
+            admins.map((admin) => (
+              <Text key={admin} style={{ color: colors.text.secondary }}>
+                {admin}
+              </Text>
+            ))
+          )}
+        </View>
         <EnvironmentSettings colors={colors} admins={admins} />
         <RpcSettings colors={colors} />
         <LanguageSettings colors={colors} currentLanguage={currentLanguage} />
@@ -270,5 +384,41 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginLeft: 8,
+  },
+  adminCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  cardTitle: { fontSize: 16, fontWeight: '600' },
+  inviteRow: { flexDirection: 'row', gap: 12, alignItems: 'center' },
+  inviteInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  inviteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  inviteItem: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  approveInviteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
   },
 });

--- a/components/settings/MoonPaySettings.tsx
+++ b/components/settings/MoonPaySettings.tsx
@@ -7,9 +7,10 @@ interface Props {
   fiatKeyInput: string;
   setFiatKeyInput: (v: string) => void;
   colors: any;
+  disabled?: boolean;
 }
 
-const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, colors }) => {
+const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, colors, disabled = false }) => {
   return (
     <Card
       style={[
@@ -33,12 +34,16 @@ const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, color
                 color: colors.text.primary,
               },
             ]}
-            value={fiatKeyInput}
-            onChangeText={setFiatKeyInput}
-            placeholder="pk_live_..."
+            value={disabled ? '' : fiatKeyInput}
+            onChangeText={disabled ? undefined : setFiatKeyInput}
+            placeholder={disabled ? 'בקרוב' : 'pk_live_...'}
+            editable={!disabled}
             textAlign="right"
             placeholderTextColor={colors.text.tertiary}
           />
+          {disabled ? (
+            <Text style={[styles.helper, { color: colors.text.secondary }]}>השדה חסום בגרסה זו.</Text>
+          ) : null}
         </View>
       </View>
     </Card>
@@ -82,6 +87,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     fontSize: 16,
+  },
+  helper: {
+    marginTop: 8,
+    fontSize: 12,
+    textAlign: 'right',
   },
 });
 

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -28,6 +28,7 @@ const envSchema = z.object({
     .string()
     .optional()
     .default('false'),
+  EXPO_PUBLIC_FEATURE_MOONPAY: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -138,5 +139,11 @@ export function triggerDeliveryNotificationsRollback(): void {
   deliveryNotificationsFlag.rollback = true;
 }
 export { deliveryNotificationsFlag };
+
+const moonPayFeatureEnabled = env.EXPO_PUBLIC_FEATURE_MOONPAY === 'true';
+
+export function isMoonPayEnabled(): boolean {
+  return moonPayFeatureEnabled;
+}
 
 export default warmCacheFlag;

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -2,6 +2,7 @@ export * from './message';
 export * from './settings';
 export * from './notification';
 export * from './product.updated';
+export * from './product.deleted';
 export * from './order.status';
 export * from './admin.joinRequested';
 export * from './admin.approve';

--- a/schemas/waku/product.deleted.ts
+++ b/schemas/waku/product.deleted.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+export const productDeletedPayloadSchema = z.object({
+  id: z.string(),
+  storeId: z.string(),
+  deletedAt: z.string().optional(),
+});
+
+export const productDeletedSchema = wakuMessageSchema.extend({
+  type: z.literal('product.deleted'),
+  payload: productDeletedPayloadSchema,
+});
+
+export type ProductDeletedMessage = z.infer<typeof productDeletedSchema>;
+
+export function parseProductDeletedMessage(
+  data: unknown,
+): ProductDeletedMessage | null {
+  const res = productDeletedSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/schemas/waku/product.updated.ts
+++ b/schemas/waku/product.updated.ts
@@ -33,6 +33,7 @@ export const productSchema: z.ZodType<Product> = z.object({
   mixGroupId: z.string().optional(),
   storeId: z.string(),
   stock: z.number(),
+  isActive: z.boolean().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
 });

--- a/services/database.ts
+++ b/services/database.ts
@@ -19,6 +19,7 @@ import { getPrivateKey } from '@/services/localIdentity';
 import { aesEncrypt, aesDecrypt } from '@/utils/encryption';
 import { sha256 } from '@noble/hashes/sha256';
 import { Buffer } from 'buffer';
+import { publishProductDeleted } from '@/services/productEvents';
 
 let listAllReviews: (() => Promise<Review[]>) | undefined;
 if (chain === 'near') {
@@ -217,7 +218,11 @@ class DatabaseService {
   }
 
   async deleteProduct(id: string): Promise<void> {
+    const existing = await fetchProduct(id);
     await productsAgent.remove(id);
+    if (existing) {
+      await publishProductDeleted(id, existing.storeId);
+    }
   }
 
   // Subcategories

--- a/services/database.ts
+++ b/services/database.ts
@@ -19,7 +19,7 @@ import { getPrivateKey } from '@/services/localIdentity';
 import { aesEncrypt, aesDecrypt } from '@/utils/encryption';
 import { sha256 } from '@noble/hashes/sha256';
 import { Buffer } from 'buffer';
-import { publishProductDeleted } from '@/services/productEvents';
+import { publishProductDeleted, publishProductUpdated } from '@/services/productEvents';
 
 let listAllReviews: (() => Promise<Review[]>) | undefined;
 if (chain === 'near') {
@@ -208,6 +208,11 @@ class DatabaseService {
     const id = `prod_${Date.now()}`;
     const full: Product = { id, ...product };
     await productsAgent.add(full);
+    try {
+      await publishProductUpdated(full);
+    } catch (err) {
+      errorLog('Failed to publish product.updated', err);
+    }
     return id;
   }
 
@@ -215,6 +220,11 @@ class DatabaseService {
     const existing = await fetchProduct(id);
     if (!existing) return;
     await productsAgent.update({ ...existing, ...data });
+    try {
+      await publishProductUpdated({ ...existing, ...data, id } as Product);
+    } catch (err) {
+      errorLog('Failed to publish product.updated', err);
+    }
   }
 
   async deleteProduct(id: string): Promise<void> {

--- a/services/kycReceipts.ts
+++ b/services/kycReceipts.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { sign } from '@noble/ed25519';
+import { Buffer } from 'buffer';
 import { uuid } from '@/utils/uuid';
 import { canonicalJson } from '@/utils/serialization';
 import { publish } from '@/services/waku';

--- a/services/kycReceipts.ts
+++ b/services/kycReceipts.ts
@@ -1,0 +1,80 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { sign } from '@noble/ed25519';
+import { uuid } from '@/utils/uuid';
+import { canonicalJson } from '@/utils/serialization';
+import { publish } from '@/services/waku';
+import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
+
+const RECEIPT_STORAGE_PREFIX = 'kyc.receipt:';
+const NOTIFICATIONS_TOPIC = '/blue-ocean/notifications/1';
+
+export interface KycReceipt {
+  id: string;
+  buyerPublicKey: string;
+  issuerPublicKey: string;
+  issuedAt: string;
+  signature: string;
+  payload: Record<string, unknown>;
+}
+
+export async function loadKycReceipt(buyerPublicKey: string): Promise<KycReceipt | null> {
+  if (!buyerPublicKey) return null;
+  try {
+    const raw = await AsyncStorage.getItem(`${RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as KycReceipt;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function issueKycReceipt(
+  buyerPublicKey: string,
+  data: Record<string, unknown>,
+): Promise<KycReceipt> {
+  const receiptId = uuid();
+  const issuedAt = new Date().toISOString();
+  const payload = {
+    receiptId,
+    buyerPublicKey,
+    issuedAt,
+    ...data,
+  };
+  const [priv, issuerPublicKey] = await Promise.all([
+    getPrivateKey(),
+    getPublicKeyHex(),
+  ]);
+  const sender = { publicKey: issuerPublicKey, role: 'admin' as const };
+  const bytes = new TextEncoder().encode(
+    canonicalJson({ type: 'kyc.receipt', payload, sender }),
+  );
+  const signature = await sign(bytes, priv);
+  const message = {
+    id: receiptId,
+    type: 'kyc.receipt',
+    payload,
+    sender,
+    signature: Buffer.from(signature).toString('hex'),
+  };
+  await AsyncStorage.setItem(
+    `${RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`,
+    canonicalJson({
+      id: receiptId,
+      buyerPublicKey,
+      issuerPublicKey,
+      issuedAt,
+      signature: message.signature,
+      payload,
+    }),
+  );
+  await publish(NOTIFICATIONS_TOPIC, message);
+  return {
+    id: receiptId,
+    buyerPublicKey,
+    issuerPublicKey,
+    issuedAt,
+    signature: message.signature,
+    payload,
+  };
+}

--- a/services/productEvents.ts
+++ b/services/productEvents.ts
@@ -1,4 +1,5 @@
 import { sign } from '@noble/ed25519';
+import { Buffer } from 'buffer';
 import type { Product } from '@/types';
 import { canonicalJson } from '@/utils/serialization';
 import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';

--- a/services/productEvents.ts
+++ b/services/productEvents.ts
@@ -1,0 +1,53 @@
+import { sign } from '@noble/ed25519';
+import type { Product } from '@/types';
+import { canonicalJson } from '@/utils/serialization';
+import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
+import { publish } from '@/services/waku';
+
+const PRODUCT_TOPIC = '/blue-ocean/products/1';
+
+type ProductEventType = 'product.updated' | 'product.deleted';
+
+type ProductDeletedPayload = {
+  id: string;
+  storeId: string;
+  deletedAt: string;
+};
+
+async function buildSignedMessage<T extends Record<string, unknown>>(
+  type: ProductEventType,
+  payload: T,
+) {
+  const [priv, pub] = await Promise.all([getPrivateKey(), getPublicKeyHex()]);
+  const sender = { publicKey: pub, role: 'admin' as const };
+  const body = { type, payload, sender };
+  const bytes = new TextEncoder().encode(
+    canonicalJson({ type, payload, sender }),
+  );
+  const signature = await sign(bytes, priv);
+  return {
+    ...body,
+    signature: Buffer.from(signature).toString('hex'),
+  };
+}
+
+export async function publishProductUpdated(product: Product) {
+  const normalized: Product = {
+    ...product,
+    isActive: product.isActive !== false,
+  };
+  const message = await buildSignedMessage('product.updated', normalized);
+  await publish(PRODUCT_TOPIC, message);
+  return message;
+}
+
+export async function publishProductDeleted(id: string, storeId: string) {
+  const payload: ProductDeletedPayload = {
+    id,
+    storeId,
+    deletedAt: new Date().toISOString(),
+  };
+  const message = await buildSignedMessage('product.deleted', payload);
+  await publish(PRODUCT_TOPIC, message);
+  return message;
+}

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -113,6 +113,7 @@ export default function ProductFormModal({
             category: '',
             stock: 0,
             storeId: address || '',
+            isActive: true,
           }
     );
 

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -60,6 +60,25 @@ describe('scoped tokens feature flag', () => {
   });
 });
 
+describe('moonpay feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_MOONPAY;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isMoonPayEnabled } = require('@/config/featureFlags');
+    expect(isMoonPayEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_MOONPAY = 'true';
+    jest.resetModules();
+    const { isMoonPayEnabled } = require('@/config/featureFlags');
+    expect(isMoonPayEnabled()).toBe(true);
+  });
+});
+
 describe('notifications pipeline feature flag', () => {
   beforeEach(() => {
     delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;

--- a/tests/productDeletedSchema.test.ts
+++ b/tests/productDeletedSchema.test.ts
@@ -1,0 +1,25 @@
+import { productDeletedSchema, parseProductDeletedMessage } from '../schemas/waku/product.deleted';
+
+describe('product.deleted schema', () => {
+  test('valid message parses', () => {
+    const msg = {
+      type: 'product.deleted',
+      payload: { id: 'p1', storeId: 's1', deletedAt: '2024-01-01T00:00:00Z' },
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    } as const;
+    expect(productDeletedSchema.parse(msg)).toEqual(msg);
+    expect(parseProductDeletedMessage(msg)).toEqual(msg);
+  });
+
+  test('invalid message fails', () => {
+    const bad = {
+      type: 'product.deleted',
+      payload: { id: 'p1' },
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    } as const;
+    expect(() => productDeletedSchema.parse(bad)).toThrow();
+    expect(parseProductDeletedMessage(bad)).toBeNull();
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,6 +27,7 @@ export interface Product {
   mixGroupId?: string;
   storeId: string;
   stock: number;
+  isActive?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- refresh the StoreAdmin overview to stream KPI metrics from warm caches, provide quick product add, and highlight actionable orders
- add optimistic product management, shipping/cancel flows, and KYC policy approvals that issue signed receipts via new support services
- extend the settings tab with admin invite tooling, MoonPay feature gating, and product deletion Waku schema/tests for event propagation

## Testing
- ⚠️ `yarn test --runInBand` *(command not found)*
- ⚠️ `yarn lint` *(fails: missing @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c8db6ec8c48326a31ba103aaf9ac84