### PR TITLE
Add paginated order loading and load more control

### DIFF
--- a/app/orders/index.tsx
+++ b/app/orders/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RefreshControl, StyleSheet, View } from 'react-native';
 import { ScrollArea, Container, Stack } from '@/ui/layout';
-import { Heading, Skeleton } from '@/ui/primitives';
+import { Button, Heading, Skeleton, Text } from '@/ui/primitives';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import EmptyState from '@/shared/ui/EmptyState';
 import { useWallet } from '@/contexts/WalletProvider';
@@ -10,6 +10,8 @@ import { Order } from '@/types';
 import { errorLog } from '@/utils/logger';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { AlertTriangle, RefreshCw, ShoppingCart } from 'lucide-react-native';
+
+const PAGE_SIZE = 20;
 
 function OrderSkeletonRow() {
   return (
@@ -70,6 +72,7 @@ export default function OrdersScreen() {
   const { t } = useLanguage();
   const { address, connect } = useWallet();
   const [orders, setOrders] = useState<Order[]>([]);
+  const [remainingOrders, setRemainingOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -93,7 +96,8 @@ export default function OrdersScreen() {
           const bTime = new Date(b.createdAt || 0).getTime();
           return bTime - aTime;
         });
-        setOrders(sorted);
+        setOrders(sorted.slice(0, PAGE_SIZE));
+        setRemainingOrders(sorted.slice(PAGE_SIZE));
       } catch (err) {
         errorLog('Failed to load buyer orders', err);
         setError(t('orders.loadError', 'Unable to load your orders. Please try again.'));
@@ -111,6 +115,7 @@ export default function OrdersScreen() {
   useEffect(() => {
     if (!address || !supportsBuyerOrders) {
       setOrders([]);
+      setRemainingOrders([]);
       return;
     }
     fetchOrders('initial').catch(() => {});
@@ -119,6 +124,15 @@ export default function OrdersScreen() {
   const handleRefresh = useCallback(() => {
     void fetchOrders('refresh');
   }, [fetchOrders]);
+
+  const handleLoadMore = useCallback(() => {
+    setRemainingOrders((prevRemaining) => {
+      if (prevRemaining.length === 0) return prevRemaining;
+      const nextBatch = prevRemaining.slice(0, PAGE_SIZE);
+      setOrders((prevOrders) => [...prevOrders, ...nextBatch]);
+      return prevRemaining.slice(PAGE_SIZE);
+    });
+  }, []);
 
   if (!supportsBuyerOrders) {
     return (
@@ -204,6 +218,9 @@ export default function OrdersScreen() {
                 background={colors.surface.primary}
               />
             ))}
+            {remainingOrders.length > 0 ? (
+              <Button title={t('common.loadMore', 'Load more')} onPress={handleLoadMore} />
+            ) : null}
           </Stack>
         )}
       </Container>


### PR DESCRIPTION
## Summary
- limit the initial buyer order fetch to the first 20 results and keep the remainder for pagination
- add a Load more action that appends the next 20 cached orders
- reset the stored pagination state when the user or network capability changes so cached data renders before refresh

## Testing
- yarn lint app/orders/index.tsx *(fails: missing module `@typescript-eslint/parser`)*

------
https://chatgpt.com/codex/tasks/task_e_68c99b96d2d4832694417c9e94133893