### PR TITLE
feat: add ops drawer diagnostics

### DIFF
--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -30,6 +30,7 @@ const envSchema = z.object({
     .default('false'),
   EXPO_PUBLIC_FEATURE_MOONPAY: z.string().optional().default('false'),
   EXPO_PUBLIC_FEATURE_DISPUTES: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_OPS_DRAWER: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -143,6 +144,7 @@ export { deliveryNotificationsFlag };
 
 const moonPayFeatureEnabled = env.EXPO_PUBLIC_FEATURE_MOONPAY === 'true';
 const disputesFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DISPUTES === 'true';
+const opsDrawerFeatureEnabled = env.EXPO_PUBLIC_FEATURE_OPS_DRAWER === 'true';
 
 export function isMoonPayEnabled(): boolean {
   return moonPayFeatureEnabled;
@@ -150,6 +152,10 @@ export function isMoonPayEnabled(): boolean {
 
 export function isDisputesEnabled(): boolean {
   return disputesFeatureEnabled;
+}
+
+export function isOpsDrawerEnabled(): boolean {
+  return opsDrawerFeatureEnabled;
 }
 
 export default warmCacheFlag;

--- a/contexts/WakuContext.tsx
+++ b/contexts/WakuContext.tsx
@@ -44,6 +44,7 @@ export interface WakuClient {
 
 interface WakuContextValue extends WakuClient {
   status: 'connecting' | 'connected' | 'disconnected';
+  getPeerSummary: () => { peers: number; connections: number };
 }
 
 const noop = async () => {};
@@ -56,6 +57,7 @@ const defaultValue: WakuContextValue = {
   subscribeSystem: async () => () => {},
   broadcastNotification: noop,
   subscribeNotifications: async () => () => {},
+  getPeerSummary: () => ({ peers: 0, connections: 0 }),
 };
 
 const WakuContext = createContext<WakuContextValue>(defaultValue);
@@ -308,6 +310,32 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  const getPeerSummary = useCallback(() => {
+    const node = nodeRef.current as any;
+    if (!node?.libp2p) {
+      return { peers: 0, connections: 0 };
+    }
+    const libp2p = node.libp2p;
+    const connections = typeof libp2p.getConnections === 'function'
+      ? libp2p.getConnections().length
+      : Array.isArray(libp2p?.connectionManager?.connections)
+        ? libp2p.connectionManager.connections.length
+        : 0;
+    let peers = 0;
+    const store = libp2p.peerStore as any;
+    if (store?.peers && typeof store.peers.size === 'number') {
+      peers = store.peers.size;
+    } else if (typeof store?.getPeers === 'function') {
+      try {
+        const list = store.getPeers();
+        peers = Array.isArray(list) ? list.length : 0;
+      } catch {
+        peers = 0;
+      }
+    }
+    return { peers, connections };
+  }, []);
+
   const value = useMemo(
     () => ({
       status,
@@ -318,6 +346,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       subscribeSystem,
       broadcastNotification,
       subscribeNotifications,
+      getPeerSummary,
     }),
     [
       status,
@@ -328,6 +357,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       subscribeSystem,
       broadcastNotification,
       subscribeNotifications,
+      getPeerSummary,
     ],
   );
 

--- a/src/features/opsDrawer/OpsDrawer.tsx
+++ b/src/features/opsDrawer/OpsDrawer.tsx
@@ -1,0 +1,530 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Alert,
+  Animated,
+  Easing,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  View,
+} from 'react-native';
+import { Button, Portal, Spinner, Text } from '@/ui';
+import { useTheme } from '@/ui/ThemeProvider';
+import { radius, spacing, typography } from '@/ui/tokens';
+import useReducedMotion from '@/shared/hooks/useReducedMotion';
+import { snapshotObservabilityMetrics } from '@/utils/observability';
+import { registry as monitoringRegistry } from '@/services/monitoring';
+import type { RegistrySnapshot } from '@/utils/localMetrics';
+import { snapshot as snapshotQueue } from '@/utils/wakuStore';
+import { useWaku } from '@/contexts/WakuContext';
+import { useAuth } from '@/features/auth/AuthContext';
+import { getSession } from '@/services/session';
+import { useLaunchGate } from '@/features/launchGate';
+import * as FileSystem from 'expo-file-system';
+
+const DRAWER_WIDTH = 320;
+
+interface OpsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface OpsSnapshot {
+  capturedAt: number;
+  waku: {
+    status: 'connecting' | 'connected' | 'disconnected';
+    peers: number;
+    connections: number;
+    queueDepth: number;
+  };
+  metrics: {
+    notificationsBacklog: number | null;
+    deliveryBacklog: number | null;
+    cacheLagMs: number | null;
+  };
+  session: {
+    token: string | null;
+    scopes: string[];
+  };
+  security: {
+    pinSet: boolean;
+    biometricAvailable: boolean;
+    biometricEnabled: boolean;
+  };
+  registries: {
+    observability: RegistrySnapshot;
+    monitoring: RegistrySnapshot;
+  };
+}
+
+interface GaugeEntry {
+  value: number;
+}
+
+function readGauge(snapshot: RegistrySnapshot, name: string): number | null {
+  const entries = snapshot.gauges[name] as GaugeEntry[] | undefined;
+  if (!entries || entries.length === 0) return null;
+  return entries.reduce((max, entry) => Math.max(max, entry.value), Number.NEGATIVE_INFINITY);
+}
+
+function formatNumber(value: number | null, suffix = ''): string {
+  if (value === null || Number.isNaN(value)) return '—';
+  const formatted = Math.round(value * 10) / 10;
+  return suffix ? `${formatted}${suffix}` : String(formatted);
+}
+
+type ExpoFsExtras = {
+  EncodingType?: { UTF8?: string };
+  cacheDirectory?: string;
+  documentDirectory?: string;
+};
+
+const expoFs = FileSystem as typeof FileSystem & ExpoFsExtras;
+
+async function exportSnapshot(snapshot: OpsSnapshot): Promise<string> {
+  const payload = JSON.stringify(snapshot, null, 2);
+  const fileName = `ops-status-${new Date(snapshot.capturedAt).toISOString()}.json`;
+  if (Platform.OS === 'web') {
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    return url;
+  }
+
+  if (typeof FileSystem.writeAsStringAsync === 'function') {
+    const dir = expoFs.documentDirectory ?? expoFs.cacheDirectory;
+    if (!dir) throw new Error('Writable directory unavailable');
+    const encoding = expoFs.EncodingType?.UTF8 ?? 'utf8';
+    const uri = `${dir}${fileName}`;
+    await FileSystem.writeAsStringAsync(uri, payload, { encoding: encoding as any });
+    const info = await FileSystem.getInfoAsync(uri);
+    if (!info.exists) {
+      throw new Error('Failed to verify exported report');
+    }
+    return uri;
+  }
+
+  const fs = await import('fs/promises');
+  const os = await import('os');
+  const pathMod = await import('path');
+  const filePath = pathMod.join(os.tmpdir(), fileName);
+  await fs.writeFile(filePath, payload, 'utf8');
+  return `file://${filePath}`;
+}
+
+function MetricRow({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: React.ReactNode;
+  detail?: React.ReactNode;
+}) {
+  return (
+    <View style={styles.metricRow}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <View style={styles.metricValueContainer}>
+        <Text style={styles.metricValue}>{value}</Text>
+        {detail ? <Text style={styles.metricDetail}>{detail}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
+  const { colors } = useTheme();
+  const reduceMotion = useReducedMotion();
+  const { status, getPeerSummary } = useWaku();
+  const { sessionToken } = useAuth();
+  const {
+    pinSet,
+    biometricAvailable,
+    biometricEnabled,
+    enableBiometric,
+  } = useLaunchGate();
+
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const translateX = useRef(new Animated.Value(-DRAWER_WIDTH)).current;
+  const [shouldRender, setShouldRender] = useState(open);
+  const [snapshot, setSnapshot] = useState<OpsSnapshot | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [biometricBusy, setBiometricBusy] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setShouldRender(true);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+    if (reduceMotion) {
+      overlayOpacity.setValue(open ? 1 : 0);
+      translateX.setValue(open ? 0 : -DRAWER_WIDTH);
+      if (!open) {
+        setShouldRender(false);
+      }
+      return;
+    }
+    const overlayAnim = Animated.timing(overlayOpacity, {
+      toValue: open ? 1 : 0,
+      duration: open ? 180 : 120,
+      easing: open ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    });
+    const slideAnim = Animated.timing(translateX, {
+      toValue: open ? 0 : -DRAWER_WIDTH,
+      duration: open ? 220 : 160,
+      easing: open ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    });
+    overlayAnim.start();
+    slideAnim.start(({ finished }) => {
+      if (!open && finished) {
+        setShouldRender(false);
+      }
+    });
+    return () => {
+      overlayAnim.stop();
+      slideAnim.stop();
+    };
+  }, [open, reduceMotion, overlayOpacity, translateX, shouldRender]);
+
+  const loadSnapshot = useCallback((): OpsSnapshot => {
+    const observability = snapshotObservabilityMetrics();
+    const monitoring = monitoringRegistry.snapshot();
+    const { peers, connections } = getPeerSummary();
+    const queueDepth = snapshotQueue().length;
+    const notificationsBacklog = readGauge(observability, 'notifications_backlog');
+    const deliveryBacklog = readGauge(observability, 'delivery_notifications_backlog');
+    const cacheLagMs = readGauge(monitoring, 'cache_sync_lag_ms');
+    const record = sessionToken ? getSession(sessionToken) : undefined;
+    const scopes = Array.isArray(record?.scopes) ? record!.scopes : [];
+    return {
+      capturedAt: Date.now(),
+      waku: { status, peers, connections, queueDepth },
+      metrics: {
+        notificationsBacklog,
+        deliveryBacklog,
+        cacheLagMs,
+      },
+      session: {
+        token: sessionToken ?? null,
+        scopes,
+      },
+      security: {
+        pinSet,
+        biometricAvailable,
+        biometricEnabled,
+      },
+      registries: {
+        observability,
+        monitoring,
+      },
+    };
+  }, [
+    status,
+    getPeerSummary,
+    sessionToken,
+    pinSet,
+    biometricAvailable,
+    biometricEnabled,
+  ]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSnapshot(loadSnapshot());
+  }, [open, loadSnapshot]);
+
+  const handleExport = useCallback(async () => {
+    try {
+      setExporting(true);
+      const latest = loadSnapshot();
+      setSnapshot(latest);
+      const uri = await exportSnapshot(latest);
+      Alert.alert('Status report saved', Platform.OS === 'web' ? 'Report downloaded.' : uri);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to export status report.';
+      Alert.alert('Export failed', message);
+    } finally {
+      setExporting(false);
+    }
+  }, [loadSnapshot]);
+
+  const handleToggleBiometric = useCallback(
+    async (value: boolean) => {
+      try {
+        setBiometricBusy(true);
+        await enableBiometric(value);
+        setSnapshot((current) =>
+          current
+            ? {
+                ...current,
+                security: { ...current.security, biometricEnabled: value },
+              }
+            : current,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unable to update biometric preference.';
+        Alert.alert('Biometric update failed', message);
+      } finally {
+        setBiometricBusy(false);
+      }
+    },
+    [enableBiometric],
+  );
+
+  const biometricDisabled = !snapshot?.security.pinSet || !snapshot.security.biometricAvailable || biometricBusy;
+
+  const capturedAt = useMemo(() => {
+    if (!snapshot) return '';
+    try {
+      return new Date(snapshot.capturedAt).toLocaleTimeString();
+    } catch {
+      return '';
+    }
+  }, [snapshot]);
+
+  if (!shouldRender) return null;
+
+  return (
+    <Portal>
+      <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+        <Animated.View
+          style={[
+            StyleSheet.absoluteFill,
+            styles.overlay,
+            { opacity: overlayOpacity },
+          ]}
+          pointerEvents={open ? 'auto' : 'none'}
+        >
+          <Pressable
+            onPress={onClose}
+            style={StyleSheet.absoluteFill}
+            accessibilityRole="button"
+            accessibilityLabel="Close ops console"
+          />
+        </Animated.View>
+        <Animated.View
+          style={[
+            styles.drawer,
+            {
+              backgroundColor: colors.surface?.elevated ?? colors.canvas,
+              transform: [{ translateX }],
+            },
+          ]}
+        >
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>Ops Console</Text>
+            <Text style={[styles.subtitle, { color: colors.text.secondary }]}>Trust diagnostics</Text>
+            {capturedAt ? (
+              <Text style={[styles.timestamp, { color: colors.text.tertiary }]}>Captured {capturedAt}</Text>
+            ) : null}
+          </View>
+          <ScrollView
+            contentContainerStyle={[styles.content, { paddingBottom: spacing.spacer20 }]}
+          >
+            {!snapshot ? (
+              <View style={styles.loading}>
+                <Spinner />
+              </View>
+            ) : (
+              <>
+                <Section title="Connectivity">
+                  <MetricRow label="Waku" value={snapshot.waku.status} />
+                  <MetricRow
+                    label="Peers"
+                    value={formatNumber(snapshot.waku.peers)}
+                    detail={`Connections ${formatNumber(snapshot.waku.connections)}`}
+                  />
+                  <MetricRow
+                    label="Replay queue"
+                    value={formatNumber(snapshot.waku.queueDepth)}
+                  />
+                </Section>
+                <Section title="Sync">
+                  <MetricRow
+                    label="Cache lag"
+                    value={`${formatNumber(snapshot.metrics.cacheLagMs, ' ms')}`}
+                  />
+                </Section>
+                <Section title="Backlog">
+                  <MetricRow
+                    label="Notifications"
+                    value={formatNumber(snapshot.metrics.notificationsBacklog)}
+                  />
+                  <MetricRow
+                    label="Deliveries"
+                    value={formatNumber(snapshot.metrics.deliveryBacklog)}
+                  />
+                </Section>
+                <Section title="Token scopes">
+                  {snapshot.session.scopes.length ? (
+                    <View style={styles.scopeList}>
+                      {snapshot.session.scopes.map((scope) => (
+                        <View key={scope} style={[styles.scopePill, { backgroundColor: colors.surface?.muted ?? 'rgba(0,0,0,0.05)' }]}>
+                          <Text style={[styles.scopeText, { color: colors.text.primary }]}>{scope}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  ) : (
+                    <Text style={[styles.emptyScopes, { color: colors.text.secondary }]}>No active scopes</Text>
+                  )}
+                </Section>
+                <Section title="Security">
+                  <MetricRow label="PIN enrolled" value={snapshot.security.pinSet ? 'Yes' : 'No'} />
+                  <View style={styles.toggleRow}>
+                    <Text style={[styles.metricLabel, { flex: 1 }]}>Biometric unlock</Text>
+                    <Switch
+                      value={snapshot.security.biometricEnabled}
+                      onValueChange={handleToggleBiometric}
+                      disabled={biometricDisabled}
+                      accessibilityLabel="Toggle biometric unlock"
+                    />
+                  </View>
+                  {!snapshot.security.biometricAvailable ? (
+                    <Text style={[styles.helperText, { color: colors.text.tertiary }]}>Device does not report biometric support.</Text>
+                  ) : null}
+                  {!snapshot.security.pinSet ? (
+                    <Text style={[styles.helperText, { color: colors.text.tertiary }]}>Set a PIN to enable biometric unlock.</Text>
+                  ) : null}
+                </Section>
+              </>
+            )}
+          </ScrollView>
+          <View style={styles.footer}>
+            <Button
+              title="Status report"
+              onPress={handleExport}
+              loading={exporting}
+              accessibilityLabel="Export status report"
+            />
+          </View>
+        </Animated.View>
+      </View>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  drawer: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: DRAWER_WIDTH,
+    paddingHorizontal: spacing.spacer16,
+    paddingTop: spacing.spacer20,
+    shadowColor: 'rgba(0,0,0,0.2)',
+    shadowOffset: { width: 2, height: 0 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+    elevation: 12,
+  },
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.35)',
+  },
+  header: {
+    marginBottom: spacing.spacer16,
+  },
+  title: {
+    ...typography.lg,
+    fontWeight: '600',
+  },
+  subtitle: {
+    ...typography.sm,
+    marginTop: 2,
+  },
+  timestamp: {
+    ...typography.xs,
+    marginTop: spacing.spacer4,
+  },
+  content: {
+    paddingBottom: spacing.spacer16,
+  },
+  section: {
+    marginBottom: spacing.spacer20,
+  },
+  sectionTitle: {
+    ...typography.sm,
+    fontWeight: '600',
+    marginBottom: spacing.spacer12,
+  },
+  metricRow: {
+    marginBottom: spacing.spacer8,
+  },
+  metricLabel: {
+    ...typography.sm,
+    color: '#666',
+  },
+  metricValueContainer: {
+    marginTop: 2,
+  },
+  metricValue: {
+    ...typography.md,
+    fontWeight: '500',
+  },
+  metricDetail: {
+    ...typography.xs,
+    marginTop: 2,
+    color: '#666',
+  },
+  scopeList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.spacer8,
+  },
+  scopePill: {
+    borderRadius: radius.lg,
+    paddingVertical: 4,
+    paddingHorizontal: spacing.spacer12,
+  },
+  scopeText: {
+    ...typography.sm,
+    fontWeight: '500',
+  },
+  emptyScopes: {
+    ...typography.sm,
+  },
+  toggleRow: {
+    marginTop: spacing.spacer12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  helperText: {
+    ...typography.xs,
+    marginTop: spacing.spacer6,
+  },
+  footer: {
+    paddingBottom: spacing.spacer20,
+  },
+  loading: {
+    alignItems: 'center',
+    paddingVertical: spacing.spacer20,
+  },
+});

--- a/src/features/opsDrawer/index.ts
+++ b/src/features/opsDrawer/index.ts
@@ -1,0 +1,1 @@
+export { default as OpsDrawer } from './OpsDrawer';

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,6 +1,6 @@
 // Touchpoint: Ensure bottom navigation remains sticky on mobile devices
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { View, useWindowDimensions, Platform } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PanResponder, StyleSheet, View, useWindowDimensions, Platform } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { Slot, usePathname } from 'expo-router';
@@ -17,6 +17,8 @@ import { useTenant } from '@/contexts/TenantContext';
 import { getShopTenantId } from '@/services/config';
 import { useLaunchGate } from '@/features/launchGate';
 import { useAppRouter } from '@/services/useAppRouter';
+import { OpsDrawer } from '@/features/opsDrawer';
+import { isOpsDrawerEnabled } from '@/config/featureFlags';
 
 interface NavItemConfig extends NavItem {
   requiresAuth?: boolean;
@@ -69,6 +71,7 @@ const NAV_ITEMS: readonly NavItemConfig[] = [
 
 const LARGE_SCREEN = 768;
 const BOTTOM_BAR_HEIGHT = 72; // ~ spacing.spacer24 * 3
+const OPS_GESTURE_WIDTH = 24;
 
 export default function RootLayout() {
   const { theme, colors } = useTheme();
@@ -85,6 +88,60 @@ export default function RootLayout() {
   const { openAuthModal } = useAuthModal();
   const { recordActivity, ready: launchReady, pinSet } = useLaunchGate();
   const { replace } = useAppRouter();
+  const opsDrawerFeature = isOpsDrawerEnabled();
+  const [opsDrawerOpen, setOpsDrawerOpen] = useState(false);
+  const opsOpenRef = useRef(false);
+
+  useEffect(() => {
+    opsOpenRef.current = opsDrawerOpen;
+  }, [opsDrawerOpen]);
+
+  useEffect(() => {
+    if (!opsDrawerFeature && opsDrawerOpen) {
+      opsOpenRef.current = false;
+      setOpsDrawerOpen(false);
+    }
+  }, [opsDrawerFeature, opsDrawerOpen]);
+
+  const openOpsDrawer = useCallback(() => {
+    if (opsOpenRef.current) return;
+    opsOpenRef.current = true;
+    setOpsDrawerOpen(true);
+  }, []);
+
+  const closeOpsDrawer = useCallback(() => {
+    opsOpenRef.current = false;
+    setOpsDrawerOpen(false);
+  }, []);
+
+  const opsGestureResponder = useMemo(() => {
+    if (!opsDrawerFeature) return null;
+    return PanResponder.create({
+      onStartShouldSetPanResponder: (evt) => {
+        const pageX =
+          typeof evt.nativeEvent.pageX === 'number'
+            ? evt.nativeEvent.pageX
+            : evt.nativeEvent.locationX;
+        return pageX <= OPS_GESTURE_WIDTH;
+      },
+      onMoveShouldSetPanResponder: (evt, gesture) => {
+        const startX =
+          typeof evt.nativeEvent.pageX === 'number'
+            ? evt.nativeEvent.pageX
+            : evt.nativeEvent.locationX;
+        if (startX > OPS_GESTURE_WIDTH) return false;
+        if (Math.abs(gesture.dy) > 25) return false;
+        return gesture.dx > 12;
+      },
+      onPanResponderMove: (_evt, gesture) => {
+        if (gesture.dx > 40) openOpsDrawer();
+      },
+      onPanResponderRelease: (_evt, gesture) => {
+        if (gesture.dx > 40) openOpsDrawer();
+      },
+      onPanResponderTerminationRequest: () => true,
+    });
+  }, [opsDrawerFeature, openOpsDrawer]);
 
   const navItems = useMemo(() => {
     const replaced = NAV_ITEMS.map((item) => ({
@@ -193,10 +250,32 @@ export default function RootLayout() {
           </Portal>
         )}
         {showCartWidget && <FloatingCartWidget />}
+        {opsDrawerFeature && opsGestureResponder && (
+          <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+            <View
+              style={styles.opsGestureStrip}
+              pointerEvents="auto"
+              {...opsGestureResponder.panHandlers}
+            />
+          </View>
+        )}
+        {opsDrawerFeature && (
+          <OpsDrawer open={opsDrawerOpen} onClose={closeOpsDrawer} />
+        )}
       </SafeAreaView>
     </ErrorBoundary>
   );
 }
+
+const styles = StyleSheet.create({
+  opsGestureStrip: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: OPS_GESTURE_WIDTH,
+  },
+});
 
 // Acceptance: Bottom navigation is mobile-only and content has padding to avoid overlap
 


### PR DESCRIPTION
## Summary
- add an opsDrawer feature flag and expose Waku peer summaries
- integrate a swipe gesture hook in the root layout and render the ops drawer portal
- implement the ops diagnostics drawer with health metrics, security controls, and status export

## Testing
- `yarn lint` *(fails: @waku/core requires node >=22 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e1eac710832684b13d1af0f07835