### PR TITLE
Fix profile quick actions and store type

### DIFF
--- a/src/features/profile/components/ProfileOverview.tsx
+++ b/src/features/profile/components/ProfileOverview.tsx
@@ -6,7 +6,6 @@ import { useWallet } from '@/contexts/WalletProvider';
 import { chainAdapter } from '@/services/chain';
 import { Heading, Text, Card, Button } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
-import { routes } from '@/utils/routes';
 import { listStores } from '@/features/stores/services/nearStores';
 import { Store } from '@/types';
 import { useNotificationActions } from '@/components/NotificationContext';
@@ -48,7 +47,8 @@ export default function ProfileOverview() {
       const amt = await chainAdapter.getBalance(address);
       setBalance(amt);
       const all = await listStores('default');
-      setStores(all.filter((s) => s.owner === address));
+      const owner = address?.toLowerCase() || '';
+      setStores(all.filter((s) => (s.owner || '').toLowerCase() === owner));
       // NFTs: disabled by default to avoid web bundle issues. Enable behind a flag in the future.
     } finally {
       setLoading(false);
@@ -64,6 +64,24 @@ export default function ProfileOverview() {
     const sum = stores.reduce((acc, s) => acc + (s.reputation || 0), 0);
     return Math.round((sum / stores.length) * 10) / 10; // 1 decimal
   }, [stores]);
+
+  const primaryStore = useMemo(() => {
+    return stores[0] ?? null;
+  }, [stores]);
+
+  const handleViewOrders = useCallback(() => {
+    push('/orders');
+  }, [push]);
+
+  const handleOpenSettings = useCallback(() => {
+    push('/settings');
+  }, [push]);
+
+  const handleManageStore = useCallback(() => {
+    if (!primaryStore) return;
+    void prefetchStoreBundle(primaryStore.id);
+    push(`/store/${primaryStore.id}/admin`);
+  }, [primaryStore, push]);
 
   if (!address) {
     return (

--- a/types/index.ts
+++ b/types/index.ts
@@ -51,6 +51,7 @@ export interface Store {
   reputation?: number;
   plan?: 'free' | 'premium';
   createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- add quick action handlers to the profile overview, including a primary store lookup and navigation helpers
- filter owned stores case-insensitively and prefetch admin bundles before navigation
- extend the `Store` type with an optional `updatedAt` timestamp so persisted records type-check

## Testing
- yarn typecheck *(fails: existing TypeScript errors in unrelated modules such as HMRClient.ts and app/orders/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c95cce69f48326be6d9f63e97b1b07