### PR TITLE
Improve admin flows and KYC tooling

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -38,10 +38,10 @@ import AgentError from '@/types/AgentError';
 import { canonicalJson } from '@/utils/serialization';
 
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  order_received: ['courier_found'],
-  courier_found: ['courier_picked_up'],
-  courier_picked_up: ['courier_on_way'],
-  courier_on_way: ['delivered'],
+  order_received: ['courier_found', 'refunded'],
+  courier_found: ['courier_picked_up', 'refunded'],
+  courier_picked_up: ['courier_on_way', 'refunded'],
+  courier_on_way: ['delivered', 'refunded'],
   delivered: ['released', 'refunded', 'disputed'],
   disputed: ['released', 'refunded'],
   released: [],

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -33,7 +33,8 @@ type SettingKey =
   | 'paymentFactoryAddress'
   | 'rpcUrl'
   | 'rpcFallbackUrls'
-  | 'paymentFactoryAddress';
+  | 'paymentFactoryAddress'
+  | 'kyc.required';
 
 class SettingsAgent {
   private static instance: SettingsAgent;

--- a/app/store/[storeId]/admin/_DashboardScreen.tsx
+++ b/app/store/[storeId]/admin/_DashboardScreen.tsx
@@ -1,124 +1,355 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  RefreshControl,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
 import { useAppRouter } from '@/services';
-import { useTheme } from '@/ui/ThemeProvider';
-import { useLanguage } from '@/ui/ThemeProvider';
+import type { Order, Product, User } from '@/types';
+import { ordersWarmCache } from '@/services/nearOrders';
+import { productsWarmCache } from '@/features/products/services/nearProducts';
+import { usersWarmCache } from '@/features/auth/services/nearUsers';
+import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
 import FeeDashboard from '@/features/billing/components/FeeDashboard';
-import { useAuth } from '@/features/auth/AuthContext';
-import { getStore as getNearStore } from '@/features/stores/services/nearStores';
-import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
-import { routes } from '@/utils/routes';
-import { Spinner } from '@/ui/primitives';
-import AdminOnboardingChecklist from '@/features/home/components/AdminOnboardingChecklist';
 
-export default function StoreDashboardScreen() {
-  console.debug('SD: mount');
-  const { replace, push } = useAppRouter();
-  const { storeId, impersonate } = useLocalSearchParams<{ storeId: string; impersonate?: string }>();
+const LOW_STOCK_THRESHOLD = 5;
+
+function isToday(date: string | undefined): boolean {
+  if (!date) return false;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return false;
+  const now = new Date();
+  return (
+    parsed.getFullYear() === now.getFullYear() &&
+    parsed.getMonth() === now.getMonth() &&
+    parsed.getDate() === now.getDate()
+  );
+}
+
+function isOrderForStore(order: Order | undefined, storeId: string): order is Order {
+  if (!order) return false;
+  return order.items?.some((item) => item.product?.storeId === storeId) ?? false;
+}
+
+function getOrderAttentionScore(order: Order): number {
+  const toTime = (value?: string | null) => {
+    if (!value) return 0;
+    const parsed = new Date(value).getTime();
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  return Math.max(toTime(order.updatedAt), toTime(order.createdAt));
+}
+
+interface Kpis {
+  ordersToday: number;
+  pendingKyc: number;
+  lowStock: number;
+}
+
+const initialKpis: Kpis = { ordersToday: 0, pendingKyc: 0, lowStock: 0 };
+
+export default function StoreDashboardScreen(): React.ReactElement {
+  const { storeId } = useLocalSearchParams<{ storeId: string }>();
   const { colors } = useTheme();
   const { t } = useLanguage();
-  const { user } = useAuth();
-  const [productCount, setProductCount] = useState(0);
-  const [authorized, setAuthorized] = useState(false);
-  const [store, setStore] = useState<any>(null);
-  const [products, setProducts] = useState<any[]>([]);
+  const { push } = useAppRouter();
+  const [kpis, setKpis] = useState<Kpis>(initialKpis);
+  const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const handleOpenProducts = useCallback(() => {
-    if (!storeId) return;
-    push(`/store/${storeId}/admin/products`);
-  }, [push, storeId]);
+  const computeKpis = useCallback(
+    (nextOrders: Order[], nextProducts: Product[], nextUsers: User[]) => {
+      const ordersToday = nextOrders.filter((order) => isToday(order.createdAt)).length;
+      const pendingKyc = nextUsers.filter((user) => user.kycStatus === 'pending').length;
+      const lowStock = nextProducts.filter(
+        (product) => product.storeId === storeId && (product.stock ?? 0) <= LOW_STOCK_THRESHOLD,
+      ).length;
+      setKpis({ ordersToday, pendingKyc, lowStock });
+    },
+    [storeId],
+  );
 
-  useEffect(() => {
-    let active = true;
-    (async () => {
-      if (!storeId) return;
-      try {
-        console.debug('SD: fetch store', storeId);
-        const s = await getNearStore(storeId, storeId);
-        if (active) setStore(s);
-      } catch {
-        // ignore
-      }
-      try {
-        console.debug('SD: fetch products', storeId);
-        const ps = await listNearProducts(storeId);
-        if (active) setProducts(ps || []);
-      } catch {
-        // ignore
-      }
-      if (active) setLoading(false);
-    })();
-    return () => {
-      active = false;
-    };
+  const loadFromCaches = useCallback(() => {
+    if (!storeId) return { orders: [], products: [], users: [] };
+    let cachedOrders: Order[] = [];
+    let cachedProducts: Product[] = [];
+    let cachedUsers: User[] = [];
+    try {
+      cachedOrders = ordersWarmCache.list((_, order) => isOrderForStore(order, storeId));
+    } catch {}
+    try {
+      cachedProducts = productsWarmCache.list((_, product) => product.storeId === storeId);
+    } catch {}
+    try {
+      cachedUsers = usersWarmCache.list();
+    } catch {}
+    return { orders: cachedOrders, products: cachedProducts, users: cachedUsers };
   }, [storeId]);
 
   useEffect(() => {
-    if (!storeId || !store) return;
-    const isAdmin = impersonate === 'true' && user?.role === 'platform-admin';
-    if (store.owner !== user?.address && !isAdmin) {
-      replace(routes.store(storeId));
-      return;
-    }
-    setAuthorized(true);
-    setProductCount(products.filter((p) => p.storeId === storeId).length);
-  }, [storeId, store, user?.address, products, impersonate]);
-  
+    if (!storeId) return;
+    let cancelled = false;
+    const hydrate = () => {
+      const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+        loadFromCaches();
+      if (cancelled) return;
+      setOrders(
+        cachedOrders
+          .slice()
+          .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+      );
+      computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      setLoading(false);
+    };
 
-  if (!authorized) {
-    console.debug('SD: not authorized yet');
+    hydrate();
+
+    const unsubOrders = ordersWarmCache.subscribe(
+      (_, order) => {
+        if (!storeId) return false;
+        if (!order) return false;
+        return isOrderForStore(order, storeId);
+      },
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        setOrders(
+          cachedOrders
+            .slice()
+            .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+        );
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
+
+    const unsubProducts = productsWarmCache.subscribe(
+      (_, product) => {
+        if (!storeId) return false;
+        return !!product && product.storeId === storeId;
+      },
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
+
+    const unsubUsers = usersWarmCache.subscribe(
+      (_id, _user) => true,
+      () => {
+        const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+          loadFromCaches();
+        if (cancelled) return;
+        computeKpis(cachedOrders, cachedProducts, cachedUsers);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      unsubOrders?.();
+      unsubProducts?.();
+      unsubUsers?.();
+    };
+  }, [storeId, loadFromCaches, computeKpis]);
+
+  const onRefresh = useCallback(() => {
+    if (!storeId) return;
+    setRefreshing(true);
+    const { orders: cachedOrders, products: cachedProducts, users: cachedUsers } =
+      loadFromCaches();
+    setOrders(
+      cachedOrders
+        .slice()
+        .sort((a, b) => getOrderAttentionScore(b) - getOrderAttentionScore(a)),
+    );
+    computeKpis(cachedOrders, cachedProducts, cachedUsers);
+    setRefreshing(false);
+  }, [computeKpis, loadFromCaches, storeId]);
+
+  const actionableOrders = useMemo(
+    () =>
+      orders
+        .filter(
+          (order) =>
+            !['delivered', 'released', 'refunded'].includes(order.status) &&
+            order.items?.length,
+        )
+        .slice(0, 3),
+    [orders],
+  );
+
+  const addProduct = useCallback(() => {
+    if (!storeId) return;
+    push(`/store/${storeId}/admin/products?create=1`);
+  }, [push, storeId]);
+
+  const openOrder = useCallback(
+    (orderId: string) => {
+      if (!storeId || !orderId) return;
+      push(`/store/${storeId}/admin/orders?orderId=${orderId}`);
+    },
+    [push, storeId],
+  );
+
+  if (loading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
         <Spinner />
       </View>
     );
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
-      <AdminOnboardingChecklist onAddProduct={handleOpenProducts} />
-      <View style={{ height: 16 }} />
-      <View style={styles.stats}>
-        <Text style={[styles.statText, { color: colors.text.primary }]}>
-          {t('admin.productCount', { count: productCount })}
-        </Text>
-        {storeId && <OrderRevenueMetrics storeId={storeId} />}
-      </View>
-      {storeId && <FeeDashboard tenantId={storeId} />}
-      <View style={styles.nav}>
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.title, { color: colors.text.primary }]}>{t('admin.dashboard')}</Text>
         <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/products`)}
-        >
-          <Text style={{ color: colors.text.primary }}>{t('admin.manageProducts')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.navButton, { borderColor: colors.border.primary }]}
-          onPress={() => push(`/store/${storeId}/admin/orders`)}
-        >
-          <Text style={{ color: colors.text.primary }}>{t('admin.viewOrders')}</Text>
+          accessibilityRole="button"
+          style={[styles.addButton, { borderColor: colors.border.primary }]}
+          onPress={addProduct}>
+          <Text style={[styles.addButtonText, { color: colors.text.primary }]}>הוסף מוצר מהיר</Text>
         </TouchableOpacity>
       </View>
+
+      <View style={styles.kpiRow}>
+        <KpiCard
+          label="הזמנות היום"
+          value={kpis.ordersToday}
+          colors={colors}
+        />
+        <KpiCard
+          label="בקשות KYC ממתינות"
+          value={kpis.pendingKyc}
+          colors={colors}
+        />
+        <KpiCard
+          label={`מלאי נמוך (<${LOW_STOCK_THRESHOLD})`}
+          value={kpis.lowStock}
+          colors={colors}
+        />
+      </View>
+
+      {storeId ? (
+        <View style={styles.metricsSection}>
+          <OrderRevenueMetrics storeId={storeId} />
+          <View style={styles.metricSpacer} />
+          <FeeDashboard tenantId={storeId} />
+        </View>
+      ) : null}
+
+      <AdminOnboardingChecklist onAddProduct={addProduct} />
+
+      <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>הזמנות לטיפול</Text>
+      {actionableOrders.length === 0 ? (
+        <Text style={{ color: colors.text.secondary }}>אין הזמנות הדורשות פעולה.</Text>
+      ) : (
+        <View style={styles.bannerColumn}>
+          {actionableOrders.map((order) => (
+            <TouchableOpacity
+              key={order.id}
+              style={[styles.orderBanner, { borderColor: colors.border.primary }]}
+              onPress={() => openOrder(order.id)}>
+              <View style={styles.bannerText}>
+                <Text style={[styles.orderId, { color: colors.text.primary }]}>#{order.id}</Text>
+                <Text style={{ color: colors.text.secondary }}>{order.status}</Text>
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                {new Date(order.createdAt || order.updatedAt || Date.now()).toLocaleString('he-IL')}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+interface KpiCardProps {
+  label: string;
+  value: number;
+  colors: any;
+}
+
+function KpiCard({ label, value, colors }: KpiCardProps) {
+  return (
+    <View
+      style={[
+        styles.kpiCard,
+        {
+          backgroundColor: colors.surface.primary,
+          borderColor: colors.border.primary,
+        },
+      ]}>
+      <Text style={[styles.kpiValue, { color: colors.text.primary }]}>{value}</Text>
+      <Text style={[styles.kpiLabel, { color: colors.text.secondary }]}>{label}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 24, textAlign: 'right' },
-  stats: { marginBottom: 24, gap: 8, alignItems: 'flex-end' },
-  statText: { fontSize: 16 },
-  nav: { gap: 12 },
-  navButton: {
-    paddingVertical: 12,
+  container: { flex: 1 },
+  content: {
+    padding: 16,
+    gap: 16,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 22, fontWeight: '700' },
+  addButton: {
+    paddingVertical: 10,
     paddingHorizontal: 16,
     borderWidth: 1,
-    borderRadius: 8,
+    borderRadius: 10,
+  },
+  addButtonText: { fontSize: 14, fontWeight: '600' },
+  kpiRow: {
+    flexDirection: 'row',
+    gap: 12,
+    justifyContent: 'space-between',
+  },
+  kpiCard: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+  },
+  kpiValue: { fontSize: 28, fontWeight: '700', textAlign: 'center' },
+  kpiLabel: { fontSize: 14, textAlign: 'center', marginTop: 4 },
+  metricsSection: {
+    gap: 12,
+  },
+  metricSpacer: { height: 8 },
+  sectionTitle: { fontSize: 18, fontWeight: '600' },
+  bannerColumn: { gap: 12 },
+  orderBanner: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
   },
+  bannerText: { gap: 4 },
+  orderId: { fontSize: 16, fontWeight: '600' },
 });
-

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -1,233 +1,363 @@
-import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ScrollView,
   Alert,
+  Linking,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useAppRouter } from '@/services';
-import { ArrowLeft, CircleCheck as CheckCircle, Circle as XCircle, Clock, User, Mail, FileText, Calendar } from 'lucide-react-native';
-import { useAuth } from '@/features/auth/AuthContext';
+import { ArrowLeft, FileText, ShieldCheck, X, XCircle } from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
-import DatabaseService from '@/services/database';
-import { User as UserType } from '../../../../types';
+import { useAppRouter } from '@/services';
+import SettingsAgent from '@/agents/settings-agent';
+import usersAgent from '@/agents/users-agent';
+import type { User } from '@/types';
 import { Spinner } from '@/ui/primitives';
-import commonStyles from '@/constants/styles';
-import SmartImage from '../../../../components/SmartImage';
+import { issueKycReceipt, loadKycReceipt } from '@/services/kycReceipts';
+import { resolveKycPackage, type KycPackageResolution } from '@/services/kycPackages';
+import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
 
+const POLICY_SETTING_KEY = 'kyc.required';
 
-
-export default function KycApprovalsScreen() {
-  const [pendingRequests, setPendingRequests] = useState<UserType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const { isAdmin, isDriver, user } = useAuth();
+export default function KycApprovalsScreen(): React.ReactElement {
   const { colors } = useTheme();
-  const { replace, back } = useAppRouter();
+  const { back } = useAppRouter();
+  const { requireUnlock } = useLaunchGate();
+  const [policyRequired, setPolicyRequired] = useState(false);
+  const [pending, setPending] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [policySaving, setPolicySaving] = useState(false);
+  const [processingId, setProcessingId] = useState<string | null>(null);
+  const [previewVisible, setPreviewVisible] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewData, setPreviewData] = useState<KycPackageResolution | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isAdmin && !isDriver) {
-      Alert.alert('גישה מוגבלת', 'רק מנהלים יכולים לגשת לדף זה', [
-        { text: 'אישור', onPress: () => replace('/') }
-      ]);
-      return;
-    }
-
-    loadPendingRequests();
-  }, [isAdmin, isDriver]);
-
-  const loadPendingRequests = async () => {
+  const refreshData = useCallback(async () => {
     setLoading(true);
     try {
-      const db = DatabaseService.getInstance();
-      const requests = await db.getPendingKycRequests();
-      setPendingRequests(requests);
+      const [policyValue, users] = await Promise.all([
+        SettingsAgent.getInstance().getSettingValue(POLICY_SETTING_KEY),
+        usersAgent.getAll(),
+      ]);
+      setPolicyRequired((policyValue || '').toLowerCase() === 'on');
+      setPending(users.filter((user) => user.kycStatus === 'pending'));
     } catch (error) {
-      errorLog('Error loading pending KYC requests:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה בטעינת בקשות האימות');
+      Alert.alert('שגיאה', 'טעינת בקשות KYC נכשלה');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const approveRequest = async (userId: string) => {
-    if (!user) return;
-    
+  useEffect(() => {
+    void refreshData();
+  }, [refreshData]);
+
+  const togglePolicy = useCallback(async () => {
+    const next = !policyRequired;
+    setPolicySaving(true);
     try {
-      const db = DatabaseService.getInstance();
-      const success = await db.updateUserKycStatus(userId, 'verified', user.id);
-      
-      if (success) {
-        // Update local state
-        setPendingRequests(prev => prev.filter(req => req.id !== userId));
-        Alert.alert('הצלחה', 'אימות KYC אושר בהצלחה');
-      } else {
-        Alert.alert('שגיאה', 'אירעה שגיאה באישור האימות');
-      }
+      await SettingsAgent.getInstance().updateSettingValue(
+        POLICY_SETTING_KEY,
+        next ? 'on' : 'off',
+      );
+      setPolicyRequired(next);
     } catch (error) {
-      errorLog('Error approving KYC request:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה באישור האימות');
+      Alert.alert('שגיאה', 'עדכון מדיניות KYC נכשל');
+    } finally {
+      setPolicySaving(false);
     }
-  };
+  }, [policyRequired]);
 
-  const rejectRequest = async (userId: string) => {
-    if (!user) return;
-    
+  const closePreview = useCallback(() => {
+    setPreviewVisible(false);
+    setPreviewLoading(false);
+    setPreviewData(null);
+    setPreviewError(null);
+  }, []);
+
+  const handlePreview = useCallback(
+    async (user: User) => {
+      if (user.kycRequestNotes && !user.kycDocumentUri) {
+        Alert.alert('הערות משתמש', user.kycRequestNotes);
+        return;
+      }
+      if (!user.kycDocumentUri) {
+        Alert.alert('מידע חסר', 'לא נמצאו מסמכי אימות עבור משתמש זה.');
+        return;
+      }
+      setPreviewVisible(true);
+      setPreviewLoading(true);
+      setPreviewError(null);
+      setPreviewData(null);
+      try {
+        const resolved = await resolveKycPackage(user.kycDocumentUri);
+        if (!resolved) {
+          closePreview();
+          Linking.openURL(user.kycDocumentUri).catch(() =>
+            Alert.alert('שגיאה', 'לא ניתן לפתוח את מסמך ה-KYC'),
+          );
+          return;
+        }
+        setPreviewData(resolved);
+      } catch (error) {
+        setPreviewError('טעינת החבילה נכשלה, ננסה לפתוח את הקובץ המקורי.');
+        Linking.openURL(user.kycDocumentUri).catch(() =>
+          Alert.alert('שגיאה', 'לא ניתן לפתוח את מסמך ה-KYC'),
+        );
+      } finally {
+        setPreviewLoading(false);
+      }
+    },
+    [closePreview],
+  );
+
+  const approveRequest = useCallback(
+    async (user: User) => {
+      setProcessingId(user.id);
+      try {
+        await requireUnlock('admin.approval');
+        await usersAgent.updateKyc(user.id, 'verified');
+        if (user.publicKey) {
+          const existingReceipt = await loadKycReceipt(user.publicKey);
+          if (!existingReceipt) {
+            await issueKycReceipt(user.publicKey, { userId: user.id });
+          }
+        }
+        setPending((prev) => prev.filter((item) => item.id !== user.id));
+        Alert.alert('הצלחה', 'האימות אושר ונשלחה קבלה חתומה');
+      } catch (error) {
+        Alert.alert('שגיאה', 'אישור הבקשה נכשל');
+      } finally {
+        setProcessingId(null);
+      }
+    },
+    [requireUnlock],
+  );
+
+  const declineRequest = useCallback(async (user: User) => {
+    setProcessingId(user.id);
     try {
-      const db = DatabaseService.getInstance();
-      const success = await db.updateUserKycStatus(userId, 'rejected', user.id);
-      
-      if (success) {
-        // Update local state
-        setPendingRequests(prev => prev.filter(req => req.id !== userId));
-        Alert.alert('הצלחה', 'אימות KYC נדחה');
-      } else {
-        Alert.alert('שגיאה', 'אירעה שגיאה בדחיית האימות');
-      }
+      await requireUnlock('admin.approval');
+      await usersAgent.updateKyc(user.id, 'rejected');
+      setPending((prev) => prev.filter((item) => item.id !== user.id));
+      Alert.alert('עודכן', 'הבקשה נדחתה והמשתמש עודכן.');
     } catch (error) {
-      errorLog('Error rejecting KYC request:', error);
-      Alert.alert('שגיאה', 'אירעה שגיאה בדחיית האימות');
+      Alert.alert('שגיאה', 'דחיית הבקשה נכשלה');
+    } finally {
+      setProcessingId(null);
     }
-  };
+  }, [requireUnlock]);
 
-  const formatDate = (dateString?: string) => {
-    if (!dateString) return 'לא זמין';
-    return new Date(dateString).toLocaleDateString('he-IL', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
+  const policyDescription = useMemo(
+    () =>
+      policyRequired
+        ? 'לקוחות ללא קבלה חתומה ייחסמו בקופה.'
+        : 'הקופה תתאפשר ללא אימות מוקדם.',
+    [policyRequired],
+  );
 
   if (loading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
-        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-          <TouchableOpacity onPress={() => back()}>
+        <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
+          <TouchableOpacity onPress={back} accessibilityRole="button">
             <ArrowLeft size={24} color={colors.text.primary} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>
-          <View style={commonStyles.spacer24} />
+          <Text style={[styles.title, { color: colors.text.primary }]}>אישורי KYC</Text>
+          <View style={{ width: 24 }} />
         </View>
-        <Spinner />
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.header, { borderBottomColor: colors.border.primary }]}>
-        <TouchableOpacity onPress={() => back()}>
-          <ArrowLeft size={24} color={colors.text.primary} />
-        </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text.primary }]}>אישורי KYC</Text>
-        <View style={commonStyles.spacer24} />
-      </View>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
+      <View style={[styles.header, { borderBottomColor: colors.border.primary }]}> 
+        <TouchableOpacity onPress={back} accessibilityRole="button"> 
+          <ArrowLeft size={24} color={colors.text.primary} /> 
+        </TouchableOpacity> 
+        <Text style={[styles.title, { color: colors.text.primary }]}>אישורי KYC</Text> 
+        <View style={{ width: 24 }} /> 
+      </View> 
 
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.titleContainer}>
-          <Clock size={24} color={colors.gold} />
-          <Text style={[styles.title, { color: colors.text.primary }]}>בקשות אימות KYC ממתינות</Text>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}> 
+        <View style={[styles.policyCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
+          <View style={styles.policyHeader}> 
+            <ShieldCheck size={20} color={colors.gold} /> 
+            <Text style={[styles.policyTitle, { color: colors.text.primary }]}>מדיניות אימות</Text> 
+          </View> 
+          <View style={styles.policyToggle}> 
+            <Text style={{ color: colors.text.primary }}>דרוש KYC לפני רכישה</Text> 
+            <Switch
+              value={policyRequired}
+              onValueChange={togglePolicy}
+              thumbColor={policyRequired ? colors.gold : colors.border.primary}
+              disabled={policySaving}
+            />
+          </View>
+          <Text style={{ color: colors.text.secondary }}>{policyDescription}</Text>
         </View>
 
-        {pendingRequests.length > 0 ? (
-          <View style={styles.requestsList}>
-            {pendingRequests.map((request) => (
-              <View key={request.id} style={[styles.requestCard, { 
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary 
-              }]}>
-                <View style={styles.userInfo}>
-                  <View style={styles.avatarContainer}>
-                    {request.avatar ? (
-                      <SmartImage
-                        uri={request.avatar}
-                        width={60}
-                        height={60}
-                        style={[styles.avatar, { borderColor: colors.gold }]}
-                      />
-                    ) : (
-                      <View style={[styles.avatarPlaceholder, { 
-                        backgroundColor: colors.surface.secondary,
-                        borderColor: colors.border.primary 
-                      }]}>
-                        <User size={24} color={colors.interactive.disabled} />
-                      </View>
-                    )}
-                  </View>
-                  
-                  <View style={styles.userDetails}>
-                    <Text style={[styles.userName, { color: colors.text.primary }]}>{request.displayName}</Text>
-                    <View style={styles.userDetailRow}>
-                      <User size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>@{request.username}</Text>
-                    </View>
-                    <View style={styles.userDetailRow}>
-                      <Mail size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>{request.email}</Text>
-                    </View>
-                    <View style={styles.userDetailRow}>
-                      <Calendar size={14} color={colors.text.secondary} />
-                      <Text style={[styles.userDetailText, { color: colors.text.secondary }]}>
-                        בקשה מ: {formatDate(request.kycRequestedAt)}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-
-                {request.kycRequestNotes && (
-                  <View style={[styles.notesContainer, { backgroundColor: colors.surface.secondary }]}>
-                    <View style={styles.notesHeader}>
-                      <FileText size={16} color={colors.gold} />
-                      <Text style={[styles.notesTitle, { color: colors.text.primary }]}>הערות המשתמש:</Text>
-                    </View>
-                    <Text style={[styles.notesText, { color: colors.text.secondary }]}>{request.kycRequestNotes}</Text>
-                  </View>
-                )}
-
-                <View style={styles.actionButtons}>
-                  <TouchableOpacity 
-                    style={[styles.approveButton, { backgroundColor: colors.status.success }]}
-                    onPress={() => approveRequest(request.id)}
-                  >
-                    <CheckCircle size={20} color={colors.text.inverse} />
-                    <Text style={[styles.approveButtonText, { color: colors.text.inverse }]}>אשר</Text>
-                  </TouchableOpacity>
-                  
-                  <TouchableOpacity 
-                    style={[styles.rejectButton, { backgroundColor: colors.status.error }]}
-                    onPress={() => rejectRequest(request.id)}
-                  >
-                    <XCircle size={20} color={colors.text.inverse} />
-                    <Text style={[styles.rejectButtonText, { color: colors.text.inverse }]}>דחה</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            ))}
-          </View>
+        <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>בקשות ממתינות</Text>
+      {pending.length === 0 ? (
+        <View style={styles.emptyState}>
+          <ShieldCheck size={48} color={colors.interactive.disabled} />
+          <Text style={{ color: colors.text.secondary }}>אין בקשות חדשות</Text>
+        </View>
         ) : (
-          <View style={styles.emptyContainer}>
-            <CheckCircle size={80} color={colors.interactive.disabled} />
-            <Text style={[styles.emptyTitle, { color: colors.text.primary }]}>אין בקשות אימות ממתינות</Text>
-            <Text style={[styles.emptyMessage, { color: colors.text.secondary }]}>
-              כל בקשות האימות טופלו. בדוק שוב מאוחר יותר.
-            </Text>
-          </View>
+          pending.map((user) => (
+            <View
+              key={user.id}
+              style={[styles.requestCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
+              <View style={styles.requestHeader}> 
+                <View> 
+                  <Text style={[styles.requestName, { color: colors.text.primary }]}>{user.displayName || user.username}</Text> 
+                  <Text style={{ color: colors.text.secondary }}>{user.email}</Text> 
+                </View> 
+                <TouchableOpacity
+                  style={styles.previewButton}
+                  onPress={() => handlePreview(user)}
+                  accessibilityRole="button">
+                  <FileText size={18} color={colors.text.primary} />
+                  <Text style={{ color: colors.text.primary }}>תצוגה</Text>
+                </TouchableOpacity>
+              </View>
+              <Text style={{ color: colors.text.secondary }}>
+                בקשה: {formatDate(user.kycRequestedAt)}
+              </Text>
+              {user.kycRequestNotes ? (
+                <Text style={[styles.notes, { color: colors.text.secondary }]}>{user.kycRequestNotes}</Text>
+              ) : null}
+              <View style={styles.actionsRow}>
+                <TouchableOpacity
+                  style={[styles.approveButton, { borderColor: colors.status.success }]}
+                  onPress={() => approveRequest(user)}
+                  disabled={processingId === user.id}>
+                  <ShieldCheck size={18} color={colors.status.success} />
+                  <Text style={{ color: colors.status.success }}>אשר</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.rejectButton, { borderColor: colors.status.error }]}
+                  onPress={() => declineRequest(user)}
+                  disabled={processingId === user.id}>
+                  <XCircle size={18} color={colors.status.error} />
+                  <Text style={{ color: colors.status.error }}>דחה</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ))
         )}
       </ScrollView>
+
+      <KycPreviewModal
+        visible={previewVisible}
+        loading={previewLoading}
+        data={previewData}
+        error={previewError}
+        onClose={closePreview}
+        colors={colors}
+      />
     </SafeAreaView>
   );
 }
 
+function formatDate(value?: string): string {
+  if (!value) return 'לא זמין';
+  try {
+    return new Date(value).toLocaleString('he-IL');
+  } catch {
+    return value;
+  }
+}
+
+interface KycPreviewModalProps {
+  visible: boolean;
+  loading: boolean;
+  data: KycPackageResolution | null;
+  error: string | null;
+  onClose: () => void;
+  colors: any;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringifyPayload(payload: unknown): string {
+  if (payload === null || payload === undefined) return '';
+  if (typeof payload === 'string') return payload;
+  try {
+    return JSON.stringify(payload, null, 2);
+  } catch {
+    return String(payload);
+  }
+}
+
+function KycPreviewModal({ visible, loading, data, error, onClose, colors }: KycPreviewModalProps) {
+  const payload = data?.payload;
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.modalBackdrop}>
+        <View
+          style={[
+            styles.modalCard,
+            { backgroundColor: colors.surface.primary, borderColor: colors.border.primary },
+          ]}>
+          <View style={styles.modalHeader}>
+            <Text style={[styles.modalTitle, { color: colors.text.primary }]}>חבילת KYC</Text>
+            <TouchableOpacity onPress={onClose} accessibilityRole="button">
+              <X size={20} color={colors.text.primary} />
+            </TouchableOpacity>
+          </View>
+          {loading ? (
+            <View style={styles.previewCentered}>
+              <Spinner />
+            </View>
+          ) : error ? (
+            <Text style={{ color: colors.status.error }}>{error}</Text>
+          ) : data ? (
+            <ScrollView style={styles.previewScroll} contentContainerStyle={styles.previewContent}>
+              {data.sender ? (
+                <Text style={{ color: colors.text.secondary }}>נשלח ממפתח: {data.sender}</Text>
+              ) : null}
+              <Text style={{ color: colors.text.secondary }}>
+                מקור: {data.source.replace(/^https?:\/\//, '')}
+              </Text>
+              {isPlainObject(payload) && 'documents' in payload && Array.isArray((payload as any).documents) ? (
+                <View style={styles.previewSection}>
+                  <Text style={[styles.sectionHeading, { color: colors.text.primary }]}>מסמכים</Text>
+                  {(payload as any).documents.map((doc: any, idx: number) => (
+                    <Text key={idx} style={{ color: colors.text.secondary }}>
+                      {doc?.label || doc?.type || `מסמך ${idx + 1}`}: {doc?.uri || doc?.url || 'לא ידוע'}
+                    </Text>
+                  ))}
+                </View>
+              ) : null}
+              <Text style={[styles.sectionHeading, { color: colors.text.primary }]}>תוכן מפוענח</Text>
+              <Text style={[styles.codeBlock, { color: colors.text.primary, borderColor: colors.border.primary }]}>
+                {stringifyPayload(payload)}
+              </Text>
+            </ScrollView>
+          ) : (
+            <Text style={{ color: colors.text.secondary }}>לא נמצא מידע להצגה.</Text>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -236,137 +366,58 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     borderBottomWidth: 1,
   },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  content: {
-    flex: 1,
-    padding: 16,
-  },
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginLeft: 8,
-  },
-  requestsList: {
-    gap: 16,
-  },
-  requestCard: {
-    borderRadius: 16,
-    padding: 16,
+  title: { fontSize: 18, fontWeight: 'bold' },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  content: { padding: 16, gap: 16, paddingBottom: 40 },
+  policyCard: {
     borderWidth: 1,
-  },
-  userInfo: {
-    flexDirection: 'row',
-    marginBottom: 16,
-  },
-  avatarContainer: {
-    marginRight: 16,
-  },
-  avatar: {
-    borderRadius: 30,
-    borderWidth: 2,
-  },
-  avatarPlaceholder: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-  },
-  userDetails: {
-    flex: 1,
-  },
-  userName: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 8,
-    textAlign: 'right',
-  },
-  userDetailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-    justifyContent: 'flex-end',
-  },
-  userDetailText: {
-    fontSize: 14,
-    marginRight: 6,
-  },
-  notesContainer: {
     borderRadius: 12,
-    padding: 12,
-    marginBottom: 16,
-  },
-  notesHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-    justifyContent: 'flex-end',
-  },
-  notesTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginRight: 8,
-  },
-  notesText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'right',
-  },
-  actionButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    padding: 16,
     gap: 12,
   },
-  approveButton: {
+  policyHeader: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  policyTitle: { fontSize: 16, fontWeight: '600' },
+  policyToggle: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  sectionTitle: { fontSize: 18, fontWeight: '600' },
+  emptyState: { alignItems: 'center', gap: 12, paddingVertical: 40 },
+  requestCard: { borderWidth: 1, borderRadius: 12, padding: 16, gap: 12 },
+  requestHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  requestName: { fontSize: 16, fontWeight: '600' },
+  previewButton: { flexDirection: 'row', gap: 6, alignItems: 'center' },
+  notes: { fontStyle: 'italic' },
+  actionsRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  approveButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
+  rejectButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
+  modalBackdrop: {
     flex: 1,
-    borderRadius: 12,
-    paddingVertical: 12,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  modalCard: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 20,
+    gap: 12,
+    maxHeight: '80%',
+  },
+  modalHeader: {
     flexDirection: 'row',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     alignItems: 'center',
   },
-  approveButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  rejectButton: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  rejectButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 60,
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 16,
-    marginBottom: 8,
-  },
-  emptyMessage: {
-    fontSize: 16,
-    textAlign: 'center',
-    lineHeight: 24,
+  modalTitle: { fontSize: 18, fontWeight: '600' },
+  previewCentered: { paddingVertical: 24, alignItems: 'center', justifyContent: 'center' },
+  previewScroll: { maxHeight: 280 },
+  previewContent: { gap: 12 },
+  previewSection: { gap: 6 },
+  sectionHeading: { fontSize: 14, fontWeight: '600' },
+  codeBlock: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    fontFamily: 'monospace',
+    fontSize: 12,
+    textAlign: 'left',
   },
 });

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -1,86 +1,384 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
-import { debugLog } from '@/utils/logger';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import { useTheme } from '@/ui/ThemeProvider';
-import { chainAdapter } from '@/services/chain';
-import { useWallet } from '@/contexts/WalletProvider';
-import type { Order } from '../../../../types';
-import { useLanguage } from '@/ui/ThemeProvider';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import type { Order, OrderStatus } from '@/types';
+import { useOrders } from '@/services/useOrders';
+import { ordersWarmCache } from '@/services/nearOrders';
+import ordersAgent, { ALLOWED_STATUS_TRANSITIONS } from '@/agents/orders-agent';
+import { Spinner } from '@/ui/primitives';
+import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
+import OrderTrackingModal from '@/components/OrderTrackingModal';
+import { useAppRouter } from '@/services';
 
-export default function StoreOrdersScreen() {
-  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+const SHIPPING_SEQUENCE: OrderStatus[] = [
+  'order_received',
+  'courier_found',
+  'courier_picked_up',
+  'courier_on_way',
+];
+
+const FILTERS = [
+  { id: 'open', label: 'פתוחות' },
+  { id: 'completed', label: 'הושלמו' },
+  { id: 'refunded', label: 'בוטלו' },
+  { id: 'all', label: 'הכל' },
+] as const;
+
+type FilterKey = typeof FILTERS[number]['id'];
+
+function getCreatedAt(order: Order): number {
+  const ts = order.createdAt ? new Date(order.createdAt).getTime() : 0;
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString('he-IL');
+  } catch {
+    return value;
+  }
+}
+
+function getFilterPredicate(filter: FilterKey): (order: Order) => boolean {
+  switch (filter) {
+    case 'open':
+      return (order) => !['delivered', 'released', 'refunded'].includes(order.status);
+    case 'completed':
+      return (order) => ['delivered', 'released'].includes(order.status);
+    case 'refunded':
+      return (order) => order.status === 'refunded';
+    default:
+      return () => true;
+  }
+}
+
+async function advanceStatus(order: Order, target: OrderStatus): Promise<Order> {
+  let current = order;
+  const visited = new Set<OrderStatus>();
+  while (current.status !== target) {
+    visited.add(current.status);
+    const allowed = ALLOWED_STATUS_TRANSITIONS[current.status] || [];
+    if (allowed.length === 0) break;
+    const next = allowed.includes(target) ? target : allowed[0];
+    if (visited.has(next)) break;
+    const updated: Order = {
+      ...current,
+      status: next,
+      updatedAt: new Date().toISOString(),
+    };
+    await ordersAgent.update(updated);
+    ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
+    current = updated;
+  }
+  return current;
+}
+
+export default function StoreOrdersScreen(): React.ReactElement {
+  const params = useLocalSearchParams<{ storeId: string; orderId?: string | string[] }>();
+  const storeId = params.storeId;
+  const orderIdParam = Array.isArray(params.orderId) ? params.orderId[0] : params.orderId;
   const { colors } = useTheme();
-  const [orders, setOrders] = useState<Order[]>([]);
-  const { address } = useWallet();
   const { t } = useLanguage();
-
-  const handlePress = (order: Order) => {
-    debugLog('Pressed order', order.id);
-  };
-
-  const handleLongPress = (order: Order) => {
-    debugLog('Long pressed order', order.id);
-  };
+  const { requireUnlock } = useLaunchGate();
+  const { replace } = useAppRouter();
+  const [filter, setFilter] = useState<FilterKey>('open');
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [detailsVisible, setDetailsVisible] = useState(false);
+  const {
+    data: fetchedOrders = [],
+    isLoading,
+    isRefetching,
+    refetch,
+  } = useOrders(storeId ?? null);
 
   useEffect(() => {
-    const load = async () => {
-      if (!storeId || address !== storeId || !chainAdapter.listOrdersBySeller) return;
-      const all = await chainAdapter.listOrdersBySeller(storeId, storeId);
-      setOrders(all);
-    };
-    load();
-  }, [storeId, address]);
+    if (!storeId) return;
+    const sorted = fetchedOrders
+      .filter((order) => order.items?.[0]?.product?.storeId === storeId)
+      .slice()
+      .sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
+    setOrders(sorted);
+  }, [fetchedOrders, storeId]);
 
-  if (address !== storeId) {
+  useEffect(() => {
+    if (!storeId) return;
+    const unsubscribe = ordersWarmCache.subscribe(
+      (_, value) => {
+        if (!storeId) return false;
+        if (!value) return true;
+        return value.items?.[0]?.product?.storeId === storeId;
+      },
+      (id, value) => {
+        setOrders((prev) => {
+          if (!value) {
+            return prev.filter((order) => order.id !== id);
+          }
+          if (value.items?.[0]?.product?.storeId !== storeId) return prev;
+          const next = prev.some((order) => order.id === value.id)
+            ? prev.map((order) => (order.id === value.id ? value : order))
+            : [value, ...prev];
+          return next
+            .slice()
+            .sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
+        });
+      },
+    );
+    return () => unsubscribe?.();
+  }, [storeId]);
+
+  useEffect(() => {
+    if (!orderIdParam) {
+      setDetailsVisible(false);
+      setSelectedOrder(null);
+      return;
+    }
+    const match = orders.find((order) => order.id === orderIdParam);
+    if (match) {
+      setSelectedOrder(match);
+      setDetailsVisible(true);
+    }
+  }, [orderIdParam, orders]);
+
+  useEffect(() => {
+    if (!detailsVisible || !selectedOrder) return;
+    const updated = orders.find((order) => order.id === selectedOrder.id);
+    if (updated) setSelectedOrder(updated);
+  }, [detailsVisible, orders, selectedOrder?.id]);
+
+  const filtered = useMemo(() => orders.filter(getFilterPredicate(filter)), [orders, filter]);
+
+  const handleMarkShipped = useCallback(
+    async (order: Order) => {
+      setPendingId(order.id);
+      try {
+        let target: OrderStatus | null = null;
+        if (order.status === 'courier_on_way') {
+          target = 'delivered';
+        } else if (SHIPPING_SEQUENCE.includes(order.status)) {
+          target = 'courier_on_way';
+        }
+        if (!target) {
+          throw new Error('לא ניתן לסמן הזמנה זו כנשלחה');
+        }
+        const pathIndex = SHIPPING_SEQUENCE.indexOf(order.status);
+        let updated = order;
+        if (target === 'courier_on_way' && pathIndex >= 0) {
+          for (const step of SHIPPING_SEQUENCE.slice(pathIndex + 1)) {
+            updated = await advanceStatus(updated, step);
+            if (step === 'courier_on_way') break;
+          }
+        } else {
+          updated = await advanceStatus(updated, target);
+        }
+        setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      } catch (error) {
+        Alert.alert('שגיאה', 'עדכון סטטוס ההזמנה נכשל');
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [],
+  );
+
+  const handleCancel = useCallback(
+    (order: Order) => {
+      Alert.alert('ביטול הזמנה', 'האם לבטל את ההזמנה?', [
+        { text: 'לא', style: 'cancel' },
+        {
+          text: 'כן, בטל',
+          style: 'destructive',
+          onPress: async () => {
+            setPendingId(order.id);
+            try {
+              await requireUnlock('order.cancel');
+              const updated: Order = {
+                ...order,
+                status: 'refunded',
+                updatedAt: new Date().toISOString(),
+              };
+              await ordersAgent.update(updated);
+              ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
+              setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+            } catch (error) {
+              Alert.alert('שגיאה', 'ביטול ההזמנה נכשל');
+            } finally {
+              setPendingId(null);
+            }
+          },
+        },
+      ]);
+    },
+    [requireUnlock],
+  );
+
+  const closeDetails = useCallback(() => {
+    setDetailsVisible(false);
+    setSelectedOrder(null);
+    if (storeId) {
+      replace(`/store/${storeId}/admin/orders`);
+    }
+  }, [replace, storeId]);
+
+  const refreshing = isLoading || isRefetching;
+
+  if (!storeId) {
     return (
-      <View
-        style={[
-          styles.container,
-          styles.content,
-          { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>{t('orders.connectWallet')}</Text>
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>בחר חנות להצגת הזמנות.</Text>
       </View>
     );
   }
 
   return (
-    <FlatList
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={styles.content}
-      data={orders}
-      keyExtractor={(order) => order.id}
-      renderItem={({ item: o }) => (
-        <TouchableOpacity
-          style={[styles.orderItem, { borderColor: colors.border.primary }]}
-          onPress={() => handlePress(o)}
-          onLongPress={() => handleLongPress(o)}
-        >
-          <Text style={{ color: colors.text.primary }}>#{o.id}</Text>
-          <Text style={{ color: colors.text.primary }}>{o.status}</Text>
-          <Text style={{ color: colors.text.primary }}>{o.total}</Text>
-        </TouchableOpacity>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={styles.filterRow}>
+        {FILTERS.map((item) => {
+          const active = filter === item.id;
+          return (
+            <TouchableOpacity
+              key={item.id}
+              style={[
+                styles.filterButton,
+                {
+                  borderColor: active ? colors.gold : colors.border.primary,
+                  backgroundColor: active ? colors.surface.secondary : 'transparent',
+                },
+              ]}
+              onPress={() => setFilter(item.id)}
+              accessibilityRole="button">
+              <Text style={{ color: active ? colors.gold : colors.text.primary }}>{item.label}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {isLoading && orders.length === 0 ? (
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(order) => order.id}
+          renderItem={({ item }) => (
+            <OrderRow
+              order={item}
+              colors={colors}
+              busy={pendingId === item.id}
+              onMarkShipped={handleMarkShipped}
+              onCancel={handleCancel}
+            />
+          )}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refetch} />}
+          ListEmptyComponent={
+            <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+              {t('orders.emptyTitle', 'אין הזמנות להצגה')}
+            </Text>
+          }
+          contentContainerStyle={styles.listContent}
+        />
       )}
-      ListEmptyComponent={
-        <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
-          {t('orders.emptyTitle')}
+      <OrderTrackingModal visible={detailsVisible} order={selectedOrder} onClose={closeDetails} />
+    </View>
+  );
+}
+
+interface OrderRowProps {
+  order: Order;
+  colors: any;
+  busy: boolean;
+  onMarkShipped: (order: Order) => void;
+  onCancel: (order: Order) => void;
+}
+
+function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProps) {
+  const actionableStatuses: OrderStatus[] = [
+    'order_received',
+    'courier_found',
+    'courier_picked_up',
+    'courier_on_way',
+  ];
+  const actionable = actionableStatuses.includes(order.status);
+  const cancellable = ['order_received', 'courier_found'].includes(order.status);
+  return (
+    <View
+      style={[
+        styles.orderCard,
+        { borderColor: colors.border.primary, backgroundColor: colors.surface.primary, opacity: busy ? 0.6 : 1 },
+      ]}>
+      <View style={styles.orderHeader}>
+        <Text style={[styles.orderTitle, { color: colors.text.primary }]}>#{order.id}</Text>
+        <Text style={{ color: colors.text.secondary }}>{formatDate(order.createdAt)}</Text>
+      </View>
+      <View style={styles.orderMeta}>
+        <Text style={{ color: colors.text.secondary }}>סטטוס: {order.status}</Text>
+        <Text style={{ color: colors.text.secondary }}>
+          סכום: ₪{order.total.toLocaleString('he-IL')}
         </Text>
-      }
-      ListHeaderComponent={
-        <Text style={[styles.title, { color: colors.text.primary }]}>
-          {t('navigation.orders')}
-        </Text>
-      }
-    />
+      </View>
+      <View style={styles.actionRow}>
+        <TouchableOpacity
+          style={[styles.secondaryButton, { borderColor: colors.border.primary }]}
+          onPress={() => onMarkShipped(order)}
+          disabled={!actionable || busy}>
+          <Text style={{ color: colors.text.primary }}>
+            {order.status === 'courier_on_way' ? 'סמן נמסר' : 'סמן נשלח'}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.dangerButton, { borderColor: colors.status.error }]}
+          onPress={() => onCancel(order)}
+          disabled={!cancellable || busy}>
+          <Text style={{ color: colors.status.error }}>בטל</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  content: { padding: 16 },
-  title: { fontSize: 20, fontWeight: '600', marginBottom: 16, textAlign: 'right' },
-  orderItem: { padding: 12, borderWidth: 1, borderRadius: 8, marginBottom: 12 },
+  container: { flex: 1, padding: 16 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  filterRow: { flexDirection: 'row', gap: 12, marginBottom: 16 },
+  filterButton: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+  },
+  listContent: { gap: 12, paddingBottom: 48 },
+  orderCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  orderHeader: { flexDirection: 'row', justifyContent: 'space-between' },
+  orderTitle: { fontSize: 16, fontWeight: '600' },
+  orderMeta: { flexDirection: 'row', justifyContent: 'space-between' },
+  actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  dangerButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
 });
-

--- a/app/store/[storeId]/admin/_ProductsScreen.tsx
+++ b/app/store/[storeId]/admin/_ProductsScreen.tsx
@@ -1,114 +1,320 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useTheme } from '@/ui/ThemeProvider';
-import { Product } from '../../../../types';
-import { spacing, radius } from '@/shared/ui/tokens';
+import type { Product } from '@/types';
 import { useProducts } from '@/services/useProducts';
-import { ProductCard, ProductFormModal } from '@/features/products';
-import { useWallet } from '@/contexts/WalletProvider';
-import { useAuth } from '@/features/auth/AuthContext';
+import { productsWarmCache } from '@/features/products/services/nearProducts';
+import { useLanguage } from '@/ui/ThemeProvider';
+import { Spinner } from '@/ui/primitives';
+import DatabaseService from '@/services/database';
+import { ProductFormModal } from '@/features/products';
+import { useAppRouter } from '@/services/useAppRouter';
 
-const ITEM_HEIGHT = 200;
-
-interface ProductItemProps {
+interface ProductRowProps {
   product: Product;
-  onEdit: (p: Product) => void;
+  colors: any;
+  busy: boolean;
+  onEdit: (product: Product) => void;
+  onToggle: (product: Product) => void;
+  onDelete: (product: Product) => void;
 }
 
-const ProductItem = React.memo(({ product, onEdit }: ProductItemProps) => (
-  <TouchableOpacity
-    style={{ marginBottom: spacing.spacer12 }}
-    onPress={() => onEdit(product)}
-  >
-    <ProductCard key={product.id} product={product} />
-  </TouchableOpacity>
-));
+const LOW_STOCK_THRESHOLD = 5;
 
-export default function StoreProductsScreen() {
-  const { storeId } = useLocalSearchParams<{ storeId: string }>();
+function ProductRow({ product, colors, busy, onEdit, onToggle, onDelete }: ProductRowProps) {
+  const isActive = product.isActive !== false;
+  const stock = product.stock ?? 0;
+  const price = Number.isFinite(product.price) ? product.price : Number(product.price ?? 0);
+  return (
+    <View
+      style={[
+        styles.row,
+        {
+          borderColor: colors.border.primary,
+          backgroundColor: colors.surface.primary,
+          opacity: busy ? 0.5 : 1,
+        },
+      ]}>
+      <View style={styles.rowInfo}>
+        <Text style={[styles.productName, { color: colors.text.primary }]}>{product.name}</Text>
+        <Text style={{ color: colors.text.secondary }}>
+          ₪{price.toLocaleString('he-IL')} · מלאי {stock}
+        </Text>
+        {!isActive && (
+          <Text style={[styles.statusBadge, { color: colors.status.error }]}>מושבת</Text>
+        )}
+        {stock <= LOW_STOCK_THRESHOLD && isActive ? (
+          <Text style={[styles.statusBadge, { color: colors.status.warning }]}>מלאי נמוך</Text>
+        ) : null}
+      </View>
+      <View style={styles.rowActions}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.actionButton, { borderColor: colors.border.primary }]}
+          onPress={() => onEdit(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.text.primary }}>עריכה</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.actionButton, { borderColor: colors.border.primary }]}
+          onPress={() => onToggle(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.text.primary }}>{isActive ? 'השהה' : 'הפעל'}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={[styles.deleteButton, { borderColor: colors.status.error }]}
+          onPress={() => onDelete(product)}
+          disabled={busy}>
+          <Text style={{ color: colors.status.error }}>מחק</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+export default function StoreProductsScreen(): React.ReactElement {
+  const params = useLocalSearchParams<{ storeId: string; create?: string; productId?: string }>();
+  const storeId = Array.isArray(params.storeId) ? params.storeId[0] : params.storeId;
+  const createParam = Array.isArray(params.create) ? params.create[0] : params.create;
+  const productIdParam = Array.isArray(params.productId) ? params.productId[0] : params.productId;
   const { colors } = useTheme();
+  const { t } = useLanguage();
+  const db = useMemo(() => DatabaseService.getInstance(), []);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [formVisible, setFormVisible] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null);
+  const { replace } = useAppRouter();
   const {
-    data: initialProducts = [],
+    data: fetchedProducts = [],
     isLoading,
+    isRefetching,
     refetch,
   } = useProducts(storeId ?? null);
-  const [products, setProducts] = useState<Product[]>(initialProducts);
-  const [formVisible, setFormVisible] = useState(false);
-  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
-  const { address } = useWallet();
-  const { isStoreOwner } = useAuth();
 
   useEffect(() => {
-    setProducts(initialProducts.filter((p) => p.storeId === storeId));
-  }, [initialProducts, storeId]);
+    if (!storeId) return;
+    setProducts(
+      fetchedProducts
+        .filter((product) => product.storeId === storeId)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    );
+  }, [fetchedProducts, storeId]);
 
-  const openForm = useCallback((p?: Product) => {
-    setEditingProduct(p || null);
-    setFormVisible(true);
-  }, []);
+  useEffect(() => {
+    if (!storeId) return;
+    const unsubscribe = productsWarmCache.subscribe(
+      (_, product) => {
+        if (!storeId) return false;
+        if (!product) return true;
+        return product.storeId === storeId;
+      },
+      (id, product) => {
+        setProducts((prev) => {
+          if (!product) {
+            return prev.filter((item) => item.id !== id);
+          }
+          if (product.storeId !== storeId) return prev;
+          const next = prev.some((item) => item.id === id)
+            ? prev.map((item) => (item.id === id ? product : item))
+            : [...prev, product];
+          return next
+            .filter((item) => item.storeId === storeId)
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
+      },
+    );
+    return () => unsubscribe?.();
+  }, [storeId]);
 
-  const handleSaved = useCallback((p: Product, isNew: boolean) => {
-    if (isNew) {
-      setProducts((prev) => [...prev, p]);
-    } else {
-      setProducts((prev) => prev.map((prod) => (prod.id === p.id ? p : prod)));
-    }
-  }, []);
-
-  const handleDeleted = useCallback((productId: string) => {
-    setProducts((prev) => prev.filter((p) => p.id !== productId));
-  }, []);
-
-  const renderItem = useCallback(
-    ({ item }: { item: Product }) => (
-      <ProductItem product={item} onEdit={openForm} />
-    ),
-    [openForm]
+  const openForm = useCallback(
+    (product?: Product | null, source?: 'route' | 'action') => {
+      const nextProduct = product ?? null;
+      setSelectedProduct(nextProduct);
+      setFormVisible(true);
+      if (storeId && source !== 'route') {
+        const query = nextProduct ? `?productId=${nextProduct.id}` : '?create=1';
+        replace(`/store/${storeId}/admin/products${query}`);
+      }
+    },
+    [replace, storeId],
   );
 
-  if (!isStoreOwner || address !== storeId) {
-    return (
-      <View
-        style={[
-          styles.container,
-          {
-            backgroundColor: colors.background,
-            justifyContent: 'center',
-            alignItems: 'center',
+  const closeForm = useCallback(() => {
+    setFormVisible(false);
+    setSelectedProduct(null);
+    if (storeId) {
+      replace(`/store/${storeId}/admin/products`);
+    }
+  }, [replace, storeId]);
+
+  useEffect(() => {
+    if (!storeId) return;
+    if (createParam === '1') {
+      openForm(null, 'route');
+    } else if (!productIdParam) {
+      if (formVisible) {
+        closeForm();
+      }
+    }
+  }, [closeForm, createParam, formVisible, openForm, productIdParam, storeId]);
+
+  useEffect(() => {
+    if (!storeId || !productIdParam) return;
+    if (products.length === 0) return;
+    const match = products.find((item) => item.id === productIdParam);
+    if (match) {
+      openForm(match, 'route');
+    } else if (formVisible) {
+      closeForm();
+    }
+  }, [closeForm, formVisible, openForm, productIdParam, products, storeId]);
+
+  const handleToggle = useCallback(
+    async (product: Product) => {
+      if (!storeId) return;
+      const nextActive = product.isActive === false;
+      setPendingActionId(product.id);
+      const original = product;
+      setProducts((prev) =>
+        prev.map((item) =>
+          item.id === product.id ? { ...item, isActive: nextActive } : item,
+        ),
+      );
+      try {
+        await db.updateProduct(product.id, { isActive: nextActive });
+        productsWarmCache.mutate({
+          id: product.id,
+          value: { ...original, isActive: nextActive },
+          ts: Date.now(),
+        });
+        await refetch();
+      } catch (error) {
+        setProducts((prev) =>
+          prev.map((item) => (item.id === original.id ? original : item)),
+        );
+        Alert.alert('שגיאה', 'עדכון סטטוס המוצר נכשל');
+      } finally {
+        setPendingActionId(null);
+      }
+    },
+    [db, refetch, storeId],
+  );
+
+  const confirmDelete = useCallback(
+    (product: Product) => {
+      Alert.alert('מחיקת מוצר', `האם למחוק את "${product.name}"?`, [
+        { text: 'בטל', style: 'cancel' },
+        {
+          text: 'מחק',
+          style: 'destructive',
+          onPress: async () => {
+            setPendingActionId(product.id);
+            try {
+              await db.deleteProduct(product.id);
+              setProducts((prev) => prev.filter((item) => item.id !== product.id));
+              productsWarmCache.mutate({ id: product.id, op: 'delete', ts: Date.now() });
+              await refetch();
+            } catch (error) {
+              Alert.alert('שגיאה', 'מחיקת המוצר נכשלה');
+            } finally {
+              setPendingActionId(null);
+            }
           },
-        ]}
-      >
-        <Text style={{ color: colors.text.primary }}>יש להתחבר לארנק המתאים</Text>
+        },
+      ]);
+    },
+    [db, refetch],
+  );
+
+  const handleSaved = useCallback((saved: Product, isNew: boolean) => {
+    setProducts((prev) => {
+      const next = isNew
+        ? [...prev, saved]
+        : prev.map((item) => (item.id === saved.id ? saved : item));
+      return next
+        .filter((item) => item.storeId === saved.storeId)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
+    });
+    productsWarmCache.mutate({ id: saved.id, value: saved, ts: Date.now() });
+  }, []);
+
+  const handleDeleted = useCallback(
+    (id: string) => {
+      setProducts((prev) => prev.filter((item) => item.id !== id));
+      productsWarmCache.mutate({ id, op: 'delete', ts: Date.now() });
+      closeForm();
+    },
+    [closeForm],
+  );
+
+  const refreshing = isLoading || isRefetching;
+
+  if (!storeId) {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Text style={{ color: colors.text.primary }}>יש לבחור חנות לניהול מוצרים.</Text>
       </View>
     );
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       <TouchableOpacity
-        style={[styles.addButton, { borderColor: colors.border.primary }]}
+        style={[styles.primaryButton, { borderColor: colors.border.primary }]}
         onPress={() => openForm()}
-      >
-        <Text style={{ color: colors.text.primary }}>הוסף מוצר</Text>
+        accessibilityRole="button">
+        <Text style={{ color: colors.text.primary }}>הוסף מוצר חדש</Text>
       </TouchableOpacity>
-      <FlatList
-        data={products}
-        keyExtractor={(p) => p.id}
-        renderItem={renderItem}
-        ListEmptyComponent={
-          <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>אין מוצרים</Text>
-        }
-        contentContainerStyle={styles.list}
-        getItemLayout={(_, index) => ({ length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index })}
-        removeClippedSubviews
-        refreshing={isLoading}
-        onRefresh={refetch}
-      />
+
+      {isLoading && products.length === 0 ? (
+        <View style={styles.centered}>
+          <Spinner />
+        </View>
+      ) : (
+        <FlatList
+          data={products}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <ProductRow
+              product={item}
+              colors={colors}
+              busy={pendingActionId === item.id}
+              onEdit={openForm}
+              onToggle={handleToggle}
+              onDelete={confirmDelete}
+            />
+          )}
+          ListEmptyComponent={
+            <Text style={{ color: colors.text.secondary, textAlign: 'center' }}>
+              {t('products.empty', 'אין מוצרים להצגה')}
+            </Text>
+          }
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={colors.text.primary} />
+          }
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+
       <ProductFormModal
         visible={formVisible}
-        product={editingProduct}
-        onClose={() => setFormVisible(false)}
+        product={selectedProduct}
+        onClose={closeForm}
         onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
@@ -117,17 +323,36 @@ export default function StoreProductsScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: spacing.spacer16 },
-  addButton: {
-    paddingVertical: spacing.spacer12,
-    paddingHorizontal: spacing.spacer16,
+  container: { flex: 1, padding: 16 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  primaryButton: {
     borderWidth: 1,
-    borderRadius: radius.md,
+    borderRadius: 12,
+    paddingVertical: 12,
     alignItems: 'center',
-    marginBottom: spacing.spacer16,
+    marginBottom: 16,
   },
-  list: {
-    paddingBottom: spacing.spacer24,
+  listContent: { paddingBottom: 32, gap: 12 },
+  row: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  rowInfo: { gap: 4 },
+  productName: { fontSize: 16, fontWeight: '600' },
+  statusBadge: { fontSize: 12, fontWeight: '600' },
+  rowActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
+  actionButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  deleteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
 });
-

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -1,7 +1,8 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
@@ -13,6 +14,7 @@ import InfoModal from '../../../../components/InfoModal';
 import { useAppInfo } from '../../../../contexts/AppInfoContext';
 import commonStyles from '@/constants/styles';
 import SettingsAgent from '../../../../agents/settings-agent';
+import adminAgent, { type AdminAgentEvent } from '@/agents/admin-agent';
 import BrandingSettings from '../../../../components/settings/BrandingSettings';
 import CurrencySettings from '../../../../components/settings/CurrencySettings';
 import EnvironmentSettings from '../../../../components/settings/EnvironmentSettings';
@@ -21,9 +23,27 @@ import NotificationSettings from '../../../../components/settings/NotificationSe
 import RpcSettings from '../../../../components/settings/RpcSettings';
 import MoonPaySettings from '../../../../components/settings/MoonPaySettings';
 import PaymentFactorySettings from '../../../../components/settings/PaymentFactorySettings';
+import { isMoonPayEnabled } from '@/config/featureFlags';
+import eventBus from '@/services/eventBus';
+import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
+import { useWallet } from '@/contexts/WalletProvider';
+import {
+  listPendingAdminRequests,
+  approveAdminRequest,
+  rejectAdminRequest,
+  requestAdminAccess,
+  type PendingAdminRequest,
+} from '@/services/adminRequests';
+import {
+  loadAdminInvites,
+  addAdminInvite,
+  removeAdminInvite,
+} from '@/services/adminInvitesStore';
 
 export default function SettingsScreen() {
   const { replace, back } = useAppRouter();
+  const params = useLocalSearchParams<{ storeId: string }>();
+  const storeId = Array.isArray(params.storeId) ? params.storeId[0] : params.storeId;
   const [currencySymbol, setCurrencySymbolState] = useState('₪');
   const [name, setName] = useState('');
   const [logoCidInput, setLogoCidInput] = useState('');
@@ -47,6 +67,13 @@ export default function SettingsScreen() {
     setFiatKey,
   } = useAppInfo();
   const [admins, setAdmins] = useState<string[]>([]);
+  const [inviteAddress, setInviteAddress] = useState('');
+  const [pendingInvites, setPendingInvites] = useState<string[]>([]);
+  const [pendingRequests, setPendingRequests] = useState<PendingAdminRequest[]>([]);
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [requestProcessing, setRequestProcessing] = useState<string | null>(null);
+  const moonPayEnabled = useMemo(() => isMoonPayEnabled(), []);
+  const storeTopic = useMemo(() => `/blue-ocean/stores/${storeId ?? '1'}`, [storeId]);
 
   const [infoModal, setInfoModal] = useState({
     visible: false,
@@ -54,6 +81,10 @@ export default function SettingsScreen() {
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
+
+  const { requireUnlock } = useLaunchGate();
+  const { address: walletAddress } = useWallet();
+  const normalizeAddress = useCallback((value: string) => value.trim().toLowerCase(), []);
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
@@ -77,6 +108,78 @@ export default function SettingsScreen() {
     setLogoCidInput(logoCid || '');
     setFiatKeyInput(fiatKey || '');
   }, [contextCurrencySymbol, appName, logoCid, contextThemeColor, fiatKey]);
+
+  useEffect(() => {
+    loadAdminInvites()
+      .then(setPendingInvites)
+      .catch((err) => errorLog('Failed to load admin invites:', err));
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    listPendingAdminRequests()
+      .then((requests) => {
+        if (active) setPendingRequests(requests);
+      })
+      .catch((err) => errorLog('Failed to load admin requests:', err));
+
+    const onRequested = (evt: AdminAgentEvent) => {
+      if (evt.type !== 'admin.requested') return;
+      setPendingRequests((prev) => {
+        if (prev.some((item) => normalizeAddress(item.address) === normalizeAddress(evt.payload.address))) {
+          return prev;
+        }
+        return [
+          ...prev,
+          {
+            address: evt.payload.address,
+            publicKey: '',
+            requestedAt: evt.payload.requestedAt,
+          },
+        ];
+      });
+      setPendingInvites((prev) =>
+        prev.filter((item) => normalizeAddress(item) !== normalizeAddress(evt.payload.address)),
+      );
+      void removeAdminInvite(evt.payload.address).catch((err) =>
+        errorLog('Failed to sync admin invite removal', err),
+      );
+    };
+
+    const onRegistered = (evt: AdminAgentEvent) => {
+      if (evt.type !== 'admin.registered') return;
+      setPendingRequests((prev) =>
+        prev.filter((item) => normalizeAddress(item.address) !== normalizeAddress(evt.payload.address)),
+      );
+      setPendingInvites((prev) =>
+        prev.filter((item) => normalizeAddress(item) !== normalizeAddress(evt.payload.address)),
+      );
+      void removeAdminInvite(evt.payload.address).catch((err) =>
+        errorLog('Failed to sync admin invite removal', err),
+      );
+    };
+
+    const onRejected = (evt: AdminAgentEvent) => {
+      if (evt.type !== 'admin.rejected') return;
+      setPendingRequests((prev) =>
+        prev.filter((item) => normalizeAddress(item.address) !== normalizeAddress(evt.payload.address)),
+      );
+      void removeAdminInvite(evt.payload.address).catch((err) =>
+        errorLog('Failed to sync admin invite removal', err),
+      );
+    };
+
+    adminAgent.on('admin.requested', onRequested as any);
+    adminAgent.on('admin.registered', onRegistered as any);
+    adminAgent.on('admin.rejected', onRejected as any);
+
+    return () => {
+      active = false;
+      adminAgent.off('admin.requested', onRequested as any);
+      adminAgent.off('admin.registered', onRegistered as any);
+      adminAgent.off('admin.rejected', onRejected as any);
+    };
+  }, [normalizeAddress]);
 
   const loadSettings = async () => {
     setLoading(true);
@@ -114,6 +217,14 @@ export default function SettingsScreen() {
         'paymentFactoryAddress',
         paymentFactoryAddress.trim(),
       );
+      await eventBus.publish(storeTopic, 'store.updated', {
+        profile: {
+          name,
+          logoCid: logoUri,
+          themeColor,
+          currencySymbol,
+        },
+      });
       setInfoModal({
         visible: true,
         title: 'הצלחה',
@@ -130,6 +241,106 @@ export default function SettingsScreen() {
       });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const sendInvite = async () => {
+    const address = inviteAddress.trim();
+    if (!address) {
+      Alert.alert('שגיאה', 'נא להזין כתובת ארנק להזמנה');
+      return;
+    }
+    setInviteLoading(true);
+    try {
+      const normalized = normalizeAddress(address);
+      if (walletAddress && normalizeAddress(walletAddress) === normalized) {
+        await requestAdminAccess(address);
+        const refreshed = await listPendingAdminRequests();
+        setPendingRequests(refreshed);
+        setInfoModal({
+          visible: true,
+          title: 'בקשה נשלחה',
+          message: 'הבקשה הועברה לאישור מנהל קיים.',
+          type: 'success',
+        });
+      } else {
+        const updatedInvites = await addAdminInvite(address);
+        setPendingInvites(updatedInvites);
+        setInfoModal({
+          visible: true,
+          title: 'הזמנה נשמרה',
+          message: 'הזמנה נשמרה במערכת. עדכן את המועמד להגיש בקשה.',
+          type: 'success',
+        });
+      }
+      setInviteAddress('');
+    } catch (error) {
+      errorLog('Failed to process admin invitation', error);
+      Alert.alert('שגיאה', 'שליחת ההזמנה נכשלה');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleApproveRequest = async (address: string) => {
+    setRequestProcessing(address);
+    try {
+      await requireUnlock('admin.approval');
+      await approveAdminRequest(address);
+      const nextAdmins = Array.from(
+        new Set([...admins, address].map((item) => item.trim())),
+      );
+      await SettingsAgent.getInstance().setAdmins(nextAdmins);
+      setAdmins(nextAdmins);
+      setPendingRequests((prev) =>
+        prev.filter((item) => normalizeAddress(item.address) !== normalizeAddress(address)),
+      );
+      const updatedInvites = await removeAdminInvite(address);
+      setPendingInvites(updatedInvites);
+      setInfoModal({
+        visible: true,
+        title: 'הצלחה',
+        message: 'המנהל החדש נוסף בהצלחה.',
+        type: 'success',
+      });
+    } catch (error) {
+      errorLog('Failed to approve admin request', error);
+      Alert.alert('שגיאה', 'אישור הבקשה נכשל');
+    } finally {
+      setRequestProcessing(null);
+    }
+  };
+
+  const handleRejectRequest = async (address: string) => {
+    setRequestProcessing(address);
+    try {
+      await requireUnlock('admin.approval');
+      await rejectAdminRequest(address);
+      setPendingRequests((prev) =>
+        prev.filter((item) => normalizeAddress(item.address) !== normalizeAddress(address)),
+      );
+      const updatedInvites = await removeAdminInvite(address);
+      setPendingInvites(updatedInvites);
+      setInfoModal({
+        visible: true,
+        title: 'עודכן',
+        message: 'הבקשה נדחתה והוזזה מהרשימה.',
+        type: 'success',
+      });
+    } catch (error) {
+      errorLog('Failed to reject admin request', error);
+      Alert.alert('שגיאה', 'דחיית הבקשה נכשלה');
+    } finally {
+      setRequestProcessing(null);
+    }
+  };
+
+  const handleRemoveInvite = async (address: string) => {
+    try {
+      const updated = await removeAdminInvite(address);
+      setPendingInvites(updated);
+    } catch (error) {
+      errorLog('Failed to remove admin invite', error);
     }
   };
 
@@ -186,12 +397,107 @@ export default function SettingsScreen() {
           fiatKeyInput={fiatKeyInput}
           setFiatKeyInput={setFiatKeyInput}
           colors={colors}
+          disabled={!moonPayEnabled}
         />
         <PaymentFactorySettings
           paymentFactoryAddress={paymentFactoryAddress}
           setPaymentFactoryAddress={setPaymentFactoryAddress}
           colors={colors}
         />
+        <View style={styles.sectionHeader}>
+          <SettingsIcon size={24} color={colors.gold} />
+          <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>ניהול מנהלים</Text>
+        </View>
+        <View
+          style={[styles.adminCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}
+        >
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>הזמנת מנהל חדש</Text>
+          <View style={styles.inviteRow}>
+            <TextInput
+              style={[styles.inviteInput, { borderColor: colors.border.primary, color: colors.text.primary }]}
+              value={inviteAddress}
+              onChangeText={setInviteAddress}
+              placeholder="wallet.near"
+              placeholderTextColor={colors.text.tertiary}
+              textAlign="right"
+            />
+            <TouchableOpacity
+              style={[styles.inviteButton, { borderColor: colors.border.primary }]}
+              onPress={sendInvite}
+              disabled={inviteLoading}
+              accessibilityRole="button"
+            >
+              <Text style={{ color: colors.text.primary }}>שליחת הזמנה</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={{ color: colors.text.secondary }}>
+            הזמנה חדשה דורשת אישור מנהל קיים לפני כניסה למערכת.
+          </Text>
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>בקשות לאישור</Text>
+          {pendingRequests.length === 0 ? (
+            <Text style={{ color: colors.text.secondary }}>אין בקשות פעילות.</Text>
+          ) : (
+            pendingRequests.map((request) => (
+              <View
+                key={`${request.address}:${request.requestedAt}`}
+                style={[styles.inviteItem, { borderColor: colors.border.primary }]}
+              >
+                <View style={styles.requestInfo}>
+                  <Text style={{ color: colors.text.primary }}>{request.address}</Text>
+                  <Text style={{ color: colors.text.secondary }}>
+                    {new Date(request.requestedAt).toLocaleString('he-IL')}
+                  </Text>
+                </View>
+                <View style={styles.requestActions}>
+                  <TouchableOpacity
+                    style={[styles.rejectInviteButton, { borderColor: colors.status.error }]}
+                    onPress={() => handleRejectRequest(request.address)}
+                    disabled={requestProcessing === request.address}
+                  >
+                    <Text style={{ color: colors.status.error }}>דחה</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.approveInviteButton, { borderColor: colors.status.success }]}
+                    onPress={() => handleApproveRequest(request.address)}
+                    disabled={requestProcessing === request.address}
+                  >
+                    <Text style={{ color: colors.status.success }}>אשר</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))
+          )}
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>הזמנות בהמתנה</Text>
+          {pendingInvites.length === 0 ? (
+            <Text style={{ color: colors.text.secondary }}>אין הזמנות ממתינות.</Text>
+          ) : (
+            pendingInvites.map((address) => (
+              <View
+                key={address}
+                style={[styles.inviteItem, { borderColor: colors.border.primary }]}
+              >
+                <Text style={{ color: colors.text.primary }}>{address}</Text>
+                <TouchableOpacity
+                  style={[styles.rejectInviteButton, { borderColor: colors.border.primary }]}
+                  onPress={() => handleRemoveInvite(address)}
+                  disabled={inviteLoading}
+                >
+                  <Text style={{ color: colors.text.primary }}>הסר</Text>
+                </TouchableOpacity>
+              </View>
+            ))
+          )}
+          <Text style={[styles.cardTitle, { color: colors.text.primary }]}>מנהלים פעילים</Text>
+          {admins.length === 0 ? (
+            <Text style={{ color: colors.text.secondary }}>עדיין לא הוגדרו מנהלים נוספים.</Text>
+          ) : (
+            admins.map((admin) => (
+              <Text key={admin} style={{ color: colors.text.secondary }}>
+                {admin}
+              </Text>
+            ))
+          )}
+        </View>
         <EnvironmentSettings colors={colors} admins={admins} />
         <RpcSettings colors={colors} />
         <LanguageSettings colors={colors} currentLanguage={currentLanguage} />
@@ -271,4 +577,51 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginLeft: 8,
   },
+  adminCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  cardTitle: { fontSize: 16, fontWeight: '600' },
+  inviteRow: { flexDirection: 'row', gap: 12, alignItems: 'center' },
+  inviteInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  inviteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  inviteItem: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  approveInviteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    alignItems: 'center',
+  },
+  rejectInviteButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    alignItems: 'center',
+    marginRight: 8,
+  },
+  requestInfo: { flex: 1, gap: 4 },
+  requestActions: { flexDirection: 'row', alignItems: 'center', gap: 8 },
 });

--- a/components/settings/MoonPaySettings.tsx
+++ b/components/settings/MoonPaySettings.tsx
@@ -7,9 +7,10 @@ interface Props {
   fiatKeyInput: string;
   setFiatKeyInput: (v: string) => void;
   colors: any;
+  disabled?: boolean;
 }
 
-const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, colors }) => {
+const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, colors, disabled = false }) => {
   return (
     <Card
       style={[
@@ -33,12 +34,16 @@ const MoonPaySettings: React.FC<Props> = ({ fiatKeyInput, setFiatKeyInput, color
                 color: colors.text.primary,
               },
             ]}
-            value={fiatKeyInput}
-            onChangeText={setFiatKeyInput}
-            placeholder="pk_live_..."
+            value={disabled ? '' : fiatKeyInput}
+            onChangeText={disabled ? undefined : setFiatKeyInput}
+            placeholder={disabled ? 'בקרוב' : 'pk_live_...'}
+            editable={!disabled}
             textAlign="right"
             placeholderTextColor={colors.text.tertiary}
           />
+          {disabled ? (
+            <Text style={[styles.helper, { color: colors.text.secondary }]}>השדה חסום בגרסה זו.</Text>
+          ) : null}
         </View>
       </View>
     </Card>
@@ -82,6 +87,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     fontSize: 16,
+  },
+  helper: {
+    marginTop: 8,
+    fontSize: 12,
+    textAlign: 'right',
   },
 });
 

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -28,6 +28,7 @@ const envSchema = z.object({
     .string()
     .optional()
     .default('false'),
+  EXPO_PUBLIC_FEATURE_MOONPAY: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -138,5 +139,11 @@ export function triggerDeliveryNotificationsRollback(): void {
   deliveryNotificationsFlag.rollback = true;
 }
 export { deliveryNotificationsFlag };
+
+const moonPayFeatureEnabled = env.EXPO_PUBLIC_FEATURE_MOONPAY === 'true';
+
+export function isMoonPayEnabled(): boolean {
+  return moonPayFeatureEnabled;
+}
 
 export default warmCacheFlag;

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -2,6 +2,8 @@ export * from './message';
 export * from './settings';
 export * from './notification';
 export * from './product.updated';
+export * from './product.deleted';
+export * from './kyc.receipt';
 export * from './order.status';
 export * from './admin.joinRequested';
 export * from './admin.approve';

--- a/schemas/waku/kyc.receipt.ts
+++ b/schemas/waku/kyc.receipt.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+export const kycReceiptPayloadSchema = z.object({
+  receiptId: z.string(),
+  buyerPublicKey: z.string(),
+  issuerPublicKey: z.string(),
+  issuedAt: z.string(),
+  data: z.record(z.unknown()).optional().default({}),
+  ts: z.number(),
+  nonce: z.string(),
+});
+
+export const kycReceiptSchema = wakuMessageSchema.extend({
+  type: z.literal('kyc.receipt'),
+  payload: kycReceiptPayloadSchema,
+});
+
+export type KycReceiptMessage = z.infer<typeof kycReceiptSchema>;
+
+export function parseKycReceiptMessage(data: unknown): KycReceiptMessage | null {
+  const result = kycReceiptSchema.safeParse(data);
+  return result.success ? result.data : null;
+}

--- a/schemas/waku/product.deleted.ts
+++ b/schemas/waku/product.deleted.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+export const productDeletedPayloadSchema = z.object({
+  id: z.string(),
+  storeId: z.string(),
+  deletedAt: z.string().optional(),
+  ts: z.number(),
+  nonce: z.string(),
+});
+
+export const productDeletedSchema = wakuMessageSchema.extend({
+  type: z.literal('product.deleted'),
+  payload: productDeletedPayloadSchema,
+});
+
+export type ProductDeletedMessage = z.infer<typeof productDeletedSchema>;
+
+export function parseProductDeletedMessage(
+  data: unknown,
+): ProductDeletedMessage | null {
+  const res = productDeletedSchema.safeParse(data);
+  return res.success ? res.data : null;
+}

--- a/schemas/waku/product.updated.ts
+++ b/schemas/waku/product.updated.ts
@@ -33,13 +33,20 @@ export const productSchema: z.ZodType<Product> = z.object({
   mixGroupId: z.string().optional(),
   storeId: z.string(),
   stock: z.number(),
+  isActive: z.boolean().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
 });
 
+export const productUpdatedPayloadSchema = z.object({
+  product: productSchema,
+  ts: z.number(),
+  nonce: z.string(),
+});
+
 export const productUpdatedSchema = wakuMessageSchema.extend({
   type: z.literal('product.updated'),
-  payload: productSchema,
+  payload: productUpdatedPayloadSchema,
 });
 
 export type ProductUpdatedMessage = z.infer<typeof productUpdatedSchema>;

--- a/services/adminInvitesStore.ts
+++ b/services/adminInvitesStore.ts
@@ -1,0 +1,47 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'admin.invites';
+
+async function readInvites(): Promise<string[]> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string');
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+export async function loadAdminInvites(): Promise<string[]> {
+  return await readInvites();
+}
+
+export async function addAdminInvite(address: string): Promise<string[]> {
+  const current = await readInvites();
+  const normalized = address.trim();
+  if (!normalized) return current;
+  if (current.some((item) => item.toLowerCase() === normalized.toLowerCase())) {
+    return current;
+  }
+  const next = [...current, normalized];
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return next;
+}
+
+export async function removeAdminInvite(address: string): Promise<string[]> {
+  const current = await readInvites();
+  const normalized = address.trim().toLowerCase();
+  const next = current.filter((item) => item.toLowerCase() !== normalized);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return next;
+}
+
+export default {
+  loadAdminInvites,
+  addAdminInvite,
+  removeAdminInvite,
+};

--- a/services/adminRequests.ts
+++ b/services/adminRequests.ts
@@ -1,0 +1,90 @@
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
+import adminAgent, { AdminAgentEvent } from '@/agents/admin-agent';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import { publish } from '@/services/waku';
+
+const USERS_TOPIC = '/blue-ocean/users/1';
+
+export interface PendingAdminRequest {
+  address: string;
+  publicKey: string;
+  requestedAt: number;
+}
+
+function randomNonce(byteLength = 12): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
+
+export async function listPendingAdminRequests(): Promise<PendingAdminRequest[]> {
+  const pending = await adminAgent.getPendingRequests();
+  return pending.map((request) => ({
+    address: request.address,
+    publicKey: request.publicKey,
+    requestedAt: request.requestedAt || Date.now(),
+  }));
+}
+
+export async function requestAdminAccess(address: string): Promise<AdminAgentEvent['type']> {
+  const message = await makeSignedWakuMessage(
+    'admin.joinRequested',
+    {
+      address,
+      nonce: randomNonce(),
+      ts: Date.now(),
+    },
+    'admin',
+  );
+  const result = await adminAgent.requestAdmin(message);
+  try {
+    await publish(USERS_TOPIC, message);
+  } catch {
+    /* publishing is best-effort */
+  }
+  return result;
+}
+
+export async function approveAdminRequest(address: string): Promise<AdminAgentEvent['type']> {
+  const message = await makeSignedWakuMessage(
+    'admin.approve',
+    {
+      address,
+      nonce: randomNonce(),
+      ts: Date.now(),
+    },
+    'admin',
+  );
+  const result = await adminAgent.approveAdmin(message);
+  try {
+    await publish(USERS_TOPIC, message);
+  } catch {
+    /* ignore transport errors */
+  }
+  return result;
+}
+
+export async function rejectAdminRequest(address: string): Promise<AdminAgentEvent['type']> {
+  const message = await makeSignedWakuMessage(
+    'admin.reject',
+    {
+      address,
+      nonce: randomNonce(),
+      ts: Date.now(),
+    },
+    'admin',
+  );
+  const result = await adminAgent.rejectAdmin(message);
+  try {
+    await publish(USERS_TOPIC, message);
+  } catch {
+    /* ignore transport errors */
+  }
+  return result;
+}
+
+export default {
+  listPendingAdminRequests,
+  requestAdminAccess,
+  approveAdminRequest,
+  rejectAdminRequest,
+};

--- a/services/database.ts
+++ b/services/database.ts
@@ -19,6 +19,7 @@ import { getPrivateKey } from '@/services/localIdentity';
 import { aesEncrypt, aesDecrypt } from '@/utils/encryption';
 import { sha256 } from '@noble/hashes/sha256';
 import { Buffer } from 'buffer';
+import { publishProductDeleted, publishProductUpdated } from '@/services/productEvents';
 
 let listAllReviews: (() => Promise<Review[]>) | undefined;
 if (chain === 'near') {
@@ -207,6 +208,11 @@ class DatabaseService {
     const id = `prod_${Date.now()}`;
     const full: Product = { id, ...product };
     await productsAgent.add(full);
+    try {
+      await publishProductUpdated(full);
+    } catch (err) {
+      errorLog('Failed to publish product.updated', err);
+    }
     return id;
   }
 
@@ -214,10 +220,23 @@ class DatabaseService {
     const existing = await fetchProduct(id);
     if (!existing) return;
     await productsAgent.update({ ...existing, ...data });
+    try {
+      await publishProductUpdated({ ...existing, ...data, id } as Product);
+    } catch (err) {
+      errorLog('Failed to publish product.updated', err);
+    }
   }
 
   async deleteProduct(id: string): Promise<void> {
+    const existing = await fetchProduct(id);
     await productsAgent.remove(id);
+    if (existing) {
+      try {
+        await publishProductDeleted(id, existing.storeId);
+      } catch (err) {
+        errorLog('Failed to publish product.deleted', err);
+      }
+    }
   }
 
   // Subcategories

--- a/services/kycPackages.ts
+++ b/services/kycPackages.ts
@@ -1,0 +1,107 @@
+import { Buffer } from 'buffer';
+import { deriveChatSalt, deriveSharedKey, aesDecrypt } from '@/utils/encryption';
+import { getEd25519KeyPair } from '@/services/localIdentity';
+
+export interface KycPackageResolution {
+  encrypted: boolean;
+  payload: unknown;
+  raw: string;
+  source: string;
+  sender?: string;
+}
+
+interface EncryptedKycPackage {
+  cipher: string;
+  from: string;
+  kind?: string;
+}
+
+function isEncryptedPackage(value: any): value is EncryptedKycPackage {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.cipher === 'string' &&
+    value.cipher.length > 0 &&
+    typeof value.from === 'string' &&
+    value.from.length > 0
+  );
+}
+
+function resolveUri(uri: string): string {
+  if (uri.startsWith('ipfs://')) {
+    const cid = uri.slice('ipfs://'.length);
+    return `https://ipfs.io/ipfs/${cid}`;
+  }
+  return uri;
+}
+
+async function fetchUriContent(uri: string): Promise<string> {
+  if (uri.startsWith('data:')) {
+    const idx = uri.indexOf('base64,');
+    if (idx !== -1) {
+      const encoded = uri.slice(idx + 'base64,'.length);
+      return Buffer.from(encoded, 'base64').toString('utf-8');
+    }
+    const plain = uri.slice(uri.indexOf(',') + 1);
+    return decodeURIComponent(plain);
+  }
+  const resolved = resolveUri(uri);
+  if (typeof fetch !== 'function') {
+    throw new Error('fetch unavailable');
+  }
+  const response = await fetch(resolved);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch KYC package (${response.status})`);
+  }
+  return await response.text();
+}
+
+async function decryptPackage(pkg: EncryptedKycPackage): Promise<unknown> {
+  const { privateKey, publicKey } = await getEd25519KeyPair();
+  const myPublic = Buffer.from(publicKey).toString('hex');
+  const salt = deriveChatSalt(pkg.from, myPublic);
+  const key = await deriveSharedKey(privateKey, pkg.from, 'kyc', salt);
+  const plaintext = await aesDecrypt(pkg.cipher, key);
+  try {
+    return JSON.parse(plaintext);
+  } catch {
+    return plaintext;
+  }
+}
+
+export async function resolveKycPackage(uri: string): Promise<KycPackageResolution | null> {
+  if (!uri) return null;
+  const raw = await fetchUriContent(uri);
+  if (!raw) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      encrypted: false,
+      payload: raw,
+      raw,
+      source: uri,
+    };
+  }
+  if (isEncryptedPackage(parsed)) {
+    const payload = await decryptPackage(parsed);
+    return {
+      encrypted: true,
+      payload,
+      raw,
+      source: uri,
+      sender: parsed.from,
+    };
+  }
+  return {
+    encrypted: false,
+    payload: parsed,
+    raw,
+    source: uri,
+  };
+}
+
+export default { resolveKycPackage };

--- a/services/kycReceipts.ts
+++ b/services/kycReceipts.ts
@@ -1,0 +1,61 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
+import { uuid } from '@/utils/uuid';
+import { canonicalJson } from '@/utils/serialization';
+import { publish } from '@/services/waku';
+import { getPublicKeyHex } from '@/services/localIdentity';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import type { KycReceiptMessage } from '@/types/waku';
+import { kycReceiptSchema } from '@/schemas/waku';
+
+const RECEIPT_STORAGE_PREFIX = 'kyc.receipt:';
+const DM_TOPIC_PREFIX = '/blue-ocean/dm';
+
+function randomNonce(byteLength = 12): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
+
+function receiptTopic(buyerPublicKey: string): string {
+  return `${DM_TOPIC_PREFIX}/${buyerPublicKey}`;
+}
+
+export type KycReceipt = KycReceiptMessage;
+
+export async function loadKycReceipt(buyerPublicKey: string): Promise<KycReceipt | null> {
+  if (!buyerPublicKey) return null;
+  try {
+    const raw = await AsyncStorage.getItem(`${RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const validated = kycReceiptSchema.parse(parsed);
+    return validated;
+  } catch {
+    return null;
+  }
+}
+
+export async function issueKycReceipt(
+  buyerPublicKey: string,
+  data: Record<string, unknown>,
+): Promise<KycReceipt> {
+  const receiptId = uuid();
+  const issuedAt = new Date().toISOString();
+  const issuerPublicKey = await getPublicKeyHex();
+  const payload = {
+    receiptId,
+    buyerPublicKey,
+    issuerPublicKey,
+    issuedAt,
+    data,
+    ts: Date.now(),
+    nonce: randomNonce(),
+  };
+  const message = await makeSignedWakuMessage('kyc.receipt', payload, 'admin');
+  await AsyncStorage.setItem(
+    `${RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`,
+    canonicalJson(message),
+  );
+  await publish(receiptTopic(buyerPublicKey), message);
+  return message;
+}

--- a/services/productEvents.ts
+++ b/services/productEvents.ts
@@ -1,0 +1,45 @@
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
+import type { Product } from '@/types';
+import { publish } from '@/services/waku';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+
+const PRODUCT_TOPIC = '/blue-ocean/products/1';
+
+function randomNonce(byteLength = 12): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
+
+export async function publishProductUpdated(product: Product) {
+  const normalized: Product = {
+    ...product,
+    isActive: product.isActive !== false,
+  };
+  const message = await makeSignedWakuMessage(
+    'product.updated',
+    {
+      product: normalized,
+      ts: Date.now(),
+      nonce: randomNonce(),
+    },
+    'admin',
+  );
+  await publish(PRODUCT_TOPIC, message);
+  return message;
+}
+
+export async function publishProductDeleted(id: string, storeId: string) {
+  const message = await makeSignedWakuMessage(
+    'product.deleted',
+    {
+      id,
+      storeId,
+      deletedAt: new Date().toISOString(),
+      ts: Date.now(),
+      nonce: randomNonce(),
+    },
+    'admin',
+  );
+  await publish(PRODUCT_TOPIC, message);
+  return message;
+}

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -113,6 +113,7 @@ export default function ProductFormModal({
             category: '',
             stock: 0,
             storeId: address || '',
+            isActive: true,
           }
     );
 

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -60,6 +60,25 @@ describe('scoped tokens feature flag', () => {
   });
 });
 
+describe('moonpay feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_MOONPAY;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isMoonPayEnabled } = require('@/config/featureFlags');
+    expect(isMoonPayEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_MOONPAY = 'true';
+    jest.resetModules();
+    const { isMoonPayEnabled } = require('@/config/featureFlags');
+    expect(isMoonPayEnabled()).toBe(true);
+  });
+});
+
 describe('notifications pipeline feature flag', () => {
   beforeEach(() => {
     delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;

--- a/tests/kycReceiptSchema.test.ts
+++ b/tests/kycReceiptSchema.test.ts
@@ -1,0 +1,42 @@
+import {
+  kycReceiptSchema,
+  parseKycReceiptMessage,
+} from '../schemas/waku/kyc.receipt';
+
+describe('kyc.receipt schema', () => {
+  it('parses a valid receipt message', () => {
+    const msg = {
+      type: 'kyc.receipt',
+      payload: {
+        receiptId: 'r1',
+        buyerPublicKey: '0xabc',
+        issuerPublicKey: '0xdef',
+        issuedAt: '2024-01-01T00:00:00Z',
+        data: { userId: 'u1' },
+        ts: 1700000000000,
+        nonce: '123456abcdef',
+      },
+      sender: { publicKey: '0xdef', role: 'admin' },
+      signature: '0xdeadbeef',
+    } as const;
+    expect(kycReceiptSchema.parse(msg)).toEqual(msg);
+    expect(parseKycReceiptMessage(msg)).toEqual(msg);
+  });
+
+  it('rejects receipts without nonce', () => {
+    const bad = {
+      type: 'kyc.receipt',
+      payload: {
+        receiptId: 'r1',
+        buyerPublicKey: '0xabc',
+        issuerPublicKey: '0xdef',
+        issuedAt: '2024-01-01T00:00:00Z',
+        ts: 1700000000000,
+      },
+      sender: { publicKey: '0xdef', role: 'admin' },
+      signature: '0xdeadbeef',
+    } as const;
+    expect(() => kycReceiptSchema.parse(bad)).toThrow();
+    expect(parseKycReceiptMessage(bad)).toBeNull();
+  });
+});

--- a/tests/productDeletedSchema.test.ts
+++ b/tests/productDeletedSchema.test.ts
@@ -1,0 +1,31 @@
+import { productDeletedSchema, parseProductDeletedMessage } from '../schemas/waku/product.deleted';
+
+describe('product.deleted schema', () => {
+  test('valid message parses', () => {
+    const msg = {
+      type: 'product.deleted',
+      payload: {
+        id: 'p1',
+        storeId: 's1',
+        deletedAt: '2024-01-01T00:00:00Z',
+        ts: 1700000000000,
+        nonce: 'abcdef123456',
+      },
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    } as const;
+    expect(productDeletedSchema.parse(msg)).toEqual(msg);
+    expect(parseProductDeletedMessage(msg)).toEqual(msg);
+  });
+
+  test('invalid message fails', () => {
+    const bad = {
+      type: 'product.deleted',
+      payload: { id: 'p1' },
+      sender: { publicKey: '0xabc' },
+      signature: '0x123',
+    } as const;
+    expect(() => productDeletedSchema.parse(bad)).toThrow();
+    expect(parseProductDeletedMessage(bad)).toBeNull();
+  });
+});

--- a/tests/productUpdatedSchema.test.ts
+++ b/tests/productUpdatedSchema.test.ts
@@ -17,7 +17,11 @@ describe('product.updated schema', () => {
   test('valid message parses', () => {
     const msg = {
       type: 'product.updated',
-      payload: product,
+      payload: {
+        product,
+        ts: 1700000000000,
+        nonce: 'abcdef123456',
+      },
       sender: { publicKey: '0xabc' },
       signature: '0x123',
     };
@@ -28,7 +32,7 @@ describe('product.updated schema', () => {
   test('invalid message fails', () => {
     const bad = {
       type: 'product.updated',
-      payload: { id: 'p1' },
+      payload: { product: { id: 'p1' } },
       sender: { publicKey: '0xabc' },
       signature: '0x123',
     };

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,6 +27,7 @@ export interface Product {
   mixGroupId?: string;
   storeId: string;
   stock: number;
+  isActive?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -4,6 +4,7 @@ export {
   type NotificationEvent,
   type NotificationWakuPayload,
   type ProductUpdatedMessage,
+  type ProductDeletedMessage,
   type OrderStatusMessage,
   type AdminJoinRequestMessage,
   type AdminApproveMessage,
@@ -11,4 +12,5 @@ export {
   type WorkspaceCreatedMessage,
   type WorkspaceCreatedPayload,
   type DeliveryUpdateMessage,
+  type KycReceiptMessage,
 } from '../schemas/waku';


### PR DESCRIPTION
## Summary
- make the products admin screen honor create/edit query params so quick-add and deep links open the modal with local cache mutations
- add a decrypting KYC preview modal with DM package support, step-up enforcement, and signed receipt issuing guardrails
- overhaul admin settings to track pending join requests, persist invites locally, and approve/reject via signed Waku messages while exposing new helper services

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8db6ec8c48326a31ba103aaf9ac84