### PR TITLE
Enhance product gallery accessibility metadata

### DIFF
--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -294,6 +294,10 @@ export default function ProductDetailScreen() {
 
   const galleryProductName =
     product?.name || t('productDetail.galleryFallbackProductName', 'this product');
+  const galleryAccessibilityHint = t(
+    'productDetail.galleryScrollHint',
+    'Swipe left or right to browse more media items.',
+  );
 
   return (
     <ScrollView
@@ -470,17 +474,14 @@ export default function ProductDetailScreen() {
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={{ gap: spacing.spacer12, paddingVertical: spacing.spacer12 }}
-            accessibilityHint={t(
-              'productDetail.galleryScrollHint',
-              'Swipe left or right to browse more media items.',
-            )}
+            accessibilityHint={galleryAccessibilityHint}
           >
             {media.map((item, index) => {
               const fallbackDescription =
                 item.type === 'video'
                   ? t('productDetail.galleryVideoLabel', 'Video')
                   : t('productDetail.galleryImageLabel', 'Image');
-              const description = item.name || fallbackDescription;
+              const description = item.name?.trim() || fallbackDescription;
               const accessibilityLabel = t(
                 'productDetail.galleryItemAccessibilityLabel',
                 '{description} for {productName}. Item {index} of {total}.',

--- a/jest.config.js
+++ b/jest.config.js
@@ -155,6 +155,7 @@ const cfg = {
     '<rootDir>/tests/featuredStoresCarousel.test.tsx',
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/productCardAccessibility.test.tsx',
+    '<rootDir>/tests/productGalleryAccessibility.test.tsx',
     '<rootDir>/tests/productDetail.test.tsx',
     '<rootDir>/tests/themeContrast.test.tsx',
     '<rootDir>/tests/priceRange.test.tsx',

--- a/tests/productGalleryAccessibility.test.tsx
+++ b/tests/productGalleryAccessibility.test.tsx
@@ -157,10 +157,22 @@ describe('Product gallery accessibility', () => {
     });
   });
 
-  it('provides accessibility metadata for gallery images', async () => {
+  const renderProductGallery = async () => {
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
     await act(async () => {
-      renderer.create(<ProductDetailScreen />);
+      testRenderer = renderer.create(<ProductDetailScreen />);
     });
+
+    if (!testRenderer) {
+      throw new Error('Failed to render the product gallery');
+    }
+
+    return testRenderer;
+  };
+
+  it('provides accessibility metadata for gallery images', async () => {
+    const testRenderer = await renderProductGallery();
 
     const galleryImageProps = mockSmartImage.mock.calls.reduce<Record<string, any>[]>(
       (acc, call) => {
@@ -181,5 +193,25 @@ describe('Product gallery accessibility', () => {
     expect(galleryImageProps[1].accessibilityLabel).toBe(
       'Side profile for Accessible Product. Item 2 of 2.',
     );
+
+    testRenderer.unmount();
+  });
+
+  it('announces how to browse the gallery', async () => {
+    const testRenderer = await renderProductGallery();
+
+    const horizontalScrollViews = testRenderer.root.findAll(
+      (node) => Boolean(node.props?.horizontal),
+    );
+
+    expect(horizontalScrollViews.length).toBeGreaterThan(0);
+
+    const galleryScrollView = horizontalScrollViews[0];
+
+    expect(galleryScrollView.props.accessibilityHint).toBe(
+      'Swipe left or right to browse more media items.',
+    );
+
+    testRenderer.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- hoist the gallery scroll hint so the thumbnail ScrollView always exposes a consistent gesture prompt and trim media names before building accessibility labels
- extend the product gallery accessibility test harness with a reusable renderer helper and coverage for the ScrollView hint
- register the new product gallery accessibility suite with Jest so it is executed with the rest of the accessibility tests

## Testing
- yarn jest tests/productGalleryAccessibility.test.tsx *(fails: TypeScript diagnostics in existing services and product typing surfaced by ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c93eb3cdbc8326bc7b4c4482ecc735