### PR TITLE
Load tenant KYC policy for cart checkout

### DIFF
--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -53,8 +53,22 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import { requestTokenWithConsent, getCheckoutRequestScopes } from '@/services/session';
 import { uuid } from '@/utils/uuid';
 import NotificationService from '@/services/notification';
+import SettingsAgent from '@/agents/settings-agent';
+import { errorLog } from '@/utils/logger';
+import { persistCheckoutIntent, clearCheckoutIntent } from '../services/orderIntent';
 
 const PRODUCT_CACHE_TOPIC = '/blue-ocean/products/1';
+
+const BOOLEAN_TRUE_VALUES = new Set(['1', 'true', 'yes', 'y', 'on']);
+const BOOLEAN_FALSE_VALUES = new Set(['0', 'false', 'no', 'n', 'off']);
+
+function parseBooleanSetting(value: string | null): boolean | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+  if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+  return null;
+}
 
 interface CartModalProps {
   visible: boolean;
@@ -104,6 +118,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   });
 
   const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [kycRequired, setKycRequired] = useState<boolean | null>(null);
 
   const ensureSessionToken = async (): Promise<string> => {
     await requireUnlock('checkout');
@@ -116,7 +131,24 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     return token;
   };
 
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const setting = await SettingsAgent.getInstance().getSettingValue('kyc.required');
+        if (cancelled) return;
+        setKycRequired(parseBooleanSetting(setting));
+      } catch (err) {
+        errorLog('Failed to load kyc.required setting', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible]);
 
+  
   useEffect(() => {
     if (visible) {
       // reset flow
@@ -183,7 +215,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     }
 
     // KYC gate
-    if (user && user.kycStatus !== 'verified') {
+    if (kycRequired !== false && user && user.kycStatus !== 'verified') {
       let message = '';
       switch (user.kycStatus) {
         case 'none':
@@ -206,6 +238,10 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           confirmText: t('kyc.goToKyc'),
           cancelText: t('common.cancel'),
           action: () => {
+            void persistCheckoutIntent(cartItems, getTotal(), {
+              step: 'shipping',
+              returnPath: { pathname: '/', params: { showCart: 'true' } },
+            });
             onClose();
             push('/kyc');
           },
@@ -221,6 +257,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       return;
     }
 
+    void clearCheckoutIntent();
     eventBus.track('checkout.start', { items: cartItems.length, total: getTotal() });
     setCheckoutStep('shipping');
   };
@@ -310,6 +347,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
       setOrderIds(orders.map((o) => o.id));
       setOrderPlaced(true);
       await clearCart();
+      await clearCheckoutIntent();
 
       showNotification(
         t('cart.orderReceived'),

--- a/src/features/cart/services/orderIntent.ts
+++ b/src/features/cart/services/orderIntent.ts
@@ -1,0 +1,89 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { errorLog } from '@/utils/logger';
+import type { CartItem } from '@/types';
+
+export const CHECKOUT_INTENT_STORAGE_KEY = 'checkout.intent';
+
+export type CheckoutIntentStep = 'cart' | 'shipping' | 'payment' | 'confirmation';
+
+export interface CheckoutReturnPath {
+  pathname: string;
+  params?: Record<string, string>;
+}
+
+export interface CheckoutIntentItem {
+  id: string;
+  productId: string;
+  storeId?: string;
+  quantity: number;
+  unitPrice: number;
+  name: string;
+  image?: string | null;
+}
+
+export interface CheckoutIntent {
+  createdAt: number;
+  step: CheckoutIntentStep;
+  total: number;
+  returnPath: CheckoutReturnPath;
+  items: CheckoutIntentItem[];
+}
+
+export interface PersistCheckoutIntentOptions {
+  step?: CheckoutIntentStep;
+  returnPath?: CheckoutReturnPath;
+}
+
+function serializeItems(cartItems: CartItem[]): CheckoutIntentItem[] {
+  return cartItems.map((item) => ({
+    id: item.id,
+    productId: item.productId,
+    storeId: item.product.storeId,
+    quantity: item.quantity,
+    unitPrice: item.unitPrice ?? item.product.price,
+    name: item.product.name,
+    image: item.product.images?.[0] ?? null,
+  }));
+}
+
+export async function persistCheckoutIntent(
+  cartItems: CartItem[],
+  total: number,
+  options: PersistCheckoutIntentOptions = {},
+): Promise<void> {
+  const intent: CheckoutIntent = {
+    createdAt: Date.now(),
+    step: options.step ?? 'cart',
+    total,
+    returnPath: options.returnPath ?? { pathname: '/', params: { showCart: 'true' } },
+    items: serializeItems(cartItems),
+  };
+
+  try {
+    await AsyncStorage.setItem(
+      CHECKOUT_INTENT_STORAGE_KEY,
+      JSON.stringify(intent),
+    );
+  } catch (error) {
+    errorLog('Failed to persist checkout intent', error);
+  }
+}
+
+export async function loadCheckoutIntent(): Promise<CheckoutIntent | null> {
+  try {
+    const raw = await AsyncStorage.getItem(CHECKOUT_INTENT_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as CheckoutIntent;
+  } catch (error) {
+    errorLog('Failed to load checkout intent', error);
+    return null;
+  }
+}
+
+export async function clearCheckoutIntent(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(CHECKOUT_INTENT_STORAGE_KEY);
+  } catch (error) {
+    errorLog('Failed to clear checkout intent', error);
+  }
+}


### PR DESCRIPTION
## Summary
- load the tenant `kyc.required` setting when the cart modal opens and gate checkout only when required
- persist checkout intent before redirecting unverified buyers to the KYC flow and clear it once checkout continues or completes
- add a cart order intent storage helper for saving and clearing the intended checkout context

## Testing
- npx eslint src/features/cart/components/CartModal.tsx src/features/cart/services/orderIntent.ts *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c966161fe88326bb5cde86cdb23aa2