### PR TITLE
Add nonce guard for admin order actions

### DIFF
--- a/app/store/[storeId]/admin/_OrdersScreen.tsx
+++ b/app/store/[storeId]/admin/_OrdersScreen.tsx
@@ -19,6 +19,7 @@ import { useLaunchGate } from '@/features/launchGate/LaunchGateContext';
 import OrderTrackingModal from '@/components/OrderTrackingModal';
 import { useAppRouter } from '@/services';
 import { promptCancelOrder } from '@/features/orders/adminActions';
+import { useActionNonceGuard } from '@/features/orders/actionNonceGuard';
 
 const SHIPPING_SEQUENCE: OrderStatus[] = [
   'order_received',
@@ -98,6 +99,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { requireUnlock } = useLaunchGate();
+  const nonceGuard = useActionNonceGuard();
   const { replace } = useAppRouter();
   const [filter, setFilter] = useState<FilterKey>('open');
   const [orders, setOrders] = useState<Order[]>([]);
@@ -169,7 +171,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
 
   const handleMarkShipped = useCallback(
     async (order: Order) => {
-      if (pendingId === order.id) return;
+      if (!nonceGuard.acquire(order.id)) return;
       setPendingId(order.id);
       try {
         let target: OrderStatus | null = null;
@@ -196,10 +198,11 @@ export default function StoreOrdersScreen(): React.ReactElement {
       } catch (error) {
         Alert.alert('שגיאה', 'עדכון סטטוס ההזמנה נכשל');
       } finally {
-        setPendingId(null);
+        nonceGuard.release(order.id);
+        setPendingId((prev) => (prev === order.id ? null : prev));
       }
     },
-    [pendingId, requireUnlock],
+    [nonceGuard, requireUnlock],
   );
 
   const handleCancel = useCallback(
@@ -208,6 +211,7 @@ export default function StoreOrdersScreen(): React.ReactElement {
         order,
         t,
         onConfirm: async () => {
+          if (!nonceGuard.acquire(order.id)) return;
           setPendingId(order.id);
           try {
             await requireUnlock('order.cancel');
@@ -222,12 +226,13 @@ export default function StoreOrdersScreen(): React.ReactElement {
           } catch (error) {
             Alert.alert('שגיאה', 'ביטול ההזמנה נכשל');
           } finally {
-            setPendingId(null);
+            nonceGuard.release(order.id);
+            setPendingId((prev) => (prev === order.id ? null : prev));
           }
         },
       });
     },
-    [requireUnlock, t],
+    [nonceGuard, requireUnlock, t],
   );
 
   const closeDetails = useCallback(() => {

--- a/src/features/orders/actionNonceGuard.ts
+++ b/src/features/orders/actionNonceGuard.ts
@@ -1,0 +1,43 @@
+import { useRef } from 'react';
+
+export interface ActionNonceGuard {
+  acquire(id: string | null | undefined): boolean;
+  release(id: string | null | undefined): void;
+  isActive(id: string | null | undefined): boolean;
+}
+
+function normalizeId(id: string | null | undefined): string | null {
+  if (typeof id !== 'string') return null;
+  const trimmed = id.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function createActionNonceGuard(): ActionNonceGuard {
+  const active = new Set<string>();
+  return {
+    acquire(id) {
+      const key = normalizeId(id);
+      if (!key) return false;
+      if (active.has(key)) return false;
+      active.add(key);
+      return true;
+    },
+    release(id) {
+      const key = normalizeId(id);
+      if (!key) return;
+      active.delete(key);
+    },
+    isActive(id) {
+      const key = normalizeId(id);
+      return key ? active.has(key) : false;
+    },
+  };
+}
+
+export function useActionNonceGuard(): ActionNonceGuard {
+  const guardRef = useRef<ActionNonceGuard | null>(null);
+  if (!guardRef.current) {
+    guardRef.current = createActionNonceGuard();
+  }
+  return guardRef.current;
+}

--- a/tests/integration/orderActionNonceGuard.test.ts
+++ b/tests/integration/orderActionNonceGuard.test.ts
@@ -1,0 +1,31 @@
+import { createActionNonceGuard } from '@/features/orders/actionNonceGuard';
+
+describe('order action nonce guard', () => {
+  it('prevents duplicate acquires for the same id until release', () => {
+    const guard = createActionNonceGuard();
+    expect(guard.acquire('order-1')).toBe(true);
+    expect(guard.isActive('order-1')).toBe(true);
+    expect(guard.acquire('order-1')).toBe(false);
+    guard.release('order-1');
+    expect(guard.isActive('order-1')).toBe(false);
+    expect(guard.acquire('order-1')).toBe(true);
+  });
+
+  it('allows different ids concurrently', () => {
+    const guard = createActionNonceGuard();
+    expect(guard.acquire('order-a')).toBe(true);
+    expect(guard.acquire('order-b')).toBe(true);
+    expect(guard.isActive('order-a')).toBe(true);
+    expect(guard.isActive('order-b')).toBe(true);
+    guard.release('order-a');
+    expect(guard.isActive('order-a')).toBe(false);
+    expect(guard.isActive('order-b')).toBe(true);
+  });
+
+  it('ignores blank identifiers', () => {
+    const guard = createActionNonceGuard();
+    expect(guard.acquire('')).toBe(false);
+    expect(guard.acquire('   ')).toBe(false);
+    expect(guard.isActive('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable action nonce guard to keep order actions idempotent
- wire the admin mark shipped and cancel flows through the guard and keep the pending state scoped per order
- cover the guard logic with focused tests

## Testing
- yarn install --silent *(fails: @waku/core requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b82c0da08326a5f7c784830ec80d