### PR TITLE
Add disputes feature flag and gate order dispute action

### DIFF
--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -34,6 +34,7 @@ import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useLaunchGate } from '@/features/launchGate';
 import { formatTimestamp } from '@/utils/formatTimestamp';
+import { isDisputesEnabled } from '@/config/featureFlags';
 
 
 
@@ -54,6 +55,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
   const { requireUnlock } = useLaunchGate();
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
+  const disputesEnabled = isDisputesEnabled();
 
   useEffect(() => {
     if (visible && order) {
@@ -363,17 +365,47 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
 
             {/* Cancel Order Button */}
             {(order.status === 'order_received' || order.status === 'courier_found') && (
-              <TouchableOpacity 
+              <TouchableOpacity
                 style={[styles.cancelButton, { backgroundColor: colors.status.error }]}
                 onPress={cancelOrder}
               >
                 <Text style={[styles.cancelButtonText, { color: colors.text.inverse }]}>ביטול הזמנה</Text>
               </TouchableOpacity>
             )}
+            <TouchableOpacity
+              style={[
+                styles.disputeButton,
+                disputesEnabled
+                  ? { backgroundColor: colors.status.warning }
+                  : {
+                      backgroundColor: colors.surface.secondary,
+                      borderColor: colors.border.primary,
+                      borderWidth: 1,
+                    },
+              ]}
+              disabled={!disputesEnabled}
+              activeOpacity={disputesEnabled ? 0.7 : 1}
+              onPress={() => {
+                if (!disputesEnabled) return;
+                Alert.alert(t('orders.openDispute', 'Open dispute'));
+              }}
+              accessibilityRole="button"
+            >
+              <Text
+                style={[
+                  styles.disputeButtonText,
+                  { color: disputesEnabled ? colors.text.inverse : colors.text.secondary },
+                ]}
+              >
+                {disputesEnabled
+                  ? t('orders.openDispute', 'Open dispute')
+                  : t('orders.disputeComingSoon', 'בקרוב')}
+              </Text>
+            </TouchableOpacity>
           </View>
 
           {/* Order Info */}
-          <View style={[styles.orderInfo, { 
+          <View style={[styles.orderInfo, {
             backgroundColor: colors.surface.primary,
             borderColor: colors.border.primary 
           }]}>
@@ -632,6 +664,16 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   cancelButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  disputeButton: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  disputeButtonText: {
     fontSize: 14,
     fontWeight: '600',
   },

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -29,6 +29,7 @@ const envSchema = z.object({
     .optional()
     .default('false'),
   EXPO_PUBLIC_FEATURE_MOONPAY: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_DISPUTES: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -141,9 +142,14 @@ export function triggerDeliveryNotificationsRollback(): void {
 export { deliveryNotificationsFlag };
 
 const moonPayFeatureEnabled = env.EXPO_PUBLIC_FEATURE_MOONPAY === 'true';
+const disputesFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DISPUTES === 'true';
 
 export function isMoonPayEnabled(): boolean {
   return moonPayFeatureEnabled;
+}
+
+export function isDisputesEnabled(): boolean {
+  return disputesFeatureEnabled;
 }
 
 export default warmCacheFlag;

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -79,6 +79,25 @@ describe('moonpay feature flag', () => {
   });
 });
 
+describe('disputes feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_DISPUTES;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isDisputesEnabled } = require('@/config/featureFlags');
+    expect(isDisputesEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_DISPUTES = 'true';
+    jest.resetModules();
+    const { isDisputesEnabled } = require('@/config/featureFlags');
+    expect(isDisputesEnabled()).toBe(true);
+  });
+});
+
 describe('notifications pipeline feature flag', () => {
   beforeEach(() => {
     delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;

--- a/translations/en.json
+++ b/translations/en.json
@@ -651,7 +651,9 @@
     "notFoundTitle": "Order not found",
     "notFoundMessage": "We couldn't find that order",
     "statusUpdated": "Order status updated",
-    "updateStatusFailed": "Failed to update status"
+    "updateStatusFailed": "Failed to update status",
+    "openDispute": "Open dispute",
+    "disputeComingSoon": "Coming soon"
   },
   "store": {
     "store_name": "Store Name",

--- a/translations/he.json
+++ b/translations/he.json
@@ -641,7 +641,9 @@
     "notFoundTitle": "הזמנה לא נמצאה",
     "notFoundMessage": "לא הצלחנו למצוא את ההזמנה הזו",
     "statusUpdated": "סטטוס ההזמנה עודכן",
-    "updateStatusFailed": "עדכון הסטטוס נכשל"
+    "updateStatusFailed": "עדכון הסטטוס נכשל",
+    "openDispute": "פתח מחלוקת",
+    "disputeComingSoon": "בקרוב"
   },
   "store": {
     "store_name": "שם החנות",


### PR DESCRIPTION
## Summary
- extend feature flag configuration with a disputes toggle and coverage tests
- add English and Hebrew translations for the dispute action labels
- surface an order dispute call-to-action that is enabled only when the new flag is active and shows a coming-soon state otherwise

## Testing
- Not run (project dependencies are not installed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68c99b9099f4832683f012d691af28ef