### PR TITLE
Gate MoonPay button behind feature flag

### DIFF
--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -37,9 +37,14 @@ if (chain === 'near') {
 
 import OrderService from '@/services/orders';
 import eventBus from '@/services/eventBus';
-import { Spinner } from '@/ui/primitives';
+import { Button, Spinner } from '@/ui/primitives';
 import { getCacheHitRatio } from '@/services/warmCache';
-const MoonPayButton = require('@/features/payments').MoonPayButton;
+import { isMoonPayEnabled } from '@/config/featureFlags';
+const {
+  MoonPayButton,
+  MOONPAY_DISABLED_LABEL,
+  MOONPAY_DISABLED_TOOLTIP,
+} = require('@/features/payments');
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTheme } from '@/ui/ThemeProvider';
 import commonStyles from '@/constants/styles';
@@ -100,6 +105,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const { push } = useAppRouter();
   const scrollViewRef = useRef<ScrollView>(null);
   const { requireUnlock } = useLaunchGate();
+  const moonPayEnabled = useMemo(() => isMoonPayEnabled(), []);
 
   // Info/confirm modals
   const [infoModal, setInfoModal] = useState({
@@ -777,7 +783,16 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           </TouchableOpacity>
         </View>
 
-        <MoonPayButton usdAmount={getTotal()} />
+        {moonPayEnabled ? (
+          <MoonPayButton usdAmount={getTotal()} />
+        ) : (
+          <Button
+            title={MOONPAY_DISABLED_LABEL}
+            disabled
+            tooltip={MOONPAY_DISABLED_TOOLTIP}
+            style={styles.moonPayDisabledButton}
+          />
+        )}
 
         <View
           style={[
@@ -1447,6 +1462,7 @@ const styles = StyleSheet.create({
   completeOrderButton: { borderRadius: 12, paddingVertical: 12, paddingHorizontal: 24, alignItems: 'center', minWidth: 180 },
   completeOrderText: { fontSize: 16, fontWeight: '600' },
   buttonDisabled: { opacity: 0.5 },
+  moonPayDisabledButton: { marginTop: 16 },
   paymentOptions: { marginBottom: 24 },
   paymentOption: {
     flexDirection: 'row',

--- a/src/features/payments/components/MoonPayButton.tsx
+++ b/src/features/payments/components/MoonPayButton.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react';
 import { Button } from '@/ui';
 import { useAppInfo } from '@/contexts/AppInfoContext';
 import { useWallet } from '@/contexts/WalletProvider';
+import { isMoonPayEnabled } from '@/config/featureFlags';
 import MoonPayModal from './MoonPayModal';
+
+export const MOONPAY_DISABLED_LABEL = 'תשלום בכרטיס — בקרוב';
+export const MOONPAY_DISABLED_TOOLTIP =
+  'תשלום בכרטיס יהיה זמין לאחר הפעלת MoonPay באזור שלך.';
 
 interface MoonPayButtonProps {
   usdAmount: number;
@@ -14,6 +19,18 @@ export default function MoonPayButton({ usdAmount }: MoonPayButtonProps) {
   const { address: walletAddress, connect } = useWallet();
   const [visible, setVisible] = useState(false);
   const [amountNEAR, setAmountNEAR] = useState<number | undefined>(undefined);
+  const moonPayEnabled = isMoonPayEnabled();
+
+  if (!moonPayEnabled) {
+    return (
+      <Button
+        title={MOONPAY_DISABLED_LABEL}
+        disabled
+        style={{ marginTop: 16 }}
+        tooltip={MOONPAY_DISABLED_TOOLTIP}
+      />
+    );
+  }
 
   if (!fiatKey) return null;
 

--- a/src/features/payments/index.ts
+++ b/src/features/payments/index.ts
@@ -1,4 +1,8 @@
 export { default as EscrowStatusTracker } from './components/EscrowStatusTracker';
-export { default as MoonPayButton } from './components/MoonPayButton';
+export {
+  default as MoonPayButton,
+  MOONPAY_DISABLED_LABEL,
+  MOONPAY_DISABLED_TOOLTIP,
+} from './components/MoonPayButton';
 export { default as MoonPayModal } from './components/MoonPayModal';
 export { default as PayPrivatelyButton } from './components/PayPrivatelyButton';


### PR DESCRIPTION
## Summary
- gate the MoonPay checkout button behind the moonpay feature flag and present a disabled tooltip state when unavailable
- export shared MoonPay disabled label + tooltip constants for reuse across the cart flow
- avoid invoking MoonPay pricing calls when the feature is turned off

## Testing
- pnpm lint *(fails: missing @typescript-eslint/parser because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c973a21a008326b3f740ca1df2eafd