### PR TITLE
Require KYC receipt when creating orders

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -17,13 +17,21 @@ import { chainAdapter } from '@/services/chain';
 import { adminResolve, deployOrderPayment } from './nearContract';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
-import { assertCheckoutScope } from '@/services/session';
+import { assertCheckoutScope, getSession } from '@/services/session';
 import { checkoutTokenIntegrity } from '@/services/monitoring';
 import SettingsAgent from '@/agents/settings-agent';
+import { loadKycReceipt } from '@/services/kycReceipts';
+import { getPublicKeyHex } from '@/services/localIdentity';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
 const LOW_STOCK_THRESHOLD = 5;
+const KYC_RECEIPT_ERROR = 'KYC receipt missing or invalid';
+
+type VerifiedKycReceipt = {
+  receiptId: string;
+  buyerPublicKey: string;
+};
 
 export async function emitOrderEvents(
   order: Order,
@@ -37,6 +45,7 @@ export async function emitOrderEvents(
     buyerAddress: order.buyerAddress,
     sellerAddress: order.sellerAddress,
     sessionToken,
+    kycReceiptId: order.kycReceiptId,
     payment: {
       method: order.paymentMethod,
       contractAddress: order.paymentContractAddress,
@@ -115,6 +124,52 @@ class OrderService {
     return allSteps;
   }
 
+  private async verifyKycReceipt(sessionToken: string): Promise<VerifiedKycReceipt> {
+    const fail = (reason: string): never => {
+      errorLog('KYC receipt validation failed', { reason });
+      throw new Error(KYC_RECEIPT_ERROR);
+    };
+
+    const session = getSession(sessionToken);
+    if (!session || typeof session.deviceHash !== 'string' || session.deviceHash.length === 0) {
+      return fail('session_missing');
+    }
+
+    const buyerPublicKey = await getPublicKeyHex();
+    if (!buyerPublicKey) {
+      return fail('buyer_key_missing');
+    }
+
+    const receipt = await loadKycReceipt(buyerPublicKey);
+    if (!receipt) {
+      return fail('receipt_missing');
+    }
+
+    if (!receipt.payload || receipt.payload.buyerPublicKey !== buyerPublicKey) {
+      return fail('buyer_key_mismatch');
+    }
+
+    const data = receipt.payload.data || {};
+    let receiptDeviceHash: string | undefined;
+    if (data && typeof data === 'object') {
+      receiptDeviceHash =
+        data.deviceHash || data.device_hash || data['device-hash'] || data.device_hash_hex;
+    }
+
+    if (typeof receiptDeviceHash !== 'string') {
+      return fail('device_hash_missing');
+    }
+
+    if (receiptDeviceHash !== session.deviceHash) {
+      return fail('device_hash_mismatch');
+    }
+
+    return {
+      receiptId: receipt.payload.receiptId,
+      buyerPublicKey,
+    };
+  }
+
   async createOrder(
     userId: string,
     items: CartItem[],
@@ -127,8 +182,10 @@ class OrderService {
       sellerAddress?: string;
     },
     sessionToken: string,
+    verifiedKyc?: VerifiedKycReceipt,
   ): Promise<Order> {
     assertCheckoutScope(sessionToken);
+    const kyc = verifiedKyc ?? (await this.verifyKycReceipt(sessionToken));
     const total = items.reduce((sum, item) => {
       const price = item.unitPrice ?? item.product.price;
       return sum + price * item.quantity;
@@ -162,7 +219,7 @@ class OrderService {
       total,
       status: 'order_received',
       shippingAddress,
-       itemsHash,
+      itemsHash,
       paymentMethod: pay?.method ?? 'cash_on_delivery',
       buyerAddress: pay?.buyerAddress,
       sellerAddress: pay?.sellerAddress,
@@ -175,6 +232,7 @@ class OrderService {
       trackingSteps: this.getTrackingSteps('order_received'),
       platformFee: feeInfo?.platformFee,
       sellerPayout: feeInfo?.sellerPayout,
+      kycReceiptId: kyc.receiptId,
     };
 
     await ordersAgent.add(order);
@@ -201,6 +259,7 @@ class OrderService {
       throw err;
     }
     try {
+      const verifiedKyc = await this.verifyKycReceipt(sessionToken);
       const grouped: Record<string, CartItem[]> = {};
       for (const item of cartItems) {
         const storeId = item.product.storeId;
@@ -235,6 +294,7 @@ class OrderService {
           shippingAddress,
           payment,
           sessionToken,
+          verifiedKyc,
         );
         await emitOrderEvents(order, storeId, sessionToken);
         orders.push(order);

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -5,8 +5,38 @@ import OrderService from '@/services/orders';
 import { CartItem, ShippingAddress } from '@/types';
 import { requestScopes } from '@/services/session';
 import { Buffer } from 'buffer';
+import { loadKycReceipt } from '@/services/kycReceipts';
+import { getDeviceHash } from '@/utils/getDeviceHash';
 
 (global as any).Buffer = Buffer;
+
+const deviceHash = getDeviceHash();
+
+const makeReceipt = (buyerPublicKey = 'buyer-public-key') => ({
+  type: 'kyc.receipt',
+  payload: {
+    receiptId: 'receipt-123',
+    buyerPublicKey,
+    issuerPublicKey: 'issuer',
+    issuedAt: new Date(0).toISOString(),
+    data: { deviceHash },
+    ts: Date.now(),
+    nonce: 'nonce',
+  },
+  sender: { publicKey: 'issuer', role: 'admin' },
+  signature: 'sig',
+});
+
+jest.mock('@waku/sdk', () => ({}), { virtual: true });
+
+jest.mock('@/services/localIdentity', () => ({
+  getPublicKeyHex: jest.fn().mockResolvedValue('buyer-public-key'),
+}));
+
+jest.mock('@/services/kycReceipts', () => ({
+  loadKycReceipt: jest.fn(),
+  issueKycReceipt: jest.fn(),
+}));
 
 jest.mock('@noble/hashes/sha256', () => ({
   sha256: () => new Uint8Array(32),
@@ -104,6 +134,7 @@ describe('login issues session token used in checkout', () => {
   beforeEach(() => {
     mockAddOrder.mockClear();
     ordersAgentModule.default.add = mockAddOrder;
+    (loadKycReceipt as jest.Mock).mockResolvedValue(makeReceipt());
   });
 
   it('creates an order with attached session token', async () => {

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -1,9 +1,37 @@
 import OrderService from '@/services/orders';
 import { CartItem, ShippingAddress } from '../types';
 import { requestScopes } from '@/services/session';
+import { loadKycReceipt } from '@/services/kycReceipts';
+import { getDeviceHash } from '@/utils/getDeviceHash';
 
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
+
+const deviceHash = getDeviceHash();
+
+const makeReceipt = (buyerPublicKey = 'buyer-public-key') => ({
+  type: 'kyc.receipt',
+  payload: {
+    receiptId: 'receipt-123',
+    buyerPublicKey,
+    issuerPublicKey: 'issuer',
+    issuedAt: new Date(0).toISOString(),
+    data: { deviceHash },
+    ts: Date.now(),
+    nonce: 'nonce',
+  },
+  sender: { publicKey: 'issuer', role: 'admin' },
+  signature: 'sig',
+});
+
+jest.mock('@/services/localIdentity', () => ({
+  getPublicKeyHex: jest.fn().mockResolvedValue('buyer-public-key'),
+}));
+
+jest.mock('@/services/kycReceipts', () => ({
+  loadKycReceipt: jest.fn(),
+  issueKycReceipt: jest.fn(),
+}));
 
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
@@ -53,6 +81,10 @@ jest.mock('@/constants/tenant', () => ({
 }));
 
 describe('card checkout fee deduction', () => {
+  beforeEach(() => {
+    (loadKycReceipt as jest.Mock).mockResolvedValue(makeReceipt());
+  });
+
   it('deducts platform fee for card payments', async () => {
     jest
       .spyOn<any, any>(OrderService.prototype as any, 'simulateOrderProgress')

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -2,9 +2,37 @@ import OrderService from '@/services/orders';
 import { deployOrderPayment } from '@/services/nearContract';
 import { CartItem, ShippingAddress } from '../types';
 import { requestScopes } from '@/services/session';
+import { loadKycReceipt } from '@/services/kycReceipts';
+import { getDeviceHash } from '@/utils/getDeviceHash';
 
 const mockStore: Record<string, any> = {};
 const mockProducts: Record<string, any> = {};
+
+const deviceHash = getDeviceHash();
+
+const makeReceipt = (buyerPublicKey = 'buyer-public-key') => ({
+  type: 'kyc.receipt',
+  payload: {
+    receiptId: 'receipt-123',
+    buyerPublicKey,
+    issuerPublicKey: 'issuer',
+    issuedAt: new Date(0).toISOString(),
+    data: { deviceHash },
+    ts: Date.now(),
+    nonce: 'nonce',
+  },
+  sender: { publicKey: 'issuer', role: 'admin' },
+  signature: 'sig',
+});
+
+jest.mock('@/services/localIdentity', () => ({
+  getPublicKeyHex: jest.fn().mockResolvedValue('buyer-public-key'),
+}));
+
+jest.mock('@/services/kycReceipts', () => ({
+  loadKycReceipt: jest.fn(),
+  issueKycReceipt: jest.fn(),
+}));
 
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
@@ -68,6 +96,7 @@ describe('multi-seller checkout flow', () => {
     for (const key of Object.keys(mockProducts)) {
       delete mockProducts[key];
     }
+    (loadKycReceipt as jest.Mock).mockResolvedValue(makeReceipt());
   });
 
   it('creates separate orders per seller with near payment', async () => {
@@ -157,6 +186,56 @@ describe('multi-seller checkout flow', () => {
     expect(firstPayload.sellerAddress).toBe('seller_s1');
     expect(firstPayload.payment.method).toBe('near');
     expect(firstPayload.payment.contractAddress).toBe('escrow_5');
+  });
+
+  it('rejects checkout without a verified kyc receipt', async () => {
+    jest
+      .spyOn<any, any>(OrderService.prototype as any, 'simulateOrderProgress')
+      .mockImplementation(() => {});
+
+    const svc = OrderService.getInstance();
+
+    const item: CartItem = {
+      id: 'i1',
+      productId: 'p1',
+      product: {
+        id: 'p1',
+        name: 'P1',
+        price: 5,
+        description: 'd',
+        category: 'c',
+        images: [],
+        rating: 0,
+        reviews: 0,
+        storeId: 's1',
+        stock: 10,
+      },
+      quantity: 1,
+      addedAt: '',
+    };
+    mockProducts['p1'] = { ...item.product };
+
+    const shipping: ShippingAddress = {
+      name: 'A',
+      phone: '1',
+      street: 'st',
+      city: 'c',
+      postalCode: 'p',
+    };
+
+    (loadKycReceipt as jest.Mock).mockResolvedValue(null);
+
+    const { token } = requestScopes(['checkout'], () => 'sig');
+
+    await expect(
+      svc.createOrdersFromCart('user1', [item], shipping, 'near', token),
+    ).rejects.toThrow('KYC receipt missing or invalid');
+
+    const eventBus = require('@/services/eventBus');
+    expect(eventBus.track).toHaveBeenCalledWith('checkout.token_integrity', {
+      tokenValid: true,
+      success: false,
+    });
   });
 
   it('rejects checkout when session is missing the checkout scope', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -259,6 +259,7 @@ export interface Order {
   escrowAddr?: string;
   disputeEvidenceUri?: string;
   itemsHash: string;
+  kycReceiptId?: string;
   createdAt: string;
   updatedAt: string;
   trackingSteps: OrderTrackingStep[];


### PR DESCRIPTION
## Summary
- verify checkout KYC receipts before creating orders by matching the receipt to the local device and attaching its id to saved orders and emitted events
- extend the shared Order type so downstream consumers can read the recorded KYC receipt id
- update order-related tests to mock KYC receipts/local identity and cover the KYC missing case

## Testing
- yarn jest --config jest.config.js --coverage=false tests/cardCheckoutFee.test.ts tests/multiSellerCheckout.test.ts tests/auth/checkoutSessionToken.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8fbbc25908326a415cfa47010c314