### PR TITLE
Add helper for KYC capture cleanup and adjust encryption flow

### DIFF
--- a/services/kycUpload.ts
+++ b/services/kycUpload.ts
@@ -2,9 +2,21 @@ import { Buffer } from 'buffer';
 import { sha256 } from '@noble/hashes/sha256';
 import { canonicalJson } from '@/utils/serialization';
 import { deriveSharedKey, deriveChatSalt, aesEncrypt } from '@/utils/encryption';
+import { cleanupTrackedKycCapturedPaths } from '@/utils/kycTemp';
 import { getEd25519KeyPair } from './localIdentity';
 import PinataService from './pinata';
 import * as FileSystem from 'expo-file-system';
+
+type ExpoFsExtras = {
+  EncodingType?: {
+    Base64?: string;
+    UTF8?: string;
+  };
+  cacheDirectory?: string;
+  temporaryDirectory?: string;
+};
+
+const expoFs = FileSystem as typeof FileSystem & ExpoFsExtras;
 
 export interface KycUploadFile {
   uri: string;
@@ -25,8 +37,9 @@ function toFilePath(uri: string): string {
 
 async function readBinary(uri: string): Promise<Buffer> {
   if (typeof FileSystem.readAsStringAsync === 'function') {
+    const base64Encoding = expoFs.EncodingType?.Base64 ?? 'base64';
     const base64 = await FileSystem.readAsStringAsync(uri, {
-      encoding: (FileSystem.EncodingType as any)?.Base64 ?? 'base64',
+      encoding: base64Encoding as any,
     });
     return Buffer.from(base64, 'base64');
   }
@@ -45,11 +58,12 @@ function randomSuffix(): string {
 async function writeTemp(contents: string): Promise<string> {
   if (
     typeof FileSystem.writeAsStringAsync === 'function' &&
-    typeof FileSystem.cacheDirectory === 'string'
+    typeof expoFs.cacheDirectory === 'string'
   ) {
-    const path = `${FileSystem.cacheDirectory}kyc-${randomSuffix()}.json`;
+    const path = `${expoFs.cacheDirectory}kyc-${randomSuffix()}.json`;
+    const utf8Encoding = expoFs.EncodingType?.UTF8 ?? 'utf8';
     await FileSystem.writeAsStringAsync(path, contents, {
-      encoding: (FileSystem.EncodingType as any)?.UTF8 ?? 'utf8',
+      encoding: utf8Encoding as any,
     });
     return path;
   }
@@ -79,10 +93,10 @@ async function cleanupSource(uri: string): Promise<void> {
   if (!uri) return;
   if (
     typeof FileSystem.deleteAsync === 'function' &&
-    (typeof FileSystem.cacheDirectory === 'string' ||
-      typeof FileSystem.temporaryDirectory === 'string')
+    (typeof expoFs.cacheDirectory === 'string' ||
+      typeof expoFs.temporaryDirectory === 'string')
   ) {
-    const { cacheDirectory, temporaryDirectory } = FileSystem;
+    const { cacheDirectory, temporaryDirectory } = expoFs;
     if (
       (cacheDirectory && uri.startsWith(cacheDirectory)) ||
       (temporaryDirectory && uri.startsWith(temporaryDirectory))
@@ -141,8 +155,9 @@ export async function encryptForTenant(
     const name = file.name || 'document';
     const type = file.type || 'application/octet-stream';
     const buffer = await readBinary(file.uri);
-    const hash = Buffer.from(sha256(buffer)).toString('hex');
-    const base64 = buffer.toString('base64');
+    const bytes = buffer instanceof Uint8Array ? new Uint8Array(buffer) : Uint8Array.from(buffer);
+    const hash = Buffer.from(sha256(bytes)).toString('hex');
+    const base64 = Buffer.from(bytes).toString('base64');
     enriched.push({
       name,
       type,
@@ -158,7 +173,8 @@ export async function encryptForTenant(
     files: enriched.map(({ name, type, size, hash }) => ({ name, type, size, hash })),
   };
 
-  const manifestHash = Buffer.from(sha256(Buffer.from(canonicalJson(manifest)))).toString('hex');
+  const manifestBytes = Buffer.from(canonicalJson(manifest));
+  const manifestHash = Buffer.from(sha256(new Uint8Array(manifestBytes))).toString('hex');
 
   const payload = {
     ...manifest,
@@ -181,16 +197,21 @@ export async function encryptForTenant(
   try {
     const pinata = PinataService.getInstance();
     uploaded = await pinata.uploadFile(tempPath, `kyc-${Date.now()}.json`);
+
+    await cleanupTrackedKycCapturedPaths(enriched.map(({ sourceUri }) => sourceUri));
+    await Promise.all(enriched.map(({ sourceUri }) => cleanupSource(sourceUri)));
   } finally {
     await removeFile(tempPath);
-    await Promise.all(enriched.map(({ sourceUri }) => cleanupSource(sourceUri)));
   }
+
+  const encryptedBodyBytes = Buffer.from(encryptedBody);
+  const encryptedBodyHash = Buffer.from(sha256(new Uint8Array(encryptedBodyBytes))).toString('hex');
 
   let finalUri = uploaded ?? '';
   if (!uploaded || uploaded === tempPath || uploaded === `file://${tempPath}`) {
-    finalUri = `ipfs://${Buffer.from(sha256(Buffer.from(encryptedBody))).toString('hex')}`;
+    finalUri = `ipfs://${encryptedBodyHash}`;
   } else {
-    finalUri = ensureIpfs(uploaded, `ipfs://${Buffer.from(sha256(Buffer.from(encryptedBody))).toString('hex')}`);
+    finalUri = ensureIpfs(uploaded, `ipfs://${encryptedBodyHash}`);
   }
 
   return { uri: finalUri, hash: manifestHash };

--- a/tests/kycUpload.test.ts
+++ b/tests/kycUpload.test.ts
@@ -1,19 +1,62 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { sha256 } from '@noble/hashes/sha256';
-import { getPublicKey, utils as edUtils } from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+import { etc, getPublicKey, utils as edUtils } from '@noble/ed25519';
+import { randomBytes, randomUUID } from 'crypto';
 import { canonicalJson } from '@/utils/serialization';
 import PinataService from '@/services/pinata';
 import { encryptForTenant } from '@/services/kycUpload';
+import {
+  resetTrackedKycCapturedPaths,
+  trackKycCapturedPath,
+  untrackKycCapturedPath,
+} from '@/utils/kycTemp';
+
+jest.mock('@/services/localIdentity', () => ({
+  getEd25519KeyPair: jest.fn(async () => ({
+    privateKey: new Uint8Array(32).fill(1),
+    publicKey: new Uint8Array(32).fill(2),
+  })),
+}));
+
+Object.defineProperty(globalThis, 'crypto', {
+  configurable: true,
+  value: {
+    getRandomValues: (array: Uint8Array) => {
+      const bytes = randomBytes(array.length);
+      array.set(bytes);
+      return array;
+    },
+    randomUUID: () => randomUUID(),
+    subtle: {
+      importKey: async () => ({}) as CryptoKey,
+      encrypt: async (
+        _algo: AlgorithmIdentifier | AesKeyAlgorithm,
+        _key: CryptoKey,
+        data: ArrayBufferView | ArrayBuffer,
+      ) => (data instanceof ArrayBuffer ? data : (data as ArrayBufferView).buffer),
+      decrypt: async (
+        _algo: AlgorithmIdentifier | AesKeyAlgorithm,
+        _key: CryptoKey,
+        data: ArrayBufferView | ArrayBuffer,
+      ) => (data instanceof ArrayBuffer ? data : (data as ArrayBufferView).buffer),
+    },
+  } as unknown as Crypto,
+});
 
 describe('encryptForTenant', () => {
+  if (!etc.sha512Sync) {
+    etc.sha512Sync = (message: Uint8Array) => sha512(message);
+  }
+
   afterEach(() => {
+    resetTrackedKycCapturedPaths();
     jest.restoreAllMocks();
   });
 
   it('returns encrypted uri and hash while cleaning temporary files', async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kyc-upload-'));
+    const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'kyc-upload-test-'));
     const filePath = path.join(tempDir, 'doc.png');
     fs.writeFileSync(filePath, 'hello');
 
@@ -27,6 +70,7 @@ describe('encryptForTenant', () => {
       const tenantPub = await getPublicKey(tenantPriv);
       const tenantPubHex = Buffer.from(tenantPub).toString('hex');
 
+      trackKycCapturedPath(filePath);
       const result = await encryptForTenant(tenantPubHex, [
         { uri: filePath, name: 'doc.png' },
       ]);
@@ -35,18 +79,48 @@ describe('encryptForTenant', () => {
       expect(uploadSpy.mock.calls[0][0]).toContain('kyc-');
       expect(result.uri).toBe('ipfs://cid123');
 
-      const fileHash = Buffer.from(sha256(Buffer.from('hello'))).toString('hex');
+      const fileBytes = Buffer.from('hello');
+      const fileHash = Buffer.from(sha256(new Uint8Array(fileBytes))).toString('hex');
       const manifest = {
         version: 1,
         files: [
           { name: 'doc.png', type: 'application/octet-stream', size: 5, hash: fileHash },
         ],
       };
-      const expectedHash = Buffer.from(sha256(Buffer.from(canonicalJson(manifest)))).toString('hex');
+      const manifestBytes = Buffer.from(canonicalJson(manifest));
+      const expectedHash = Buffer.from(sha256(new Uint8Array(manifestBytes))).toString('hex');
       expect(result.hash).toBe(expectedHash);
 
       expect(fs.existsSync(filePath)).toBe(false);
     } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps tracked captures when upload fails', async () => {
+    const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'kyc-upload-failure-'));
+    const filePath = path.join(tempDir, 'doc.png');
+    fs.writeFileSync(filePath, 'hello');
+
+    try {
+      const pinata = PinataService.getInstance();
+      jest
+        .spyOn(pinata, 'uploadFile')
+        .mockRejectedValue(new Error('upload failed'));
+
+      const tenantPriv = edUtils.randomPrivateKey();
+      const tenantPub = await getPublicKey(tenantPriv);
+      const tenantPubHex = Buffer.from(tenantPub).toString('hex');
+
+      trackKycCapturedPath(filePath);
+
+      await expect(
+        encryptForTenant(tenantPubHex, [{ uri: filePath, name: 'doc.png' }]),
+      ).rejects.toThrow('upload failed');
+
+      expect(fs.existsSync(filePath)).toBe(true);
+    } finally {
+      untrackKycCapturedPath(filePath);
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/utils/encryption.ts
+++ b/utils/encryption.ts
@@ -56,7 +56,9 @@ export function deriveChatSalt(aHex: string, bHex: string): Uint8Array {
   const a = Buffer.from(aHex, 'hex');
   const b = Buffer.from(bHex, 'hex');
   const [first, second] = [a, b].sort(Buffer.compare);
-  return sha256(Buffer.concat([first, second]));
+  const merged = Buffer.concat([first, second]);
+  const data = new Uint8Array(merged.buffer, merged.byteOffset, merged.byteLength);
+  return sha256(data);
 }
 
 /**

--- a/utils/kycTemp.ts
+++ b/utils/kycTemp.ts
@@ -1,0 +1,86 @@
+import * as FileSystem from 'expo-file-system';
+
+const trackedPaths = new Set<string>();
+
+function isTrackableUri(uri: string): boolean {
+  if (!uri) return false;
+  return uri.startsWith('file://') || uri.startsWith('/') || uri.startsWith('content://');
+}
+
+function toExpoUri(uri: string): string {
+  if (uri.startsWith('file://') || uri.startsWith('content://')) {
+    return uri;
+  }
+  return `file://${uri}`;
+}
+
+function toFsPath(uri: string): string {
+  return uri.startsWith('file://') ? uri.slice('file://'.length) : uri;
+}
+
+async function deleteUri(uri: string): Promise<void> {
+  const expoUri = toExpoUri(uri);
+
+  if (typeof FileSystem.deleteAsync === 'function') {
+    try {
+      await FileSystem.deleteAsync(expoUri, { idempotent: true });
+      return;
+    } catch {}
+  }
+
+  if (uri.startsWith('content://')) {
+    return;
+  }
+
+  try {
+    const fs = await import('fs/promises');
+    await fs.unlink(toFsPath(uri));
+  } catch {}
+}
+
+export function trackKycCapturedPath(uri?: string | null): void {
+  if (!uri) return;
+  if (!isTrackableUri(uri)) return;
+  trackedPaths.add(uri);
+}
+
+export function untrackKycCapturedPath(uri?: string | null): void {
+  if (!uri) return;
+  trackedPaths.delete(uri);
+}
+
+export async function cleanupTrackedKycCapturedPaths(
+  uris?: Iterable<string>,
+): Promise<void> {
+  const targets = new Set<string>();
+
+  if (uris) {
+    for (const uri of uris) {
+      if (uri && trackedPaths.has(uri)) {
+        targets.add(uri);
+      }
+    }
+  } else {
+    for (const uri of trackedPaths) {
+      targets.add(uri);
+    }
+  }
+
+  if (!targets.size) return;
+
+  await Promise.all(
+    [...targets].map(async (uri) => {
+      await deleteUri(uri);
+      trackedPaths.delete(uri);
+    }),
+  );
+}
+
+export function getTrackedKycCapturedPaths(): string[] {
+  return [...trackedPaths];
+}
+
+export function resetTrackedKycCapturedPaths(): void {
+  trackedPaths.clear();
+}
+


### PR DESCRIPTION
## Summary
- add a KYC temp helper to track captured image URIs and clear them once uploads succeed
- update encryptForTenant to clean tracked captures only after a successful upload and to hash using Uint8Array buffers
- adjust deriveChatSalt and the KYC upload test suite for the new helper and Node test environment stubs

## Testing
- node node_modules/jest/bin/jest.js --config jest.config.js --testMatch '<rootDir>/tests/kycUpload.test.ts' --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68c93e950530832685254c7ff793d721