### PR TITLE
Add on-device universal search experience

### DIFF
--- a/app/search/index.tsx
+++ b/app/search/index.tsx
@@ -1,0 +1,722 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, StyleSheet, Pressable, ScrollView } from 'react-native';
+import { ScrollArea, Container, Stack } from '@/ui/layout';
+import { Heading, Text, TextField, Divider } from '@/ui/primitives';
+import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { spacing, radius, typography } from '@/ui/tokens';
+import { useTenant } from '@/contexts/TenantContext';
+import { useProducts, useStores } from '@/services';
+import { useWallet } from '@/contexts/WalletProvider';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import { useAppRouter } from '@/services/useAppRouter';
+import search, {
+  type SearchDomain,
+  type SearchResult,
+  type ProductFilters,
+  type StoreFilters,
+  type OrderFilters,
+  type MessageFilters,
+} from '@/services/search';
+import { ordersWarmCache } from '@/services/nearOrders';
+import DatabaseService from '@/services/database';
+import { errorLog } from '@/utils/logger';
+import EmptyState from '@/shared/ui/EmptyState';
+import type { Order, OrderStatus } from '@/types';
+import {
+  Package,
+  Store as StoreIcon,
+  Receipt,
+  MessageSquare,
+  Search as SearchIcon,
+  Filter as FilterIcon,
+} from 'lucide-react-native';
+
+interface ThreadOption {
+  id: string;
+  label: string;
+}
+
+const DEFAULT_STORE_ID = 'default';
+
+function normalizeAddress(value?: string | null): string {
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function orderMatchesBuyer(order: Order | undefined, buyer: string): boolean {
+  if (!order || !buyer) return false;
+  const buyerAddress = normalizeAddress(order.buyerAddress);
+  const userId = normalizeAddress(order.userId);
+  return buyerAddress === buyer || userId === buyer;
+}
+
+function formatDateLabel(value?: string | number | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+export default function GlobalSearchScreen() {
+  const { colors } = useTheme();
+  const { t, isRTL } = useLanguage();
+  const { tenantId } = useTenant();
+  const storeId = tenantId ?? DEFAULT_STORE_ID;
+  const { data: products = [] } = useProducts(storeId);
+  const { data: stores = [] } = useStores(DEFAULT_STORE_ID);
+  const { address } = useWallet();
+  const { currencySymbol } = useCurrency();
+  const { push } = useAppRouter();
+
+  const [buyerOrders, setBuyerOrders] = useState<Order[]>([]);
+  const [messageThreads, setMessageThreads] = useState<ThreadOption[]>([]);
+  const [query, setQuery] = useState('');
+  const [domain, setDomain] = useState<SearchDomain>('products');
+  const [productFilters, setProductFilters] = useState<ProductFilters>({ category: null, inStockOnly: false });
+  const [storeFilters, setStoreFilters] = useState<StoreFilters>({ plan: null });
+  const [orderFilters, setOrderFilters] = useState<OrderFilters>({ status: null });
+  const [messageFilters, setMessageFilters] = useState<MessageFilters>({ threadId: null });
+  const [results, setResults] = useState<SearchResult[]>([]);
+
+  useEffect(() => {
+    search.index({ products });
+  }, [products]);
+
+  useEffect(() => {
+    search.index({ stores });
+  }, [stores]);
+
+  useEffect(() => {
+    let active = true;
+    const normalized = normalizeAddress(address);
+    if (!normalized) {
+      setBuyerOrders([]);
+      search.index({ orders: [] });
+      return undefined;
+    }
+
+    const load = () => {
+      try {
+        const list = ordersWarmCache.list((_, value) => orderMatchesBuyer(value, normalized));
+        if (!active) return;
+        setBuyerOrders(list);
+        search.index({ orders: list });
+      } catch (err) {
+        if (!active) return;
+        errorLog('global search orders index failed', err);
+        setBuyerOrders([]);
+        search.index({ orders: [] });
+      }
+    };
+
+    load();
+    const unsubscribe = ordersWarmCache.subscribe(
+      (_, value) => orderMatchesBuyer(value, normalized),
+      () => load(),
+    );
+
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [address]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadMessages = async () => {
+      try {
+        const db = DatabaseService.getInstance();
+        const rooms = await db.getChatRooms();
+        const payload = await Promise.all(
+          rooms.map(async (room) => ({
+            room,
+            messages: await db.getChatMessages(room.id),
+          })),
+        );
+        if (cancelled) return;
+        setMessageThreads(
+          rooms.map((room) => ({
+            id: room.id,
+            label: room.userName || room.id,
+          })),
+        );
+        search.index({ messages: payload });
+      } catch (err) {
+        if (cancelled) return;
+        errorLog('global search message index failed', err);
+        setMessageThreads([]);
+        search.index({ messages: [] });
+      }
+    };
+
+    loadMessages();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const tabs = useMemo(
+    () => [
+      { id: 'products' as const, label: t('search.tabs.products', 'Products'), icon: Package },
+      { id: 'stores' as const, label: t('search.tabs.stores', 'Stores'), icon: StoreIcon },
+      { id: 'orders' as const, label: t('search.tabs.orders', 'My Orders'), icon: Receipt },
+      { id: 'messages' as const, label: t('search.tabs.messages', 'Messages'), icon: MessageSquare },
+    ],
+    [t],
+  );
+
+  const productCategories = useMemo(() => {
+    const set = new Set<string>();
+    products.forEach((product) => {
+      if (product.category) set.add(product.category);
+    });
+    return Array.from(set);
+  }, [products]);
+
+  const storePlanOptions = useMemo(() => {
+    const set = new Set<string>();
+    stores.forEach((store) => {
+      if (store.plan) set.add(store.plan);
+    });
+    return Array.from(set);
+  }, [stores]);
+
+  const orderStatuses = useMemo(() => {
+    const set = new Set<OrderStatus>();
+    buyerOrders.forEach((order) => {
+      set.add(order.status);
+    });
+    return Array.from(set);
+  }, [buyerOrders]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      let filters: ProductFilters | StoreFilters | OrderFilters | MessageFilters | undefined;
+      if (domain === 'products') filters = productFilters;
+      if (domain === 'stores') filters = storeFilters;
+      if (domain === 'orders') filters = orderFilters;
+      if (domain === 'messages') filters = messageFilters;
+      const next = search.query(query, { domain, filters });
+      setResults(next);
+    }, 75);
+    return () => clearTimeout(timeout);
+  }, [
+    query,
+    domain,
+    productFilters,
+    storeFilters,
+    orderFilters,
+    messageFilters,
+    products,
+    stores,
+    buyerOrders,
+    messageThreads,
+  ]);
+
+  const handleResultPress = useCallback(
+    (item: SearchResult) => {
+      if (item.params) {
+        push({ pathname: item.route, params: item.params });
+      } else {
+        push(item.route);
+      }
+    },
+    [push],
+  );
+
+  const orderStatusLabel = useCallback(
+    (status: string) => {
+      switch (status) {
+        case 'order_received':
+          return t('search.orderStatus.order_received', 'Order received');
+        case 'courier_found':
+          return t('search.orderStatus.courier_found', 'Courier found');
+        case 'courier_picked_up':
+          return t('search.orderStatus.courier_picked_up', 'Courier picked up');
+        case 'courier_on_way':
+          return t('search.orderStatus.courier_on_way', 'Courier on the way');
+        case 'delivered':
+          return t('search.orderStatus.delivered', 'Delivered');
+        case 'disputed':
+          return t('search.orderStatus.disputed', 'Disputed');
+        case 'released':
+          return t('search.orderStatus.released', 'Released');
+        case 'refunded':
+          return t('search.orderStatus.refunded', 'Refunded');
+        default:
+          return status;
+      }
+    },
+    [t],
+  );
+
+  const renderMetadata = useCallback(
+    (item: SearchResult) => {
+      if (item.domain === 'products') {
+        const price = item.metadata?.price;
+        const category = item.metadata?.category as string | undefined;
+        const parts: string[] = [];
+        if (category) parts.push(category);
+        if (typeof price === 'number' && price > 0) {
+          parts.push(`${currencySymbol}${price.toFixed(2)}`);
+        }
+        return parts.join(' • ');
+      }
+      if (item.domain === 'stores') {
+        const plan = item.metadata?.plan as string | undefined;
+        const reputation = item.metadata?.reputation as number | undefined;
+        const planLabel = plan
+          ? plan === 'premium'
+            ? t('common.premium', 'Premium')
+            : t('common.free', 'Free')
+          : null;
+        const parts: string[] = [];
+        if (planLabel) parts.push(planLabel);
+        if (typeof reputation === 'number' && reputation >= 0) {
+          parts.push(`${t('search.reputation', 'Reputation')}: ${reputation.toFixed(2)}`);
+        }
+        return parts.join(' • ');
+      }
+      if (item.domain === 'orders') {
+        const status = item.metadata?.status as string | undefined;
+        const created = formatDateLabel(item.metadata?.createdAt as string | undefined);
+        const parts: string[] = [];
+        if (status) parts.push(orderStatusLabel(status));
+        if (created) parts.push(created);
+        return parts.join(' • ');
+      }
+      if (item.domain === 'messages') {
+        const sender = item.metadata?.sender as string | undefined;
+        const timestamp = item.metadata?.timestamp as number | undefined;
+        const parts: string[] = [];
+        if (sender) parts.push(sender);
+        if (typeof timestamp === 'number') {
+          const label = formatDateLabel(timestamp);
+          if (label) parts.push(label);
+        }
+        return parts.join(' • ');
+      }
+      return '';
+    },
+    [currencySymbol, orderStatusLabel, t],
+  );
+
+  const planLabel = useCallback(
+    (plan: string | null | undefined) => {
+      if (!plan || plan === 'all') return t('search.filters.all', 'All');
+      if (plan === 'premium') return t('common.premium', 'Premium');
+      if (plan === 'free') return t('common.free', 'Free');
+      return plan;
+    },
+    [t],
+  );
+
+  const renderFilters = () => {
+    if (domain === 'products') {
+      return (
+        <View style={styles.filterSection}>
+          <View style={styles.filterHeader}>
+            <FilterIcon
+              size={16}
+              color={colors.text.secondary}
+              style={{ marginEnd: spacing.spacer8 }}
+            />
+            <Text style={[styles.filterHeading, { color: colors.text.secondary }]}>
+              {t('search.filters.category', 'Categories')}
+            </Text>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.filterScroll}
+          >
+            <FilterPill
+              label={t('search.filters.all', 'All')}
+              active={!productFilters.category}
+              onPress={() =>
+                setProductFilters((prev) => ({ ...prev, category: null }))
+              }
+              testID="search-filter-products-all"
+            />
+            {productCategories.map((category) => (
+              <FilterPill
+                key={category}
+                label={category}
+                active={productFilters.category === category}
+                onPress={() =>
+                  setProductFilters((prev) => ({
+                    ...prev,
+                    category: prev.category === category ? null : category,
+                  }))
+                }
+                testID={`search-filter-products-category-${category}`}
+              />
+            ))}
+          </ScrollView>
+          <View style={styles.filterRow}>
+            <FilterPill
+              label={t('search.filters.inStock', 'In stock only')}
+              active={productFilters.inStockOnly ?? false}
+              onPress={() =>
+                setProductFilters((prev) => ({
+                  ...prev,
+                  inStockOnly: !prev.inStockOnly,
+                }))
+              }
+              testID="search-filter-products-instock"
+            />
+          </View>
+        </View>
+      );
+    }
+
+    if (domain === 'stores') {
+      return (
+        <View style={styles.filterSection}>
+          <View style={styles.filterHeader}>
+            <FilterIcon
+              size={16}
+              color={colors.text.secondary}
+              style={{ marginEnd: spacing.spacer8 }}
+            />
+            <Text style={[styles.filterHeading, { color: colors.text.secondary }]}>
+              {t('search.filters.plan', 'Plan')}
+            </Text>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.filterScroll}
+          >
+            <FilterPill
+              label={t('search.filters.all', 'All')}
+              active={!storeFilters.plan || storeFilters.plan === 'all'}
+              onPress={() => setStoreFilters({ plan: null })}
+              testID="search-filter-stores-all"
+            />
+            {storePlanOptions.map((plan) => (
+              <FilterPill
+                key={plan}
+                label={planLabel(plan)}
+                active={storeFilters.plan === plan}
+                onPress={() =>
+                  setStoreFilters((prev) => ({
+                    plan: prev.plan === plan ? null : plan,
+                  }))
+                }
+                testID={`search-filter-stores-plan-${plan}`}
+              />
+            ))}
+          </ScrollView>
+        </View>
+      );
+    }
+
+    if (domain === 'orders') {
+      return (
+        <View style={styles.filterSection}>
+          <View style={styles.filterHeader}>
+            <FilterIcon
+              size={16}
+              color={colors.text.secondary}
+              style={{ marginEnd: spacing.spacer8 }}
+            />
+            <Text style={[styles.filterHeading, { color: colors.text.secondary }]}>
+              {t('search.filters.status', 'Status')}
+            </Text>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.filterScroll}
+          >
+            <FilterPill
+              label={t('search.filters.all', 'All')}
+              active={!orderFilters.status}
+              onPress={() => setOrderFilters({ status: null })}
+              testID="search-filter-orders-all"
+            />
+            <FilterPill
+              label={t('search.filters.open', 'Open')}
+              active={orderFilters.status === 'open'}
+              onPress={() =>
+                setOrderFilters((prev) => ({
+                  status: prev.status === 'open' ? null : 'open',
+                }))
+              }
+              testID="search-filter-orders-open"
+            />
+            {orderStatuses.map((status) => (
+              <FilterPill
+                key={status}
+                label={orderStatusLabel(status)}
+                active={orderFilters.status === status}
+                onPress={() =>
+                  setOrderFilters((prev) => ({
+                    status: prev.status === status ? null : status,
+                  }))
+                }
+                testID={`search-filter-orders-status-${status}`}
+              />
+            ))}
+          </ScrollView>
+        </View>
+      );
+    }
+
+    const threads = messageThreads;
+    return (
+      <View style={styles.filterSection}>
+        <View style={styles.filterHeader}>
+          <FilterIcon
+            size={16}
+            color={colors.text.secondary}
+            style={{ marginEnd: spacing.spacer8 }}
+          />
+          <Text style={[styles.filterHeading, { color: colors.text.secondary }]}>
+            {t('search.filters.thread', 'Threads')}
+          </Text>
+        </View>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterScroll}
+        >
+          <FilterPill
+            label={t('search.filters.all', 'All')}
+            active={!messageFilters.threadId}
+            onPress={() => setMessageFilters({ threadId: null })}
+            testID="search-filter-messages-all"
+          />
+          {threads.map((thread) => (
+            <FilterPill
+              key={thread.id}
+              label={thread.label}
+              active={messageFilters.threadId === thread.id}
+              onPress={() =>
+                setMessageFilters((prev) => ({
+                  threadId: prev.threadId === thread.id ? null : thread.id,
+                }))
+              }
+              testID={`search-filter-messages-thread-${thread.id}`}
+            />
+          ))}
+        </ScrollView>
+      </View>
+    );
+  };
+
+  const renderResults = () => {
+    if (results.length === 0) {
+      return (
+        <EmptyState
+          icon={SearchIcon}
+          title={query.trim() ? t('search.empty.noResults', 'No matches found') : t('search.empty.noQuery', 'Start typing to search your marketplace.')}
+          message={query.trim() ? t('search.empty.tryAgain', 'Try another phrase or adjust your filters.') : undefined}
+        />
+      );
+    }
+
+    return results.map((item) => (
+      <Pressable
+        key={`${item.domain}-${item.id}`}
+        style={[
+          styles.resultRow,
+          {
+            borderColor: colors.border.primary,
+            backgroundColor: colors.surface.primary,
+          },
+        ]}
+        onPress={() => handleResultPress(item)}
+        testID={`search-result-${item.domain}-${item.id}`}
+      >
+        <Text style={[styles.resultTitle, { color: colors.text.primary }]}>{item.title}</Text>
+        {item.subtitle ? (
+          <Text
+            style={[styles.resultSubtitle, { color: colors.text.secondary }]}
+            numberOfLines={2}
+          >
+            {item.subtitle}
+          </Text>
+        ) : null}
+        <Text style={[styles.resultMeta, { color: colors.text.tertiary }]}>
+          {renderMetadata(item)}
+        </Text>
+      </Pressable>
+    ));
+  };
+
+  return (
+    <ScrollArea
+      backgroundColor={colors.canvas}
+      contentContainerStyle={{ flexGrow: 1 }}
+      testID="global-search-screen"
+    >
+      <Container style={{ paddingVertical: spacing.spacer16 }}>
+        <Stack gap="spacer16">
+          <Heading size="xl" style={{ color: colors.text.primary }}>
+            {t('search.title', 'Universal search')}
+          </Heading>
+          <TextField
+            variant="search"
+            value={query}
+            onChangeText={setQuery}
+            placeholder={t('search.placeholder', 'Search products, stores, orders, and messages')}
+            style={styles.searchField}
+            textAlign={isRTL ? 'right' : 'left'}
+            autoFocus
+          />
+          <View
+            style={[styles.tabRow, { borderColor: colors.border.primary }]}
+            accessibilityRole="tablist"
+          >
+            {tabs.map((tab) => {
+              const Icon = tab.icon;
+              const active = domain === tab.id;
+              return (
+                <Pressable
+                  key={tab.id}
+                  onPress={() => setDomain(tab.id)}
+                  style={[
+                    styles.tabButton,
+                    {
+                      backgroundColor: active ? colors.surface.primary : 'transparent',
+                      borderColor: active ? colors.border.focus : 'transparent',
+                      flexDirection: isRTL ? 'row-reverse' : 'row',
+                    },
+                  ]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: active }}
+                  testID={`search-tab-${tab.id}`}
+                >
+                  <Icon size={16} color={active ? colors.text.primary : colors.text.secondary} />
+                  <Text
+                    style={[
+                      styles.tabLabel,
+                      {
+                        color: active ? colors.text.primary : colors.text.secondary,
+                      },
+                    ]}
+                  >
+                    {tab.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          {renderFilters()}
+          <Divider style={{ marginVertical: spacing.spacer8 }} />
+          <Stack gap="spacer12">{renderResults()}</Stack>
+        </Stack>
+      </Container>
+    </ScrollArea>
+  );
+}
+
+interface FilterPillProps {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  testID?: string;
+}
+
+function FilterPill({ label, active, onPress, testID }: FilterPillProps) {
+  const { colors } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.filterPill,
+        {
+          backgroundColor: active ? colors.surface.primary : 'transparent',
+          borderColor: active ? colors.border.focus : colors.border.primary,
+        },
+      ]}
+      testID={testID}
+    >
+      <Text
+        style={[
+          styles.filterPillLabel,
+          {
+            color: active ? colors.text.primary : colors.text.secondary,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  searchField: {
+    marginTop: spacing.spacer8,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderRadius: radius.lg,
+    overflow: 'hidden',
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.spacer12,
+    paddingHorizontal: spacing.spacer8,
+    borderWidth: 1,
+  },
+  tabLabel: {
+    ...typography.sm,
+    marginLeft: spacing.spacer8,
+    marginRight: spacing.spacer8,
+  },
+  filterSection: {
+    marginTop: spacing.spacer8,
+  },
+  filterHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.spacer8,
+  },
+  filterHeading: {
+    ...typography.sm,
+    fontWeight: '600',
+  },
+  filterScroll: {
+    paddingVertical: spacing.spacer4,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  filterPill: {
+    borderRadius: radius.full,
+    borderWidth: 1,
+    paddingVertical: spacing.spacer8,
+    paddingHorizontal: spacing.spacer12,
+    marginRight: spacing.spacer8,
+    marginBottom: spacing.spacer8,
+  },
+  filterPillLabel: {
+    ...typography.sm,
+  },
+  resultRow: {
+    borderWidth: 1,
+    borderRadius: radius.lg,
+    padding: spacing.spacer16,
+  },
+  resultTitle: {
+    ...typography.md,
+    fontWeight: '600',
+    marginBottom: spacing.spacer4,
+  },
+  resultSubtitle: {
+    ...typography.sm,
+    marginBottom: spacing.spacer4,
+  },
+  resultMeta: {
+    ...typography.xs,
+  },
+});
+

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,13 +1,6 @@
 // TOUCHPOINT: components/GlobalHeader.tsx renders in production — Fix Pack v2
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  View,
-  StyleSheet,
-  Pressable,
-  TextInput,
-  Platform,
-  useWindowDimensions,
-} from 'react-native';
+import { View, StyleSheet, Pressable, Platform, useWindowDimensions } from 'react-native';
 import { Text, Chip } from '@/ui';
 import SmartImage from './SmartImage';
 import { Search, Bell, Globe } from 'lucide-react-native';
@@ -41,8 +34,6 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const pathname = usePathname();
   const { width } = useWindowDimensions();
   const isMd = width >= 768;
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [query, setQuery] = useState('');
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [consoleVisible, setConsoleVisible] = useState(false);
   const tapTimesRef = useRef<number[]>([]);
@@ -63,11 +54,6 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const toggleLanguage = async () => {
     const next = currentLanguage === 'he' ? 'en' : 'he';
     await setLanguage(next as any);
-  };
-
-  const handleSearchSubmit = () => {
-    setSearchOpen(false);
-    if (pathname !== '/' && pathname !== '/index') push('/');
   };
 
   const walletLabel = address ? `@${address}` : t('auth.not_connected', 'Not connected');
@@ -131,54 +117,25 @@ export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
         ]}
       >
         {showSearch && (
-          searchOpen ? (
-            <View
-              style={[
-                styles.searchContainer,
-                {
-                  backgroundColor: colors.surface.primary,
-                  borderColor: colors.border.primary,
-                },
-              ]}
-            >
-              <TextInput
-                style={[
-                  styles.searchInput,
-                  {
-                    color: colors.text.primary,
-                    textAlign: isRTL ? 'right' : 'left',
-                  },
-                ]}
-                placeholder={t('home.searchPlaceholder')}
-                placeholderTextColor={colors.text.tertiary}
-                value={query}
-                onChangeText={setQuery}
-                autoFocus
-                onSubmitEditing={handleSearchSubmit}
-                onBlur={() => setSearchOpen(false)}
-              />
-            </View>
-          ) : (
-            <Pressable
-              onPress={() => setSearchOpen(true)}
-              accessibilityLabel={t('home.searchPlaceholder')}
-              accessibilityRole="button"
-              focusable
-              {...(Platform.OS === 'web'
-                ? { title: t('home.searchPlaceholder') }
-                : {})}
-              style={(state) => [
-                styles.iconButton,
-                { backgroundColor: colors.surface.primary },
-                (state as any).focused && {
-                  borderColor: colors.border.focus,
-                  borderWidth: 2,
-                },
-              ]}
-            >
-              <Search size={24} color={colors.text.primary} />
-            </Pressable>
-          )
+          <Pressable
+            onPress={() => push('/search')}
+            accessibilityLabel={t('home.searchPlaceholder')}
+            accessibilityRole="button"
+            focusable
+            {...(Platform.OS === 'web'
+              ? { title: t('home.searchPlaceholder') }
+              : {})}
+            style={(state) => [
+              styles.iconButton,
+              { backgroundColor: colors.surface.primary },
+              (state as any).focused && {
+                borderColor: colors.border.focus,
+                borderWidth: 2,
+              },
+            ]}
+          >
+            <Search size={24} color={colors.text.primary} />
+          </Pressable>
         )}
 
         <Pressable
@@ -310,19 +267,6 @@ const styles = StyleSheet.create({
   badgeText: {
     ...typography.xs,
     fontWeight: 'bold',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderRadius: radius.full,
-    paddingHorizontal: spacing.spacer16,
-    paddingVertical: spacing.spacer8,
-    borderWidth: 1,
-    flex: 1,
-  },
-  searchInput: {
-    flex: 1,
-    ...typography.md,
   },
 });
 

--- a/services/database.ts
+++ b/services/database.ts
@@ -44,7 +44,7 @@ import {
   UserRole,
 } from '../types';
 
-const CHAT_MESSAGE_LIMIT = 50;
+const CHAT_MESSAGE_LIMIT = 100;
 const CHAT_STORAGE_PREFIX = 'chat_messages_';
 const WISHLIST_STORAGE_PREFIX = 'wishlist_';
 

--- a/src/services/search/index.ts
+++ b/src/services/search/index.ts
@@ -1,0 +1,507 @@
+import Fuse from 'fuse.js';
+import type { Product, Store, Order, ChatMessage, ChatRoom, OrderStatus } from '@/types';
+import { normalizeHebrew } from '@/utils/strings';
+
+export type SearchDomain = 'products' | 'stores' | 'orders' | 'messages';
+
+export interface ProductFilters {
+  category?: string | null;
+  inStockOnly?: boolean;
+}
+
+export interface StoreFilters {
+  plan?: string | null;
+  minReputation?: number;
+}
+
+export interface OrderFilters {
+  status?: OrderStatus | 'open' | null;
+}
+
+export interface MessageFilters {
+  threadId?: string | null;
+}
+
+export interface SearchResult {
+  id: string;
+  domain: SearchDomain;
+  title: string;
+  subtitle?: string;
+  route: string;
+  params?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+  score: number;
+}
+
+export interface SearchIndexPayload {
+  products?: Product[];
+  stores?: Store[];
+  orders?: Order[];
+  messages?: Array<{ room: ChatRoom; messages: ChatMessage[] }>;
+}
+
+interface ProductDoc extends Product {}
+
+interface StoreDoc extends Store {
+  reputationScore: number;
+}
+
+interface OrderDoc extends Order {
+  itemText: string;
+  createdAtValue: number;
+}
+
+interface MessageDoc {
+  id: string;
+  threadId: string;
+  threadName: string;
+  senderName: string;
+  message: string;
+  messageNormalized: string;
+  senderNormalized: string;
+  threadNormalized: string;
+  tokens: Set<string>;
+  timestamp: number;
+}
+
+const NORMALIZED_EMPTY = '' as const;
+
+function toNormalized(value: string | null | undefined): string {
+  if (!value) return NORMALIZED_EMPTY;
+  return normalizeHebrew(value).toLowerCase();
+}
+
+function normalizeSearchValue(value: unknown): string | readonly string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? toNormalized(entry) : null))
+      .filter((entry): entry is string => entry !== null);
+  }
+
+  if (typeof value === 'string') {
+    return toNormalized(value);
+  }
+
+  if (value == null) {
+    return NORMALIZED_EMPTY;
+  }
+
+  return toNormalized(String(value));
+}
+
+function scheduleIdle(callback: () => void) {
+  const idle = (globalThis as unknown as { requestIdleCallback?: (cb: () => void) => void })
+    .requestIdleCallback;
+  if (typeof idle === 'function') {
+    idle(callback);
+  } else {
+    setTimeout(callback, 16);
+  }
+}
+
+function toScoreFromFuse(score?: number | null, index = 0): number {
+  if (typeof score === 'number') {
+    const clamped = Math.max(0, Math.min(1, score));
+    return 1 - clamped;
+  }
+  return Math.max(0.1, 0.95 - index * 0.05);
+}
+
+function parseDate(value?: string | number | null): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (!value) return 0;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function generateNgrams(text: string): Set<string> {
+  const normalized = toNormalized(text).replace(/\s+/g, ' ').trim();
+  const grams = new Set<string>();
+  if (!normalized) return grams;
+  const words = normalized.split(' ');
+  for (const word of words) {
+    const clean = word.trim();
+    if (!clean) continue;
+    const len = clean.length;
+    for (let size = 1; size <= 4; size += 1) {
+      if (len < size) continue;
+      for (let start = 0; start <= len - size; start += 1) {
+        grams.add(clean.slice(start, start + size));
+      }
+    }
+    grams.add(clean);
+  }
+  return grams;
+}
+
+let productDocs: ProductDoc[] = [];
+let storeDocs: StoreDoc[] = [];
+let orderDocs: OrderDoc[] = [];
+let messageDocs: MessageDoc[] = [];
+
+let productFuse: Fuse<ProductDoc> | null = null;
+let storeFuse: Fuse<StoreDoc> | null = null;
+let orderFuse: Fuse<OrderDoc> | null = null;
+
+function buildProductFuse(docs: ProductDoc[]) {
+  if (docs.length === 0) {
+    productFuse = null;
+    return;
+  }
+  productFuse = new Fuse(docs, {
+    keys: ['name', 'description', 'category', 'name_en', 'name_he', 'description_en', 'description_he'],
+    threshold: 0.3,
+    ignoreLocation: true,
+    getFn: (obj, path) => {
+      const value = Fuse.config.getFn(obj, path);
+      return normalizeSearchValue(value);
+    },
+  });
+}
+
+function buildStoreFuse(docs: StoreDoc[]) {
+  if (docs.length === 0) {
+    storeFuse = null;
+    return;
+  }
+  storeFuse = new Fuse(docs, {
+    keys: ['name', 'owner', 'plan'],
+    threshold: 0.3,
+    ignoreLocation: true,
+    getFn: (obj, path) => {
+      const value = Fuse.config.getFn(obj, path);
+      return normalizeSearchValue(value);
+    },
+  });
+}
+
+function buildOrderFuse(docs: OrderDoc[]) {
+  if (docs.length === 0) {
+    orderFuse = null;
+    return;
+  }
+  orderFuse = new Fuse(docs, {
+    keys: ['id', 'status', 'itemText', 'buyerAddress', 'sellerAddress', 'userId'],
+    threshold: 0.35,
+    ignoreLocation: true,
+    getFn: (obj, path) => {
+      const value = Fuse.config.getFn(obj, path);
+      return normalizeSearchValue(value);
+    },
+  });
+}
+
+function indexProducts(products: Product[]) {
+  productDocs = products.slice();
+  buildProductFuse(productDocs);
+}
+
+function indexStores(stores: Store[]) {
+  storeDocs = stores.map((store) => ({
+    ...store,
+    reputationScore: typeof store.reputation === 'number' ? store.reputation : 0,
+  }));
+  buildStoreFuse(storeDocs);
+}
+
+function indexOrders(orders: Order[]) {
+  orderDocs = orders.map((order) => ({
+    ...order,
+    itemText: order.items
+      ?.map((item) => item.product?.name || item.product?.id || '')
+      .filter(Boolean)
+      .join(' '),
+    createdAtValue: parseDate(order.createdAt),
+  }));
+  buildOrderFuse(orderDocs);
+}
+
+function indexMessages(payload: Array<{ room: ChatRoom; messages: ChatMessage[] }>) {
+  const docs: MessageDoc[] = [];
+  for (const { room, messages } of payload) {
+    const relevant = messages.slice(-100);
+    for (const message of relevant) {
+      docs.push({
+        id: message.id,
+        threadId: room.id,
+        threadName: room.userName || room.id,
+        senderName: message.senderName || '',
+        message: message.message || '',
+        messageNormalized: toNormalized(message.message || ''),
+        senderNormalized: toNormalized(message.senderName || ''),
+        threadNormalized: toNormalized(room.userName || room.id),
+        tokens: generateNgrams(message.message || ''),
+        timestamp: message.timestamp || 0,
+      });
+    }
+  }
+  messageDocs = docs;
+}
+
+function formatPrice(price: number | undefined): number {
+  if (typeof price !== 'number' || Number.isNaN(price)) return 0;
+  return price;
+}
+
+function filterProducts(docs: ProductDoc[], filters?: ProductFilters) {
+  let result = docs;
+  if (filters?.category) {
+    result = result.filter((item) => item.category === filters.category);
+  }
+  if (filters?.inStockOnly) {
+    result = result.filter((item) => (item.stock ?? 0) > 0);
+  }
+  return result;
+}
+
+function filterStores(docs: StoreDoc[], filters?: StoreFilters) {
+  let result = docs;
+  if (filters?.plan && filters.plan !== 'all') {
+    result = result.filter((item) => item.plan === filters.plan);
+  }
+  if (typeof filters?.minReputation === 'number') {
+    result = result.filter((item) => item.reputationScore >= filters.minReputation!);
+  }
+  return result;
+}
+
+function filterOrders(docs: OrderDoc[], filters?: OrderFilters) {
+  if (!filters?.status) return docs;
+  if (filters.status === 'open') {
+    return docs.filter(
+      (order) => !['delivered', 'released', 'refunded'].includes(order.status),
+    );
+  }
+  return docs.filter((order) => order.status === filters.status);
+}
+
+function filterMessages(docs: MessageDoc[], filters?: MessageFilters) {
+  if (!filters?.threadId) return docs;
+  return docs.filter((doc) => doc.threadId === filters.threadId);
+}
+
+function queryProducts(query: string, filters?: ProductFilters): SearchResult[] {
+  const trimmed = query.trim();
+  let baseList: ProductDoc[] = [];
+  const scores = new Map<string, number>();
+  if (!trimmed) {
+    baseList = productDocs.slice(0, 25);
+  } else if (productFuse) {
+    const results = productFuse.search(toNormalized(trimmed));
+    results.forEach(({ item, score }) => {
+      baseList.push(item);
+      if (typeof score === 'number') {
+        scores.set(item.id, score);
+      }
+    });
+  }
+  const filtered = filterProducts(baseList.length ? baseList : productDocs, filters);
+  return filtered.slice(0, 20).map((product, index) => ({
+    id: product.id,
+    domain: 'products',
+    title: product.name,
+    subtitle: product.description,
+    route: `/store/${product.storeId}/product/${product.id}`,
+    metadata: {
+      category: product.category,
+      price: formatPrice(product.price),
+    },
+    score: scores.size
+      ? toScoreFromFuse(scores.get(product.id), index)
+      : 0.9 - index * 0.03,
+  }));
+}
+
+function queryStores(query: string, filters?: StoreFilters): SearchResult[] {
+  const trimmed = query.trim();
+  let baseList: StoreDoc[] = [];
+  const scores = new Map<string, number>();
+  if (!trimmed) {
+    baseList = storeDocs.slice(0, 25);
+  } else if (storeFuse) {
+    const results = storeFuse.search(toNormalized(trimmed));
+    results.forEach(({ item, score }) => {
+      baseList.push(item);
+      if (typeof score === 'number') {
+        scores.set(item.id, score);
+      }
+    });
+  }
+  const filtered = filterStores(baseList.length ? baseList : storeDocs, filters);
+  return filtered.slice(0, 20).map((store, index) => ({
+    id: store.id,
+    domain: 'stores',
+    title: store.name,
+    subtitle: store.owner,
+    route: `/store/${store.id}`,
+    metadata: {
+      plan: store.plan || 'free',
+      reputation: store.reputationScore,
+    },
+    score: scores.size
+      ? toScoreFromFuse(scores.get(store.id), index)
+      : 0.85 - index * 0.03,
+  }));
+}
+
+function queryOrders(query: string, filters?: OrderFilters): SearchResult[] {
+  const trimmed = query.trim();
+  let baseList: OrderDoc[] = [];
+  const scores = new Map<string, number>();
+  if (!trimmed) {
+    baseList = orderDocs.slice().sort((a, b) => b.createdAtValue - a.createdAtValue);
+  } else if (orderFuse) {
+    const results = orderFuse.search(toNormalized(trimmed));
+    results.forEach(({ item, score }) => {
+      baseList.push(item);
+      if (typeof score === 'number') {
+        scores.set(item.id, score);
+      }
+    });
+  }
+  const filtered = filterOrders(baseList.length ? baseList : orderDocs, filters);
+  return filtered.slice(0, 20).map((order, index) => ({
+    id: order.id,
+    domain: 'orders',
+    title: `#${order.id}`,
+    subtitle: order.itemText || order.status,
+    route: `/orders/${order.id}`,
+    metadata: {
+      status: order.status,
+      createdAt: order.createdAt,
+    },
+    score: scores.size
+      ? toScoreFromFuse(scores.get(order.id), index)
+      : 0.8 - index * 0.03,
+  }));
+}
+
+function scoreMessage(doc: MessageDoc, queryText: string, index: number): number {
+  const normalizedQuery = toNormalized(queryText);
+  if (!normalizedQuery) {
+    return 1 - Math.min(index * 0.02, 0.6);
+  }
+  const direct = doc.messageNormalized.includes(normalizedQuery) ? 0.6 : 0;
+  const senderMatch = doc.senderNormalized.includes(normalizedQuery)
+    ? 0.2
+    : doc.threadNormalized.includes(normalizedQuery)
+      ? 0.15
+      : 0;
+  const grams = generateNgrams(queryText);
+  let gramScore = 0;
+  if (grams.size > 0) {
+    let hits = 0;
+    grams.forEach((token) => {
+      if (doc.tokens.has(token)) {
+        hits += 1;
+      }
+    });
+    gramScore = grams.size > 0 ? (hits / grams.size) * 0.4 : 0;
+  }
+  const total = direct + senderMatch + gramScore;
+  return Math.max(0, Math.min(1, total));
+}
+
+function queryMessages(query: string, filters?: MessageFilters): SearchResult[] {
+  const filtered = filterMessages(messageDocs, filters);
+  if (!filtered.length) return [];
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return filtered
+      .slice()
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, 20)
+      .map((doc, index) => ({
+        id: doc.id,
+        domain: 'messages',
+        title: doc.threadName,
+        subtitle: doc.message,
+        route: '/messages',
+        params: { threadId: doc.threadId },
+        metadata: {
+          sender: doc.senderName,
+          timestamp: doc.timestamp,
+        },
+        score: 1 - Math.min(index * 0.02, 0.5),
+      }));
+  }
+
+  const scored = filtered
+    .map((doc, index) => ({ doc, score: scoreMessage(doc, trimmed, index) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return b.doc.timestamp - a.doc.timestamp;
+    })
+    .slice(0, 20);
+
+  return scored.map(({ doc, score }) => ({
+    id: doc.id,
+    domain: 'messages',
+    title: doc.threadName,
+    subtitle: doc.message,
+    route: '/messages',
+    params: { threadId: doc.threadId },
+    metadata: {
+      sender: doc.senderName,
+      timestamp: doc.timestamp,
+    },
+    score,
+  }));
+}
+
+export const search = {
+  index(payload: SearchIndexPayload) {
+    scheduleIdle(() => {
+      if (payload.products) {
+        indexProducts(payload.products);
+      }
+      if (payload.stores) {
+        indexStores(payload.stores);
+      }
+      if (payload.orders) {
+        indexOrders(payload.orders);
+      }
+      if (payload.messages) {
+        indexMessages(payload.messages);
+      }
+    });
+  },
+  query(
+    queryText: string,
+    options?: {
+      domain?: SearchDomain;
+      filters?: ProductFilters | StoreFilters | OrderFilters | MessageFilters;
+    },
+  ): SearchResult[] {
+    const domain = options?.domain;
+    if (domain === 'products') {
+      return queryProducts(queryText, options?.filters as ProductFilters | undefined);
+    }
+    if (domain === 'stores') {
+      return queryStores(queryText, options?.filters as StoreFilters | undefined);
+    }
+    if (domain === 'orders') {
+      return queryOrders(queryText, options?.filters as OrderFilters | undefined);
+    }
+    if (domain === 'messages') {
+      return queryMessages(queryText, options?.filters as MessageFilters | undefined);
+    }
+
+    const results: SearchResult[] = [];
+    results.push(
+      ...queryProducts(queryText, options?.filters as ProductFilters | undefined),
+      ...queryStores(queryText, options?.filters as StoreFilters | undefined),
+      ...queryOrders(queryText, options?.filters as OrderFilters | undefined),
+      ...queryMessages(queryText, options?.filters as MessageFilters | undefined),
+    );
+    return results
+      .slice()
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 40);
+  },
+};
+
+export default search;

--- a/tests/searchScreen.test.tsx
+++ b/tests/searchScreen.test.tsx
@@ -1,0 +1,343 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import SearchScreen from '@app/search';
+import type { Order, Product, Store, ChatRoom, ChatMessage } from '@/types';
+
+jest.mock('expo-secure-store');
+
+const mockPush = jest.fn();
+const mockRefreshNotifications = jest.fn();
+
+const themeColors = {
+  background: '#fff',
+  canvas: '#fff',
+  surface: { primary: '#f5f5f5' },
+  border: { primary: '#e0e0e0', focus: '#1976d2' },
+  text: { primary: '#111', secondary: '#666', tertiary: '#999', inverse: '#fff' },
+  gold: '#ffc107',
+};
+
+jest.mock('@/ui/ThemeProvider', () => ({
+  useTheme: () => ({ colors: themeColors, getColor: () => '#111' }),
+  useLanguage: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    isRTL: false,
+    currentLanguage: 'en',
+    setLanguage: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ tenantId: 'default', isNetwork: false }),
+}));
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: 'buyer.near' }),
+}));
+
+jest.mock('@/contexts/CurrencyContext', () => ({
+  useCurrency: () => ({ currencySymbol: '₪' }),
+}));
+
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/NotificationContext', () => ({
+  useNotificationState: () => ({
+    unreadCount: 0,
+    refreshNotifications: mockRefreshNotifications,
+  }),
+}));
+
+jest.mock('@/components/UserAvatar', () => () => null);
+
+jest.mock('@/components/CommandPalette', () => () => null);
+jest.mock('@/components/GadgetLabConsole', () => () => null);
+
+const sampleProducts: Product[] = [
+  {
+    id: 'product-espresso',
+    tenant_id: 'default',
+    name: 'Espresso Machine',
+    price: 499,
+    description: 'Compact espresso maker',
+    category: 'kitchen',
+    images: [],
+    rating: 4.5,
+    reviews: 10,
+    storeId: 'store-a',
+    stock: 3,
+  },
+  {
+    id: 'product-milk',
+    tenant_id: 'default',
+    name: 'Fresh Milk',
+    price: 12,
+    description: 'Local dairy milk',
+    category: 'grocery',
+    images: [],
+    rating: 4.0,
+    reviews: 5,
+    storeId: 'store-b',
+    stock: 10,
+  },
+];
+
+const sampleStores: Store[] = [
+  {
+    id: 'store-a',
+    name: 'Coffee Hub',
+    owner: 'owner.near',
+    nftId: 'nft1',
+    reputation: 0.92,
+    plan: 'premium',
+  },
+  {
+    id: 'store-b',
+    name: 'Daily Goods',
+    owner: 'seller.near',
+    nftId: 'nft2',
+    reputation: 0.65,
+    plan: 'free',
+  },
+];
+
+const baseCartItem = {
+  id: 'cart-1',
+  quantity: 1,
+  addedAt: '2023-01-01T00:00:00.000Z',
+  productId: 'product-espresso',
+  product: sampleProducts[0],
+};
+
+const sampleOrders: Order[] = [
+  {
+    id: 'order-open',
+    tenant_id: 'default',
+    userId: 'buyer.near',
+    items: [baseCartItem],
+    total: 499,
+    status: 'order_received',
+    paymentMethod: 'near',
+    shippingAddress: {
+      name: 'Buyer',
+      phone: '123',
+      street: 'Main',
+      city: 'Tel Aviv',
+      postalCode: '00000',
+    },
+    createdAt: '2023-01-01T00:00:00.000Z',
+    updatedAt: '2023-01-01T00:00:00.000Z',
+    trackingSteps: [],
+    buyerAddress: 'buyer.near',
+  },
+  {
+    id: 'order-closed',
+    tenant_id: 'default',
+    userId: 'buyer.near',
+    items: [baseCartItem],
+    total: 120,
+    status: 'delivered',
+    paymentMethod: 'near',
+    shippingAddress: {
+      name: 'Buyer',
+      phone: '123',
+      street: 'Main',
+      city: 'Tel Aviv',
+      postalCode: '00000',
+    },
+    createdAt: '2022-12-25T00:00:00.000Z',
+    updatedAt: '2022-12-26T00:00:00.000Z',
+    trackingSteps: [],
+    buyerAddress: 'buyer.near',
+  },
+];
+
+const sampleRooms: ChatRoom[] = [
+  {
+    id: 'room-support',
+    userId: 'support.near',
+    userName: 'Support',
+    lastMessage: 'We are here to help',
+    lastMessageTime: Date.now(),
+    unreadCount: 0,
+  },
+];
+
+const sampleMessages: Record<string, ChatMessage[]> = {
+  'room-support': [
+    {
+      id: 'msg-1',
+      senderId: 'support.near',
+      senderName: 'Support Agent',
+      message: 'How can we assist with your espresso machine? ',
+      timestamp: Date.now() - 1_000,
+      isAdmin: true,
+    },
+    {
+      id: 'msg-2',
+      senderId: 'buyer.near',
+      senderName: 'Buyer',
+      message: 'My order arrived damaged',
+      timestamp: Date.now(),
+      isAdmin: false,
+    },
+  ],
+};
+
+let latestTextFieldProps: any = null;
+
+jest.mock('@/ui/primitives/TextField', () => ({
+  __esModule: true,
+  default: jest.fn((props) => {
+    latestTextFieldProps = props;
+    return null;
+  }),
+}));
+
+jest.mock('@/ui/primitives/Divider', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/services/useProducts', () => ({
+  useProducts: () => ({ data: sampleProducts }),
+}));
+
+jest.mock('@/services/useStores', () => ({
+  useStores: () => ({ data: sampleStores }),
+}));
+
+const ordersWarmCacheMock = {
+  list: jest.fn((predicate?: (id: string, value: Order) => boolean) => {
+    if (typeof predicate === 'function') {
+      return sampleOrders.filter((order) => predicate(order.id, order));
+    }
+    return sampleOrders;
+  }),
+  subscribe: jest.fn(() => () => {}),
+  mutate: jest.fn(),
+  getById: jest.fn(),
+};
+
+jest.mock('@/services/nearOrders', () => ({
+  ordersWarmCache: ordersWarmCacheMock,
+}));
+
+const mockDatabase = {
+  getChatRooms: jest.fn(async () => sampleRooms),
+  getChatMessages: jest.fn(async (roomId: string) => sampleMessages[roomId] ?? []),
+};
+
+jest.mock('@/services/database', () => ({
+  __esModule: true,
+  default: { getInstance: () => mockDatabase },
+}));
+
+jest.mock('lucide-react-native', () => {
+  const React = require('react');
+  return new Proxy({}, {
+    get: (_target, prop) => {
+      return (props: any) => React.createElement('Icon', { ...props, name: String(prop) });
+    },
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  latestTextFieldProps = null;
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function getResultPressables(root: renderer.ReactTestRendererJSON | renderer.ReactTestRenderer) {
+  const tree = (root as any).root ?? root;
+  return tree.findAll(
+    (node: any) => node.props?.testID && String(node.props.testID).startsWith('search-result-'),
+  );
+}
+
+describe('SearchScreen', () => {
+  it('returns relevant product matches', async () => {
+    let testRenderer: renderer.ReactTestRenderer;
+    await act(async () => {
+      testRenderer = renderer.create(<SearchScreen />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(latestTextFieldProps).toBeTruthy();
+    await act(async () => {
+      latestTextFieldProps.onChangeText('espresso');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    const results = getResultPressables(testRenderer!);
+    expect(results[0]?.props?.testID).toBe('search-result-products-product-espresso');
+  });
+
+  it('applies order status filters', async () => {
+    const testRenderer = renderer.create(<SearchScreen />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const root = testRenderer.root;
+    const ordersTab = root.find((node) => node.props?.testID === 'search-tab-orders');
+    await act(async () => {
+      ordersTab.props.onPress();
+      jest.advanceTimersByTime(80);
+    });
+
+    const openFilter = root.find((node) => node.props?.testID === 'search-filter-orders-open');
+    await act(async () => {
+      openFilter.props.onPress();
+      jest.advanceTimersByTime(100);
+    });
+
+    const results = getResultPressables(testRenderer);
+    const resultIds = results.map((node: any) => node.props?.testID);
+    expect(resultIds).toEqual(['search-result-orders-order-open']);
+  });
+
+  it('does not trigger network fetch during queries', async () => {
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = mockFetch;
+
+    await act(async () => {
+      renderer.create(<SearchScreen />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestTextFieldProps.onChangeText('support');
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    (global as any).fetch = originalFetch;
+  });
+});

--- a/translations/en.json
+++ b/translations/en.json
@@ -54,6 +54,41 @@
     "products": "Products",
     "orders": "Orders"
   },
+  "search": {
+    "title": "Universal search",
+    "placeholder": "Search products, stores, orders, and messages",
+    "reputation": "Reputation",
+    "tabs": {
+      "products": "Products",
+      "stores": "Stores",
+      "orders": "My Orders",
+      "messages": "Messages"
+    },
+    "filters": {
+      "category": "Categories",
+      "plan": "Plan",
+      "status": "Status",
+      "thread": "Threads",
+      "all": "All",
+      "inStock": "In stock only",
+      "open": "Open"
+    },
+    "empty": {
+      "noResults": "No matches found",
+      "noQuery": "Start typing to search your marketplace.",
+      "tryAgain": "Try another phrase or adjust your filters."
+    },
+    "orderStatus": {
+      "order_received": "Order received",
+      "courier_found": "Courier found",
+      "courier_picked_up": "Courier picked up",
+      "courier_on_way": "Courier on the way",
+      "delivered": "Delivered",
+      "disputed": "Disputed",
+      "released": "Released",
+      "refunded": "Refunded"
+    }
+  },
   "auth": {
     "login": "Login",
     "logout": "Logout",

--- a/translations/he.json
+++ b/translations/he.json
@@ -54,6 +54,41 @@
     "products": "מוצרים",
     "orders": "הזמנות"
   },
+  "search": {
+    "title": "חיפוש אוניברסלי",
+    "placeholder": "חיפוש מוצרים, חנויות, הזמנות והודעות",
+    "reputation": "מוניטין",
+    "tabs": {
+      "products": "מוצרים",
+      "stores": "חנויות",
+      "orders": "ההזמנות שלי",
+      "messages": "הודעות"
+    },
+    "filters": {
+      "category": "קטגוריות",
+      "plan": "מסלול",
+      "status": "סטטוס",
+      "thread": "שיחות",
+      "all": "הכל",
+      "inStock": "זמין במלאי בלבד",
+      "open": "פתוחות"
+    },
+    "empty": {
+      "noResults": "לא נמצאו התאמות",
+      "noQuery": "התחילו להקליד כדי לחפש במרקטפלייס.",
+      "tryAgain": "נסו ביטוי אחר או עדכנו את המסננים."
+    },
+    "orderStatus": {
+      "order_received": "הזמנה התקבלה",
+      "courier_found": "נמצא שליח מתאים",
+      "courier_picked_up": "שליח אסף את ההזמנה",
+      "courier_on_way": "שליח בדרך אלייך",
+      "delivered": "נמסרה",
+      "disputed": "מחלוקת פתוחה",
+      "released": "תשלום שוחרר",
+      "refunded": "תשלום הוחזר"
+    }
+  },
   "auth": {
     "login": "התחבר",
     "logout": "התנתק",


### PR DESCRIPTION
## Summary
- add a shared search service that indexes products, stores, orders, and messages with domain-specific filters and n-gram message scoring
- build the /search screen with tabbed filters, offline data wiring, and result routing; wire the global header search icon to open it
- bump the cached message history to 100 items and expand translations plus unit coverage for the new experience

## Testing
- npx jest --config tests/jest.unit.config.js tests/searchScreen.test.tsx *(fails: local jest binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d35c6700832684ab29bd93f38907