### PR TITLE
Add cached store profile page and offline-aware hero

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -1,45 +1,53 @@
-// TOUCHPOINT: app/store/[storeId]/_StoreScreen.tsx renders in production — Fix Pack v2
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
-import StoreHeader from '@/features/stores/components/store/StoreHeader';
-import StoreTabs from '@/features/stores/components/store/StoreTabs';
-import { ProductGrid, ProductCardSkeleton } from '@/features/products';
+import { Text, Button } from '@/ui/primitives';
+import StoreHeader, { StoreHeaderSkeleton } from '@/features/stores/components/store/StoreHeader';
 import CategoryChips from '@/features/home/components/CategoryChips';
+import { ProductGrid, ProductCardSkeleton } from '@/features/products';
 import { useProducts, useCategories, useStoreReviews } from '@/services';
-import { selectStore } from '@/agents/stores-agent';
-import type { Store, Product } from '@/types';
-import { spacing } from '@/shared/ui/tokens';
+import { useStoreProfile } from '@/features/stores/hooks/useStoreProfile';
+import type { Product } from '@/types';
+import { spacing, radius } from '@/shared/ui/tokens';
 import EmptyState from '@/shared/ui/EmptyState';
-import Button from '@/ui/primitives/Button';
+import { useNotificationActions } from '@/components/NotificationContext';
 import { useAppRouter } from '@/services/useAppRouter';
+import { useAuth } from '@/features/auth/AuthContext';
+import { useAuthModal } from '@/features/auth/AuthModalContext';
+import { openDM } from '@/services/openDM';
+import { openProduct } from '@/services/openProduct';
 import { AlertTriangle } from 'lucide-react-native';
 
 export default function StoreScreen() {
-  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+  const { storeId: rawStoreId } = useLocalSearchParams<{ storeId: string }>();
+  const storeId = typeof rawStoreId === 'string' ? rawStoreId : undefined;
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
-  const [store, setStore] = useState<Store | null>(null);
-  const [loaded, setLoaded] = useState(false);
-  const { push } = useAppRouter();
+  const { showNotification } = useNotificationActions();
+  const appRouter = useAppRouter();
+  const { isLoggedIn } = useAuth();
+  const { openAuthModal } = useAuthModal();
+
+  const { store, isLoading: storeLoading, error: storeError, isOffline } = useStoreProfile(storeId);
   const {
     data: products = [],
     isLoading: productsLoading,
     refetch: refetchProducts,
     isRefetching: productsRefetching,
     error: productsError,
-  } = useProducts(storeId);
+  } = useProducts(storeId ?? null);
   const {
     data: categories = [],
     isLoading: categoriesLoading,
     refetch: refetchCategories,
     isRefetching: categoriesRefetching,
     error: categoriesError,
-  } = useCategories(storeId);
-  const { data: { score } = { score: 0 } } = useStoreReviews(storeId);
-  const [tab, setTab] = useState<'products' | 'about' | 'reviews'>('products');
+  } = useCategories(storeId ?? null);
+  const { data: { score: reputationScore } = { score: 0 } } = useStoreReviews(storeId ?? null);
+
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [contacting, setContacting] = useState(false);
 
   const refreshing = productsRefetching || categoriesRefetching;
 
@@ -47,16 +55,61 @@ export default function StoreScreen() {
     void Promise.all([refetchProducts(), refetchCategories()]);
   }, [refetchProducts, refetchCategories]);
 
-  const handleProductPress = useCallback(
-    (product: Product) => {
-      const targetStore = product.storeId || storeId;
-      if (!targetStore) return;
-      push(`/store/${targetStore}/product/${product.id}`);
-    },
-    [push, storeId],
-  );
+  const handleProductPress = useCallback((product: Product) => {
+    void openProduct(product.id);
+  }, []);
 
-  const loadError = productsError || categoriesError;
+  const storeIdentifier = store?.id || storeId;
+  const contactLabel = t('productDetail.contactStore', 'Contact store');
+
+  const handleContactStore = useCallback(async () => {
+    if (!storeIdentifier) {
+      showNotification(
+        t('common.error', 'Error'),
+        t(
+          'productDetail.contactStoreError',
+          'We could not start a chat with this store. Please try again later.',
+        ),
+        'error',
+      );
+      return;
+    }
+
+    if (!isLoggedIn) {
+      openAuthModal();
+      return;
+    }
+
+    setContacting(true);
+    try {
+      await openDM(storeIdentifier);
+      appRouter.push('/messages');
+    } catch (err) {
+      if (err instanceof Error && err.message === 'WALLET_REQUIRED') {
+        openAuthModal();
+        showNotification(
+          t('common.error', 'Error'),
+          t('auth.walletConnectionFailed', 'Wallet connection failed'),
+          'error',
+        );
+      } else {
+        showNotification(
+          t('common.error', 'Error'),
+          err instanceof Error
+            ? err.message
+            : t(
+                'productDetail.contactStoreError',
+                'We could not start a chat with this store. Please try again later.',
+              ),
+          'error',
+        );
+      }
+    } finally {
+      setContacting(false);
+    }
+  }, [appRouter, isLoggedIn, openAuthModal, openDM, showNotification, storeIdentifier, t]);
+
+  const loadError = storeError || productsError || categoriesError;
   const loadErrorMessage = loadError
     ? loadError instanceof Error
       ? loadError.message
@@ -66,143 +119,198 @@ export default function StoreScreen() {
   const filteredProducts = useMemo(
     () =>
       selectedCategory
-        ? products.filter((p) => p.category === selectedCategory)
+        ? products.filter((product) => product.category === selectedCategory)
         : products,
     [products, selectedCategory],
   );
 
-  useEffect(() => {
-    let active = true;
-    const load = async () => {
-      if (!storeId) return;
-      const s = await selectStore(storeId);
-      if (active) setStore(s);
-      if (active) setLoaded(true);
-    };
-    void load();
-    return () => {
-      active = false;
-    };
-  }, [storeId]);
+  const bannerUri = useMemo(() => {
+    if (!store) return null;
+    const raw = (store as Record<string, unknown>).bannerUri;
+    return typeof raw === 'string' ? raw : null;
+  }, [store]);
 
-  if (!loaded) {
+  const avatarUri = useMemo(() => {
+    if (!store) return null;
+    const raw = (store as Record<string, unknown>).avatarUri;
+    return typeof raw === 'string' ? raw : null;
+  }, [store]);
+
+  const tagline = useMemo(() => {
+    if (!store) return null;
+    const raw =
+      (store as Record<string, unknown>).tagline ??
+      (store as Record<string, unknown>).tagLine ??
+      (store as Record<string, unknown>).description;
+    return typeof raw === 'string' && raw.trim().length > 0 ? raw : null;
+  }, [store]);
+
+  const reputation = useMemo(() => {
+    if (typeof reputationScore === 'number' && reputationScore > 0) {
+      return reputationScore;
+    }
+    if (store && typeof store.reputation === 'number') {
+      return store.reputation;
+    }
+    return 0;
+  }, [reputationScore, store]);
+
+  if (!storeId && !store) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.background }}>
-        <ProductCardSkeleton />
-      </View>
-    );
-  }
-  if (!store) {
-    return (
-      <View style={{ flex: 1, backgroundColor: colors.background }}>
+      <View style={[styles.container, { backgroundColor: colors.background }]}> 
         <EmptyState
-          title={t('store.not_found')}
-          description={t('store.not_found_sub')}
-          action={<Button onPress={() => push('/')}>{t('cta.back_home')}</Button>}
+          icon={AlertTriangle}
+          title={t('store.not_found', 'Store not found')}
+          message={t('store.not_found_sub', "We couldn't find that store.")}
         />
       </View>
     );
   }
 
+  if (!store && storeLoading) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}> 
+        <StoreHeaderSkeleton />
+        <View style={styles.productSkeletonRow}>
+          {Array.from({ length: 4 }).map((_, index) => (
+            <View key={index} style={styles.productSkeletonWrapper}>
+              <ProductCardSkeleton />
+            </View>
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  if (!store && loadErrorMessage) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}> 
+        <EmptyState
+          icon={AlertTriangle}
+          title={t('store.not_found', 'Store not found')}
+          message={loadErrorMessage}
+        />
+      </View>
+    );
+  }
+
+  if (!store) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}> 
+        <EmptyState
+          icon={AlertTriangle}
+          title={t('store.not_found', 'Store not found')}
+          message={t('store.not_found_sub', "We couldn't find that store.")}
+        />
+      </View>
+    );
+  }
+
+  const showCategories = categories.length > 0 && !categoriesLoading;
+
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
       <StoreHeader
         name={store.name}
-        reputation={score}
-        bannerUri={(store as any).bannerUri}
-        avatarUri={(store as any).avatarUri}
-        tagline={(store as any).tagline}
+        reputation={reputation}
+        bannerUri={bannerUri}
+        avatarUri={avatarUri}
+        tagline={tagline}
       />
-      <StoreTabs active={tab} onChange={setTab} />
-      {tab === 'products' && (
-        <>
-          {!!categories.length && !categoriesLoading && (
-            <CategoryChips
-              categories={categories}
-              selectedCategory={selectedCategory}
-              setSelectedCategory={setSelectedCategory}
-            />
+
+      <View
+        style={[
+          styles.actionsRow,
+          { flexDirection: isRTL ? 'row-reverse' : 'row' },
+        ]}
+      >
+        <Button
+          title={contactLabel}
+          accessibilityLabel={contactLabel}
+          onPress={handleContactStore}
+          loading={contacting}
+          disabled={!storeIdentifier || contacting}
+        />
+      </View>
+
+      {isOffline ? (
+        <Text
+          variant="sm"
+          style={{
+            marginHorizontal: spacing.spacer16,
+            marginTop: spacing.spacer8,
+            color: colors.status.warning,
+            textAlign: isRTL ? 'right' : 'left',
+          }}
+        >
+          {t(
+            'stores.offlineNotice',
+            'Viewing cached data. Some details may be out of date.',
           )}
-          {productsLoading ? (
-            <View style={styles.productsGrid}>
-              {Array.from({ length: 4 }).map((_, idx) => (
-                <View key={idx} style={styles.productWrapper}>
-                  <ProductCardSkeleton />
-                </View>
-              ))}
-            </View>
-          ) : loadErrorMessage ? (
-            <EmptyState
-              icon={AlertTriangle}
-              title={t('home.loadErrorTitle', 'Unable to load products')}
-              message={loadErrorMessage}
-              actionText={t('common.reload', 'Reload')}
-              onAction={handleRefresh}
-            />
-          ) : (
-            <ProductGrid
-              products={filteredProducts}
-              refreshing={refreshing}
-              onRefresh={handleRefresh}
-              onProductPress={handleProductPress}
-            />
-          )}
-        </>
-      )}
-      {tab === 'about' && (
-        <View style={styles.section}>
-          <Text
-            style={[
-              styles.sectionTitle,
-              { color: colors.text.primary, textAlign: isRTL ? 'right' : 'left' },
-            ]}
-          >
-            {t('stores.about')}
-          </Text>
-          <Text
-            style={[
-              styles.sectionText,
-              { color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' },
-            ]}
-          >
-            {t('stores.aboutDescription')}
-          </Text>
+        </Text>
+      ) : null}
+
+      {showCategories ? (
+        <View style={{ marginTop: spacing.spacer16 }}>
+          <CategoryChips
+            categories={categories}
+            selectedCategory={selectedCategory}
+            setSelectedCategory={setSelectedCategory}
+          />
         </View>
-      )}
-      {tab === 'reviews' && (
-        <View style={styles.section}>
-          <Text
-            style={[
-              styles.sectionText,
-              { color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' },
-            ]}
-          >
-            {t('stores.reviewsComingSoon')}
-          </Text>
-        </View>
-      )}
+      ) : null}
+
+      <View style={styles.catalogContainer}>
+        {productsLoading ? (
+          <View style={styles.productSkeletonRow}>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <View key={index} style={styles.productSkeletonWrapper}>
+                <ProductCardSkeleton />
+              </View>
+            ))}
+          </View>
+        ) : loadErrorMessage ? (
+          <EmptyState
+            icon={AlertTriangle}
+            title={t('home.loadErrorTitle', 'Unable to load products')}
+            message={loadErrorMessage}
+            actionText={t('common.reload', 'Reload')}
+            onAction={handleRefresh}
+          />
+        ) : (
+          <ProductGrid
+            products={filteredProducts}
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            onProductPress={handleProductPress}
+          />
+        )}
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, gap: spacing.spacer24 },
-  productsGrid: {
+  container: { flex: 1 },
+  actionsRow: {
+    paddingHorizontal: spacing.spacer16,
+    paddingTop: spacing.spacer16,
+  },
+  catalogContainer: {
+    flex: 1,
+    paddingTop: spacing.spacer8,
+  },
+  productSkeletonRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
     paddingHorizontal: spacing.spacer16,
     paddingVertical: spacing.spacer16,
+    gap: spacing.spacer16,
   },
-  productWrapper: { width: '48%', marginBottom: spacing.spacer16 },
-  section: { padding: spacing.spacer16 },
-  sectionTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: spacing.spacer8,
+  productSkeletonWrapper: {
+    width: '48%',
+    borderRadius: radius.md,
   },
-  sectionText: {},
 });
-
-// AC: Missing store renders friendly EmptyState with Back to Home button.
 

--- a/src/features/stores/components/store/StoreHeader.tsx
+++ b/src/features/stores/components/store/StoreHeader.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { View, Text, Image, Platform } from 'react-native';
+import { View, Image, StyleSheet } from 'react-native';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { Heading, Text, Skeleton } from '@/ui/primitives';
+import { spacing, radius } from '@/shared/ui/tokens';
+import { Star } from 'lucide-react-native';
 
 interface Props {
   name: string;
@@ -10,71 +13,204 @@ interface Props {
   tagline?: string | null;
 }
 
-export default function StoreHeader({ name, reputation = 0, bannerUri, avatarUri, tagline }: Props) {
+export default function StoreHeader({
+  name,
+  reputation = 0,
+  bannerUri,
+  avatarUri,
+  tagline,
+}: Props) {
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
+  const fallbackName = name || t('stores.storeName');
+  const bannerLabel = t('stores.bannerAlt', { name: fallbackName });
+  const avatarLabel = t('stores.avatarAlt', { name: fallbackName });
+
   return (
     <View>
-      <View style={{ width: '100%', height: 160, backgroundColor: colors.surface.secondary }}>
+      <View
+        style={[styles.banner, { backgroundColor: colors.surface.secondary }]}
+        accessible={!!bannerUri}
+        accessibilityRole="image"
+        accessibilityLabel={bannerUri ? bannerLabel : undefined}
+      >
         {bannerUri ? (
-          <Image source={{ uri: bannerUri }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+          <Image
+            source={{ uri: bannerUri }}
+            style={styles.bannerImage}
+            resizeMode="cover"
+            accessible
+            accessibilityRole="image"
+            accessibilityLabel={bannerLabel}
+          />
         ) : null}
       </View>
       <View
-        style={{
-          marginTop: -28,
-          paddingHorizontal: 16,
-          flexDirection: isRTL ? 'row-reverse' : 'row',
-          alignItems: 'center',
-          gap: 12,
-        }}
+        style={[
+          styles.profileRow,
+          {
+            flexDirection: isRTL ? 'row-reverse' : 'row',
+          },
+        ]}
       >
         <View
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 28,
-            overflow: 'hidden',
-            backgroundColor: colors.surface.primary,
-            borderWidth: 2,
-            borderColor: colors.background,
-          }}
+          style={[
+            styles.avatarWrapper,
+            {
+              borderColor: colors.background,
+              backgroundColor: colors.surface.primary,
+            },
+          ]}
         >
-          {avatarUri ? <Image source={{ uri: avatarUri }} style={{ width: '100%', height: '100%' }} /> : null}
+          {avatarUri ? (
+            <Image
+              source={{ uri: avatarUri }}
+              style={styles.avatarImage}
+              resizeMode="cover"
+              accessible
+              accessibilityRole="image"
+              accessibilityLabel={avatarLabel}
+            />
+          ) : (
+            <View
+              style={[styles.avatarPlaceholder, { backgroundColor: colors.surface.secondary }]}
+              accessible
+              accessibilityRole="image"
+              accessibilityLabel={avatarLabel}
+            >
+              <Text variant="lg" weight="600" style={{ color: colors.text.secondary }}>
+                {fallbackName.slice(0, 1).toUpperCase()}
+              </Text>
+            </View>
+          )}
         </View>
-        <View style={{ flex: 1 }}>
-          <Text
+        <View
+          style={[
+            styles.info,
+            {
+              alignItems: isRTL ? 'flex-end' : 'flex-start',
+              marginStart: isRTL ? 0 : spacing.spacer16,
+              marginEnd: isRTL ? spacing.spacer16 : 0,
+            },
+          ]}
+        >
+          <Heading
+            size="xl"
             style={{
               color: colors.text.primary,
-              fontSize: 22,
-              fontWeight: Platform.OS === 'web' ? ('700' as any) : '700',
               textAlign: isRTL ? 'right' : 'left',
             }}
           >
-            {name}
-          </Text>
-          <Text
-            style={{ color: colors.text.secondary, textAlign: isRTL ? 'right' : 'left' }}
+            {fallbackName}
+          </Heading>
+          <View
+            style={[
+              styles.ratingRow,
+              { flexDirection: isRTL ? 'row-reverse' : 'row' },
+            ]}
           >
-            {t('stores.reputation')} {reputation.toFixed(1)}
-          </Text>
-          {!!tagline && (
-            <Text style={{ color: colors.text.tertiary, textAlign: isRTL ? 'right' : 'left' }}>
+            <Star size={16} color={colors.gold} />
+            <Text
+              variant="sm"
+              weight="500"
+              style={{
+                color: colors.text.primary,
+                marginStart: isRTL ? 0 : spacing.spacer4,
+                marginEnd: isRTL ? spacing.spacer4 : 0,
+              }}
+            >
+              {t('stores.reputation', 'Reputation:')} {reputation.toFixed(1)}
+            </Text>
+          </View>
+          {tagline ? (
+            <Text
+              variant="sm"
+              style={{
+                color: colors.text.secondary,
+                textAlign: isRTL ? 'right' : 'left',
+                marginTop: spacing.spacer4,
+              }}
+            >
               {tagline}
             </Text>
-          )}
+          ) : null}
         </View>
       </View>
-      <View style={{ height: 8 }} />
-      <View
-        style={{
-          height: 2,
-          marginHorizontal: 16,
-          backgroundColor: colors.gold,
-          borderRadius: 1,
-        }}
-      />
     </View>
   );
 }
+
+export function StoreHeaderSkeleton() {
+  return (
+    <View>
+      <Skeleton height={160} />
+      <View style={styles.skeletonRow}>
+        <Skeleton width={72} height={72} borderRadius={36} />
+        <View style={styles.skeletonInfo}>
+          <Skeleton height={24} width="60%" />
+          <Skeleton height={16} width="40%" style={styles.skeletonLine} />
+          <Skeleton height={16} width="70%" style={styles.skeletonLine} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    width: '100%',
+    height: 160,
+    borderBottomLeftRadius: radius.lg,
+    borderBottomRightRadius: radius.lg,
+    overflow: 'hidden',
+  },
+  bannerImage: {
+    width: '100%',
+    height: '100%',
+  },
+  profileRow: {
+    marginTop: -36,
+    paddingHorizontal: spacing.spacer16,
+    alignItems: 'center',
+  },
+  avatarWrapper: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    borderWidth: 2,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  avatarImage: {
+    width: '100%',
+    height: '100%',
+  },
+  avatarPlaceholder: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  info: {
+    flex: 1,
+  },
+  ratingRow: {
+    alignItems: 'center',
+    marginTop: spacing.spacer4,
+  },
+  skeletonRow: {
+    marginTop: -36,
+    paddingHorizontal: spacing.spacer16,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  skeletonInfo: {
+    flex: 1,
+    marginStart: spacing.spacer16,
+  },
+  skeletonLine: {
+    marginTop: spacing.spacer8,
+  },
+});
 

--- a/src/features/stores/hooks/useStoreProfile.ts
+++ b/src/features/stores/hooks/useStoreProfile.ts
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { selectStore } from '@/agents/stores-agent';
+import type { Store } from '@/types';
+
+type WarmCache = {
+  getById(id: string): Store | undefined;
+  subscribe(
+    filter: (id: string, value: Store | undefined) => boolean,
+    cb: (id: string, value: Store | undefined) => void,
+  ): () => void;
+};
+
+let warmCache: WarmCache | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('@/features/stores/services/nearStores');
+  if (mod && typeof mod === 'object' && 'storesWarmCache' in mod) {
+    warmCache = mod.storesWarmCache as WarmCache;
+  }
+} catch {
+  warmCache = null;
+}
+
+type Source = 'cache' | 'network';
+
+export interface UseStoreProfileResult {
+  store: (Store & Record<string, unknown>) | null;
+  isLoading: boolean;
+  error: Error | null;
+  source: Source | null;
+  isOffline: boolean;
+}
+
+export function useStoreProfile(storeId?: string | null): UseStoreProfileResult {
+  const [store, setStore] = useState<(Store & Record<string, unknown>) | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [hasCacheData, setHasCacheData] = useState(false);
+  const [hasNetworkData, setHasNetworkData] = useState(false);
+  const [stale, setStale] = useState(false);
+
+  const storeRef = useRef(store);
+  const hasCacheRef = useRef(hasCacheData);
+  const hasNetworkRef = useRef(hasNetworkData);
+
+  useEffect(() => {
+    storeRef.current = store;
+  }, [store]);
+
+  useEffect(() => {
+    hasCacheRef.current = hasCacheData;
+  }, [hasCacheData]);
+
+  useEffect(() => {
+    hasNetworkRef.current = hasNetworkData;
+  }, [hasNetworkData]);
+
+  useEffect(() => {
+    if (!storeId) {
+      setStore(null);
+      setIsLoading(false);
+      setError(new Error('STORE_ID_REQUIRED'));
+      setHasCacheData(false);
+      setHasNetworkData(false);
+      setStale(false);
+      return;
+    }
+
+    let active = true;
+    let unsubscribe: (() => void) | undefined;
+
+    const applyStore = (value: Store, from: Source) => {
+      if (!active) return;
+      const snapshot = value as Store & Record<string, unknown>;
+      setStore(snapshot);
+      if (from === 'cache') {
+        setHasCacheData(true);
+      }
+      if (from === 'network') {
+        setHasNetworkData(true);
+        setStale(false);
+        setError(null);
+      }
+      if (from === 'cache' && !hasNetworkRef.current) {
+        setError(null);
+      }
+      setIsLoading(false);
+    };
+
+    const clearCache = () => {
+      if (!active) return;
+      setHasCacheData(false);
+      if (!hasNetworkRef.current) {
+        setStore(null);
+        setIsLoading(true);
+      }
+    };
+
+    setIsLoading(!storeRef.current);
+    setError(null);
+    setStale(false);
+    setHasCacheData(false);
+    setHasNetworkData(false);
+
+    if (warmCache) {
+      try {
+        const cached = warmCache.getById(storeId);
+        if (cached) {
+          applyStore(cached, 'cache');
+        }
+        unsubscribe = warmCache.subscribe(
+          (id) => id === storeId,
+          (id, value) => {
+            if (!active || id !== storeId) return;
+            if (value) {
+              applyStore(value, 'cache');
+            } else {
+              clearCache();
+            }
+          },
+        );
+      } catch {
+        // ignore cache failures
+      }
+    }
+
+    (async () => {
+      try {
+        const fresh = await selectStore(storeId);
+        if (!active) return;
+        if (fresh) {
+          applyStore(fresh, 'network');
+        } else if (!hasCacheRef.current) {
+          setStore(null);
+          setError(new Error('STORE_NOT_FOUND'));
+        }
+      } catch (err) {
+        if (!active) return;
+        if (hasCacheRef.current) {
+          setStale(true);
+        } else {
+          setError(err instanceof Error ? err : new Error('FAILED_TO_LOAD_STORE'));
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+      if (unsubscribe) {
+        try {
+          unsubscribe();
+        } catch {
+          // ignore unsubscribe errors
+        }
+      }
+    };
+  }, [storeId]);
+
+  const source: Source | null = useMemo(() => {
+    if (hasNetworkData) return 'network';
+    if (hasCacheData) return 'cache';
+    return null;
+  }, [hasCacheData, hasNetworkData]);
+
+  const computedError = store ? null : error;
+  const isOffline = Boolean(stale || (hasCacheData && !hasNetworkData));
+
+  return {
+    store,
+    isLoading,
+    error: computedError,
+    source,
+    isOffline,
+  };
+}
+
+export default useStoreProfile;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -15,3 +15,4 @@ export * from './useReviews';
 export * from './useUsers';
 export * from './useStoreReviews';
 export * from './openDM';
+export * from './openProduct';

--- a/src/services/openProduct.ts
+++ b/src/services/openProduct.ts
@@ -1,0 +1,83 @@
+import { selectProduct } from '@/agents/products-agent';
+import type { Product } from '@/types';
+import DatabaseService from '@/services/database';
+import { prefetchStoreBundle } from '@/features/stores/services/prefetch';
+import { push } from '@/services/navigation';
+import { errorLog } from '@/utils/logger';
+
+interface ProductCache {
+  getById(id: string): Product | undefined;
+}
+
+let productsWarmCache: ProductCache | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('@/features/products/services/nearProducts');
+  if (mod && typeof mod === 'object' && 'productsWarmCache' in mod) {
+    productsWarmCache = mod.productsWarmCache as ProductCache;
+  }
+} catch {
+  productsWarmCache = null;
+}
+
+function resolveStoreIdFromCache(productId: string): string | null {
+  if (!productsWarmCache) return null;
+  try {
+    const cached = productsWarmCache.getById(productId);
+    if (cached?.storeId) {
+      return cached.storeId;
+    }
+  } catch (err) {
+    errorLog('Failed to read product cache', err);
+  }
+  return null;
+}
+
+async function resolveStoreId(productId: string): Promise<string | null> {
+  const fromCache = resolveStoreIdFromCache(productId);
+  if (fromCache) return fromCache;
+
+  try {
+    const product = await selectProduct(productId);
+    if (product?.storeId) {
+      return product.storeId;
+    }
+  } catch (err) {
+    errorLog('Failed to load product via agent', err);
+  }
+
+  try {
+    const db = DatabaseService.getInstance();
+    const local = await db.getProduct(productId);
+    if (local?.storeId) {
+      return local.storeId;
+    }
+  } catch (err) {
+    errorLog('Failed to resolve product from local database', err);
+  }
+
+  return null;
+}
+
+export async function openProduct(productId: string): Promise<string> {
+  const id = productId?.trim();
+  if (!id) {
+    throw new Error('INVALID_PRODUCT_ID');
+  }
+
+  const storeId = await resolveStoreId(id);
+  if (!storeId) {
+    throw new Error('PRODUCT_NOT_FOUND');
+  }
+
+  const path = `/store/${encodeURIComponent(storeId)}/product/${encodeURIComponent(id)}`;
+  try {
+    void prefetchStoreBundle(storeId);
+  } catch (err) {
+    errorLog('Failed to prefetch store bundle for product navigation', err);
+  }
+  push(path);
+  return path;
+}
+
+export default openProduct;

--- a/tests/storeScreen.test.tsx
+++ b/tests/storeScreen.test.tsx
@@ -2,76 +2,220 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import StoreScreen from '@app/store/[storeId]';
 
+const mockUseStoreProfile = jest.fn();
+const mockUseProducts = jest.fn();
+const mockUseCategories = jest.fn();
+const mockUseStoreReviews = jest.fn();
+const mockUseAppRouter = { push: jest.fn() };
+const mockOpenDM = jest.fn();
+const mockOpenProduct = jest.fn();
+
 jest.mock('expo-router', () => ({
-  useLocalSearchParams: () => ({ storeId: 's1' }),
+  useLocalSearchParams: () => ({ storeId: 'store-1' }),
 }));
 
 jest.mock('@/ui/ThemeProvider', () => ({
   useTheme: () => ({
     colors: {
       background: '#fff',
-      text: { primary: '#000', secondary: '#666', inverse: '#fff' },
-      border: { primary: '#000' },
+      surface: { primary: '#ffffff', secondary: '#f5f5f5' },
+      text: { primary: '#111', secondary: '#666', inverse: '#fff' },
+      border: { primary: '#ddd' },
+      gold: '#ffd700',
+      status: { warning: '#ff8800' },
     },
   }),
-}));
-
-jest.mock('../agents/stores-agent', () => ({
-  get: jest.fn(async () => ({ id: 's1', name: 'Test Store' })),
-  getReputationScore: jest.fn(() => 4.5),
-  subscribe: jest.fn(),
-  unsubscribe: jest.fn(),
-}));
-
-jest.mock('../agents/products-agent', () => ({
-  getAll: jest.fn(async () => [
-    {
-      id: 'p1',
-      name: 'Apple',
-      storeId: 's1',
-      price: 1,
-      stock: 1,
-      description: '',
-      images: [],
-      category: 'fruits',
-    } as any,
-    {
-      id: 'p2',
-      name: 'Carrot',
-      storeId: 's1',
-      price: 1,
-      stock: 1,
-      description: '',
-      images: [],
-      category: 'vegetables',
-    } as any,
-  ]),
-}));
-
-jest.mock('../agents/review-agent', () => ({
-  getByProduct: jest.fn(async (id: string) => {
-    if (id === 'p1') return [{ rating: 4 }, { rating: 5 }] as any;
-    if (id === 'p2') return [{ rating: 3 }] as any;
-    return [];
+  useLanguage: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    isRTL: false,
   }),
+}));
+
+jest.mock('@/components/NotificationContext', () => ({
+  useNotificationActions: () => ({ showNotification: jest.fn() }),
+}));
+
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ isLoggedIn: true }),
+}));
+
+jest.mock('@/features/auth/AuthModalContext', () => ({
+  useAuthModal: () => ({ openAuthModal: jest.fn() }),
+}));
+
+jest.mock('@/features/stores/hooks/useStoreProfile', () => ({
+  useStoreProfile: (id: string) => mockUseStoreProfile(id),
+}));
+
+jest.mock('@/services', () => ({
+  useProducts: (...args: any[]) => mockUseProducts(...args),
+  useCategories: (...args: any[]) => mockUseCategories(...args),
+  useStoreReviews: (...args: any[]) => mockUseStoreReviews(...args),
+}));
+
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => mockUseAppRouter,
+}));
+
+jest.mock('@/services/openDM', () => ({
+  openDM: (...args: any[]) => mockOpenDM(...args),
+}));
+
+jest.mock('@/services/openProduct', () => ({
+  openProduct: (...args: any[]) => mockOpenProduct(...args),
+}));
+
+jest.mock('@/features/home/components/CategoryChips', () => ({
+  __esModule: true,
+  default: (props: any) => React.createElement('CategoryChips', props),
 }));
 
 jest.mock('@/features/products', () => ({
-  ProductCard: ({ product }: any) => React.createElement('ProductCard', null, product.name),
+  ProductGrid: ({ products }: any) =>
+    React.createElement(
+      'ProductGrid',
+      null,
+      products.map((p: any) => React.createElement('Product', { key: p.id }, p.name)),
+    ),
+  ProductCardSkeleton: () => React.createElement('ProductSkeleton'),
 }));
 
-describe('StoreScreen', () => {
-  it('shows store catalog with reviews', async () => {
+jest.mock('@/shared/ui/EmptyState', () => ({
+  __esModule: true,
+  default: (props: any) => React.createElement('EmptyState', props, props.title),
+}));
+
+describe('StoreScreen (public view)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStoreProfile.mockReturnValue({
+      store: null,
+      isLoading: false,
+      error: null,
+      source: null,
+      isOffline: false,
+    });
+    mockUseProducts.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    });
+    mockUseCategories.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    });
+    mockUseStoreReviews.mockReturnValue({ data: { score: 0 } });
+  });
+
+  it('renders store hero with accessible media', async () => {
+    mockUseStoreProfile.mockReturnValue({
+      store: {
+        id: 'store-1',
+        name: 'Test Store',
+        owner: 'owner.test',
+        nftId: 'nft',
+        bannerUri: 'banner.png',
+        avatarUri: 'avatar.png',
+        tagline: 'Fresh goods daily',
+      } as any,
+      isLoading: false,
+      error: null,
+      source: 'network',
+      isOffline: false,
+    });
+    mockUseProducts.mockReturnValue({
+      data: [
+        {
+          id: 'prod-1',
+          name: 'Apples',
+          price: 3,
+          description: '',
+          category: 'fruit',
+          images: [],
+          rating: 4,
+          reviews: 2,
+          storeId: 'store-1',
+          stock: 5,
+        },
+      ],
+      isLoading: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    });
+    mockUseStoreReviews.mockReturnValue({ data: { score: 4.2 } });
+
     let root: renderer.ReactTestRenderer;
     await act(async () => {
       root = renderer.create(<StoreScreen />);
     });
-    await act(async () => {});
-    const str = JSON.stringify(root!.toJSON());
-    expect(str).toContain('Test Store');
-    expect(str).toContain('Apple');
-    expect(str).toContain('Carrot');
-    expect(str).toContain('⭐ 4.5 (2)');
-    expect(str).toContain('⭐ 3.0 (1)');
+
+    const tree = root!.toJSON();
+    expect(tree).toMatchSnapshot();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('Store banner for Test Store');
+    expect(json).toContain('Store avatar for Test Store');
+  });
+
+  it('shows skeletons while loading store data', async () => {
+    mockUseStoreProfile.mockReturnValue({
+      store: null,
+      isLoading: true,
+      error: null,
+      source: null,
+      isOffline: false,
+    });
+    mockUseProducts.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    });
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StoreScreen />);
+    });
+
+    const tree = root!.toJSON();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('ProductSkeleton');
+  });
+
+  it('renders offline notice when using cached data', async () => {
+    mockUseStoreProfile.mockReturnValue({
+      store: {
+        id: 'store-1',
+        name: 'Cached Store',
+        owner: 'owner',
+        nftId: 'nft',
+      } as any,
+      isLoading: false,
+      error: null,
+      source: 'cache',
+      isOffline: true,
+    });
+    mockUseProducts.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+      isRefetching: false,
+      error: null,
+    });
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<StoreScreen />);
+    });
+
+    const tree = root!.toJSON();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('Viewing cached data. Some details may be out of date.');
   });
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -671,6 +671,9 @@
   },
   "stores": {
     "storeName": "Store Name",
+    "bannerAlt": "Store banner for {name}",
+    "avatarAlt": "Store avatar for {name}",
+    "offlineNotice": "Viewing cached data. Some details may be out of date.",
     "mintStore": "Mint Store",
     "transactionFailed": "Transaction failed",
     "insufficientFunds": "Insufficient funds to deploy the store",

--- a/translations/he.json
+++ b/translations/he.json
@@ -662,6 +662,9 @@
   },
   "stores": {
     "storeName": "שם החנות",
+    "bannerAlt": "תמונת הבאנר של החנות {name}",
+    "avatarAlt": "תמונת הפרופיל של החנות {name}",
+    "offlineNotice": "מציג נתוני מטמון. ייתכן שחלק מהפרטים אינם מעודכנים.",
     "mintStore": "צור חנות",
     "transactionFailed": "העסקה נכשלה",
     "insufficientFunds": "אין מספיק כספים לפריסת החנות",


### PR DESCRIPTION
## Summary
- rebuild the public store screen to use cached profile data, contact actions, and offline messaging
- refresh the store header with accessible banner/avatar labels and skeleton support
- add utilities and tests for cached navigation plus new translation strings

## Testing
- ⚠️ `yarn install --silent` *(fails: requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee0741cc8326b7754ff881d20a9a