### PR TITLE
Add accessibility metadata to product gallery

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -11,6 +11,7 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Heading, Text, Button, Skeleton } from '@/ui/primitives';
 import { spacing, typography, radius } from '@/ui/tokens';
 import SmartImage from '@/components/SmartImage';
+import type { ProductVariant } from '@/types';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import CartService from '@/features/cart/services/cart';
 import { useNotificationActions } from '@/components/NotificationContext';
@@ -55,6 +56,13 @@ const DisabledTooltip = ({ label, children }: DisabledTooltipProps) => {
   });
 };
 
+const getVariantKey = (variant: ProductVariant, index: number) => {
+  if (variant.id && variant.id.trim().length > 0) {
+    return variant.id;
+  }
+  return `variant-${index}`;
+};
+
 export default function ProductDetailScreen() {
   const { storeId, productId } = useLocalSearchParams<{ storeId: string; productId: string }>();
   const { colors } = useTheme();
@@ -96,18 +104,19 @@ export default function ProductDetailScreen() {
   }, [product?.storeId, storeId]);
 
   useEffect(() => {
-    if (!product?.variants || product.variants.length === 0) {
+    const variants = product?.variants;
+    if (!variants || variants.length === 0) {
       setSelectedVariantId(undefined);
       return;
     }
 
     setSelectedVariantId((prev) => {
       if (prev) {
-        const existingIndex = product.variants.findIndex(
+        const existingIndex = variants.findIndex(
           (variant, index) => getVariantKey(variant, index) === prev,
         );
         if (existingIndex >= 0) {
-          const existingVariant = product.variants[existingIndex];
+          const existingVariant = variants[existingIndex];
           const hasStock =
             typeof existingVariant.stock === 'number' ? existingVariant.stock > 0 : true;
           if (hasStock) {
@@ -116,11 +125,11 @@ export default function ProductDetailScreen() {
         }
       }
 
-      const availableIndex = product.variants.findIndex((variant) =>
+      const availableIndex = variants.findIndex((variant) =>
         typeof variant.stock === 'number' ? variant.stock > 0 : true,
       );
       const fallbackIndex = availableIndex >= 0 ? availableIndex : 0;
-      const fallbackVariant = product.variants[fallbackIndex];
+      const fallbackVariant = variants[fallbackIndex];
       if (!fallbackVariant) {
         return undefined;
       }
@@ -129,8 +138,9 @@ export default function ProductDetailScreen() {
   }, [product]);
 
   const selectedVariant = useMemo(() => {
-    if (!product?.variants || !selectedVariantId) return undefined;
-    return product.variants.find((variant, index) => getVariantKey(variant, index) === selectedVariantId);
+    const variants = product?.variants;
+    if (!variants || !selectedVariantId) return undefined;
+    return variants.find((variant, index) => getVariantKey(variant, index) === selectedVariantId);
   }, [product?.variants, selectedVariantId]);
 
   useEffect(() => {
@@ -281,6 +291,9 @@ export default function ProductDetailScreen() {
       </View>
     </View>
   );
+
+  const galleryProductName =
+    product?.name || t('productDetail.galleryFallbackProductName', 'this product');
 
   return (
     <ScrollView
@@ -457,17 +470,41 @@ export default function ProductDetailScreen() {
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={{ gap: spacing.spacer12, paddingVertical: spacing.spacer12 }}
+            accessibilityHint={t(
+              'productDetail.galleryScrollHint',
+              'Swipe left or right to browse more media items.',
+            )}
           >
-            {media.map((item) => (
-              <SmartImage
-                key={item.uri}
-                uri={item.uri}
-                width={120}
-                height={120}
-                style={{ borderRadius: radius.md }}
-                contentFit="cover"
-              />
-            ))}
+            {media.map((item, index) => {
+              const fallbackDescription =
+                item.type === 'video'
+                  ? t('productDetail.galleryVideoLabel', 'Video')
+                  : t('productDetail.galleryImageLabel', 'Image');
+              const description = item.name || fallbackDescription;
+              const accessibilityLabel = t(
+                'productDetail.galleryItemAccessibilityLabel',
+                '{description} for {productName}. Item {index} of {total}.',
+                {
+                  description,
+                  productName: galleryProductName,
+                  index: index + 1,
+                  total: media.length,
+                },
+              );
+
+              return (
+                <SmartImage
+                  key={item.uri}
+                  uri={item.uri}
+                  width={120}
+                  height={120}
+                  style={{ borderRadius: radius.md }}
+                  contentFit="cover"
+                  accessibilityRole="image"
+                  accessibilityLabel={accessibilityLabel}
+                />
+              );
+            })}
           </ScrollView>
         </View>
       ) : null}

--- a/jest.config.js
+++ b/jest.config.js
@@ -155,6 +155,7 @@ const cfg = {
     '<rootDir>/tests/featuredStoresCarousel.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/productCardAccessibility.test.tsx',
+    '<rootDir>/tests/productGalleryAccessibility.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',
     '<rootDir>/tests/wallet/**/*.test.ts',

--- a/tests/__mocks__/react-native.js
+++ b/tests/__mocks__/react-native.js
@@ -8,6 +8,8 @@ const TouchableOpacity = ({ children, onPress, style }) =>
   React.createElement('TouchableOpacity', { onPress, style }, children);
 const Pressable = ({ children, onPress, style, onKeyDown }) =>
   React.createElement('Pressable', { onPress, style, onKeyDown }, children);
+const RefreshControl = ({ refreshing, onRefresh, tintColor }) =>
+  React.createElement('RefreshControl', { refreshing, onRefresh, tintColor });
 const TextInput = ({ value, onChangeText, placeholder, style, testID }) =>
   React.createElement('TextInput', { value, onChangeText, placeholder, style, testID });
 const ActivityIndicator = (props) => React.createElement('ActivityIndicator', props);
@@ -66,6 +68,7 @@ module.exports = {
   Text,
   ScrollView,
   FlatList,
+  RefreshControl,
   TouchableOpacity,
   Pressable,
   TextInput,

--- a/tests/productGalleryAccessibility.test.tsx
+++ b/tests/productGalleryAccessibility.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import ProductDetailScreen from '@app/store/[storeId]/product/_ProductScreen';
+
+let mockSmartImage: jest.Mock;
+const mockUseProductDetail = jest.fn();
+const mockCartServiceInstance = {
+  addToCart: jest.fn(),
+  isInWishlist: jest.fn(() => false),
+  removeFromWishlist: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};
+
+jest.mock('@/features/cart/services/cart', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => mockCartServiceInstance,
+  },
+}));
+
+jest.mock('@/components/SmartImage', () => ({
+  __esModule: true,
+  default: (...args: any[]) => {
+    if (!mockSmartImage) {
+      mockSmartImage = jest.fn(() => null);
+    }
+    return mockSmartImage(...args);
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ storeId: 'store-1', productId: 'product-1' }),
+}));
+
+const renderTemplate = (template: string, options?: Record<string, string | number>) =>
+  template.replace(/\{(.*?)\}/g, (_, key) => String(options?.[key] ?? ''));
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useTheme: () => ({
+    colors: {
+      canvas: '#ffffff',
+      surface: { primary: '#ffffff', secondary: '#f4f4f4' },
+      text: { primary: '#111111', secondary: '#666666', inverse: '#ffffff' },
+      border: { primary: '#cccccc' },
+      interactive: { secondary: '#eeeeee' },
+      status: { error: '#ff0000' },
+      gold: '#ffcc00',
+    },
+  }),
+  useLanguage: () => ({
+    t: (key: string, fallbackOrOptions?: any, maybeOptions?: any) => {
+      if (typeof fallbackOrOptions === 'string') {
+        return renderTemplate(fallbackOrOptions, maybeOptions);
+      }
+      if (fallbackOrOptions && typeof fallbackOrOptions === 'object') {
+        return renderTemplate(key, fallbackOrOptions);
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock('@/contexts/CurrencyContext', () => ({
+  useCurrency: () => ({ currencySymbol: '$' }),
+}));
+
+jest.mock('@/components/NotificationContext', () => ({
+  useNotificationActions: () => ({ showNotification: jest.fn() }),
+}));
+
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ isLoggedIn: true }),
+}));
+
+jest.mock('@/features/auth/AuthModalContext', () => ({
+  useAuthModal: () => ({ openAuthModal: jest.fn() }),
+}));
+
+jest.mock('@/services/openDM', () => ({
+  openDM: jest.fn(),
+}));
+
+jest.mock('@/ui/primitives', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Heading: ({ children, ...rest }: any) => React.createElement(Text, rest, children),
+    Text,
+    Button: ({ children, ...rest }: any) => React.createElement('Button', rest, children),
+    Skeleton: (props: any) => React.createElement('Skeleton', props),
+  };
+});
+
+jest.mock('@/features/products/hooks/useProductDetail', () => ({
+  __esModule: true,
+  useProductDetail: (...args: any[]) => mockUseProductDetail(...args),
+  default: (...args: any[]) => mockUseProductDetail(...args),
+}));
+
+const mediaItems = [
+  {
+    id: 'image-1',
+    uri: 'https://example.com/image-1.jpg',
+    type: 'image' as const,
+    name: 'Front view',
+  },
+  {
+    id: 'image-2',
+    uri: 'https://example.com/image-2.jpg',
+    type: 'image' as const,
+    name: 'Side profile',
+  },
+];
+
+describe('Product gallery accessibility', () => {
+  beforeEach(() => {
+    if (mockSmartImage) {
+      mockSmartImage.mockReset();
+    }
+    mockSmartImage = jest.fn(() => null);
+    mockUseProductDetail.mockReset();
+
+    mockUseProductDetail.mockReturnValue({
+      product: {
+        id: 'product-1',
+        storeId: 'store-1',
+        name: 'Accessible Product',
+        description: 'A demo product',
+        price: 19.99,
+        stock: 5,
+        images: ['https://example.com/main.jpg'],
+        variants: [],
+        disabled: false,
+      },
+      isLoading: false,
+      refreshing: false,
+      refresh: jest.fn(),
+      error: null,
+      quantity: 1,
+      incrementQuantity: jest.fn(),
+      decrementQuantity: jest.fn(),
+      setQuantity: jest.fn(),
+      effectivePrice: 19.99,
+      totalPrice: 19.99,
+      currentPricingTier: null,
+      showTieredPricing: false,
+      media: mediaItems,
+      mainImageUri: 'https://example.com/main.jpg',
+      isFavorite: false,
+      toggleFavorite: jest.fn(),
+      notFound: false,
+    });
+  });
+
+  it('provides accessibility metadata for gallery images', async () => {
+    await act(async () => {
+      renderer.create(<ProductDetailScreen />);
+    });
+
+    const galleryImageProps = mockSmartImage.mock.calls.reduce<Record<string, any>[]>(
+      (acc, call) => {
+        const props = (call as any[])[0] as Record<string, any> | undefined;
+        if (props && props.width === 120 && props.height === 120) {
+          acc.push(props);
+        }
+        return acc;
+      },
+      [],
+    );
+
+    expect(galleryImageProps).toHaveLength(mediaItems.length);
+    expect(galleryImageProps.every((props) => props.accessibilityRole === 'image')).toBe(true);
+    expect(galleryImageProps[0].accessibilityLabel).toBe(
+      'Front view for Accessible Product. Item 1 of 2.',
+    );
+    expect(galleryImageProps[1].accessibilityLabel).toBe(
+      'Side profile for Accessible Product. Item 2 of 2.',
+    );
+  });
+});

--- a/types/lucide-react-native.d.ts
+++ b/types/lucide-react-native.d.ts
@@ -10,6 +10,7 @@ declare module 'lucide-react-native' {
 
   export const ArrowLeft: FC<LucideProps>;
   export const ArrowUpDown: FC<LucideProps>;
+  export const AlertTriangle: FC<LucideProps>;
   export const Bell: FC<LucideProps>;
   export const Calendar: FC<LucideProps>;
   export const Camera: FC<LucideProps>;


### PR DESCRIPTION
## Summary
- ensure product variant selection logic uses a stable key helper
- add accessibility labels, roles, and swipe hint to product gallery images
- stub RefreshControl in the React Native test mock and add targeted gallery accessibility test
- register the new test in Jest and extend lucide icon typings

## Testing
- yarn jest tests/productGalleryAccessibility.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8f1a9d2e48326a70798ded2686eef