### PR TITLE
Add disabled metadata to products and update add-to-cart tooltip

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -238,7 +238,19 @@ export default function ProductDetailScreen() {
   const isStockKnown = rawStock !== undefined && rawStock !== null;
   const isOutOfStock = isStockKnown ? rawStock <= 0 : true;
   const isProductDisabled = Boolean(product?.disabled);
-  const disabledReason = isProductDisabled ? product?.disabledReason : undefined;
+  const productDisabledReason = product?.disabledReason;
+  const disabledReason = useMemo(() => {
+    if (!isProductDisabled) {
+      return undefined;
+    }
+
+    const reason = productDisabledReason?.trim();
+    if (reason && reason.length > 0) {
+      return reason;
+    }
+
+    return t('productDetail.disabledFallback', 'This product is currently unavailable.');
+  }, [isProductDisabled, productDisabledReason, t]);
 
   if (!productId) {
     return (

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,8 @@ export interface Product {
   mixGroupId?: string;
   storeId: string;
   stock: number;
+  disabled?: boolean;
+  disabledReason?: string;
   isActive?: boolean;
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary
- add optional disabled metadata fields to the Product type definition
- surface disabled messaging on the product screen with a translated fallback tooltip when products are disabled

## Testing
- yarn lint *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c93eae1f2c8326a4d83dd802ff76a2