### PR TITLE
Enforce admin scope validation in session service

### DIFF
--- a/services/session.ts
+++ b/services/session.ts
@@ -20,6 +20,7 @@ export const CHECKOUT_SCOPE = 'checkout';
 export const LEGACY_CHECKOUT_SCOPE = 'write';
 
 const BASE_SCOPE_POLICY = new Set<string>(['read', LEGACY_CHECKOUT_SCOPE, CHECKOUT_SCOPE]);
+const ADMIN_SCOPE_PREFIX = 'admin:';
 const ADMIN_SCOPE_POLICY = new Set<AdminScope>(ALL_ADMIN_SCOPES);
 
 // Allow a small amount of clock skew when validating expirations
@@ -68,7 +69,7 @@ function assertRateLimit(): void {
 }
 
 export function isAdminScope(scope: string): boolean {
-  return scope.startsWith('admin:');
+  return scope.startsWith(ADMIN_SCOPE_PREFIX);
 }
 
 function assertScopePolicy(scopes: string[]): AdminScope[] {
@@ -100,13 +101,15 @@ async function ensureAdminScopes(scopes: AdminScope[]): Promise<void> {
     throw new Error('{E_SCOPE}');
   }
   const settings = SettingsAgent.getInstance();
-  for (const scope of uniqueScopes) {
-    const allowed = await settings.hasAdminScope(actor, scope);
-    if (!allowed) {
-      authInvalidScopeCounter.inc({ scope });
-      throw new Error('{E_SCOPE}');
-    }
-  }
+  await Promise.all(
+    uniqueScopes.map(async (scope) => {
+      const allowed = await settings.hasAdminScope(actor, scope);
+      if (!allowed) {
+        authInvalidScopeCounter.inc({ scope });
+        throw new Error('{E_SCOPE}');
+      }
+    }),
+  );
 }
 
 function validateScopes(scopes: string[]): void | Promise<void> {

--- a/tests/auth/session.spec.ts
+++ b/tests/auth/session.spec.ts
@@ -101,6 +101,14 @@ describe('session scope validation', () => {
     expect(mockHasAdminScope).toHaveBeenCalledWith('user.testnet', 'admin:settings');
   });
 
+  it('rejects admin scope requests for non-admin wallets with sync signer', async () => {
+    mockChainAdapter.getAccountId.mockReturnValue('user.testnet');
+    await expect(
+      Promise.resolve(requestScopes(['admin:orders'], (payload) => `sig:${payload}`)),
+    ).rejects.toThrow('{E_SCOPE}');
+    expect(mockHasAdminScope).toHaveBeenCalledWith('user.testnet', 'admin:orders');
+  });
+
   it('rejects admin scope requests without a connected wallet', async () => {
     await expect(
       requestScopes(['admin:settings'], async (payload) => `sig:${payload}`),


### PR DESCRIPTION
## Summary
- add an explicit admin scope prefix constant and use it in the session scope policy
- check all requested admin scopes in parallel via SettingsAgent.hasAdminScope
- cover non-admin admin-scope requests with both async and sync signers in session tests

## Testing
- `YARN_IGNORE_OPTIONAL=true yarn install --no-lockfile` *(fails: @waku/core@0.0.38 requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fa4298e88326abac55dd68ba45b6