### PR TITLE
Add contact store action to product detail

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -443,21 +443,45 @@ export default function ProductDetailScreen() {
                 {t('productDetail.stock', 'In stock')}: {isStockKnown ? rawStock : t('common.unknown', 'Unknown')}
               </Text>
             </View>
-            <DisabledTooltip label={disabledReason}>
+            <View style={styles.actionButtons}>
               <Button
-                onPress={handleAddToCart}
-                loading={adding}
-                disabled={isOutOfStock || isProductDisabled}
-                accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
+                onPress={handleContactStore}
+                loading={contacting}
+                disabled={!storeIdentifier || contacting}
+                accessibilityLabel={t('productDetail.contactStore', 'Contact store')}
+                accessibilityHint={t(
+                  'productDetail.contactStoreHint',
+                  'Open a chat with this store.',
+                )}
+                tooltip={t('productDetail.contactStoreHint', 'Open a chat with this store.')}
+                style={[
+                  styles.secondaryButton,
+                  { backgroundColor: colors.surface.secondary, borderColor: colors.border.primary },
+                ]}
               >
                 <View style={styles.buttonContent}>
-                  <ShoppingCart size={18} color={colors.text.inverse} />
-                  <Text style={[styles.buttonText, { color: colors.text.inverse }]}> 
-                    {t('productDetail.addToCart', 'Add to cart')}
+                  <MessageCircle size={18} color={colors.text.primary} />
+                  <Text style={[styles.buttonText, { color: colors.text.primary }]}>
+                    {t('productDetail.contactStore', 'Contact store')}
                   </Text>
                 </View>
               </Button>
-            </DisabledTooltip>
+              <DisabledTooltip label={disabledReason}>
+                <Button
+                  onPress={handleAddToCart}
+                  loading={adding}
+                  disabled={isOutOfStock || isProductDisabled}
+                  accessibilityLabel={t('productDetail.addToCart', 'Add to cart')}
+                >
+                  <View style={styles.buttonContent}>
+                    <ShoppingCart size={18} color={colors.text.inverse} />
+                    <Text style={[styles.buttonText, { color: colors.text.inverse }]}>
+                      {t('productDetail.addToCart', 'Add to cart')}
+                    </Text>
+                  </View>
+                </Button>
+              </DisabledTooltip>
+            </View>
           </View>
         </View>
       )}

--- a/translations/en.json
+++ b/translations/en.json
@@ -221,6 +221,7 @@
   },
   "productDetail": {
     "contactStore": "Contact store",
+    "contactStoreHint": "Open a chat with this store.",
     "contactStoreError": "We could not start a chat with this store. Please try again later."
   },
   "category": {

--- a/translations/he.json
+++ b/translations/he.json
@@ -218,6 +218,7 @@
   },
   "productDetail": {
     "contactStore": "צור קשר עם החנות",
+    "contactStoreHint": "פתח צ'אט עם החנות.",
     "contactStoreError": "לא ניתן להתחיל צ'אט עם החנות. נסה שוב מאוחר יותר."
   },
   "category": {


### PR DESCRIPTION
## Summary
- add a translated "Contact store" button to the product detail action area
- wire the button to open the direct message flow with the store and navigate to messages
- add supporting accessibility hint translations in English and Hebrew

## Testing
- yarn lint *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c93ea76eb88326a0f032301f9974ac