### PR TITLE
Add checkout nonce guard for cart orders

### DIFF
--- a/services/orders.ts
+++ b/services/orders.ts
@@ -17,7 +17,11 @@ import { chainAdapter } from '@/services/chain';
 import { adminResolve, deployOrderPayment } from './nearContract';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
-import { assertCheckoutScope, getSession } from '@/services/session';
+import {
+  assertCheckoutScope,
+  getSession,
+  setSessionCheckoutNonce,
+} from '@/services/session';
 import { checkoutTokenIntegrity } from '@/services/monitoring';
 import SettingsAgent from '@/agents/settings-agent';
 import { loadKycReceipt } from '@/services/kycReceipts';
@@ -35,6 +39,16 @@ type VerifiedKycReceipt = {
   signature: string;
   hash: string;
 };
+
+interface OrderDraft {
+  sessionToken: string;
+  nonce: string;
+  storeId: string;
+  total: number;
+  itemsHash: string;
+  buyerAddress?: string;
+  sellerAddress?: string;
+}
 
 export async function emitOrderEvents(
   order: Order,
@@ -74,6 +88,7 @@ export async function emitOrderEvents(
 class OrderService {
   private static instance: OrderService;
   private listeners: Set<() => void> = new Set();
+  private checkoutNonceLocks: Map<string, string> = new Map();
 
   private constructor() {
     ordersAgent.subscribe(() => this.notifyListeners());
@@ -96,6 +111,42 @@ class OrderService {
 
   public removeListener(listener: () => void) {
     this.listeners.delete(listener);
+  }
+
+  private reserveCheckoutNonce(sessionToken: string, nonce: string): void {
+    if (typeof nonce !== 'string' || nonce.length === 0) {
+      throw new Error('ERR_DUPLICATE_NONCE');
+    }
+    const active = this.checkoutNonceLocks.get(sessionToken);
+    if (active) {
+      throw new Error('ERR_DUPLICATE_NONCE');
+    }
+    const session = getSession(sessionToken);
+    if (session?.checkoutNonce && session.checkoutNonce !== nonce) {
+      throw new Error('ERR_DUPLICATE_NONCE');
+    }
+    this.checkoutNonceLocks.set(sessionToken, nonce);
+    setSessionCheckoutNonce(sessionToken, nonce);
+  }
+
+  private releaseCheckoutNonce(sessionToken: string, nonce: string): void {
+    const active = this.checkoutNonceLocks.get(sessionToken);
+    if (active === nonce) {
+      this.checkoutNonceLocks.delete(sessionToken);
+      setSessionCheckoutNonce(sessionToken, null);
+    }
+  }
+
+  private async deployEscrow(
+    draft: OrderDraft,
+  ): Promise<{ contractAddress: string; txHash: string }> {
+    debugLog('Deploying escrow', {
+      nonce: draft.nonce,
+      storeId: draft.storeId,
+      total: draft.total,
+      itemsHash: draft.itemsHash,
+    });
+    return deployOrderPayment(draft.total);
   }
 
   private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
@@ -225,6 +276,8 @@ class OrderService {
       sellerAddress?: string;
     },
     sessionToken: string,
+    nonce: string,
+    storeId: string,
     verifiedKyc?: VerifiedKycReceipt,
   ): Promise<Order> {
     assertCheckoutScope(sessionToken);
@@ -234,12 +287,25 @@ class OrderService {
       return sum + price * item.quantity;
     }, 0);
 
+    const itemsHash = Buffer.from(
+      sha256(Buffer.from(canonicalJson(items)))
+    ).toString('hex');
+
     let pay = payment;
     if (pay?.method === 'near' && (!pay.contractAddress || !pay.txHash)) {
       if (!chainAdapter.getAccountId()) {
         await chainAdapter.openModal();
       }
-      const { contractAddress, txHash } = await deployOrderPayment(total);
+      const draft: OrderDraft = {
+        sessionToken,
+        nonce,
+        storeId,
+        total,
+        itemsHash,
+        buyerAddress: pay?.buyerAddress,
+        sellerAddress: pay?.sellerAddress,
+      };
+      const { contractAddress, txHash } = await this.deployEscrow(draft);
       pay = { ...pay, contractAddress, txHash };
     }
 
@@ -249,9 +315,6 @@ class OrderService {
 
     const orderId = uuid();
     const timestamp = new Date().toISOString();
-    const itemsHash = Buffer.from(
-      sha256(Buffer.from(canonicalJson(items)))
-    ).toString('hex');
     const feeInfo =
       pay?.method === 'card' ? await calculateCardFees(total) : undefined;
 
@@ -292,6 +355,7 @@ class OrderService {
     shippingAddress: ShippingAddress,
     paymentMethod: 'cash_on_delivery' | 'near' | 'card' = 'cash_on_delivery',
     sessionToken: string,
+    nonce: string,
   ): Promise<Order[]> {
     try {
       assertCheckoutScope(sessionToken);
@@ -303,6 +367,7 @@ class OrderService {
       checkoutTokenIntegrity.inc({ token_valid: 'false', success: 'false' });
       throw err;
     }
+    this.reserveCheckoutNonce(sessionToken, nonce);
     try {
       const verifiedKyc = await this.verifyKycReceipt(sessionToken);
       const grouped: Record<string, CartItem[]> = {};
@@ -339,6 +404,8 @@ class OrderService {
           shippingAddress,
           payment,
           sessionToken,
+          nonce,
+          storeId,
           verifiedKyc,
         );
         await emitOrderEvents(order, storeId, sessionToken);
@@ -357,6 +424,8 @@ class OrderService {
       });
       checkoutTokenIntegrity.inc({ token_valid: 'true', success: 'false' });
       throw err;
+    } finally {
+      this.releaseCheckoutNonce(sessionToken, nonce);
     }
   }
 

--- a/services/session.ts
+++ b/services/session.ts
@@ -39,6 +39,7 @@ export interface SessionToken {
   exp: number;
   deviceHash: string;
   sealed?: EncryptedScopePayload;
+  checkoutNonce?: string;
 }
 
 export interface ScopeRequestOptions {
@@ -322,6 +323,24 @@ export async function requestTokenWithConsent(
 
 export function getSession(token: string): SessionToken | undefined {
   return store.get(token);
+}
+
+export function setSessionCheckoutNonce(
+  token: string,
+  nonce: string | null,
+): void {
+  const session = store.get(token);
+  if (!session) return;
+  if (typeof nonce === 'string' && nonce.length > 0) {
+    session.checkoutNonce = nonce;
+  } else if ('checkoutNonce' in session) {
+    delete session.checkoutNonce;
+  }
+  void saveSession(session);
+}
+
+export function getSessionCheckoutNonce(token: string): string | undefined {
+  return store.get(token)?.checkoutNonce;
 }
 
 export async function revokeToken(token: string): Promise<void> {

--- a/services/tokenCache.ts
+++ b/services/tokenCache.ts
@@ -25,6 +25,7 @@ export async function saveSession(record: SessionToken): Promise<void> {
       scopes: record.scopes,
       exp: record.exp,
       deviceHash: record.deviceHash,
+      ...(record.checkoutNonce ? { checkoutNonce: record.checkoutNonce } : {}),
       ...(record.sealed ? { sealed: record.sealed } : {}),
     } satisfies SessionToken;
     await SecureStore.setItemAsync(
@@ -52,6 +53,7 @@ export async function loadSessions(): Promise<SessionToken[]> {
         exp?: unknown;
         deviceHash?: unknown;
         sealed?: unknown;
+        checkoutNonce?: unknown;
       };
       if (
         parsed &&
@@ -75,6 +77,10 @@ export async function loadSessions(): Promise<SessionToken[]> {
         ) {
           continue;
         }
+        const checkoutNonce =
+          typeof parsed.checkoutNonce === 'string' && parsed.checkoutNonce.length > 0
+            ? parsed.checkoutNonce
+            : undefined;
         const record: SessionToken = sealed
           ? {
               token: parsed.token,
@@ -82,12 +88,14 @@ export async function loadSessions(): Promise<SessionToken[]> {
               exp: parsed.exp,
               deviceHash: parsed.deviceHash,
               sealed,
+              ...(checkoutNonce ? { checkoutNonce } : {}),
             }
           : {
               token: parsed.token,
               scopes: parsed.scopes as string[],
               exp: parsed.exp,
               deviceHash: parsed.deviceHash,
+              ...(checkoutNonce ? { checkoutNonce } : {}),
             };
         out.push(record);
       }

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -50,7 +50,11 @@ import { useLaunchGate } from '@/features/launchGate';
 import { useAppRouter } from '@/services';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
-import { requestTokenWithConsent, getCheckoutRequestScopes } from '@/services/session';
+import {
+  requestTokenWithConsent,
+  getCheckoutRequestScopes,
+  setSessionCheckoutNonce,
+} from '@/services/session';
 import { uuid } from '@/utils/uuid';
 import NotificationService from '@/services/notification';
 import SettingsAgent from '@/agents/settings-agent';
@@ -92,6 +96,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const [loading, setLoading] = useState(false);
   const [orderPlaced, setOrderPlaced] = useState(false);
   const [orderIds, setOrderIds] = useState<string[]>([]);
+  const [checkoutNonce, setCheckoutNonce] = useState<string | null>(null);
   const { isLoggedIn, user } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
@@ -328,8 +333,15 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
   const placeOrder = async () => {
     if (!validateShippingAddress()) return;
     const token = await ensureSessionToken();
+    let nonce = checkoutNonce;
+    if (!nonce) {
+      nonce = uuid();
+      setCheckoutNonce(nonce);
+      setSessionCheckoutNonce(token, nonce);
+    }
 
     setLoading(true);
+    let resetNonce = false;
     try {
       const orders = await OrderService.getInstance().createOrdersFromCart(
         user?.id || 'guest',
@@ -337,7 +349,9 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
         shippingAddress,
         'near',
         token,
+        nonce,
       );
+      resetNonce = true;
       eventBus.track('checkout.complete', {
         orderIds: orders.map((o) => o.id),
         total: getTotal(),
@@ -357,7 +371,14 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
 
       setTimeout(() => onClose(), 5000);
     } catch (error: any) {
-      if (error?.message === '{E_EXPIRED}' || error?.message === '{E_SCOPE}') {
+      if (error?.message === 'ERR_DUPLICATE_NONCE') {
+        setInfoModal({
+          visible: true,
+          title: t('common.error'),
+          message: t('cart.paymentAlreadyProcessing'),
+          type: 'warning',
+        });
+      } else if (error?.message === '{E_EXPIRED}' || error?.message === '{E_SCOPE}') {
         setInfoModal({
           visible: true,
           title: t('common.error'),
@@ -372,8 +393,15 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           type: 'error',
         });
       }
+      if (error?.message !== 'ERR_DUPLICATE_NONCE') {
+        resetNonce = true;
+      }
     } finally {
       setLoading(false);
+      if (resetNonce) {
+        setCheckoutNonce(null);
+        setSessionCheckoutNonce(token, null);
+      }
     }
   };
 

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -182,7 +182,14 @@ describe('login issues session token used in checkout', () => {
     };
 
     requestScopes(['checkout'], () => 'checkout-token');
-    await svc.createOrdersFromCart('user1', [item], shipping, 'cash_on_delivery', 'checkout-token');
+    await svc.createOrdersFromCart(
+      'user1',
+      [item],
+      shipping,
+      'cash_on_delivery',
+      'checkout-token',
+      'nonce-auth-1',
+    );
 
     expect(mockAddOrder).toHaveBeenCalled();
     const passedOrder = mockAddOrder.mock.calls[0][0];

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -128,7 +128,14 @@ describe('card checkout fee deduction', () => {
     };
 
     const { token } = requestScopes(['checkout'], () => 'sig');
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'card', token);
+    const orders = await svc.createOrdersFromCart(
+      'user1',
+      items,
+      shipping,
+      'card',
+      token,
+      'nonce-card-1',
+    );
     expect(orders).toHaveLength(1);
     const order = orders[0];
     expect(order.total).toBe(100);

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -161,7 +161,14 @@ describe('multi-seller checkout flow', () => {
     };
 
     const { token } = requestScopes(['checkout'], () => 'sig');
-    const orders = await svc.createOrdersFromCart('user1', items, shipping, 'near', token);
+    const orders = await svc.createOrdersFromCart(
+      'user1',
+      items,
+      shipping,
+      'near',
+      token,
+      'nonce-multi-1',
+    );
     expect(orders).toHaveLength(2);
     expect(deployOrderPayment).toHaveBeenCalledTimes(2);
     const totals = orders.map((o) => o.total).sort();
@@ -234,7 +241,7 @@ describe('multi-seller checkout flow', () => {
     const { token } = requestScopes(['checkout'], () => 'sig');
 
     await expect(
-      svc.createOrdersFromCart('user1', [item], shipping, 'near', token),
+      svc.createOrdersFromCart('user1', [item], shipping, 'near', token, 'nonce-multi-2'),
     ).rejects.toThrow('KYC receipt missing or invalid');
 
     const eventBus = require('@/services/eventBus');
@@ -282,7 +289,7 @@ describe('multi-seller checkout flow', () => {
     const { token } = requestScopes(['read'], () => 'sig');
 
     await expect(
-      svc.createOrdersFromCart('user1', [item], shipping, 'near', token),
+      svc.createOrdersFromCart('user1', [item], shipping, 'near', token, 'nonce-multi-3'),
     ).rejects.toThrow('{E_SCOPE}');
 
     const eventBus = require('@/services/eventBus');

--- a/translations/en.json
+++ b/translations/en.json
@@ -562,6 +562,7 @@
     "orderReceived": "Order Received",
     "ordersCreated": "Created {count} orders successfully",
     "orderCreationError": "An error occurred while creating the order",
+    "paymentAlreadyProcessing": "Payment already processing",
     "invalidSession": "Session expired. Please refresh and try again",
     "shippingAddress": "Shipping Address",
     "fullName": "Full Name *",

--- a/translations/he.json
+++ b/translations/he.json
@@ -552,6 +552,7 @@
     "orderReceived": "הזמנה התקבלה",
     "ordersCreated": "נוצרו {count} הזמנות בהצלחה",
     "orderCreationError": "אירעה שגיאה ביצירת ההזמנה",
+    "paymentAlreadyProcessing": "התשלום כבר בתהליך",
     "invalidSession": "אסימון הסשן פג. נא לרענן ולנסות שוב",
     "shippingAddress": "כתובת משלוח",
     "fullName": "שם מלא *",


### PR DESCRIPTION
## Summary
- generate and store a checkout nonce in the cart modal so duplicate submissions surface a "Payment already processing" warning
- lock checkout attempts per session nonce in the order service and deploy escrow with an order draft carrying the nonce
- persist the nonce on session tokens, update translations, and adjust tests for the new order service signature

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser)*
- yarn test --watch=false *(fails: script not found in package.json)*
- yarn typecheck *(fails: missing project type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68c973f1277c8326882ccbfa44745223