### PR TITLE
Verify KYC receipt proof on orders

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -22,6 +22,7 @@ import { checkoutTokenIntegrity } from '@/services/monitoring';
 import SettingsAgent from '@/agents/settings-agent';
 import { loadKycReceipt } from '@/services/kycReceipts';
 import { getPublicKeyHex } from '@/services/localIdentity';
+import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
@@ -31,6 +32,8 @@ const KYC_RECEIPT_ERROR = 'KYC receipt missing or invalid';
 type VerifiedKycReceipt = {
   receiptId: string;
   buyerPublicKey: string;
+  signature: string;
+  hash: string;
 };
 
 export async function emitOrderEvents(
@@ -149,6 +152,26 @@ class OrderService {
       return fail('buyer_key_mismatch');
     }
 
+    if (!receipt.signature || typeof receipt.signature !== 'string') {
+      return fail('signature_missing');
+    }
+
+    const issuerPublicKey = receipt.payload.issuerPublicKey;
+    const senderPublicKey = receipt.sender?.publicKey;
+
+    if (typeof senderPublicKey !== 'string' || senderPublicKey.length === 0) {
+      return fail('issuer_missing');
+    }
+
+    if (issuerPublicKey !== senderPublicKey) {
+      return fail('issuer_mismatch');
+    }
+
+    const signatureValid = await verifyMessageSignature(receipt, senderPublicKey);
+    if (!signatureValid) {
+      return fail('signature_invalid');
+    }
+
     const data = receipt.payload.data || {};
     let receiptDeviceHash: string | undefined;
     if (data && typeof data === 'object') {
@@ -164,9 +187,29 @@ class OrderService {
       return fail('device_hash_mismatch');
     }
 
+    const receiptHash = Buffer.from(
+      sha256(
+        Buffer.from(
+          canonicalJson({
+            type: receipt.type,
+            payload: receipt.payload,
+            sender: receipt.sender,
+            signature: receipt.signature,
+          }),
+        ),
+      ),
+    ).toString('hex');
+
+    const sealedHash = session.sealed?.kycReceiptHash;
+    if (typeof sealedHash === 'string' && sealedHash !== receiptHash) {
+      return fail('receipt_hash_mismatch');
+    }
+
     return {
       receiptId: receipt.payload.receiptId,
       buyerPublicKey,
+      signature: receipt.signature,
+      hash: receiptHash,
     };
   }
 
@@ -233,6 +276,8 @@ class OrderService {
       platformFee: feeInfo?.platformFee,
       sellerPayout: feeInfo?.sellerPayout,
       kycReceiptId: kyc.receiptId,
+      kycReceiptHash: kyc.hash,
+      kycReceiptSignature: kyc.signature,
     };
 
     await ordersAgent.add(order);

--- a/services/session.ts
+++ b/services/session.ts
@@ -30,6 +30,7 @@ export interface EncryptedScopePayload {
   cipher: string;
   walletPublicKey: string;
   identityPublicKey: string;
+  kycReceiptHash?: string;
 }
 
 export interface SessionToken {
@@ -42,6 +43,7 @@ export interface SessionToken {
 
 export interface ScopeRequestOptions {
   sealed?: EncryptedScopePayload | (() => EncryptedScopePayload | undefined);
+  kycReceiptHash?: string;
 }
 
 export type SyncSessionSigner = (message: string) => string;
@@ -151,8 +153,16 @@ export function requestScopes(
 
     const persist = (maybeToken: string | undefined): SessionToken => {
       const token = maybeToken || uuid();
-      const sealed =
+      const resolvedSealed =
         typeof options.sealed === 'function' ? options.sealed() : options.sealed;
+      const receiptHash =
+        typeof options.kycReceiptHash === 'string' && options.kycReceiptHash.length > 0
+          ? options.kycReceiptHash
+          : undefined;
+      const sealed =
+        resolvedSealed && receiptHash
+          ? { ...resolvedSealed, kycReceiptHash: receiptHash }
+          : resolvedSealed;
       const record: SessionToken = sealed
         ? { token, scopes, exp, sealed, deviceHash }
         : { token, scopes, exp, deviceHash };

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -38,6 +38,10 @@ jest.mock('@/services/kycReceipts', () => ({
   issueKycReceipt: jest.fn(),
 }));
 
+jest.mock('@/utils/verifyMessageSignature', () => ({
+  verifyMessageSignature: jest.fn().mockResolvedValue(true),
+}));
+
 jest.mock('@noble/hashes/sha256', () => ({
   sha256: () => new Uint8Array(32),
 }));
@@ -183,6 +187,9 @@ describe('login issues session token used in checkout', () => {
     expect(mockAddOrder).toHaveBeenCalled();
     const passedOrder = mockAddOrder.mock.calls[0][0];
     expect(passedOrder.sessionToken).toBe('checkout-token');
+    expect(passedOrder.kycReceiptSignature).toBe('sig');
+    expect(typeof passedOrder.kycReceiptHash).toBe('string');
+    expect(passedOrder.kycReceiptHash).toHaveLength(64);
   });
 });
 

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -33,6 +33,10 @@ jest.mock('@/services/kycReceipts', () => ({
   issueKycReceipt: jest.fn(),
 }));
 
+jest.mock('@/utils/verifyMessageSignature', () => ({
+  verifyMessageSignature: jest.fn().mockResolvedValue(true),
+}));
+
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
   getOrder: jest.fn(async (id: string) => mockStore[id] || null),
@@ -130,6 +134,8 @@ describe('card checkout fee deduction', () => {
     expect(order.total).toBe(100);
     expect(order.platformFee).toBeCloseTo(2.5);
     expect(order.sellerPayout).toBeCloseTo(97.5);
+    expect(order.kycReceiptSignature).toBe('sig');
+    expect(typeof order.kycReceiptHash).toBe('string');
   });
 });
 

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -34,6 +34,10 @@ jest.mock('@/services/kycReceipts', () => ({
   issueKycReceipt: jest.fn(),
 }));
 
+jest.mock('@/utils/verifyMessageSignature', () => ({
+  verifyMessageSignature: jest.fn().mockResolvedValue(true),
+}));
+
 jest.mock('@/services/nearOrders', () => ({
   setOrder: jest.fn(async (o: any) => { mockStore[o.id] = o; }),
   getOrder: jest.fn(async (id: string) => mockStore[id] || null),
@@ -168,6 +172,8 @@ describe('multi-seller checkout flow', () => {
     expect(orders.every((o) => o.paymentTxHash && o.paymentContractAddress)).toBe(
       true,
     );
+    expect(orders.every((o) => o.kycReceiptSignature === 'sig')).toBe(true);
+    expect(orders.every((o) => typeof o.kycReceiptHash === 'string')).toBe(true);
 
     const eventBus = require('@/services/eventBus');
     expect(eventBus.publish).toHaveBeenCalledTimes(4);

--- a/types/index.ts
+++ b/types/index.ts
@@ -265,6 +265,8 @@ export interface Order {
   disputeEvidenceUri?: string;
   itemsHash: string;
   kycReceiptId?: string;
+  kycReceiptHash?: string;
+  kycReceiptSignature?: string;
   createdAt: string;
   updatedAt: string;
   trackingSteps: OrderTrackingStep[];


### PR DESCRIPTION
## Summary
- verify KYC receipt signatures and compute a canonical hash before creating orders
- persist KYC receipt proof details on orders and allow session tokens to carry the receipt hash
- update checkout-focused tests to mock signature verification and assert the new proof fields

## Testing
- yarn jest tests/auth/checkoutSessionToken.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c93e93eb488326a038b39c799577a2