### PR TITLE
feat: gate reviews and driver chat features

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -42,6 +42,7 @@ import AdminOnboardingChecklist from '@/features/home/components/AdminOnboarding
 import { useAppRouter } from '@/services/useAppRouter';
 import eventBus from '@/services/eventBus';
 import { localIndex } from '@/services/localIndex';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
@@ -50,6 +51,7 @@ function HomeScreenContent() {
   const { appName, logoCid } = useAppInfo();
   const { width: windowWidth } = useWindowDimensions();
   const appRouter = useAppRouter();
+  const reviewsEnabled = isReviewsEnabled();
 
   const home = useHome(tenantId);
 
@@ -180,7 +182,7 @@ function HomeScreenContent() {
       case 'price-high':
         return t('home.priceHighLow');
       case 'rating':
-        return t('home.highRating');
+        return reviewsEnabled ? t('home.highRating') : t('common.comingSoon', 'Coming Soon');
       case 'newest':
       default:
         return t('home.newest');

--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/features/auth/AuthContext';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import { openDM } from '@/services/openDM';
 import { openProduct } from '@/services/openProduct';
+import { isDriverChatEnabled } from '@/config/featureFlags';
 import { AlertTriangle } from 'lucide-react-native';
 
 export default function StoreScreen() {
@@ -48,6 +49,7 @@ export default function StoreScreen() {
 
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [contacting, setContacting] = useState(false);
+  const driverChatEnabled = useMemo(() => isDriverChatEnabled(), []);
 
   const refreshing = productsRefetching || categoriesRefetching;
 
@@ -61,8 +63,15 @@ export default function StoreScreen() {
 
   const storeIdentifier = store?.id || storeId;
   const contactLabel = t('productDetail.contactStore', 'Contact store');
+  const contactHint = driverChatEnabled
+    ? t('productDetail.contactStoreHint', 'Open a chat with this store.')
+    : t('common.comingSoon', 'Coming Soon');
 
   const handleContactStore = useCallback(async () => {
+    if (!driverChatEnabled) {
+      return;
+    }
+
     if (!storeIdentifier) {
       showNotification(
         t('common.error', 'Error'),
@@ -107,7 +116,7 @@ export default function StoreScreen() {
     } finally {
       setContacting(false);
     }
-  }, [appRouter, isLoggedIn, openAuthModal, openDM, showNotification, storeIdentifier, t]);
+  }, [appRouter, driverChatEnabled, isLoggedIn, openAuthModal, openDM, showNotification, storeIdentifier, t]);
 
   const loadError = storeError || productsError || categoriesError;
   const loadErrorMessage = loadError
@@ -227,9 +236,11 @@ export default function StoreScreen() {
         <Button
           title={contactLabel}
           accessibilityLabel={contactLabel}
+          accessibilityHint={contactHint}
           onPress={handleContactStore}
           loading={contacting}
-          disabled={!storeIdentifier || contacting}
+          disabled={!driverChatEnabled || !storeIdentifier || contacting}
+          tooltip={contactHint}
         />
       </View>
 

--- a/app/store/[storeId]/product/_ProductScreen.tsx
+++ b/app/store/[storeId]/product/_ProductScreen.tsx
@@ -21,6 +21,7 @@ import { useProductDetail } from '@/features/products/hooks/useProductDetail';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useAuthModal } from '@/features/auth/AuthModalContext';
 import { openDM } from '@/services/openDM';
+import { isDriverChatEnabled } from '@/config/featureFlags';
 import { AlertTriangle, Heart, MessageCircle, Minus, Plus, ShoppingCart } from 'lucide-react-native';
 
 type TooltipChildProps = {
@@ -97,11 +98,23 @@ export default function ProductDetailScreen() {
   const [adding, setAdding] = useState(false);
   const [contacting, setContacting] = useState(false);
   const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>();
+  const driverChatEnabled = useMemo(() => isDriverChatEnabled(), []);
 
   const storeIdentifier = useMemo(() => {
     if (product?.storeId) return product.storeId;
     return typeof storeId === 'string' ? storeId : undefined;
   }, [product?.storeId, storeId]);
+  const contactLabel = useMemo(
+    () => t('productDetail.contactStore', 'Contact store'),
+    [t],
+  );
+  const contactHint = useMemo(
+    () =>
+      driverChatEnabled
+        ? t('productDetail.contactStoreHint', 'Open a chat with this store.')
+        : t('common.comingSoon', 'Coming Soon'),
+    [driverChatEnabled, t],
+  );
 
   useEffect(() => {
     const variants = product?.variants;
@@ -175,6 +188,10 @@ export default function ProductDetailScreen() {
   }, [product, quantity, selectedVariantId, showNotification, t]);
 
   const handleContactStore = useCallback(async () => {
+    if (!driverChatEnabled) {
+      return;
+    }
+
     if (!storeIdentifier) {
       showNotification(
         t('common.error', 'Error'),
@@ -219,7 +236,7 @@ export default function ProductDetailScreen() {
     } finally {
       setContacting(false);
     }
-  }, [appRouter, isLoggedIn, openAuthModal, openDM, showNotification, storeIdentifier, t]);
+  }, [appRouter, driverChatEnabled, isLoggedIn, openAuthModal, openDM, showNotification, storeIdentifier, t]);
 
   const handleBack = useCallback(() => {
     if (storeId) {
@@ -463,22 +480,22 @@ export default function ProductDetailScreen() {
               <Button
                 onPress={handleContactStore}
                 loading={contacting}
-                disabled={!storeIdentifier || contacting}
-                accessibilityLabel={t('productDetail.contactStore', 'Contact store')}
-                accessibilityHint={t(
-                  'productDetail.contactStoreHint',
-                  'Open a chat with this store.',
-                )}
-                tooltip={t('productDetail.contactStoreHint', 'Open a chat with this store.')}
+                disabled={!driverChatEnabled || !storeIdentifier || contacting}
+                accessibilityLabel={contactLabel}
+                accessibilityHint={contactHint}
+                tooltip={contactHint}
                 style={[
                   styles.secondaryButton,
                   { backgroundColor: colors.surface.secondary, borderColor: colors.border.primary },
                 ]}
               >
                 <View style={styles.buttonContent}>
-                  <MessageCircle size={18} color={colors.text.primary} />
-                  <Text style={[styles.buttonText, { color: colors.text.primary }]}>
-                    {t('productDetail.contactStore', 'Contact store')}
+                  <MessageCircle
+                    size={18}
+                    color={driverChatEnabled ? colors.text.primary : colors.text.secondary}
+                  />
+                  <Text style={[styles.buttonText, { color: colors.text.primary }]}> 
+                    {contactLabel}
                   </Text>
                 </View>
               </Button>

--- a/components/OrderTrackingModal.tsx
+++ b/components/OrderTrackingModal.tsx
@@ -20,7 +20,7 @@ import { useAuth } from '@/features/auth/AuthContext';
 import { useLanguage } from '@/ui/ThemeProvider';
 import { useLaunchGate } from '@/features/launchGate';
 import { formatTimestamp } from '@/utils/formatTimestamp';
-import { isDisputesEnabled } from '@/config/featureFlags';
+import { isDisputesEnabled, isReviewsEnabled } from '@/config/featureFlags';
 import OrderTimeline from '@/components/OrderTimeline';
 
 
@@ -41,6 +41,7 @@ export default function OrderTrackingModal({ visible, onClose, order }: OrderTra
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
   const disputesEnabled = isDisputesEnabled();
+  const reviewsEnabled = isReviewsEnabled();
 
   useEffect(() => {
     if (visible && order) {
@@ -426,11 +427,11 @@ ${order.items.map(item => `- ${item.product.name} x${item.quantity} - ${currency
           )}
 
           {/* Review Prompt */}
-          {order.status === 'delivered' && (
-            <View style={[styles.reviewPrompt, { 
+          {reviewsEnabled && order.status === 'delivered' && (
+            <View style={[styles.reviewPrompt, {
               backgroundColor: colors.surface.primary,
-              borderColor: colors.border.primary 
-            }]}>
+              borderColor: colors.border.primary
+            }]}> 
               <Star size={24} color={colors.gold} />
               <Text style={[styles.reviewTitle, { color: colors.text.primary }]}>איך היה המשלוח?</Text>
               <Text style={[styles.reviewText, { color: colors.text.secondary }]}>

--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -31,6 +31,8 @@ const envSchema = z.object({
   EXPO_PUBLIC_FEATURE_MOONPAY: z.string().optional().default('false'),
   EXPO_PUBLIC_FEATURE_DISPUTES: z.string().optional().default('false'),
   EXPO_PUBLIC_FEATURE_OPS_DRAWER: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_REVIEWS: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_DRIVER_CHAT: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -145,6 +147,8 @@ export { deliveryNotificationsFlag };
 const moonPayFeatureEnabled = env.EXPO_PUBLIC_FEATURE_MOONPAY === 'true';
 const disputesFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DISPUTES === 'true';
 const opsDrawerFeatureEnabled = env.EXPO_PUBLIC_FEATURE_OPS_DRAWER === 'true';
+const reviewsFeatureEnabled = env.EXPO_PUBLIC_FEATURE_REVIEWS === 'true';
+const driverChatFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DRIVER_CHAT === 'true';
 
 export function isMoonPayEnabled(): boolean {
   return moonPayFeatureEnabled;
@@ -156,6 +160,14 @@ export function isDisputesEnabled(): boolean {
 
 export function isOpsDrawerEnabled(): boolean {
   return opsDrawerFeatureEnabled;
+}
+
+export function isReviewsEnabled(): boolean {
+  return reviewsFeatureEnabled;
+}
+
+export function isDriverChatEnabled(): boolean {
+  return driverChatFeatureEnabled;
 }
 
 export default warmCacheFlag;

--- a/src/features/auth/components/UserProfileModal.tsx
+++ b/src/features/auth/components/UserProfileModal.tsx
@@ -12,6 +12,7 @@ import { X } from 'lucide-react-native';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import DatabaseService from '@/services/database';
 import { Spinner } from '@/ui/primitives';
+import { isDriverChatEnabled } from '@/config/featureFlags';
 
 interface UserProfileModalProps {
   visible: boolean;
@@ -24,6 +25,7 @@ interface UserProfileModalProps {
 export default function UserProfileModal({ visible, userId, onClose, isAdmin = false, onMessage }: UserProfileModalProps) {
   const { colors } = useTheme();
   const { t } = useLanguage();
+  const driverChatEnabled = isDriverChatEnabled();
   const [loading, setLoading] = useState(false);
   const [profile, setProfile] = useState<{ username: string; displayName: string; exists: boolean } | null>(null);
   const [orders, setOrders] = useState<{ id: string; total: number; status: string; createdAt: string }[]>([]);
@@ -101,14 +103,30 @@ export default function UserProfileModal({ visible, userId, onClose, isAdmin = f
                       ))}
                     </View>
                   )}
-                  {isAdmin && onMessage && (
-                    <TouchableOpacity
-                      style={[styles.messageButton, { backgroundColor: colors.gold }]}
-                      onPress={() => onMessage(userId, profile.displayName)}
-                    >
-                      <Text style={[styles.messageButtonText, { color: colors.text.inverse }]}>{t('navigation.messages')}</Text>
-                    </TouchableOpacity>
-                  )}
+                  {isAdmin && onMessage
+                    ? driverChatEnabled
+                      ? (
+                          <TouchableOpacity
+                            style={[styles.messageButton, { backgroundColor: colors.gold }]}
+                            onPress={() => onMessage(userId, profile.displayName)}
+                          >
+                            <Text style={[styles.messageButtonText, { color: colors.text.inverse }]}>
+                              {t('navigation.messages')}
+                            </Text>
+                          </TouchableOpacity>
+                        )
+                      : (
+                          <Text
+                            style={{
+                              marginTop: 16,
+                              color: colors.text.secondary,
+                              textAlign: 'center',
+                            }}
+                          >
+                            {t('common.comingSoon', 'Coming Soon')}
+                          </Text>
+                        )
+                    : null}
                 </>
               ) : (
                 <Text style={[styles.displayName, { color: colors.text.primary }]}>{t('chat.noUsersFound')}</Text>

--- a/src/features/cart/components/WishlistModal.tsx
+++ b/src/features/cart/components/WishlistModal.tsx
@@ -14,6 +14,7 @@ import { WishlistItem } from '@/types';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import useWishlist from '../hooks/useWishlist';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 interface WishlistModalProps {
   visible: boolean;
@@ -24,6 +25,7 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
   const { wishlistItems, removeFromWishlist, addToCart } = useWishlist(visible);
   const { colors } = useTheme();
   const { currencySymbol } = useCurrency();
+  const reviewsEnabled = isReviewsEnabled();
 
   const handleAddToCart = async (item: WishlistItem) => {
     await addToCart(item);
@@ -62,10 +64,12 @@ export default function WishlistModal({ visible, onClose }: WishlistModalProps) 
           )}
         </View>
 
-        <View style={styles.ratingContainer}>
-          <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {item.product.rating}</Text>
-          <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({item.product.reviews})</Text>
-        </View>
+        {reviewsEnabled ? (
+          <View style={styles.ratingContainer}>
+            <Text style={[styles.rating, { color: colors.text.primary }]}>⭐ {item.product.rating}</Text>
+            <Text style={[styles.reviews, { color: colors.text.tertiary }]}>({item.product.reviews})</Text>
+          </View>
+        ) : null}
 
         <View style={styles.stockContainer}>
           <View

--- a/src/features/home/components/SortModal.tsx
+++ b/src/features/home/components/SortModal.tsx
@@ -3,6 +3,7 @@ import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { X as XIcon } from 'lucide-react-native';
 import { useLanguage, useTheme } from '@/ui/ThemeProvider';
 import { SortOption } from '@/features/home/hooks/useHomeFilters';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 interface SortModalProps {
   visible: boolean;
@@ -21,12 +22,13 @@ export default function SortModal({
   const { colors: themeColors } = useTheme();
   const CloseIcon: any = (XIcon as any) || ((_: any) => null);
 
+  const reviewsEnabled = isReviewsEnabled();
   const options = [
     { key: 'newest', label: t('home.newest') },
     { key: 'price-low', label: t('home.priceLowHigh') },
     { key: 'price-high', label: t('home.priceHighLow') },
     { key: 'rating', label: t('home.highRating') },
-  ];
+  ].filter((option) => reviewsEnabled || option.key !== 'rating');
 
   return (
     <Modal

--- a/src/features/home/hooks/useHomeFilters.ts
+++ b/src/features/home/hooks/useHomeFilters.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Product } from '@/types';
 import { localIndex, type ResultSet } from '@/services/localIndex';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 export type SortOption = 'newest' | 'price-low' | 'price-high' | 'rating';
 
 export function useHomeFilters(products: Product[]) {
+  const reviewsEnabled = isReviewsEnabled();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Product[]>(products);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -18,6 +20,12 @@ export function useHomeFilters(products: Product[]) {
   useEffect(() => {
     queryRef.current = searchQuery;
   }, [searchQuery]);
+
+  useEffect(() => {
+    if (!reviewsEnabled && sortBy === 'rating') {
+      setSortBy('newest');
+    }
+  }, [reviewsEnabled, sortBy]);
 
   useEffect(() => {
     localIndex.setProducts(products);
@@ -72,7 +80,13 @@ export function useHomeFilters(products: Product[]) {
         case 'price-high':
           return b.price - a.price;
         case 'rating':
-          return b.rating - a.rating;
+          if (!reviewsEnabled) {
+            return (
+              new Date(b.createdAt || 0).getTime() -
+              new Date(a.createdAt || 0).getTime()
+            );
+          }
+          return (b.rating ?? 0) - (a.rating ?? 0);
         case 'newest':
         default:
           return (
@@ -81,7 +95,7 @@ export function useHomeFilters(products: Product[]) {
           );
       }
     });
-  }, [searchResults, selectedCategory, minPrice, maxPrice, sortBy]);
+  }, [maxPrice, minPrice, reviewsEnabled, searchResults, selectedCategory, sortBy]);
 
   return {
     filteredProducts,

--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -6,6 +6,7 @@ import { Text, Button, Skeleton } from '@/ui';
 import { spacing, radius, typography } from '@/ui/tokens';
 import { Product } from '@/types';
 import { useProductCard } from './hooks/useProductCard';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 interface ProductCardProps {
   product: Product;
@@ -22,6 +23,7 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
     price,
     originalPrice,
   } = useProductCard(product);
+  const reviewsEnabled = isReviewsEnabled();
   const accessibilityLabel = React.useMemo(() => {
     if (!price) {
       return product.name;
@@ -79,14 +81,16 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
             {price}
           </Text>
         </View>
-        <View style={styles.ratingRow}>
-          <Star size={12} color={colors.gold} />
-          <Text
-            style={[typography.xs, { fontWeight: '500', marginStart: spacing.spacer4, color: colors.text.primary }]}
-          >
-            {product.rating ?? 0}
-          </Text>
-        </View>
+        {reviewsEnabled ? (
+          <View style={styles.ratingRow}>
+            <Star size={12} color={colors.gold} />
+            <Text
+              style={[typography.xs, { fontWeight: '500', marginStart: spacing.spacer4, color: colors.text.primary }]}
+            >
+              {product.rating ?? 0}
+            </Text>
+          </View>
+        ) : null}
         {onCTAPress && (
           <Button title="Buy" onPress={onCTAPress} style={styles.cta} />
         )}

--- a/src/features/stores/components/store/StoreHeader.tsx
+++ b/src/features/stores/components/store/StoreHeader.tsx
@@ -4,6 +4,7 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Heading, Text, Skeleton } from '@/ui/primitives';
 import { spacing, radius } from '@/shared/ui/tokens';
 import { Star } from 'lucide-react-native';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 interface Props {
   name: string;
@@ -25,6 +26,7 @@ export default function StoreHeader({
   const fallbackName = name || t('stores.storeName');
   const bannerLabel = t('stores.bannerAlt', { name: fallbackName });
   const avatarLabel = t('stores.avatarAlt', { name: fallbackName });
+  const reviewsEnabled = isReviewsEnabled();
 
   return (
     <View>
@@ -103,25 +105,38 @@ export default function StoreHeader({
           >
             {fallbackName}
           </Heading>
-          <View
-            style={[
-              styles.ratingRow,
-              { flexDirection: isRTL ? 'row-reverse' : 'row' },
-            ]}
-          >
-            <Star size={16} color={colors.gold} />
+          {reviewsEnabled ? (
+            <View
+              style={[
+                styles.ratingRow,
+                { flexDirection: isRTL ? 'row-reverse' : 'row' },
+              ]}
+            >
+              <Star size={16} color={colors.gold} />
+              <Text
+                variant="sm"
+                weight="500"
+                style={{
+                  color: colors.text.primary,
+                  marginStart: isRTL ? 0 : spacing.spacer4,
+                  marginEnd: isRTL ? spacing.spacer4 : 0,
+                }}
+              >
+                {t('stores.reputation', 'Reputation:')} {reputation.toFixed(1)}
+              </Text>
+            </View>
+          ) : (
             <Text
               variant="sm"
-              weight="500"
               style={{
-                color: colors.text.primary,
-                marginStart: isRTL ? 0 : spacing.spacer4,
-                marginEnd: isRTL ? spacing.spacer4 : 0,
+                color: colors.text.secondary,
+                marginTop: spacing.spacer4,
+                textAlign: isRTL ? 'right' : 'left',
               }}
             >
-              {t('stores.reputation', 'Reputation:')} {reputation.toFixed(1)}
+              {t('stores.reviewsComingSoon', 'Reviews coming soon.')}
             </Text>
-          </View>
+          )}
           {tagline ? (
             <Text
               variant="sm"

--- a/src/features/stores/components/store/StoreTabs.tsx
+++ b/src/features/stores/components/store/StoreTabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
+import { isReviewsEnabled } from '@/config/featureFlags';
 
 type TabKey = 'products' | 'about' | 'reviews';
 
@@ -13,11 +14,14 @@ export default function StoreTabs({
 }) {
   const { colors } = useTheme();
   const { t, isRTL } = useLanguage();
+  const reviewsEnabled = isReviewsEnabled();
   const tabs: { key: TabKey; label: string }[] = [
     { key: 'products', label: t('stores.tabs.products') },
     { key: 'about', label: t('stores.tabs.about') },
-    { key: 'reviews', label: t('stores.tabs.reviews') },
   ];
+  if (reviewsEnabled) {
+    tabs.push({ key: 'reviews', label: t('stores.tabs.reviews') });
+  }
   return (
     <View
       style={{

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -18,7 +18,7 @@ import { getShopTenantId } from '@/services/config';
 import { useLaunchGate } from '@/features/launchGate';
 import { useAppRouter } from '@/services/useAppRouter';
 import { OpsDrawer } from '@/features/opsDrawer';
-import { isOpsDrawerEnabled } from '@/config/featureFlags';
+import { isOpsDrawerEnabled, isDriverChatEnabled } from '@/config/featureFlags';
 
 interface NavItemConfig extends NavItem {
   requiresAuth?: boolean;
@@ -89,6 +89,7 @@ export default function RootLayout() {
   const { recordActivity, ready: launchReady, pinSet } = useLaunchGate();
   const { replace } = useAppRouter();
   const opsDrawerFeature = isOpsDrawerEnabled();
+  const driverChatEnabled = isDriverChatEnabled();
   const [opsDrawerOpen, setOpsDrawerOpen] = useState(false);
   const opsOpenRef = useRef(false);
 
@@ -144,7 +145,10 @@ export default function RootLayout() {
   }, [opsDrawerFeature, openOpsDrawer]);
 
   const navItems = useMemo(() => {
-    const replaced = NAV_ITEMS.map((item) => ({
+    const filtered = driverChatEnabled
+      ? NAV_ITEMS
+      : NAV_ITEMS.filter((item) => item.href !== '/messages');
+    const replaced = filtered.map((item) => ({
       ...item,
       href: item.href.replace('[storeId]', tenantId ?? ''),
     }));
@@ -169,7 +173,7 @@ export default function RootLayout() {
         (needsAuth && !isLoggedIn) || (needsOwner && !isStoreOwner) || (needsTenant && !tenantId);
       return shouldIntercept ? ({ ...item, onPress: guardedOnPress } as NavItem) : (item as NavItem);
     });
-  }, [isLoggedIn, isStoreOwner, tenantId, openAuthModal]);
+  }, [driverChatEnabled, isLoggedIn, isStoreOwner, tenantId, openAuthModal]);
 
   useEffect(() => {
     if (!launchReady) return;

--- a/src/services/useStoreReviews.ts
+++ b/src/services/useStoreReviews.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { isReviewsEnabled } from '@/config/featureFlags';
 import reviewAgent from '@/agents/review-agent';
 import storesAgent from '@/agents/stores-agent';
 import { useProducts } from './useProducts';
@@ -11,11 +12,13 @@ interface ReviewInfo {
 export type ReviewMap = Record<string, ReviewInfo>;
 
 export function useStoreReviews(storeId: string | null) {
+  const reviewsEnabled = isReviewsEnabled();
   const { data: products = [] } = useProducts(storeId);
 
   return useQuery({
     queryKey: ['store-reviews', storeId],
     queryFn: async () => {
+      if (!reviewsEnabled) return { reviews: {} as ReviewMap, score: 0 };
       if (!storeId) return { reviews: {} as ReviewMap, score: 0 };
       const entries = await Promise.all(
         products.map(async (p) => {
@@ -31,7 +34,7 @@ export function useStoreReviews(storeId: string | null) {
     },
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
-    enabled: !!storeId && products.length > 0,
+    enabled: reviewsEnabled && !!storeId && products.length > 0,
     initialData: { reviews: {} as ReviewMap, score: 0 },
   });
 }

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -98,6 +98,44 @@ describe('disputes feature flag', () => {
   });
 });
 
+describe('reviews feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_REVIEWS;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isReviewsEnabled } = require('@/config/featureFlags');
+    expect(isReviewsEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_REVIEWS = 'true';
+    jest.resetModules();
+    const { isReviewsEnabled } = require('@/config/featureFlags');
+    expect(isReviewsEnabled()).toBe(true);
+  });
+});
+
+describe('driver chat feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_DRIVER_CHAT;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isDriverChatEnabled } = require('@/config/featureFlags');
+    expect(isDriverChatEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_DRIVER_CHAT = 'true';
+    jest.resetModules();
+    const { isDriverChatEnabled } = require('@/config/featureFlags');
+    expect(isDriverChatEnabled()).toBe(true);
+  });
+});
+
 describe('notifications pipeline feature flag', () => {
   beforeEach(() => {
     delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;


### PR DESCRIPTION
## Summary
- parse EXPO_PUBLIC_FEATURE_REVIEWS and EXPO_PUBLIC_FEATURE_DRIVER_CHAT environment values and expose helpers
- hide reviews UI and driver chat entry points when their feature flags are disabled
- update home sorting, store review queries, and feature flag unit tests to respect the new flags

## Testing
- Not run (dependency install requires Node >=22 and fails under Node 20.19.4)


------
https://chatgpt.com/codex/tasks/task_e_68ca10529148832698cf9cbebd66a6e7