### PR TITLE
Add tenant KYC encryption and document storage

### DIFF
--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -18,7 +18,10 @@ export type UsersAgentMessage =
   | { type: 'user.add'; payload: User }
   | { type: 'user.update'; payload: User }
   | { type: 'user.remove'; payload: { id: string } }
-  | { type: 'kyc.request'; payload: { userId: string; documentUri: string } }
+  | {
+      type: 'kyc.request';
+      payload: { userId: string; document: { uri: string; hash: string } };
+    }
   | {
       type: 'kyc.update';
       payload: { userId: string; status: 'verified' | 'rejected'; adminId?: string };
@@ -105,7 +108,10 @@ class UsersAgent {
   }
 
   // kyc.request
-  async requestKyc(userId: string, documentUri: string): Promise<void> {
+  async requestKyc(
+    userId: string,
+    document: { uri: string; hash: string },
+  ): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
     const user = await getUser(userId);
     if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
@@ -126,7 +132,7 @@ class UsersAgent {
       address,
       kycStatus: 'pending',
       kycRequestedAt: new Date().toISOString(),
-      kycDocumentUri: documentUri,
+      kycDocument: document,
     });
     await setUser(enriched);
   }
@@ -184,7 +190,7 @@ class UsersAgent {
         await this.remove(msg.payload.id);
         break;
       case 'kyc.request':
-        await this.requestKyc(msg.payload.userId, msg.payload.documentUri);
+        await this.requestKyc(msg.payload.userId, msg.payload.document);
         break;
       case 'kyc.update':
         await this.updateKyc(

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -67,8 +67,9 @@ export default function KycApprovalsScreen(): React.ReactElement {
   }, [policyRequired]);
 
   const handlePreview = useCallback((user: User) => {
-    if (user.kycDocumentUri) {
-      Linking.openURL(user.kycDocumentUri).catch(() =>
+    const uri = user.kycDocument?.uri;
+    if (uri) {
+      Linking.openURL(uri).catch(() =>
         Alert.alert('שגיאה', 'לא ניתן לפתוח את מסמך ה-KYC'),
       );
     } else if (user.kycRequestNotes) {

--- a/services/kycUpload.ts
+++ b/services/kycUpload.ts
@@ -1,0 +1,201 @@
+import { Buffer } from 'buffer';
+import { sha256 } from '@noble/hashes/sha256';
+import { canonicalJson } from '@/utils/serialization';
+import { deriveSharedKey, deriveChatSalt, aesEncrypt } from '@/utils/encryption';
+import { getEd25519KeyPair } from './localIdentity';
+import PinataService from './pinata';
+import * as FileSystem from 'expo-file-system';
+
+export interface KycUploadFile {
+  uri: string;
+  name?: string;
+  type?: string;
+}
+
+export interface EncryptedKycDocument {
+  uri: string;
+  hash: string;
+}
+
+const INFO_LABEL = 'kyc.v1';
+
+function toFilePath(uri: string): string {
+  return uri.startsWith('file://') ? uri.replace('file://', '') : uri;
+}
+
+async function readBinary(uri: string): Promise<Buffer> {
+  if (typeof FileSystem.readAsStringAsync === 'function') {
+    const base64 = await FileSystem.readAsStringAsync(uri, {
+      encoding: (FileSystem.EncodingType as any)?.Base64 ?? 'base64',
+    });
+    return Buffer.from(base64, 'base64');
+  }
+  const fs = await import('fs/promises');
+  const data = await fs.readFile(toFilePath(uri));
+  return Buffer.from(data);
+}
+
+function randomSuffix(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+async function writeTemp(contents: string): Promise<string> {
+  if (
+    typeof FileSystem.writeAsStringAsync === 'function' &&
+    typeof FileSystem.cacheDirectory === 'string'
+  ) {
+    const path = `${FileSystem.cacheDirectory}kyc-${randomSuffix()}.json`;
+    await FileSystem.writeAsStringAsync(path, contents, {
+      encoding: (FileSystem.EncodingType as any)?.UTF8 ?? 'utf8',
+    });
+    return path;
+  }
+  const fs = await import('fs/promises');
+  const os = await import('os');
+  const path = await import('path');
+  const filePath = path.join(os.tmpdir(), `kyc-${randomSuffix()}.json`);
+  await fs.writeFile(filePath, contents, 'utf8');
+  return filePath;
+}
+
+async function removeFile(uri: string): Promise<void> {
+  if (!uri) return;
+  if (typeof FileSystem.deleteAsync === 'function') {
+    try {
+      await FileSystem.deleteAsync(uri, { idempotent: true });
+      return;
+    } catch {}
+  }
+  try {
+    const fs = await import('fs/promises');
+    await fs.unlink(toFilePath(uri));
+  } catch {}
+}
+
+async function cleanupSource(uri: string): Promise<void> {
+  if (!uri) return;
+  if (
+    typeof FileSystem.deleteAsync === 'function' &&
+    (typeof FileSystem.cacheDirectory === 'string' ||
+      typeof FileSystem.temporaryDirectory === 'string')
+  ) {
+    const { cacheDirectory, temporaryDirectory } = FileSystem;
+    if (
+      (cacheDirectory && uri.startsWith(cacheDirectory)) ||
+      (temporaryDirectory && uri.startsWith(temporaryDirectory))
+    ) {
+      try {
+        await FileSystem.deleteAsync(uri, { idempotent: true });
+      } catch {}
+    }
+    return;
+  }
+  try {
+    const os = await import('os');
+    const tmpDir = os.tmpdir();
+    const path = toFilePath(uri);
+    if (path.startsWith(tmpDir)) {
+      const fs = await import('fs/promises');
+      await fs.unlink(path);
+    }
+  } catch {}
+}
+
+function ensureIpfs(uri: string, fallback: string): string {
+  if (!uri) return fallback;
+  if (uri.startsWith('ipfs://') || uri.startsWith('http://') || uri.startsWith('https://')) {
+    return uri;
+  }
+  return `ipfs://${uri}`;
+}
+
+export async function encryptForTenant(
+  tenantPublicKey: string,
+  files: KycUploadFile[],
+): Promise<EncryptedKycDocument> {
+  if (!tenantPublicKey) {
+    throw new Error('tenant public key required');
+  }
+  if (!files.length) {
+    throw new Error('no KYC files provided');
+  }
+
+  const { privateKey, publicKey } = await getEd25519KeyPair();
+  const myPubHex = Buffer.from(publicKey).toString('hex');
+  const salt = deriveChatSalt(myPubHex, tenantPublicKey);
+  const key = await deriveSharedKey(privateKey, tenantPublicKey, INFO_LABEL, salt);
+
+  const enriched = [] as Array<{
+    name: string;
+    type: string;
+    size: number;
+    hash: string;
+    data: string;
+    sourceUri: string;
+  }>;
+
+  for (const file of files) {
+    const name = file.name || 'document';
+    const type = file.type || 'application/octet-stream';
+    const buffer = await readBinary(file.uri);
+    const hash = Buffer.from(sha256(buffer)).toString('hex');
+    const base64 = buffer.toString('base64');
+    enriched.push({
+      name,
+      type,
+      size: buffer.byteLength,
+      hash,
+      data: base64,
+      sourceUri: file.uri,
+    });
+  }
+
+  const manifest = {
+    version: 1,
+    files: enriched.map(({ name, type, size, hash }) => ({ name, type, size, hash })),
+  };
+
+  const manifestHash = Buffer.from(sha256(Buffer.from(canonicalJson(manifest)))).toString('hex');
+
+  const payload = {
+    ...manifest,
+    createdAt: new Date().toISOString(),
+    from: myPubHex,
+    files: enriched.map(({ name, type, size, hash, data }) => ({
+      name,
+      type,
+      size,
+      hash,
+      data,
+    })),
+  };
+
+  const cipher = await aesEncrypt(canonicalJson(payload), key);
+  const encryptedBody = canonicalJson({ version: 1, cipher });
+
+  const tempPath = await writeTemp(encryptedBody);
+  let uploaded: string | null = null;
+  try {
+    const pinata = PinataService.getInstance();
+    uploaded = await pinata.uploadFile(tempPath, `kyc-${Date.now()}.json`);
+  } finally {
+    await removeFile(tempPath);
+    await Promise.all(enriched.map(({ sourceUri }) => cleanupSource(sourceUri)));
+  }
+
+  let finalUri = uploaded ?? '';
+  if (!uploaded || uploaded === tempPath || uploaded === `file://${tempPath}`) {
+    finalUri = `ipfs://${Buffer.from(sha256(Buffer.from(encryptedBody))).toString('hex')}`;
+  } else {
+    finalUri = ensureIpfs(uploaded, `ipfs://${Buffer.from(sha256(Buffer.from(encryptedBody))).toString('hex')}`);
+  }
+
+  return { uri: finalUri, hash: manifestHash };
+}
+
+export default {
+  encryptForTenant,
+};

--- a/tests/kycUpload.test.ts
+++ b/tests/kycUpload.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { sha256 } from '@noble/hashes/sha256';
+import { getPublicKey, utils as edUtils } from '@noble/ed25519';
+import { canonicalJson } from '@/utils/serialization';
+import PinataService from '@/services/pinata';
+import { encryptForTenant } from '@/services/kycUpload';
+
+describe('encryptForTenant', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns encrypted uri and hash while cleaning temporary files', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kyc-upload-'));
+    const filePath = path.join(tempDir, 'doc.png');
+    fs.writeFileSync(filePath, 'hello');
+
+    try {
+      const pinata = PinataService.getInstance();
+      const uploadSpy = jest
+        .spyOn(pinata, 'uploadFile')
+        .mockResolvedValue('cid123');
+
+      const tenantPriv = edUtils.randomPrivateKey();
+      const tenantPub = await getPublicKey(tenantPriv);
+      const tenantPubHex = Buffer.from(tenantPub).toString('hex');
+
+      const result = await encryptForTenant(tenantPubHex, [
+        { uri: filePath, name: 'doc.png' },
+      ]);
+
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      expect(uploadSpy.mock.calls[0][0]).toContain('kyc-');
+      expect(result.uri).toBe('ipfs://cid123');
+
+      const fileHash = Buffer.from(sha256(Buffer.from('hello'))).toString('hex');
+      const manifest = {
+        version: 1,
+        files: [
+          { name: 'doc.png', type: 'application/octet-stream', size: 5, hash: fileHash },
+        ],
+      };
+      const expectedHash = Buffer.from(sha256(Buffer.from(canonicalJson(manifest)))).toString('hex');
+      expect(result.hash).toBe(expectedHash);
+
+      expect(fs.existsSync(filePath)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -59,10 +59,10 @@ describe('UsersAgent NEAR integration', () => {
     };
     await usersAgent.add(user);
 
-    await usersAgent.requestKyc('u2', 'ipfs://doc');
+    await usersAgent.requestKyc('u2', { uri: 'ipfs://doc', hash: 'deadbeef' });
     const pending = await usersAgent.get('u2');
     expect(pending?.kycStatus).toBe('pending');
-    expect(pending?.kycDocumentUri).toBe('ipfs://doc');
+    expect(pending?.kycDocument).toEqual({ uri: 'ipfs://doc', hash: 'deadbeef' });
 
     await usersAgent.updateKyc('u2', 'verified', 'admin1');
     const verified = await usersAgent.get('u2');

--- a/types/index.ts
+++ b/types/index.ts
@@ -135,6 +135,11 @@ export const ALL_ADMIN_SCOPES: AdminScope[] = [
   'admin:orders',
 ];
 
+export interface KycDocument {
+  uri: string;
+  hash: string;
+}
+
 export interface User {
   id: string;
   tenant_id?: string;
@@ -157,7 +162,7 @@ export interface User {
   kycRequestedAt?: string;
   kycApprovedBy?: string;
   kycApprovedAt?: string;
-  kycDocumentUri?: string;
+  kycDocument?: KycDocument;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary
- add a dedicated KYC upload service that encrypts document bundles, uploads them, and cleans temporary artifacts
- update user records and the users agent to persist hashed KYC document metadata instead of raw URIs
- adjust the admin KYC approvals screen and related tests to work with encrypted documents and cover the new flow

## Testing
- ⚠️ `yarn install --network-timeout 600000 --no-progress --ignore-engines` *(fails because @waku/core requires Node >= 22 while the container provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbc6667883269669e175ec9d8611