### PR TITLE
Use badges for order status

### DIFF
--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -14,7 +14,7 @@ import type { Order, OrderStatus } from '@/types';
 import { useOrders } from '@/services/useOrders';
 import { ordersWarmCache } from '@/services/nearOrders';
 import ordersAgent, { ALLOWED_STATUS_TRANSITIONS } from '@/agents/orders-agent';
-import { Spinner } from '@/ui/primitives';
+import { Badge, Spinner } from '@/ui/primitives';
 import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
 import OrderTrackingModal from '@/components/OrderTrackingModal';
 import { useAppRouter } from '@/services';
@@ -47,6 +47,13 @@ function formatDate(value?: string): string {
   } catch {
     return value;
   }
+}
+
+function formatStatusLabel(status: OrderStatus): string {
+  return status
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 }
 
 function getFilterPredicate(filter: FilterKey): (order: Order) => boolean {
@@ -304,6 +311,7 @@ interface OrderRowProps {
 }
 
 function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProps) {
+  const { t } = useLanguage();
   const actionableStatuses: OrderStatus[] = [
     'order_received',
     'courier_found',
@@ -312,6 +320,19 @@ function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProp
   ];
   const actionable = actionableStatuses.includes(order.status);
   const cancellable = ['order_received', 'courier_found'].includes(order.status);
+  const statusColors: Record<OrderStatus, string> = {
+    order_received: colors.status.info,
+    courier_found: colors.status.info,
+    courier_picked_up: colors.status.info,
+    courier_on_way: colors.status.info,
+    delivered: colors.status.success,
+    disputed: colors.status.warning,
+    released: colors.status.success,
+    refunded: colors.status.error,
+  };
+  const currentStatusLabel = t('orders.currentStatus', 'סטטוס');
+  const statusLabel = t(`orders.status.${order.status}`, formatStatusLabel(order.status));
+  const badgeColor = statusColors[order.status] ?? colors.status.info;
   return (
     <View
       style={[
@@ -323,7 +344,16 @@ function OrderRow({ order, colors, busy, onMarkShipped, onCancel }: OrderRowProp
         <Text style={{ color: colors.text.secondary }}>{formatDate(order.createdAt)}</Text>
       </View>
       <View style={styles.orderMeta}>
-        <Text style={{ color: colors.text.secondary }}>סטטוס: {order.status}</Text>
+        <View style={styles.statusRow}>
+          <Text style={{ color: colors.text.secondary }}>{`${currentStatusLabel}:`}</Text>
+          <Badge
+            label={statusLabel}
+            style={[styles.statusBadge, { backgroundColor: badgeColor }]}
+            accessibilityRole="text"
+            accessibilityLabel={`${currentStatusLabel}: ${statusLabel}`}
+            accessible
+          />
+        </View>
         <Text style={{ color: colors.text.secondary }}>
           סכום: ₪{order.total.toLocaleString('he-IL')}
         </Text>
@@ -367,7 +397,9 @@ const styles = StyleSheet.create({
   },
   orderHeader: { flexDirection: 'row', justifyContent: 'space-between' },
   orderTitle: { fontSize: 16, fontWeight: '600' },
-  orderMeta: { flexDirection: 'row', justifyContent: 'space-between' },
+  orderMeta: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  statusRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  statusBadge: { alignSelf: 'center' },
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
   secondaryButton: {
     borderWidth: 1,

--- a/src/ui/primitives/Badge.tsx
+++ b/src/ui/primitives/Badge.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { View, Text, StyleProp, ViewStyle, TextStyle } from 'react-native';
+import { View, Text, StyleProp, ViewStyle, TextStyle, AccessibilityProps } from 'react-native';
 import { useTheme } from '../ThemeProvider';
 import { radius, spacing, typography } from '../tokens';
 
-interface BadgeProps {
+interface BadgeProps extends AccessibilityProps {
   label: string;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
 }
 
-export default function Badge({ label, style, textStyle }: BadgeProps) {
+export default function Badge({ label, style, textStyle, ...accessibilityProps }: BadgeProps) {
   const { colors } = useTheme();
   return (
     <View
@@ -19,6 +19,7 @@ export default function Badge({ label, style, textStyle }: BadgeProps) {
         paddingHorizontal: spacing.spacer8,
         paddingVertical: spacing.spacer4,
       }, style]}
+      {...accessibilityProps}
     >
       <Text style={[{ color: colors.text.inverse, ...typography.sm }, textStyle]}>{label}</Text>
     </View>

--- a/translations/en.json
+++ b/translations/en.json
@@ -631,6 +631,7 @@
       "courier_picked_up": "Courier Picked Up",
       "courier_on_way": "Courier On The Way",
       "delivered": "Delivered",
+      "disputed": "Disputed",
       "released": "Payment released",
       "refunded": "Payment refunded"
     },

--- a/translations/he.json
+++ b/translations/he.json
@@ -621,6 +621,7 @@
       "courier_picked_up": "שליח אסף",
       "courier_on_way": "שליח בדרך",
       "delivered": "נמסר",
+      "disputed": "מחלוקת",
       "released": "תשלום שוחרר",
       "refunded": "תשלום הוחזר"
     },


### PR DESCRIPTION
## Summary
- render order status chips with the shared Badge component and theme-based colors
- expose accessibility props on the Badge primitive and add fallback formatting for status labels
- localize the disputed status label in English and Hebrew

## Testing
- yarn lint *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c99b976f4c8326bc1911bb24a2fbcd