### PR TITLE
feat: add unified order timeline and guard admin actions

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -38,6 +38,9 @@ import { normalizeMessage } from '../lib/normalizeMessage';
 import AgentError from '@/types/AgentError';
 import { canonicalJson } from '@/utils/serialization';
 
+const ORDER_TOPIC = '/blue-ocean/orders/1';
+const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
+
 export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   order_received: ['courier_found', 'refunded'],
   courier_found: ['courier_picked_up', 'refunded'],
@@ -332,11 +335,18 @@ class OrdersAgent {
       timestamp: Date.now(),
     });
     const sid = normalized.items?.[0]?.product?.storeId || '';
-    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
+    const publishPayload = {
       ...this.buildBaseEvent(normalized),
       prevStatus: current.status,
       newStatus: normalized.status,
-    });
+    };
+    const publishOptions = {
+      orderId: normalized.id,
+      orderNonce: normalized.updatedAt || new Date().toISOString(),
+    } as const;
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(NOTIFICATION_TOPIC, 'order.updated', publishPayload, publishOptions);
     this.subscribers.forEach((cb) => cb(normalized));
     if (statusChanged) {
       await notificationsAgent.handleOrderEvent('status.updated', {
@@ -471,11 +481,18 @@ class OrdersAgent {
       timestamp: Date.now(),
     });
     const sid = normalized.items?.[0]?.product?.storeId || '';
-    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
+    const publishPayload = {
       ...this.buildBaseEvent(normalized),
       prevStatus: order.status,
       newStatus: normalized.status,
-    });
+    };
+    const publishOptions = {
+      orderId: normalized.id,
+      orderNonce: normalized.updatedAt || new Date().toISOString(),
+    } as const;
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(NOTIFICATION_TOPIC, 'order.updated', publishPayload, publishOptions);
     await eventBus.publish(buildTopic('orders', sid), 'payment.received', {
       ...this.buildBaseEvent(normalized),
     });
@@ -546,11 +563,18 @@ class OrdersAgent {
       timestamp: Date.now(),
     });
     const sid = normalized.items?.[0]?.product?.storeId || '';
-    await eventBus.publish(buildTopic('orders', sid), 'order.updated', {
+    const publishPayload = {
       ...this.buildBaseEvent(normalized),
       prevStatus: order.status,
       newStatus: normalized.status,
-    });
+    };
+    const publishOptions = {
+      orderId: normalized.id,
+      orderNonce: normalized.updatedAt || new Date().toISOString(),
+    } as const;
+    await eventBus.publish(buildTopic('orders', sid), 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(ORDER_TOPIC, 'order.updated', publishPayload, publishOptions);
+    await eventBus.publish(NOTIFICATION_TOPIC, 'order.updated', publishPayload, publishOptions);
     this.subscribers.forEach((cb) => cb(normalized));
     await notificationsAgent.handleOrderEvent('status.updated', {
       orderId: normalized.id,

--- a/app/orders/[orderId].tsx
+++ b/app/orders/[orderId].tsx
@@ -12,6 +12,10 @@ import { Order } from '@/types';
 import { errorLog } from '@/utils/logger';
 import { AlertTriangle, RefreshCw, ShoppingCart } from 'lucide-react-native';
 import { useAppRouter } from '@/services/useAppRouter';
+import { ordersWarmCache } from '@/services/nearOrders';
+import { loadKycReceipt } from '@/services/kycReceipts';
+import { getPublicKeyHex } from '@/services/localIdentity';
+import OrderTimeline from '@/components/OrderTimeline';
 
 function formatDateTime(value?: string): string {
   if (!value) return '—';
@@ -109,6 +113,32 @@ export default function OrderDetailScreen() {
     fetchOrder('initial').catch(() => {});
   }, [orderId, address, supportsBuyerOrders, fetchOrder]);
 
+  useEffect(() => {
+    if (!orderId) return;
+    try {
+      const unsubscribe = ordersWarmCache.subscribe(
+        (id) => id === orderId,
+        (_id, value) => {
+          if (!value) {
+            setNotFound(true);
+            return;
+          }
+          setOrder((prev) => {
+            if (prev && prev.updatedAt === value.updatedAt) {
+              return prev;
+            }
+            return value;
+          });
+          setNotFound(false);
+        },
+      );
+      return () => unsubscribe?.();
+    } catch (err) {
+      errorLog('order detail warm cache subscribe failed', err);
+      return undefined;
+    }
+  }, [orderId]);
+
   const createdAtLabel = useMemo(() => formatDateTime(order?.createdAt), [order?.createdAt]);
   const updatedAtLabel = useMemo(() => formatDateTime(order?.updatedAt), [order?.updatedAt]);
 
@@ -162,6 +192,45 @@ export default function OrderDetailScreen() {
       t('orders.detailSupportTitle', 'Need help?'),
       t('orders.detailSupportMessage', 'Support chat is on the way.'),
     );
+  }, [t]);
+
+  const handleViewReceipt = useCallback(async () => {
+    try {
+      const publicKey = await getPublicKeyHex();
+      if (!publicKey) {
+        Alert.alert(
+          t('orders.receiptUnavailableTitle', 'Receipt unavailable'),
+          t('orders.receiptUnavailableMessage', 'Connect your wallet again to view the receipt.'),
+        );
+        return;
+      }
+      const receipt = await loadKycReceipt(publicKey);
+      if (!receipt) {
+        Alert.alert(
+          t('orders.receiptMissingTitle', 'Receipt not found'),
+          t('orders.receiptMissingMessage', 'We could not find a local receipt for this order.'),
+        );
+        return;
+      }
+      const issuedAt = formatDateTime(receipt.payload.issuedAt);
+      const messageTemplate = t(
+        'orders.receiptBody',
+        'Receipt #{id}\nIssued {date}',
+      );
+      const message = messageTemplate
+        .replace('{id}', receipt.payload.receiptId)
+        .replace('{date}', issuedAt);
+      Alert.alert(
+        t('orders.receiptTitle', 'Order receipt'),
+        message,
+      );
+    } catch (err) {
+      errorLog('Failed to load receipt', err);
+      Alert.alert(
+        t('orders.receiptErrorTitle', 'Unable to load receipt'),
+        t('orders.receiptErrorMessage', 'Please try again later.'),
+      );
+    }
   }, [t]);
 
   const handleBack = useCallback(() => {
@@ -293,6 +362,10 @@ export default function OrderDetailScreen() {
         </Card>
 
         <Card>
+          <OrderTimeline order={order} withBorder={false} style={{ padding: 0 }} />
+        </Card>
+
+        <Card>
           <Stack gap="spacer12">
             <Heading size="md" style={{ color: colors.text.primary }}>
               {t('orders.detailItemsHeading', 'Items')}
@@ -401,6 +474,9 @@ export default function OrderDetailScreen() {
               </Button>
               <Button style={styles.fullWidthButton} onPress={handleContactSupport}>
                 {t('orders.detailSupportAction', 'Contact support')}
+              </Button>
+              <Button style={styles.fullWidthButton} onPress={handleViewReceipt}>
+                {t('orders.detailReceiptAction', 'View receipt')}
               </Button>
               <Button style={styles.fullWidthButton} onPress={handleBack}>
                 {t('orders.detailBackAction', 'Back to orders')}

--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -18,6 +18,7 @@ import { Badge, Spinner } from '@/ui/primitives';
 import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
 import OrderTrackingModal from '@/components/OrderTrackingModal';
 import { useAppRouter } from '@/services';
+import { promptCancelOrder } from '@/features/orders/adminActions';
 
 const SHIPPING_SEQUENCE: OrderStatus[] = [
   'order_received',
@@ -168,6 +169,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
 
   const handleMarkShipped = useCallback(
     async (order: Order) => {
+      if (pendingId === order.id) return;
       setPendingId(order.id);
       try {
         let target: OrderStatus | null = null;
@@ -179,6 +181,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
         if (!target) {
           throw new Error('לא ניתן לסמן הזמנה זו כנשלחה');
         }
+        await requireUnlock('order.fulfill');
         const pathIndex = SHIPPING_SEQUENCE.indexOf(order.status);
         let updated = order;
         if (target === 'courier_on_way' && pathIndex >= 0) {
@@ -196,38 +199,35 @@ export default function StoreOrdersScreen(): React.ReactElement {
         setPendingId(null);
       }
     },
-    [],
+    [pendingId, requireUnlock],
   );
 
   const handleCancel = useCallback(
     (order: Order) => {
-      Alert.alert('ביטול הזמנה', 'האם לבטל את ההזמנה?', [
-        { text: 'לא', style: 'cancel' },
-        {
-          text: 'כן, בטל',
-          style: 'destructive',
-          onPress: async () => {
-            setPendingId(order.id);
-            try {
-              await requireUnlock('order.cancel');
-              const updated: Order = {
-                ...order,
-                status: 'refunded',
-                updatedAt: new Date().toISOString(),
-              };
-              await ordersAgent.update(updated);
-              ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
-              setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
-            } catch (error) {
-              Alert.alert('שגיאה', 'ביטול ההזמנה נכשל');
-            } finally {
-              setPendingId(null);
-            }
-          },
+      promptCancelOrder({
+        order,
+        t,
+        onConfirm: async () => {
+          setPendingId(order.id);
+          try {
+            await requireUnlock('order.cancel');
+            const updated: Order = {
+              ...order,
+              status: 'refunded',
+              updatedAt: new Date().toISOString(),
+            };
+            await ordersAgent.update(updated);
+            ordersWarmCache.mutate({ id: updated.id, value: updated, ts: Date.now() });
+            setOrders((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+          } catch (error) {
+            Alert.alert('שגיאה', 'ביטול ההזמנה נכשל');
+          } finally {
+            setPendingId(null);
+          }
         },
-      ]);
+      });
     },
-    [requireUnlock],
+    [requireUnlock, t],
   );
 
   const closeDetails = useCallback(() => {

--- a/components/OrderTimeline.tsx
+++ b/components/OrderTimeline.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { CheckCircle, Circle } from 'lucide-react-native';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { formatTimestamp } from '@/utils/formatTimestamp';
+import type { Order, OrderStatus } from '@/types';
+import { buildTimelineEntries } from '@/features/orders/orderTimeline';
+
+interface OrderTimelineProps {
+  order: Order;
+  withBorder?: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+const STATUS_TRANSLATIONS: Record<OrderStatus, { title: string; description: string }> = {
+  order_received: {
+    title: 'orders.timeline.order_received.title',
+    description: 'orders.timeline.order_received.description',
+  },
+  courier_found: {
+    title: 'orders.timeline.courier_found.title',
+    description: 'orders.timeline.courier_found.description',
+  },
+  courier_picked_up: {
+    title: 'orders.timeline.courier_picked_up.title',
+    description: 'orders.timeline.courier_picked_up.description',
+  },
+  courier_on_way: {
+    title: 'orders.timeline.courier_on_way.title',
+    description: 'orders.timeline.courier_on_way.description',
+  },
+  delivered: {
+    title: 'orders.timeline.delivered.title',
+    description: 'orders.timeline.delivered.description',
+  },
+  released: {
+    title: 'orders.timeline.released.title',
+    description: 'orders.timeline.released.description',
+  },
+  refunded: {
+    title: 'orders.timeline.refunded.title',
+    description: 'orders.timeline.refunded.description',
+  },
+  disputed: {
+    title: 'orders.timeline.disputed.title',
+    description: 'orders.timeline.disputed.description',
+  },
+};
+
+export default function OrderTimeline({ order, withBorder = true, style }: OrderTimelineProps) {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+
+  const entries = useMemo(() => buildTimelineEntries(order), [order]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        withBorder && { borderColor: colors.border.primary, borderWidth: 1 },
+        style,
+      ]}
+    >
+      {entries.map((entry, index) => {
+        const translation = STATUS_TRANSLATIONS[entry.status];
+        const title = translation
+          ? t(translation.title, translation.title)
+          : entry.status;
+        const description = translation
+          ? t(translation.description, translation.description)
+          : '';
+        const timestampLabel = entry.timestamp
+          ? formatTimestamp(entry.timestamp)
+          : t('orders.timeline.pending', 'Pending');
+        const IconComponent = entry.completed ? CheckCircle : Circle;
+        const iconColor = entry.completed ? colors.gold : colors.interactive.disabled;
+        const textColor = entry.completed ? colors.text.primary : colors.text.secondary;
+        const secondaryColor = entry.completed ? colors.text.secondary : colors.text.tertiary;
+        return (
+          <View
+            key={`${entry.status}-${index}`}
+            style={[styles.row, index === entries.length - 1 ? styles.rowLast : null]}
+          >
+            <View style={styles.iconColumn}>
+              <IconComponent size={20} color={iconColor} />
+              {index < entries.length - 1 ? (
+                <View style={[styles.connector, { backgroundColor: colors.border.secondary }]} />
+              ) : null}
+            </View>
+            <View style={styles.contentColumn}>
+              <Text
+                style={[
+                  styles.title,
+                  { color: textColor },
+                  entry.isCurrent && { color: colors.gold },
+                ]}
+              >
+                {title}
+              </Text>
+              {description ? (
+                <Text style={[styles.description, { color: secondaryColor }]}>{description}</Text>
+              ) : null}
+              <Text style={[styles.timestamp, { color: colors.text.tertiary }]}>
+                {timestampLabel}
+              </Text>
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 12,
+    padding: 16,
+    gap: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  rowLast: {
+    paddingBottom: 0,
+  },
+  iconColumn: {
+    alignItems: 'center',
+  },
+  connector: {
+    width: 2,
+    flex: 1,
+    marginTop: 4,
+  },
+  contentColumn: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  description: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  timestamp: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+});
+

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -7,24 +7,10 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  Animated,
-  Easing,
   Alert,
-  Platform,
 } from 'react-native';
 import SmartImage from './SmartImage';
-import {
-  X,
-  CircleCheck as CheckCircle,
-  Circle,
-  Package,
-  Truck,
-  MapPin,
-  Star,
-  Phone,
-  MessageCircle,
-  Copy,
-} from 'lucide-react-native';
+import { X, MapPin, Star, Phone, MessageCircle, Copy } from 'lucide-react-native';
 import { Order, OrderStatus } from '../types';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useCurrency } from '../contexts/CurrencyContext';
@@ -35,6 +21,7 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import { useLaunchGate } from '@/features/launchGate';
 import { formatTimestamp } from '@/utils/formatTimestamp';
 import { isDisputesEnabled } from '@/config/featureFlags';
+import OrderTimeline from '@/components/OrderTimeline';
 
 
 
@@ -45,8 +32,6 @@ interface OrderTrackingModalProps {
 }
 
 export default function OrderTrackingModal({ visible, onClose, order }: OrderTrackingModalProps) {
-  const [progressAnimation] = useState(new Animated.Value(0));
-  const [currentStep, setCurrentStep] = useState(0);
   const [estimatedDelivery, setEstimatedDelivery] = useState('');
   const { isAdmin } = useAuth();
   const { t } = useLanguage();
@@ -59,27 +44,6 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
 
   useEffect(() => {
     if (visible && order) {
-      // Calculate current step based on order status
-      const statusOrder: OrderStatus[] = [
-        'order_received',
-        'courier_found',
-        'courier_picked_up',
-        'courier_on_way',
-        'delivered'
-      ];
-      
-      const stepIndex = statusOrder.indexOf(order.status);
-      setCurrentStep(stepIndex);
-      
-      // Animate progress bar
-      Animated.timing(progressAnimation, {
-        toValue: stepIndex / (statusOrder.length - 1),
-        duration: 1000,
-        easing: Easing.out(Easing.ease),
-        useNativeDriver: Platform.OS !== 'web',
-      }).start();
-      
-      // Set estimated delivery time
       calculateEstimatedDelivery(order);
     }
   }, [visible, order]);
@@ -113,7 +77,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
         estimatedMinutes = 15;
         break;
       case 'delivered':
-        setEstimatedDelivery('הזמנה נמסרה');
+        setEstimatedDelivery(t('orders.status.delivered', 'Delivered'));
         return;
     }
     
@@ -132,23 +96,6 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
       case 'courier_on_way': return 'שליח בדרך';
       case 'delivered': return 'נמסר';
       default: return status;
-    }
-  };
-
-  const getStatusDescription = (status: OrderStatus) => {
-    switch (status) {
-      case 'order_received': 
-        return 'ההזמנה שלך התקבלה ונמצאת בטיפול';
-      case 'courier_found': 
-        return 'מצאנו שליח שיטפל בהזמנה שלך';
-      case 'courier_picked_up': 
-        return 'השליח אסף את ההזמנה שלך מהחנות';
-      case 'courier_on_way': 
-        return 'השליח בדרך אליך עם ההזמנה';
-      case 'delivered': 
-        return 'ההזמנה נמסרה בהצלחה';
-      default: 
-        return '';
     }
   };
 
@@ -259,11 +206,6 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
 
   if (!order) return null;
 
-  const progressWidth = progressAnimation.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0%', '100%'],
-  });
-
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="pageSheet">
       <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -294,47 +236,7 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
             </View>
 
             {/* Progress Bar */}
-            <View style={[styles.progressBarContainer, { backgroundColor: colors.interactive.disabled }]}>
-              <Animated.View 
-                style={[
-                  styles.progressBar,
-                  { width: progressWidth, backgroundColor: colors.gold }
-                ]} 
-              />
-            </View>
-
-            {/* Tracking Steps */}
-            <View style={styles.trackingSteps}>
-              {order.trackingSteps.map((step, index) => (
-                <View key={step.status} style={styles.trackingStep}>
-                  <View style={styles.stepIconContainer}>
-                    {step.completed ? (
-                      <CheckCircle size={24} color={colors.gold} />
-                    ) : (
-                      <Circle size={24} color={colors.interactive.disabled} />
-                    )}
-                  </View>
-                  
-                  <View style={styles.stepContent}>
-                    <Text style={[
-                      styles.stepTitle,
-                      { color: colors.text.primary },
-                      step.completed && { color: colors.gold }
-                    ]}>
-                      {step.title}
-                    </Text>
-                    <Text style={[styles.stepDescription, { color: colors.text.secondary }]}>
-                      {getStatusDescription(step.status)}
-                    </Text>
-                    {step.timestamp && step.completed && (
-                      <Text style={[styles.stepTime, { color: colors.text.tertiary }]}>
-                        {formatDate(step.timestamp)}
-                      </Text>
-                    )}
-                  </View>
-                </View>
-              ))}
-            </View>
+            <OrderTimeline order={order} withBorder={false} style={styles.timeline} />
 
             {/* Contact Options */}
             {order.status === 'courier_on_way' && (
@@ -599,43 +501,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  progressBarContainer: {
-    height: 6,
-    borderRadius: 3,
-    marginBottom: 24,
-    overflow: 'hidden',
-  },
-  progressBar: {
-    height: '100%',
-    borderRadius: 3,
-  },
-  trackingSteps: {
+  timeline: {
     marginBottom: 16,
-  },
-  trackingStep: {
-    flexDirection: 'row',
-    marginBottom: 20,
-  },
-  stepIconContainer: {
-    marginRight: 16,
-  },
-  stepContent: {
-    flex: 1,
-  },
-  stepTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 4,
-    textAlign: 'right',
-  },
-  stepDescription: {
-    fontSize: 14,
-    marginBottom: 4,
-    textAlign: 'right',
-  },
-  stepTime: {
-    fontSize: 12,
-    textAlign: 'right',
   },
   contactOptions: {
     flexDirection: 'row',

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -427,7 +427,45 @@
       "courier_found": "Courier Found",
       "courier_picked_up": "Courier Picked Up",
       "courier_on_way": "Courier On The Way",
-      "delivered": "Delivered"
+      "delivered": "Delivered",
+      "disputed": "Disputed",
+      "released": "Payment released",
+      "refunded": "Payment refunded"
+    },
+    "timeline": {
+      "pending": "Pending",
+      "order_received": {
+        "title": "Order received",
+        "description": "We received your order and notified the seller."
+      },
+      "courier_found": {
+        "title": "Courier assigned",
+        "description": "A courier accepted the delivery."
+      },
+      "courier_picked_up": {
+        "title": "Order picked up",
+        "description": "The courier collected your order from the store."
+      },
+      "courier_on_way": {
+        "title": "Courier on the way",
+        "description": "Your order is on its way to you."
+      },
+      "delivered": {
+        "title": "Delivered",
+        "description": "Your order arrived."
+      },
+      "released": {
+        "title": "Payment released",
+        "description": "Funds were released to the seller."
+      },
+      "refunded": {
+        "title": "Payment refunded",
+        "description": "The payment was returned to you."
+      },
+      "disputed": {
+        "title": "Dispute opened",
+        "description": "We are reviewing the dispute for this order."
+      }
     },
     "orderNumber": "Order #{id}",
     "itemsLabel": "Items:",
@@ -439,7 +477,22 @@
     "shopNow": "Start Shopping",
     "loginRequiredTitle": "Login Required",
     "loginRequiredMessage": "You must log in to view your orders",
-    "myOrders": "My Orders"
+    "myOrders": "My Orders",
+    "detailReceiptAction": "View receipt",
+    "receiptTitle": "Order receipt",
+    "receiptBody": "Receipt #{id}\nIssued {date}",
+    "receiptUnavailableTitle": "Receipt unavailable",
+    "receiptUnavailableMessage": "Connect your wallet again to view the receipt.",
+    "receiptMissingTitle": "Receipt not found",
+    "receiptMissingMessage": "We could not find a local receipt for this order.",
+    "receiptErrorTitle": "Unable to load receipt",
+    "receiptErrorMessage": "Please try again later.",
+    "admin": {
+      "cancelTitle": "Cancel order",
+      "cancelMessage": "Are you sure you want to cancel this order?",
+      "cancelReject": "No",
+      "cancelConfirm": "Yes, cancel"
+    }
   },
   "stores": {
     "storeName": "Store Name",

--- a/src/features/orders/adminActions.ts
+++ b/src/features/orders/adminActions.ts
@@ -1,0 +1,33 @@
+import { Alert } from 'react-native';
+import type { Order } from '@/types';
+
+type TranslateFn = (key: string, fallback: string) => string;
+
+type AlertFn = typeof Alert.alert;
+
+export interface PromptCancelOptions {
+  order: Order; // reserved for future context (message customization)
+  t: TranslateFn;
+  onConfirm: () => void;
+  alertFn?: AlertFn;
+}
+
+export function promptCancelOrder({
+  t,
+  onConfirm,
+  alertFn = Alert.alert,
+}: PromptCancelOptions): void {
+  alertFn(
+    t('orders.admin.cancelTitle', 'Cancel order'),
+    t('orders.admin.cancelMessage', 'Are you sure you want to cancel this order?'),
+    [
+      { text: t('orders.admin.cancelReject', 'No'), style: 'cancel' },
+      {
+        text: t('orders.admin.cancelConfirm', 'Yes, cancel'),
+        style: 'destructive',
+        onPress: onConfirm,
+      },
+    ],
+  );
+}
+

--- a/src/features/orders/orderTimeline.ts
+++ b/src/features/orders/orderTimeline.ts
@@ -1,0 +1,96 @@
+import { Order, OrderStatus } from '@/types';
+
+export interface OrderTimelineEntry {
+  status: OrderStatus;
+  completed: boolean;
+  isCurrent: boolean;
+  timestamp: string | null;
+}
+
+const BASE_SEQUENCE: OrderStatus[] = [
+  'order_received',
+  'courier_found',
+  'courier_picked_up',
+  'courier_on_way',
+  'delivered',
+];
+
+const POST_DELIVERED_SEQUENCE: OrderStatus[] = ['disputed', 'released', 'refunded'];
+
+function uniqueStatuses(statuses: OrderStatus[]): OrderStatus[] {
+  const seen = new Set<OrderStatus>();
+  const ordered: OrderStatus[] = [];
+  for (const status of statuses) {
+    if (seen.has(status)) continue;
+    seen.add(status);
+    ordered.push(status);
+  }
+  return ordered;
+}
+
+function collectStatuses(order: Order): OrderStatus[] {
+  const trackingStatuses = new Set<OrderStatus>(
+    (order.trackingSteps ?? []).map((step) => step.status),
+  );
+  const sequence: OrderStatus[] = [...BASE_SEQUENCE];
+  for (const status of POST_DELIVERED_SEQUENCE) {
+    if (trackingStatuses.has(status) || order.status === status) {
+      sequence.push(status);
+    }
+  }
+  // ensure any additional tracking statuses are surfaced even if unexpected
+  for (const status of trackingStatuses) {
+    if (!sequence.includes(status)) {
+      sequence.push(status);
+    }
+  }
+  return uniqueStatuses(sequence);
+}
+
+export function buildTimelineEntries(order: Order): OrderTimelineEntry[] {
+  const statuses = collectStatuses(order);
+  if (statuses.length === 0) {
+    return [
+      {
+        status: 'order_received',
+        completed: true,
+        isCurrent: true,
+        timestamp: order.createdAt ?? null,
+      },
+    ];
+  }
+  const resolvedIndex = statuses.indexOf(order.status as OrderStatus);
+  const currentIndex = resolvedIndex >= 0 ? resolvedIndex : Math.max(statuses.length - 1, 0);
+  const stepMap = new Map(
+    (order.trackingSteps ?? []).map((step) => [step.status, step]),
+  );
+
+  return statuses.map((status, index) => {
+    const step = stepMap.get(status);
+    const isCurrent = status === order.status;
+    const completed = step?.completed ?? index <= currentIndex;
+    let timestamp: string | null = step?.timestamp ?? null;
+    if (!timestamp) {
+      if (status === 'order_received') {
+        timestamp = order.createdAt ?? null;
+      } else if (isCurrent && order.updatedAt) {
+        timestamp = order.updatedAt;
+      } else if (completed && order.updatedAt) {
+        timestamp = order.updatedAt;
+      }
+    }
+    return {
+      status,
+      completed,
+      isCurrent,
+      timestamp,
+    };
+  });
+}
+
+export function getCurrentTimelineIndex(
+  entries: OrderTimelineEntry[],
+): number {
+  return entries.findIndex((entry) => entry.isCurrent);
+}
+

--- a/tests/integration/adminOrderActions.test.ts
+++ b/tests/integration/adminOrderActions.test.ts
@@ -1,0 +1,20 @@
+import { promptCancelOrder } from '@/features/orders/adminActions';
+import type { Order } from '@/types';
+
+describe('admin order actions', () => {
+  it('shows confirmation prompt before cancelling', async () => {
+    const order = { id: 'order-1' } as Order;
+    const alertFn = jest.fn();
+    const onConfirm = jest.fn();
+
+    promptCancelOrder({ order, t: (_k, fallback) => fallback, onConfirm, alertFn });
+
+    expect(alertFn).toHaveBeenCalledTimes(1);
+    const [, , buttons] = alertFn.mock.calls[0];
+    expect(Array.isArray(buttons)).toBe(true);
+    const confirm = buttons.find((btn: any) => btn.style === 'destructive');
+    expect(confirm).toBeDefined();
+    await confirm?.onPress?.();
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/orderTimeline.test.ts
+++ b/tests/integration/orderTimeline.test.ts
@@ -1,0 +1,62 @@
+import { buildTimelineEntries } from '@/features/orders/orderTimeline';
+import type { Order } from '@/types';
+
+describe('order timeline builder', () => {
+  const baseOrder: Order = {
+    id: 'order-1',
+    userId: 'user-1',
+    items: [] as any,
+    total: 25,
+    status: 'order_received',
+    shippingAddress: {
+      name: 'Test',
+      phone: '123',
+      street: 'Main',
+      city: 'City',
+      postalCode: '0000',
+    },
+    paymentMethod: 'cash_on_delivery',
+    buyerAddress: 'buyer.test',
+    sellerAddress: 'seller.test',
+    itemsHash: 'hash',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    trackingSteps: [],
+  } as Order;
+
+  it('returns ordered timeline with current step highlighted', () => {
+    const order: Order = {
+      ...baseOrder,
+      status: 'courier_on_way',
+      trackingSteps: [
+        { status: 'order_received', title: 'Order received', timestamp: '2024-01-01T00:00:00.000Z', completed: true },
+        { status: 'courier_found', title: 'Courier found', timestamp: '2024-01-01T00:05:00.000Z', completed: true },
+        { status: 'courier_picked_up', title: 'Picked up', timestamp: '2024-01-01T00:10:00.000Z', completed: true },
+        { status: 'courier_on_way', title: 'On way', timestamp: '2024-01-01T00:15:00.000Z', completed: true },
+      ],
+    };
+    const entries = buildTimelineEntries(order);
+    expect(entries.map((entry) => entry.status)).toEqual([
+      'order_received',
+      'courier_found',
+      'courier_picked_up',
+      'courier_on_way',
+      'delivered',
+    ]);
+    const current = entries.find((entry) => entry.isCurrent);
+    expect(current?.status).toBe('courier_on_way');
+    const pending = entries.find((entry) => entry.status === 'delivered');
+    expect(pending?.completed).toBe(false);
+  });
+
+  it('includes refund status when order is refunded', () => {
+    const order: Order = {
+      ...baseOrder,
+      status: 'refunded',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    };
+    const entries = buildTimelineEntries(order);
+    expect(entries[entries.length - 1].status).toBe('refunded');
+    expect(entries[entries.length - 1].completed).toBe(true);
+  });
+});

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -205,10 +205,32 @@ describe('ordersAgent event emission', () => {
     } as any;
     mockStore[order.id] = order;
     await ordersAgent.update({ ...order, status: 'courier_found' });
-    expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/s',
-      'order.updated',
-      expect.objectContaining({ orderId: order.id, prevStatus: 'order_received', newStatus: 'courier_found' }),
+    const publishCalls = eventBus.publish.mock.calls.filter(([, type]) => type === 'order.updated');
+    expect(publishCalls).toEqual(
+      expect.arrayContaining([
+        [
+          '/blue-ocean/orders/s',
+          'order.updated',
+          expect.objectContaining({
+            orderId: order.id,
+            prevStatus: 'order_received',
+            newStatus: 'courier_found',
+          }),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/orders/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/notifications/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+      ]),
     );
   });
 
@@ -261,10 +283,28 @@ describe('ordersAgent event emission', () => {
       'payment.received',
       expect.objectContaining({ orderId: order.id }),
     );
-    expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/s',
-      'order.updated',
-      expect.objectContaining({ prevStatus: 'delivered', newStatus: 'released' }),
+    const orderUpdates = eventBus.publish.mock.calls.filter(([, type]) => type === 'order.updated');
+    expect(orderUpdates).toEqual(
+      expect.arrayContaining([
+        [
+          '/blue-ocean/orders/s',
+          'order.updated',
+          expect.objectContaining({ prevStatus: 'delivered', newStatus: 'released' }),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/orders/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/notifications/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+      ]),
     );
   });
 
@@ -288,10 +328,28 @@ describe('ordersAgent event emission', () => {
     } as any;
     mockStore[order.id] = order;
     await ordersAgent.refundPayment(order.id);
-    expect(eventBus.publish).toHaveBeenCalledWith(
-      '/blue-ocean/orders/s',
-      'order.updated',
-      expect.objectContaining({ prevStatus: 'delivered', newStatus: 'refunded' }),
+    const orderUpdates = eventBus.publish.mock.calls.filter(([, type]) => type === 'order.updated');
+    expect(orderUpdates).toEqual(
+      expect.arrayContaining([
+        [
+          '/blue-ocean/orders/s',
+          'order.updated',
+          expect.objectContaining({ prevStatus: 'delivered', newStatus: 'refunded' }),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/orders/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+        [
+          '/blue-ocean/notifications/1',
+          'order.updated',
+          expect.any(Object),
+          expect.objectContaining({ orderId: order.id, orderNonce: expect.any(String) }),
+        ],
+      ]),
     );
   });
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -635,6 +635,41 @@
       "released": "Payment released",
       "refunded": "Payment refunded"
     },
+    "timeline": {
+      "pending": "Pending",
+      "order_received": {
+        "title": "Order received",
+        "description": "We received your order and notified the seller."
+      },
+      "courier_found": {
+        "title": "Courier assigned",
+        "description": "A courier accepted the delivery."
+      },
+      "courier_picked_up": {
+        "title": "Order picked up",
+        "description": "The courier collected your order from the store."
+      },
+      "courier_on_way": {
+        "title": "Courier on the way",
+        "description": "Your order is on its way to you."
+      },
+      "delivered": {
+        "title": "Delivered",
+        "description": "Your order arrived."
+      },
+      "released": {
+        "title": "Payment released",
+        "description": "Funds were released to the seller."
+      },
+      "refunded": {
+        "title": "Payment refunded",
+        "description": "The payment was returned to you."
+      },
+      "disputed": {
+        "title": "Dispute opened",
+        "description": "We are reviewing the dispute for this order."
+      }
+    },
     "orderNumber": "Order #{id}",
     "itemsLabel": "Items:",
     "itemQuantity": "{name} x{quantity}",
@@ -654,7 +689,22 @@
     "statusUpdated": "Order status updated",
     "updateStatusFailed": "Failed to update status",
     "openDispute": "Open dispute",
-    "disputeComingSoon": "Coming soon"
+    "disputeComingSoon": "Coming soon",
+    "detailReceiptAction": "View receipt",
+    "receiptTitle": "Order receipt",
+    "receiptBody": "Receipt #{id}\nIssued {date}",
+    "receiptUnavailableTitle": "Receipt unavailable",
+    "receiptUnavailableMessage": "Connect your wallet again to view the receipt.",
+    "receiptMissingTitle": "Receipt not found",
+    "receiptMissingMessage": "We could not find a local receipt for this order.",
+    "receiptErrorTitle": "Unable to load receipt",
+    "receiptErrorMessage": "Please try again later.",
+    "admin": {
+      "cancelTitle": "Cancel order",
+      "cancelMessage": "Are you sure you want to cancel this order?",
+      "cancelReject": "No",
+      "cancelConfirm": "Yes, cancel"
+    }
   },
   "store": {
     "store_name": "Store Name",

--- a/translations/he.json
+++ b/translations/he.json
@@ -625,6 +625,41 @@
       "released": "תשלום שוחרר",
       "refunded": "תשלום הוחזר"
     },
+    "timeline": {
+      "pending": "ממתין",
+      "order_received": {
+        "title": "הזמנה התקבלה",
+        "description": "ההזמנה שלך התקבלה ונמצאת בטיפול"
+      },
+      "courier_found": {
+        "title": "נמצא שליח",
+        "description": "מצאנו שליח שיטפל בהזמנה שלך"
+      },
+      "courier_picked_up": {
+        "title": "השליח אסף",
+        "description": "השליח אסף את ההזמנה שלך מהחנות"
+      },
+      "courier_on_way": {
+        "title": "השליח בדרך",
+        "description": "השליח בדרך אליך עם ההזמנה"
+      },
+      "delivered": {
+        "title": "נמסר",
+        "description": "ההזמנה נמסרה בהצלחה"
+      },
+      "released": {
+        "title": "תשלום שוחרר",
+        "description": "התשלום שוחרר למוכר"
+      },
+      "refunded": {
+        "title": "תשלום הוחזר",
+        "description": "התשלום הוחזר אליך"
+      },
+      "disputed": {
+        "title": "מחלוקת נפתחה",
+        "description": "המחלוקת נבדקת כעת"
+      }
+    },
     "orderNumber": "הזמנה #{id}",
     "itemsLabel": "פריטים:",
     "itemQuantity": "{name} x{quantity}",
@@ -644,7 +679,22 @@
     "statusUpdated": "סטטוס ההזמנה עודכן",
     "updateStatusFailed": "עדכון הסטטוס נכשל",
     "openDispute": "פתח מחלוקת",
-    "disputeComingSoon": "בקרוב"
+    "disputeComingSoon": "בקרוב",
+    "detailReceiptAction": "צפה בקבלה",
+    "receiptTitle": "קבלת הזמנה",
+    "receiptBody": "קבלה מספר {id}\nהונפקה בתאריך {date}",
+    "receiptUnavailableTitle": "לא ניתן להציג קבלה",
+    "receiptUnavailableMessage": "התחבר מחדש לארנק כדי לצפות בקבלה.",
+    "receiptMissingTitle": "קבלה לא נמצאה",
+    "receiptMissingMessage": "לא מצאנו קבלה מקומית להזמנה זו.",
+    "receiptErrorTitle": "שגיאה בטעינת קבלה",
+    "receiptErrorMessage": "נסה שוב מאוחר יותר.",
+    "admin": {
+      "cancelTitle": "בטל הזמנה",
+      "cancelMessage": "האם אתה בטוח שברצונך לבטל את ההזמנה?",
+      "cancelReject": "לא",
+      "cancelConfirm": "כן, בטל"
+    }
   },
   "store": {
     "store_name": "שם החנות",


### PR DESCRIPTION
## Summary
- add shared OrderTimeline component and supporting order timeline utilities
- surface the timeline and view-receipt action in buyer and admin order detail views
- publish global order.updated events with nonce metadata and strengthen admin ship/cancel step-up flow
- add coverage for timeline building, admin cancel prompt and order agent publishing changes

## Testing
- pnpm exec jest tests/ordersAgent.test.ts tests/integration/orderTimeline.test.ts tests/integration/adminOrderActions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9a4e726708326b253f1a55022b5f6