### PR TITLE
Update escrow deployment flow and events

### DIFF
--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -21,6 +21,7 @@ import {
 import productsAgent from './products-agent';
 import { getSellerPublicKey } from '@/features/stores/services/sellerRegistry';
 import meteredBilling from '@/billing';
+import { getFeeSettings } from '@/constants/tenant';
 
 assertNearChain();
 import { encryptShippingInfo } from '../utils/shippingCrypto';
@@ -222,22 +223,23 @@ class OrdersAgent {
         ).toString('hex');
     let enriched: Order = { ...normalized, itemsHash };
     if (!normalized.paymentContractAddress || !normalized.paymentTxHash) {
+      const { feeAddress, feeBps } = await getFeeSettings();
       const draft: DeployEscrowDraft = {
         sessionToken: normalized.sessionToken,
         scopes: ['checkout'],
         nonce: normalized.id,
-        storeId,
         total: normalized.total,
-        itemsHash,
+        feeAddress,
+        feeBps,
         buyerAddress: normalized.buyerAddress,
         sellerAddress: normalized.sellerAddress,
         kycReceiptHash: normalized.kycReceiptHash,
       };
-      const { orderId, txHash } = await deployEscrow(draft);
+      const { contractAddress, txHash } = await deployEscrow(draft);
       enriched = {
         ...enriched,
-        paymentContractAddress: orderId,
-        escrowAddr: orderId,
+        paymentContractAddress: contractAddress,
+        escrowAddr: contractAddress,
         paymentTxHash: txHash,
       };
     } else if (!normalized.escrowAddr && normalized.paymentContractAddress) {

--- a/services/nearContract.ts
+++ b/services/nearContract.ts
@@ -34,16 +34,16 @@ export interface DeployEscrowDraft {
   sessionToken?: string;
   scopes?: string[];
   nonce: string;
-  storeId: string;
   total: number;
-  itemsHash: string;
+  feeAddress: string;
+  feeBps: number;
   buyerAddress?: string;
   sellerAddress?: string;
   kycReceiptHash?: string;
 }
 
 export interface DeployEscrowResult {
-  orderId: string;
+  contractAddress: string;
   txHash: string;
   expiresAt: string;
   status: typeof ESCROW_STATUS_PENDING;
@@ -107,23 +107,22 @@ export async function deployEscrow(
   const end = serviceLatency.startTimer({ service: 'near.deployEscrow' });
   try {
     const factoryAddress = await getOrderPaymentFactoryAddress();
-    const settings = await fetchSettings();
-    const feeAddress = settings.feeAddress ?? '';
-    const feeBps = settings.feeBps ?? 0;
     const txHash = await sendNear(
-      `Pay:${draft.total}:${feeAddress}:${feeBps}`,
+      `Pay:${draft.total}:${draft.feeAddress}:${draft.feeBps}:${draft.nonce}`,
     );
     logger.info(
       {
         service: 'near.deployEscrow',
         txHash,
-        orderId: factoryAddress,
-        storeId: draft.storeId,
+        contractAddress: factoryAddress,
+        nonce: draft.nonce,
+        buyerAddress: draft.buyerAddress,
+        sellerAddress: draft.sellerAddress,
       },
       'Escrow deployment submitted',
     );
     return {
-      orderId: factoryAddress,
+      contractAddress: factoryAddress,
       txHash,
       expiresAt: new Date(Date.now() + ESCROW_EXPIRATION_WINDOW_MS).toISOString(),
       status: ESCROW_STATUS_PENDING,

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -13,7 +13,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { getStore } from '@/features/stores/services/nearStores';
 import { getProduct, setProduct } from '@/features/products/services/nearProducts';
 import { chainAdapter } from '@/services/chain';
-import { adminResolve, deployOrderPayment } from './nearContract';
+import { adminResolve, deployEscrow as nearDeployEscrow } from './nearContract';
 import { canonicalJson } from '@/utils/serialization';
 import { calculateCardFees } from '@/features/payments/services/card';
 import {
@@ -23,11 +23,12 @@ import {
 } from '@/services/session';
 import { checkoutTokenIntegrity, latencyHistogram } from '@/services/monitoring';
 import SettingsAgent from '@/agents/settings-agent';
+import { getFeeSettings } from '@/constants/tenant';
 import { loadKycReceipt } from '@/services/kycReceipts';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 
-const ORDER_TOPIC = '/blue-ocean/orders/1';
+const ORDER_TOPIC_PREFIX = '/blue-ocean/orders';
 const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
 const PRODUCT_TOPIC = '/blue-ocean/products/1';
 const LOW_STOCK_THRESHOLD = 5;
@@ -84,6 +85,7 @@ interface OrderDraft {
   itemsHash: string;
   buyerAddress?: string;
   sellerAddress?: string;
+  kycReceiptHash?: string;
 }
 
 export async function emitOrderEvents(
@@ -109,6 +111,7 @@ export async function emitOrderEvents(
 
   const deterministicTimestamp = parseDeterministicTimestamp();
 
+  const orderTopic = `${ORDER_TOPIC_PREFIX}/${storeId}`;
   const baseEvent = {
     id: order.id,
     orderId: order.id,
@@ -144,11 +147,11 @@ export async function emitOrderEvents(
       storeId,
     });
     const createdPayload = { ...baseEvent };
-    await publishWithContext(ORDER_TOPIC, 'order.created', createdPayload);
+    await publishWithContext(orderTopic, 'order.created', createdPayload);
     await publishWithContext(NOTIFICATION_TOPIC, 'order.created', createdPayload);
     if (order.paymentMethod === 'near') {
       const escrowPayload = { ...baseEvent };
-      await publishWithContext(ORDER_TOPIC, 'escrow.deployed', escrowPayload);
+      await publishWithContext(orderTopic, 'escrow.deployed', escrowPayload);
       await publishWithContext(
         NOTIFICATION_TOPIC,
         'escrow.deployed',
@@ -234,15 +237,27 @@ class OrderService {
       itemsHash: draft.itemsHash,
     });
     try {
-      const result = await deployOrderPayment(draft.total);
+      const { feeAddress, feeBps } = await getFeeSettings();
+      const result = await nearDeployEscrow({
+        total: draft.total,
+        feeAddress,
+        feeBps,
+        buyerAddress: draft.buyerAddress,
+        sellerAddress: draft.sellerAddress,
+        kycReceiptHash: draft.kycReceiptHash,
+        nonce: draft.nonce,
+        sessionToken: draft.sessionToken,
+      });
       debugLog('orders.escrow.deploy.success', {
         orderId,
         orderNonce: draft.nonce,
         storeId: draft.storeId,
         contractAddress: result.contractAddress,
         txHash: result.txHash,
+        feeAddress,
+        feeBps,
       });
-      return result;
+      return { contractAddress: result.contractAddress, txHash: result.txHash };
     } catch (err) {
       errorLog('orders.escrow.deploy.failed', {
         orderId,
@@ -297,6 +312,7 @@ class OrderService {
         itemsHash,
         buyerAddress: pay?.buyerAddress,
         sellerAddress: pay?.sellerAddress,
+        kycReceiptHash: kyc.hash,
       };
       const { contractAddress, txHash } = await this.deployEscrow(draft);
       pay = { ...pay, contractAddress, txHash };

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -52,13 +52,19 @@ jest.mock('@/services/nearContract', () => ({
   deployEscrow: jest
     .fn()
     .mockImplementation(async (draft: any) => ({
-      orderId: `escrow_${draft.total}`,
+      contractAddress: `escrow_${draft.total}`,
       txHash: `tx_${draft.total}`,
       expiresAt: '2099-01-01T00:00:00.000Z',
       status: 'pending',
     })),
   releasePayment: jest.fn(),
   refundPayment: jest.fn(),
+}));
+
+jest.mock('@/constants/tenant', () => ({
+  getFeeSettings: jest
+    .fn()
+    .mockResolvedValue({ feeAddress: 'fee_addr', feeBps: 250 }),
 }));
 
 jest.mock('@/features/auth/services/nearUsers', () => ({

--- a/tests/ordersAgent.test.ts
+++ b/tests/ordersAgent.test.ts
@@ -37,13 +37,17 @@ jest.mock('@/services/nearContract', () => ({
   deployEscrow: jest
     .fn()
     .mockResolvedValue({
-      orderId: 'escrow1',
+      contractAddress: 'escrow1',
       txHash: 'tx1',
       expiresAt: '2099-01-01T00:00:00.000Z',
       status: 'pending',
     }),
   releasePayment: jest.fn().mockResolvedValue('hash-release'),
   refundPayment: jest.fn().mockResolvedValue('hash-refund'),
+}));
+
+jest.mock('@/constants/tenant', () => ({
+  getFeeSettings: jest.fn().mockResolvedValue({ feeAddress: 'fee', feeBps: 250 }),
 }));
 
 jest.mock('@/features/stores/services/sellerRegistry');


### PR DESCRIPTION
## Summary
- update order creation to fetch fee settings, pass checkout nonce into escrow deployment, and publish store-specific order topics
- adjust the NEAR escrow helper to accept fee configuration, include the nonce in the signed message, and return the contract address
- align the orders agent and unit tests with the new escrow response shape

## Testing
- ⚠️ `yarn install --silent` *(fails: @waku/core requires Node >=22, container provides Node 20.19.4)*
- ⚠️ `npx --yes --package jest@29.7.0 --package ts-jest@29.4.1 --package ts-node@10.9.2 jest tests/multiSellerCheckout.test.ts` *(fails: preset ts-jest/presets/default-esm not found without project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca22e5bdd083268e79cc7f7b368157