### PR TITLE
Update product view analytics event

### DIFF
--- a/src/features/products/hooks/useProductDetail.ts
+++ b/src/features/products/hooks/useProductDetail.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import CartService from '@/features/cart/services/cart';
 import { Product, PricingTier } from '@/types';
 import { useProduct } from './useProduct';
@@ -41,6 +41,7 @@ export function useProductDetail(id: string, storeId?: string): ProductDetailRes
   const [quantity, setQuantity] = useState(1);
   const [isFavorite, setIsFavorite] = useState(false);
   const [notFound, setNotFound] = useState(false);
+  const lastTrackedProductId = useRef<string | null>(null);
 
   const { effectivePrice, totalPrice, currentPricingTier, showTieredPricing } =
     useProductPricing(product, quantity);
@@ -53,16 +54,21 @@ export function useProductDetail(id: string, storeId?: string): ProductDetailRes
     if (!fetchedProduct) {
       setProduct(null);
       setNotFound(true);
+      lastTrackedProductId.current = null;
       return;
     }
     if (storeId && fetchedProduct.storeId !== storeId) {
       setProduct(null);
       setNotFound(true);
+      lastTrackedProductId.current = null;
       return;
     }
     setProduct(fetchedProduct);
     setNotFound(false);
-    eventBus.track('catalog.product_view', { productId: fetchedProduct.id });
+    if (lastTrackedProductId.current !== fetchedProduct.id) {
+      eventBus.track('analytics.view.product', { productId: fetchedProduct.id });
+      lastTrackedProductId.current = fetchedProduct.id;
+    }
   }, [fetchedProduct, isLoading, storeId]);
 
   useEffect(() => {

--- a/tests/integration/products/productDetailAnalytics.test.ts
+++ b/tests/integration/products/productDetailAnalytics.test.ts
@@ -1,0 +1,110 @@
+import React, { StrictMode } from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+const mockTrack = jest.fn();
+const productFixture: any = {
+  id: 'product-1',
+  storeId: 'default',
+  stock: 10,
+  price: 25,
+};
+
+jest.mock('@/services/eventBus', () => ({
+  __esModule: true,
+  default: { track: mockTrack },
+  track: mockTrack,
+  publish: jest.fn(),
+}));
+
+const mockUseProduct = jest.fn();
+jest.mock('@/features/products/hooks/useProduct', () => ({
+  useProduct: (...args: any[]) => mockUseProduct(...args),
+}));
+
+const mockUseProductPricing = jest.fn();
+jest.mock('@/services/useProductPricing', () => ({
+  __esModule: true,
+  useProductPricing: (...args: any[]) => mockUseProductPricing(...args),
+  default: (...args: any[]) => mockUseProductPricing(...args),
+}));
+
+const mockUseProductMedia = jest.fn();
+jest.mock('@/services/useProductMedia', () => ({
+  __esModule: true,
+  useProductMedia: (...args: any[]) => mockUseProductMedia(...args),
+  default: (...args: any[]) => mockUseProductMedia(...args),
+}));
+
+const mockCartInstance: any = {
+  isInWishlist: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};
+const mockGetInstance = jest.fn(() => mockCartInstance);
+
+jest.mock('@/features/cart/services/cart', () => ({
+  __esModule: true,
+  default: { getInstance: () => mockGetInstance() },
+}));
+
+import { useProductDetail } from '@/features/products/hooks/useProductDetail';
+
+describe('useProductDetail analytics tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTrack.mockResolvedValue(undefined);
+
+    mockUseProduct.mockImplementation(() => ({
+      data: productFixture,
+      isLoading: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    }));
+
+    mockUseProductPricing.mockReturnValue({
+      effectivePrice: 25,
+      totalPrice: 25,
+      currentPricingTier: null,
+      showTieredPricing: false,
+    });
+
+    mockUseProductMedia.mockReturnValue({
+      media: [],
+      mainImageUri: undefined,
+    });
+
+    mockCartInstance.isInWishlist.mockReturnValue(false);
+    mockCartInstance.addListener.mockImplementation(() => {});
+    mockCartInstance.removeListener.mockImplementation(() => {});
+  });
+
+  it('fires analytics event once when product loads', async () => {
+    const TestComponent = () => {
+      useProductDetail(productFixture.id, productFixture.storeId);
+      return null;
+    };
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(
+        React.createElement(
+          StrictMode as any,
+          null,
+          React.createElement(TestComponent),
+        ),
+      );
+    });
+
+    await act(async () => {});
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('analytics.view.product', {
+      productId: productFixture.id,
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- send product detail analytics to the new `analytics.view.product` channel
- guard tracking with a ref so the view event only fires once per product load and reset on missing products
- add an integration test that renders the hook under StrictMode to verify only one analytics call is made

## Testing
- yarn jest tests/integration/products/productDetailAnalytics.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c8e73c92ec8326b933178bed7a5ad2