### PR TITLE
Implement wallet connection helper tests

### DIFF
--- a/src/auth/wallet.ts
+++ b/src/auth/wallet.ts
@@ -14,25 +14,31 @@ import { getEd25519KeyPair } from '@/services/localIdentity';
 import { deriveSharedKey, aesEncrypt, aesDecrypt, deriveChatSalt } from '@/utils/encryption';
 
 const SESSION_ENCRYPTION_INFO = 'wallet.session';
+const WALLET_PUBLIC_KEY_ERROR = 'Wallet public key unavailable';
+
+function readAccountId(): string | null {
+  return typeof getAccountId === 'function' ? getAccountId() : null;
+}
+
+function readWalletPublicKey(): string | null {
+  return typeof getPublicKey === 'function' ? getPublicKey() : null;
+}
 
 export async function connectWallet(): Promise<{ address: string; publicKey: string }> {
-  const readAccount = typeof getAccountId === 'function' ? getAccountId : () => null;
-  const readPublicKey = typeof getPublicKey === 'function' ? getPublicKey : () => null;
-
-  let address = readAccount();
-  let publicKey = readPublicKey();
+  let address = readAccountId();
+  let publicKey = readWalletPublicKey();
 
   if (!address || !publicKey) {
     if (typeof signIn !== 'function') {
-      throw new Error('Wallet public key unavailable');
+      throw new Error(WALLET_PUBLIC_KEY_ERROR);
     }
     await signIn();
-    address = readAccount();
-    publicKey = readPublicKey();
+    address = readAccountId();
+    publicKey = readWalletPublicKey();
   }
 
   if (!address || !publicKey) {
-    throw new Error('Wallet public key unavailable');
+    throw new Error(WALLET_PUBLIC_KEY_ERROR);
   }
 
   return { address, publicKey };

--- a/tests/jest.unit.config.js
+++ b/tests/jest.unit.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const baseConfig = require('../jest.config.js');
+
+const tsTransform = Array.isArray(baseConfig.transform?.['^.+\\.tsx?$'])
+  ? baseConfig.transform['^.+\\.tsx?$']
+  : ['ts-jest', {}];
+
+module.exports = {
+  ...baseConfig,
+  rootDir: path.resolve(__dirname, '..'),
+  collectCoverage: false,
+  transform: {
+    ...baseConfig.transform,
+    '^.+\\.tsx?$': [
+      tsTransform[0],
+      {
+        ...(tsTransform[1] || {}),
+        diagnostics: false,
+      },
+    ],
+  },
+};

--- a/tests/wallet/connectWallet.test.ts
+++ b/tests/wallet/connectWallet.test.ts
@@ -2,6 +2,19 @@ const mockSignIn = jest.fn();
 const mockGetAccountId = jest.fn();
 const mockGetPublicKey = jest.fn();
 
+jest.mock('@waku/sdk', () => ({}), { virtual: true });
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ sign: jest.fn() }),
+}));
+
+jest.mock('@/services/session', () => ({
+  requestScopes: jest.fn(),
+  refreshToken: jest.fn(),
+  validateToken: jest.fn(),
+  getSession: jest.fn(),
+}));
+
 jest.mock('@/features/auth/services/nearAuth', () => ({
   signIn: mockSignIn,
   getAccountId: mockGetAccountId,


### PR DESCRIPTION
## Summary
- extract helper readers for account and public key in `connectWallet` and centralize the wallet error constant
- isolate the wallet unit tests with mocks around heavy dependencies and verify the returned address/public key
- add a lightweight Jest config that disables diagnostics/coverage for focused unit test runs

## Testing
- yarn run jest --config tests/jest.unit.config.js --runTestsByPath tests/wallet/connectWallet.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8fa42cc1883268d80b0384b6bb4f9