### PR TITLE
Handle disabled products in product screen

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -19,6 +19,39 @@ import { useAppRouter } from '@/services/useAppRouter';
 import { useProductDetail } from '@/features/products/hooks/useProductDetail';
 import { AlertTriangle, Heart, Minus, Plus, ShoppingCart } from 'lucide-react-native';
 
+type TooltipChildProps = {
+  tooltip?: string;
+  accessibilityHint?: string;
+  [key: string]: unknown;
+};
+
+interface DisabledTooltipProps {
+  label?: string;
+  children: React.ReactElement<TooltipChildProps>;
+}
+
+const appendSentence = (base?: string, addition?: string) => {
+  if (!base) return addition;
+  if (!addition) return base;
+  const trimmed = base.trim();
+  const suffix = trimmed.endsWith('.') ? '' : '.';
+  return `${trimmed}${suffix} ${addition}`;
+};
+
+const DisabledTooltip = ({ label, children }: DisabledTooltipProps) => {
+  if (!label) {
+    return children;
+  }
+
+  const existingTooltip = children.props.tooltip;
+  const existingHint = children.props.accessibilityHint;
+
+  return React.cloneElement(children, {
+    tooltip: appendSentence(existingTooltip, label),
+    accessibilityHint: appendSentence(existingHint, label),
+  });
+};
+
 export default function ProductDetailScreen() {
   const { storeId, productId } = useLocalSearchParams<{ storeId: string; productId: string }>();
   const { colors } = useTheme();
@@ -118,6 +151,8 @@ export default function ProductDetailScreen() {
   const rawStock = selectedVariant?.stock ?? product?.stock;
   const isStockKnown = rawStock !== undefined && rawStock !== null;
   const isOutOfStock = isStockKnown ? rawStock <= 0 : true;
+  const isProductDisabled = Boolean(product?.disabled);
+  const disabledReason = isProductDisabled ? product?.disabledReason : undefined;
 
   if (!productId) {
     return (
@@ -293,19 +328,21 @@ export default function ProductDetailScreen() {
                 {t('productDetail.stock', 'In stock')}: {isStockKnown ? rawStock : t('common.unknown', 'Unknown')}
               </Text>
             </View>
-            <Button
-              onPress={handleAddToCart}
-              loading={adding}
-              disabled={isOutOfStock}
-              accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
-            >
-              <View style={styles.buttonContent}>
-                <ShoppingCart size={18} color={colors.text.inverse} />
-                <Text style={[styles.buttonText, { color: colors.text.inverse }]}>
-                  {t('productDetail.addToCart', 'Add to cart')}
-                </Text>
-              </View>
-            </Button>
+            <DisabledTooltip label={disabledReason}>
+              <Button
+                onPress={handleAddToCart}
+                loading={adding}
+                disabled={isOutOfStock || isProductDisabled}
+                accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
+              >
+                <View style={styles.buttonContent}>
+                  <ShoppingCart size={18} color={colors.text.inverse} />
+                  <Text style={[styles.buttonText, { color: colors.text.inverse }]}> 
+                    {t('productDetail.addToCart', 'Add to cart')}
+                  </Text>
+                </View>
+              </Button>
+            </DisabledTooltip>
           </View>
         </View>
       )}

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,8 @@ export interface Product {
   mixGroupId?: string;
   storeId: string;
   stock: number;
+  disabled?: boolean;
+  disabledReason?: string;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- extend the shared Product type with optional disabled flags
- disable the add-to-cart button when a product is flagged and show the disabled reason via a tooltip while preserving stock checks

## Testing
- `yarn lint -- app/store/[storeId]/product/_ProductScreen.tsx` *(fails: existing lint errors in unrelated files)*
- `./node_modules/.bin/eslint app/store/[storeId]/product/_ProductScreen.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c8ec87e98c83268bd8ea56a1ccad76