### PR TITLE
Fix StoresAgent wallet guard type error

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -118,9 +118,9 @@ class StoresAgent {
     this.subscribers.delete(cb);
   }
 
-  private ensureWallet = async (): Promise<void> => {
+  private async ensureWallet(): Promise<void> {
     await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
-  };
+  }
 
   async add(item: Store): Promise<void> {
     await this.ensureWallet();


### PR DESCRIPTION
## Summary
- convert the StoresAgent wallet guard to a class method so TypeScript recognizes it

## Testing
- yarn typecheck *(fails: repository currently has unresolved diff markers in services/orders.ts and missing expo/tsconfig.base.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ca071bab0883268a45d868e0a40ce6