### PR TITLE
Refactor cart add-to-cart flow for variant support

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   View,
   StyleSheet,
@@ -36,6 +36,7 @@ export default function ProductDetailScreen() {
     quantity,
     incrementQuantity,
     decrementQuantity,
+    setQuantity,
     effectivePrice,
     totalPrice,
     currentPricingTier,
@@ -48,12 +49,43 @@ export default function ProductDetailScreen() {
   } = useProductDetail(productId ?? '', typeof storeId === 'string' ? storeId : undefined);
 
   const [adding, setAdding] = useState(false);
+  const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!product?.variants || product.variants.length === 0) {
+      setSelectedVariantId(undefined);
+      return;
+    }
+
+    setSelectedVariantId((prev) => {
+      if (prev) {
+        const exists = product.variants?.some((variant) => (variant.id ?? variant.color) === prev);
+        if (exists) {
+          return prev;
+        }
+      }
+      const first = product.variants[0];
+      return first.id ?? first.color;
+    });
+  }, [product]);
+
+  const selectedVariant = useMemo(() => {
+    if (!product?.variants || !selectedVariantId) return undefined;
+    return product.variants.find((variant) => (variant.id ?? variant.color) === selectedVariantId);
+  }, [product?.variants, selectedVariantId]);
+
+  useEffect(() => {
+    if (!selectedVariant) return;
+    if (selectedVariant.stock >= 0 && quantity > selectedVariant.stock) {
+      setQuantity(selectedVariant.stock > 0 ? selectedVariant.stock : 1);
+    }
+  }, [quantity, selectedVariant, setQuantity]);
 
   const handleAddToCart = useCallback(async () => {
     if (!product) return;
     setAdding(true);
     try {
-      await CartService.getInstance().addToCart(product, quantity);
+      await CartService.getInstance().addToCart(product.id, selectedVariantId, quantity);
       showNotification(
         t('cart.addedTitle', 'Added to cart'),
         t('cart.addedMessage', 'The item was added to your cart.'),
@@ -68,7 +100,7 @@ export default function ProductDetailScreen() {
     } finally {
       setAdding(false);
     }
-  }, [product, quantity, showNotification, t]);
+  }, [product, quantity, selectedVariantId, showNotification, t]);
 
   const handleBack = useCallback(() => {
     if (storeId) {
@@ -82,6 +114,10 @@ export default function ProductDetailScreen() {
     if (!product) return '';
     return `${currencySymbol}${effectivePrice.toFixed(2)}`;
   }, [product, currencySymbol, effectivePrice]);
+
+  const rawStock = selectedVariant?.stock ?? product?.stock;
+  const isStockKnown = rawStock !== undefined && rawStock !== null;
+  const isOutOfStock = isStockKnown ? rawStock <= 0 : true;
 
   if (!productId) {
     return (
@@ -178,6 +214,52 @@ export default function ProductDetailScreen() {
                 </Text>
               </View>
             ) : null}
+            {product.variants?.length ? (
+              <View style={styles.variantSection}>
+                <Text style={{ color: colors.text.primary, fontWeight: '600' }}>
+                  {t('product.color', 'Color')}
+                </Text>
+                <View style={styles.variantOptions}>
+                  {product.variants.map((variant, index) => {
+                    const key = variant.id ?? variant.color ?? `${index}`;
+                    const isSelected = key === selectedVariantId;
+                    return (
+                      <TouchableOpacity
+                        key={key}
+                        onPress={() => setSelectedVariantId(key)}
+                        style={[
+                          styles.variantOption,
+                          {
+                            borderColor: isSelected ? colors.gold : colors.border.primary,
+                            backgroundColor: isSelected ? colors.interactive.secondary : colors.surface.secondary,
+                          },
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: isSelected }}
+                      >
+                        <View
+                          style={[
+                            styles.variantSwatch,
+                            {
+                              backgroundColor: variant.color || colors.surface.primary,
+                              borderColor: colors.border.primary,
+                            },
+                          ]}
+                        />
+                        <View style={styles.variantInfo}>
+                          <Text style={[styles.variantLabel, { color: colors.text.primary }]}>
+                            {variant.color || t('product.color', 'Color')}
+                          </Text>
+                          <Text style={[styles.variantStock, { color: colors.text.secondary }]}>
+                            {t('product.inStock', 'In Stock ({count})', { count: variant.stock })}
+                          </Text>
+                        </View>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
+            ) : null}
             <View style={styles.quantityRow}>
               <Text style={{ color: colors.text.primary, fontWeight: '600' }}>
                 {t('productDetail.quantity', 'Quantity')}
@@ -196,7 +278,7 @@ export default function ProductDetailScreen() {
                   onPress={incrementQuantity}
                   accessibilityLabel={t('productDetail.increase', 'Increase quantity')}
                   style={[styles.quantityButton, { borderColor: colors.border.primary }]}
-                  disabled={product.stock !== undefined && quantity >= product.stock}
+                  disabled={isStockKnown && quantity >= rawStock}
                 >
                   <Plus size={16} color={colors.text.primary} />
                 </TouchableOpacity>
@@ -208,13 +290,13 @@ export default function ProductDetailScreen() {
             </Text>
             <View style={styles.stockRow}>
               <Text style={{ color: colors.text.secondary }}>
-                {t('productDetail.stock', 'In stock')}: {product.stock ?? t('common.unknown', 'Unknown')}
+                {t('productDetail.stock', 'In stock')}: {isStockKnown ? rawStock : t('common.unknown', 'Unknown')}
               </Text>
             </View>
             <Button
               onPress={handleAddToCart}
               loading={adding}
-              disabled={!product.stock || product.stock === 0}
+              disabled={isOutOfStock}
               accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
             >
               <View style={styles.buttonContent}>
@@ -287,6 +369,39 @@ const styles = StyleSheet.create({
   tierNotice: {
     padding: spacing.spacer12,
     borderRadius: radius.md,
+  },
+  variantSection: {
+    marginTop: spacing.spacer12,
+    gap: spacing.spacer8,
+  },
+  variantOptions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.spacer12,
+  },
+  variantOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.spacer8,
+    gap: spacing.spacer8,
+  },
+  variantSwatch: {
+    width: 24,
+    height: 24,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+  },
+  variantInfo: {
+    flexDirection: 'column',
+  },
+  variantLabel: {
+    ...typography.sm,
+    fontWeight: '600',
+  },
+  variantStock: {
+    ...typography.xs,
   },
   quantityRow: {
     flexDirection: 'row',

--- a/src/features/cart/hooks/useWishlist.ts
+++ b/src/features/cart/hooks/useWishlist.ts
@@ -24,7 +24,7 @@ export default function useWishlist(visible: boolean) {
   }, []);
 
   const addToCart = useCallback(async (item: WishlistItem) => {
-    await CartService.getInstance().addToCart(item.product, 1);
+    await CartService.getInstance().addToCart(item.productId, undefined, 1);
   }, []);
 
   return {

--- a/src/features/cart/services/cart.ts
+++ b/src/features/cart/services/cart.ts
@@ -1,6 +1,6 @@
 import { errorLog } from '@/utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { CartItem, WishlistItem, Product, PricingTier, PricingTierRule, MixGroup } from '@/types';
+import { CartItem, WishlistItem, Product, ProductVariant, PricingTier, PricingTierRule, MixGroup } from '@/types';
 import DatabaseService from '@/services/database';
 import cartAgent, { getCartItems } from '@/agents/cart-agent';
 import eventBus from '@/services/eventBus';
@@ -173,30 +173,73 @@ class CartService {
   }
 
   // Cart methods
-  public async addToCart(product: Product, quantity: number = 1): Promise<void> {
-    const existingItemIndex = this.cartItems.findIndex(
-      item => item.productId === product.id
-    );
-
-    if (existingItemIndex >= 0) {
-      this.cartItems[existingItemIndex].quantity += quantity;
-      await cartAgent.update(this.cartItems[existingItemIndex]);
-    } else {
-      const uid = await this.getCurrentUserId();
-      const cartItem: CartItem = {
-        id: `${uid ? uid + '_' : ''}${product.id}_${Date.now()}`,
-        productId: product.id,
-        product,
-        quantity,
-        addedAt: new Date().toISOString()
-      };
-      this.cartItems.push(cartItem);
-      await cartAgent.add(cartItem);
+  public async addToCart(productId: string, variantId?: string, qty: number = 1): Promise<void> {
+    if (qty <= 0) {
+      throw new Error('Quantity must be at least 1');
     }
-    eventBus.track('cart.add', { productId: product.id, quantity });
-    await this.recalcPricing();
-    await this.saveToStorage();
-    this.notifyListeners();
+
+    try {
+      const db = DatabaseService.getInstance();
+      const product = await db.getProduct(productId);
+
+      if (!product) {
+        throw new Error('Product not found');
+      }
+
+      let selectedVariant: ProductVariant | undefined;
+      let resolvedVariantId = variantId;
+
+      if (variantId) {
+        selectedVariant = product.variants?.find((variant) => {
+          if (variant.id && variant.id === variantId) return true;
+          return variant.color === variantId;
+        });
+
+        if (!selectedVariant) {
+          throw new Error('Selected variant is unavailable');
+        }
+
+        resolvedVariantId = selectedVariant.id ?? variantId ?? selectedVariant.color;
+      }
+
+      const variantKey = resolvedVariantId ?? undefined;
+
+      const existingItemIndex = this.cartItems.findIndex((item) => {
+        if (item.productId !== product.id) return false;
+        const itemVariantKey = item.variantId ?? item.selectedColor ?? undefined;
+        return itemVariantKey === variantKey;
+      });
+
+      if (existingItemIndex >= 0) {
+        const existingItem = this.cartItems[existingItemIndex];
+        existingItem.quantity += qty;
+        existingItem.product = product;
+        existingItem.variantId = variantKey;
+        existingItem.selectedColor = selectedVariant?.color;
+        await cartAgent.update(existingItem);
+      } else {
+        const uid = await this.getCurrentUserId();
+        const cartItem: CartItem = {
+          id: `${uid ? uid + '_' : ''}${product.id}${variantKey ? `_${variantKey}` : ''}_${Date.now()}`,
+          productId: product.id,
+          product,
+          quantity: qty,
+          addedAt: new Date().toISOString(),
+          variantId: variantKey,
+          selectedColor: selectedVariant?.color,
+        };
+        this.cartItems.push(cartItem);
+        await cartAgent.add(cartItem);
+      }
+
+      eventBus.track('cart.add', { productId: product.id, quantity: qty, variantId: variantKey ?? null });
+      await this.recalcPricing();
+      await this.saveToStorage();
+      this.notifyListeners();
+    } catch (error) {
+      errorLog('Error adding product to cart', error);
+      throw error;
+    }
   }
 
   public async removeFromCart(itemId: string): Promise<void> {

--- a/src/services/useCart.ts
+++ b/src/services/useCart.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import CartService from '@/features/cart/services/cart';
-import { CartItem, Product } from '@/types';
+import { CartItem } from '@/types';
 
 export function useCart() {
   return useQuery<CartItem[]>({
@@ -20,8 +20,15 @@ export function useCartMutations() {
   const svc = CartService.getInstance();
 
   const add = useMutation({
-    mutationFn: ({ product, quantity = 1 }: { product: Product; quantity?: number }) =>
-      svc.addToCart(product, quantity),
+    mutationFn: ({
+      productId,
+      quantity = 1,
+      variantId,
+    }: {
+      productId: string;
+      quantity?: number;
+      variantId?: string;
+    }) => svc.addToCart(productId, variantId, quantity),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cart'] });
     },

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,5 @@
 export interface ProductVariant {
+  id?: string;
   color: string;
   stock: number;
 }
@@ -223,6 +224,7 @@ export interface CartItem {
   unitPrice?: number;
   tierName?: string;
   effectiveQty?: number;
+  variantId?: string;
   selectedColor?: string;
 }
 


### PR DESCRIPTION
## Summary
- refactor `CartService.addToCart` to accept product and variant identifiers, fetch fresh catalog data, and record variant usage
- extend cart-related types and hooks to carry variant ids and call the updated API
- enhance the product detail screen with variant selection state, UI, and stock-aware controls

## Testing
- yarn typecheck *(fails: missing expo/tsconfig.base.json and typed packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e757f4448326a87e38dd6247d86b