### PR TITLE
feat: add Waku shared key derivation and metrics

### DIFF
--- a/config/featureFlags.ts
+++ b/config/featureFlags.ts
@@ -33,6 +33,7 @@ const envSchema = z.object({
   EXPO_PUBLIC_FEATURE_OPS_DRAWER: z.string().optional().default('false'),
   EXPO_PUBLIC_FEATURE_REVIEWS: z.string().optional().default('false'),
   EXPO_PUBLIC_FEATURE_DRIVER_CHAT: z.string().optional().default('false'),
+  EXPO_PUBLIC_FEATURE_WAKU_SHARED_KEYS: z.string().optional().default('false'),
 });
 
 const env = envSchema.parse(process.env);
@@ -149,6 +150,7 @@ const disputesFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DISPUTES === 'true';
 const opsDrawerFeatureEnabled = env.EXPO_PUBLIC_FEATURE_OPS_DRAWER === 'true';
 const reviewsFeatureEnabled = env.EXPO_PUBLIC_FEATURE_REVIEWS === 'true';
 const driverChatFeatureEnabled = env.EXPO_PUBLIC_FEATURE_DRIVER_CHAT === 'true';
+const wakuSharedKeysFeatureEnabled = env.EXPO_PUBLIC_FEATURE_WAKU_SHARED_KEYS === 'true';
 
 export function isMoonPayEnabled(): boolean {
   return moonPayFeatureEnabled;
@@ -168,6 +170,10 @@ export function isReviewsEnabled(): boolean {
 
 export function isDriverChatEnabled(): boolean {
   return driverChatFeatureEnabled;
+}
+
+export function isWakuSharedKeysEnabled(): boolean {
+  return wakuSharedKeysFeatureEnabled;
 }
 
 export default warmCacheFlag;

--- a/config/index.ts
+++ b/config/index.ts
@@ -18,6 +18,8 @@ const envSchema = z.object({
   EXPO_PUBLIC_WAKU_PUBLISHER_KEY: z.string().optional().default(''),
   WAKU_DISABLE: z.string().optional().default(''),
   EXPO_PUBLIC_WAKU_DISABLE: z.string().optional().default(''),
+  WAKU_KEY_EPOCH: z.string().optional().default('1'),
+  EXPO_PUBLIC_WAKU_KEY_EPOCH: z.string().optional().default('1'),
   WAKU_STRICT: z.string().optional().default(''),
   EXPO_PUBLIC_RELAYER_URL: z.string().optional().default(''),
   EXPO_PUBLIC_INDEXER_URL: z.string().optional().default(''),

--- a/schemas/waku/message.ts
+++ b/schemas/waku/message.ts
@@ -8,6 +8,7 @@ export const wakuMessageSchema = z.object({
     role: z.string().optional(),
   }),
   signature: z.string(),
+  keyEpoch: z.number().optional(),
 });
 
 export type WakuMessage<T = unknown> = z.infer<typeof wakuMessageSchema> & {

--- a/services/monitoring.ts
+++ b/services/monitoring.ts
@@ -52,6 +52,12 @@ export const cacheLagAlertCounter = registry.createCounter({
   labelNames: ['cache'],
 });
 
+export const wakuDecryptErrorCounter = registry.createCounter({
+  name: 'waku_decrypt_errors_total',
+  help: 'Count of Waku decrypt failures by reason',
+  labelNames: ['reason'],
+});
+
 export const authRateLimitCounter = registry.createCounter({
   name: 'auth_rate_limit_total',
   help: 'Number of auth requests rejected due to rate limiting',

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -7,12 +7,20 @@ import config from '@/config';
 import { canonicalJson } from '@/utils/serialization';
 import { retryWithBackoff } from '@/utils/retry';
 import { enqueue, flush } from '@/utils/wakuStore';
-import { encrypt, decrypt } from '@/utils/wakuCrypto';
+import {
+  encrypt,
+  decrypt,
+  getCurrentKeyEpoch,
+  getSupportedKeyEpochs,
+  WakuDecryptError,
+} from '@/utils/wakuCrypto';
 import { serviceLatency, serviceFailures } from '@/utils/observability';
 import { initLake } from './nearLake';
 import { topicFor } from '@blue-ocean/utils';
 import { getNetworkId, getContractId } from '@/services/config';
 import { setStore as persistStore } from '@/features/stores/services/nearStores';
+import { isWakuSharedKeysEnabled } from '@/config/featureFlags';
+import { wakuDecryptErrorCounter } from '@/services/monitoring';
 
 declare const logger: any;
 
@@ -175,24 +183,44 @@ async function sendAck(topic: string, id: string): Promise<void> {
 export async function publish(topic: string, message: any): Promise<string> {
   const client = await getClient();
   const id = message?.id || Date.now().toString();
-  const payload = client.utf8ToBytes(canonicalJson({ ...message, id }));
+  const useSharedKeys = isWakuSharedKeysEnabled();
+  const keyEpoch = useSharedKeys ? getCurrentKeyEpoch() : null;
+  const envelope = keyEpoch !== null ? { ...message, id, keyEpoch } : { ...message, id };
+  const payload = client.utf8ToBytes(canonicalJson(envelope));
   const gzSize = gzipSync(Buffer.from(payload)).length;
   if (gzSize > MAX_GZ_PAYLOAD) {
     throw new Error('Payload exceeds 200KB gz limit');
   }
-  const encPayload = encrypt(topic, payload);
+  const encryption = await encrypt(topic, payload, { keyEpoch, dualWrite: useSharedKeys });
+  const envelopes = [encryption.primary, ...(encryption.legacy ? [encryption.legacy] : [])];
+  const unsent = new Set<number>(envelopes.map((_, index) => index));
+
   try {
     const node = await ensureNode();
     if (!node) throw new Error('Waku disabled');
     const encoder = client.createEncoder({ contentTopic: topic } as any);
-    await Promise.race([
-      node.lightPush.send(encoder, { payload: encPayload }),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('TTI_EXCEEDED')), PROMPT_TTI_MS),
-      ),
-    ]);
+    for (let i = 0; i < envelopes.length; i += 1) {
+      const entry = envelopes[i];
+      try {
+        await Promise.race([
+          node.lightPush.send(encoder, { payload: entry.payload }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('TTI_EXCEEDED')), PROMPT_TTI_MS),
+          ),
+        ]);
+        unsent.delete(i);
+      } catch {
+        break;
+      }
+    }
   } catch {
-    enqueue(topic, encPayload);
+    // fall through to queue unsent envelopes
+  }
+
+  if (unsent.size > 0) {
+    for (const index of unsent) {
+      enqueue(topic, envelopes[index].payload);
+    }
   }
   return id;
 }
@@ -208,14 +236,25 @@ export async function subscribeWithAck(
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
-      const dec = decrypt(topic, wakuMsg.payload);
-      const msg = JSON.parse(client.bytesToUtf8(dec));
+      const allowedEpochs = getSupportedKeyEpochs();
+      const { plaintext } = await decrypt(topic, wakuMsg.payload, { allowedEpochs });
+      let msg: any;
+      try {
+        msg = JSON.parse(client.bytesToUtf8(plaintext));
+      } catch {
+        wakuDecryptErrorCounter.inc({ reason: 'decode_failure' });
+        return;
+      }
       if (msg.id && receivedIds.has(msg.id)) return;
       if (msg.id) receivedIds.add(msg.id);
       cb(msg);
       if (msg.id) await sendAck(topic, msg.id);
-    } catch {
-      /* ignore */
+    } catch (err) {
+      if (err instanceof WakuDecryptError) {
+        wakuDecryptErrorCounter.inc({ reason: err.code });
+      } else {
+        wakuDecryptErrorCounter.inc({ reason: 'unknown' });
+      }
     }
   };
   const maybeUnsub = (node.relay as any).addObserver(handler, [decoder]) as
@@ -246,11 +285,20 @@ export async function fetchHistory(
     for (const wakuMsg of messages) {
       if (!wakuMsg.payload) continue;
       try {
-        const dec = decrypt(topic, wakuMsg.payload);
-        const msg = JSON.parse(client.bytesToUtf8(dec));
-        cb(msg);
-      } catch {
-        /* ignore */
+        const allowedEpochs = getSupportedKeyEpochs();
+        const { plaintext } = await decrypt(topic, wakuMsg.payload, { allowedEpochs });
+        try {
+          const msg = JSON.parse(client.bytesToUtf8(plaintext));
+          cb(msg);
+        } catch {
+          wakuDecryptErrorCounter.inc({ reason: 'decode_failure' });
+        }
+      } catch (err) {
+        if (err instanceof WakuDecryptError) {
+          wakuDecryptErrorCounter.inc({ reason: err.code });
+        } else {
+          wakuDecryptErrorCounter.inc({ reason: 'unknown' });
+        }
       }
     }
     if (!res.next) break;

--- a/src/features/opsDrawer/OpsDrawer.tsx
+++ b/src/features/opsDrawer/OpsDrawer.tsx
@@ -44,6 +44,7 @@ interface OpsSnapshot {
     peers: number;
     connections: number;
     queueDepth: number;
+    decryptErrors: number | null;
   };
   metrics: {
     notificationsBacklog: number | null;
@@ -73,6 +74,12 @@ function readGauge(snapshot: RegistrySnapshot, name: string): number | null {
   const entries = snapshot.gauges[name] as GaugeEntry[] | undefined;
   if (!entries || entries.length === 0) return null;
   return entries.reduce((max, entry) => Math.max(max, entry.value), Number.NEGATIVE_INFINITY);
+}
+
+function readCounter(snapshot: RegistrySnapshot, name: string): number | null {
+  const entries = snapshot.counters[name];
+  if (!entries || entries.length === 0) return null;
+  return entries.reduce((sum, entry) => sum + (entry?.value ?? 0), 0);
 }
 
 function formatNumber(value: number | null, suffix = ''): string {
@@ -219,6 +226,7 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
     const monitoring = monitoringRegistry.snapshot();
     const { peers, connections } = getPeerSummary();
     const queueDepth = snapshotQueue().length;
+    const decryptErrors = readCounter(monitoring, 'waku_decrypt_errors_total');
     const notificationsBacklog = readGauge(observability, 'notifications_backlog');
     const deliveryBacklog = readGauge(observability, 'delivery_notifications_backlog');
     const cacheLagMs = readGauge(monitoring, 'cache_sync_lag_ms');
@@ -226,7 +234,7 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
     const scopes = Array.isArray(record?.scopes) ? record!.scopes : [];
     return {
       capturedAt: Date.now(),
-      waku: { status, peers, connections, queueDepth },
+      waku: { status, peers, connections, queueDepth, decryptErrors },
       metrics: {
         notificationsBacklog,
         deliveryBacklog,
@@ -364,6 +372,10 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
                   <MetricRow
                     label="Replay queue"
                     value={formatNumber(snapshot.waku.queueDepth)}
+                  />
+                  <MetricRow
+                    label="Decrypt errors"
+                    value={formatNumber(snapshot.waku.decryptErrors)}
                   />
                 </Section>
                 <Section title="Sync">

--- a/tests/config/featureFlags.test.ts
+++ b/tests/config/featureFlags.test.ts
@@ -136,6 +136,25 @@ describe('driver chat feature flag', () => {
   });
 });
 
+describe('waku shared keys feature flag', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_FEATURE_WAKU_SHARED_KEYS;
+    jest.resetModules();
+  });
+
+  it('is disabled by default', () => {
+    const { isWakuSharedKeysEnabled } = require('@/config/featureFlags');
+    expect(isWakuSharedKeysEnabled()).toBe(false);
+  });
+
+  it('respects environment flag', () => {
+    process.env.EXPO_PUBLIC_FEATURE_WAKU_SHARED_KEYS = 'true';
+    jest.resetModules();
+    const { isWakuSharedKeysEnabled } = require('@/config/featureFlags');
+    expect(isWakuSharedKeysEnabled()).toBe(true);
+  });
+});
+
 describe('notifications pipeline feature flag', () => {
   beforeEach(() => {
     delete process.env.EXPO_PUBLIC_NOTIFICATIONS_PIPELINE;

--- a/tests/integration/offlineQueue.integration.test.ts
+++ b/tests/integration/offlineQueue.integration.test.ts
@@ -141,8 +141,8 @@ describe('integration/offline queue encryption', () => {
 
     const decoded = await runInIsolated(async () => {
       const { decrypt } = await import('@/utils/wakuCrypto');
-      const decrypted = decrypt(topic, payload);
-      return new TextDecoder().decode(decrypted);
+      const { plaintext } = await decrypt(topic, payload);
+      return new TextDecoder().decode(plaintext);
     });
 
     expect(decoded).toBe(canonical);

--- a/tests/notificationsPipeline.test.ts
+++ b/tests/notificationsPipeline.test.ts
@@ -41,8 +41,22 @@ import {
 
 // Mock encrypt/decrypt as identity to simplify payload checks
 jest.mock('@/utils/wakuCrypto', () => ({
-  encrypt: (_t: string, b: Uint8Array) => b,
-  decrypt: (_t: string, b: Uint8Array) => b,
+  encrypt: async (_t: string, b: Uint8Array) => ({
+    primary: { payload: b, keyEpoch: null, format: 'legacy' },
+  }),
+  decrypt: async (_t: string, b: Uint8Array) => ({
+    plaintext: b,
+    keyEpoch: null,
+    format: 'legacy',
+  }),
+  getCurrentKeyEpoch: () => 0,
+  getSupportedKeyEpochs: () => [0],
+  WakuDecryptError: class MockWakuDecryptError extends Error {
+    constructor(public code: string) {
+      super(code);
+      this.name = 'WakuDecryptError';
+    }
+  },
 }));
 
 // observability stubs

--- a/utils/wakuCrypto.ts
+++ b/utils/wakuCrypto.ts
@@ -1,44 +1,302 @@
 import { xchacha20 } from '@noble/ciphers/chacha';
 import { blake2b } from '@noble/hashes/blake2b';
 import { randomBytes } from '@noble/hashes/utils';
+import config from '@/config';
+import { deriveSharedKeyRaw } from './encryption';
+import { getEd25519KeyPair } from '@/services/localIdentity';
+import { getAdminPublicKeys } from '@/services/nearSettings';
 
-// Derive a stable symmetric key for each topic using a Noise-style hash of the topic
-// and a random root secret. This avoids storing raw topic names on the wire.
-const rootSecret = randomBytes(32);
-const topicKeys = new Map<string, Uint8Array>();
+const SHARED_MAGIC = new Uint8Array([0x57, 0x53, 0x4b, 0x31]); // "WSK1"
+const NONCE_LENGTH = 24;
+const EPOCH_LENGTH = 4;
+const SHARED_HEADER_LENGTH = SHARED_MAGIC.length + EPOCH_LENGTH + NONCE_LENGTH;
 
-function topicKey(topic: string): Uint8Array {
-  if (!topicKeys.has(topic)) {
-    const enc = new TextEncoder().encode(topic);
-    // Combine root secret with topic name and hash to 32 bytes key.
-    const key = blake2b(Uint8Array.from([...rootSecret, ...enc]), { dkLen: 32 });
-    topicKeys.set(topic, key);
+const legacyRootSecret = randomBytes(32);
+const legacyTopicKeys = new Map<string, Uint8Array>();
+const sharedKeyCache = new Map<string, Uint8Array>();
+const sharedKeyPromises = new Map<string, Promise<Uint8Array>>();
+
+let cachedTenantKey: string | null = null;
+let tenantKeyPromise: Promise<string> | null = null;
+
+const encoder = new TextEncoder();
+
+class TenantKeyUnavailableError extends Error {
+  constructor(message = 'Tenant public key unavailable') {
+    super(message);
+    this.name = 'TenantKeyUnavailableError';
   }
-  return topicKeys.get(topic)!;
 }
 
-/**
- * Encrypt a payload for the given topic using xChaCha20.
- * The returned Uint8Array contains nonce || ciphertext.
- */
-export function encrypt(topic: string, payload: Uint8Array): Uint8Array {
-  const key = topicKey(topic);
-  const nonce = randomBytes(24);
+export type WakuDecryptErrorCode =
+  | 'TENANT_KEY_UNAVAILABLE'
+  | 'UNSUPPORTED_EPOCH'
+  | 'KEY_DERIVATION_FAILED';
+
+export class WakuDecryptError extends Error {
+  readonly code: WakuDecryptErrorCode;
+
+  constructor(code: WakuDecryptErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+    this.name = 'WakuDecryptError';
+  }
+}
+
+export interface EnvelopeOutput {
+  payload: Uint8Array;
+  keyEpoch: number | null;
+  format: 'shared' | 'legacy';
+}
+
+export interface EncryptOutput {
+  primary: EnvelopeOutput;
+  legacy?: EnvelopeOutput;
+}
+
+export interface DecryptResult {
+  plaintext: Uint8Array;
+  keyEpoch: number | null;
+  format: 'shared' | 'legacy';
+}
+
+export interface EncryptOptions {
+  keyEpoch?: number | null;
+  dualWrite?: boolean;
+}
+
+export interface DecryptOptions {
+  allowedEpochs?: number[];
+}
+
+function parseEpoch(raw: string | undefined): number | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const value = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(value) || Number.isNaN(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+export function getCurrentKeyEpoch(): number {
+  const publicEpoch = parseEpoch(config.EXPO_PUBLIC_WAKU_KEY_EPOCH);
+  if (publicEpoch !== null) return publicEpoch;
+  const privateEpoch = parseEpoch(config.WAKU_KEY_EPOCH);
+  return privateEpoch ?? 0;
+}
+
+export function getSupportedKeyEpochs(): number[] {
+  const current = getCurrentKeyEpoch();
+  const previous = current > 0 ? current - 1 : null;
+  return previous !== null ? [current, previous] : [current];
+}
+
+function encodeEpoch(epoch: number): Uint8Array {
+  const buffer = new ArrayBuffer(EPOCH_LENGTH);
+  const view = new DataView(buffer);
+  view.setUint32(0, epoch >>> 0, false);
+  return new Uint8Array(buffer);
+}
+
+function decodeEpoch(bytes: Uint8Array): number {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return view.getUint32(0, false);
+}
+
+function legacyTopicKey(topic: string): Uint8Array {
+  if (!legacyTopicKeys.has(topic)) {
+    const topicBytes = encoder.encode(topic);
+    const key = blake2b(Uint8Array.from([...legacyRootSecret, ...topicBytes]), { dkLen: 32 });
+    legacyTopicKeys.set(topic, key);
+  }
+  return legacyTopicKeys.get(topic)!;
+}
+
+async function getTenantPublicKey(): Promise<string> {
+  if (cachedTenantKey) return cachedTenantKey;
+  if (tenantKeyPromise) return tenantKeyPromise;
+  tenantKeyPromise = (async () => {
+    const keys = await getAdminPublicKeys();
+    const primary = keys[0];
+    if (!primary) {
+      throw new TenantKeyUnavailableError();
+    }
+    cachedTenantKey = primary;
+    return primary;
+  })();
+  try {
+    return await tenantKeyPromise;
+  } catch (err) {
+    tenantKeyPromise = null;
+    cachedTenantKey = null;
+    if (err instanceof TenantKeyUnavailableError) {
+      throw err;
+    }
+    throw new TenantKeyUnavailableError(
+      err instanceof Error ? err.message : 'Tenant public key unavailable',
+    );
+  }
+}
+
+async function deriveSharedTopicKey(topic: string, epoch: number): Promise<Uint8Array> {
+  const cacheKey = `${topic}:${epoch}`;
+  const cached = sharedKeyCache.get(cacheKey);
+  if (cached) return cached;
+
+  let promise = sharedKeyPromises.get(cacheKey);
+  if (!promise) {
+    promise = (async () => {
+      const { privateKey } = await getEd25519KeyPair();
+      const tenantPublicKey = await getTenantPublicKey();
+      const salt = encodeEpoch(epoch);
+      try {
+        const derived = await deriveSharedKeyRaw(privateKey, tenantPublicKey, topic, salt);
+        sharedKeyCache.set(cacheKey, derived);
+        return derived;
+      } catch (err) {
+        throw new WakuDecryptError(
+          'KEY_DERIVATION_FAILED',
+          err instanceof Error ? err.message : 'Failed to derive shared key',
+        );
+      }
+    })();
+    sharedKeyPromises.set(cacheKey, promise);
+    promise.finally(() => sharedKeyPromises.delete(cacheKey));
+  }
+  return promise;
+}
+
+function encodeSharedEnvelope(epoch: number, nonce: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+  const buffer = new Uint8Array(SHARED_HEADER_LENGTH + ciphertext.length);
+  let offset = 0;
+  buffer.set(SHARED_MAGIC, offset);
+  offset += SHARED_MAGIC.length;
+  buffer.set(encodeEpoch(epoch), offset);
+  offset += EPOCH_LENGTH;
+  buffer.set(nonce, offset);
+  offset += NONCE_LENGTH;
+  buffer.set(ciphertext, offset);
+  return buffer;
+}
+
+function decodeSharedEnvelope(payload: Uint8Array): {
+  epoch: number;
+  nonce: Uint8Array;
+  ciphertext: Uint8Array;
+} | null {
+  if (payload.length <= SHARED_HEADER_LENGTH) return null;
+  for (let i = 0; i < SHARED_MAGIC.length; i += 1) {
+    if (payload[i] !== SHARED_MAGIC[i]) return null;
+  }
+  const epochStart = SHARED_MAGIC.length;
+  const epochBytes = payload.slice(epochStart, epochStart + EPOCH_LENGTH);
+  const epoch = decodeEpoch(epochBytes);
+  const nonceStart = epochStart + EPOCH_LENGTH;
+  const nonce = payload.slice(nonceStart, nonceStart + NONCE_LENGTH);
+  const ciphertext = payload.slice(nonceStart + NONCE_LENGTH);
+  return { epoch, nonce, ciphertext };
+}
+
+function encryptLegacyEnvelope(topic: string, payload: Uint8Array): Uint8Array {
+  const key = legacyTopicKey(topic);
+  const nonce = randomBytes(NONCE_LENGTH);
   const enc = xchacha20(key, nonce, payload);
-  const out = new Uint8Array(nonce.length + enc.length);
-  out.set(nonce, 0);
-  out.set(enc, nonce.length);
-  return out;
+  const result = new Uint8Array(NONCE_LENGTH + enc.length);
+  result.set(nonce, 0);
+  result.set(enc, NONCE_LENGTH);
+  return result;
 }
 
-/**
- * Decrypt a payload previously encrypted with {@link encrypt}.
- */
-export function decrypt(topic: string, payload: Uint8Array): Uint8Array {
-  const key = topicKey(topic);
-  const nonce = payload.slice(0, 24);
-  const data = payload.slice(24);
+function decryptLegacyEnvelope(topic: string, payload: Uint8Array): Uint8Array {
+  const key = legacyTopicKey(topic);
+  const nonce = payload.slice(0, NONCE_LENGTH);
+  const data = payload.slice(NONCE_LENGTH);
   return xchacha20(key, nonce, data);
 }
 
-export default { encrypt, decrypt };
+async function encryptSharedEnvelope(
+  topic: string,
+  payload: Uint8Array,
+  epoch: number,
+): Promise<Uint8Array> {
+  const key = await deriveSharedTopicKey(topic, epoch);
+  const nonce = randomBytes(NONCE_LENGTH);
+  const enc = xchacha20(key, nonce, payload);
+  return encodeSharedEnvelope(epoch, nonce, enc);
+}
+
+export async function encrypt(
+  topic: string,
+  payload: Uint8Array,
+  options: EncryptOptions = {},
+): Promise<EncryptOutput> {
+  const { keyEpoch = null, dualWrite = false } = options;
+  if (typeof keyEpoch === 'number') {
+    try {
+      const sharedPayload = await encryptSharedEnvelope(topic, payload, keyEpoch);
+      const result: EncryptOutput = {
+        primary: { payload: sharedPayload, keyEpoch, format: 'shared' },
+      };
+      if (dualWrite) {
+        const legacyPayload = encryptLegacyEnvelope(topic, payload);
+        result.legacy = { payload: legacyPayload, keyEpoch, format: 'legacy' };
+      }
+      return result;
+    } catch (err) {
+      if (err instanceof TenantKeyUnavailableError) {
+        // fall back to legacy encryption below
+      } else if (err instanceof WakuDecryptError) {
+        if (err.code !== 'TENANT_KEY_UNAVAILABLE') {
+          throw err;
+        }
+      } else if (err instanceof Error) {
+        throw err;
+      } else {
+        throw new Error(String(err));
+      }
+    }
+  }
+
+  const legacyPayload = encryptLegacyEnvelope(topic, payload);
+  return {
+    primary: { payload: legacyPayload, keyEpoch: null, format: 'legacy' },
+  };
+}
+
+export async function decrypt(
+  topic: string,
+  payload: Uint8Array,
+  options: DecryptOptions = {},
+): Promise<DecryptResult> {
+  const meta = decodeSharedEnvelope(payload);
+  const allowedEpochs = options.allowedEpochs ?? getSupportedKeyEpochs();
+
+  if (meta) {
+    if (!allowedEpochs.includes(meta.epoch)) {
+      throw new WakuDecryptError('UNSUPPORTED_EPOCH', `Unsupported key epoch ${meta.epoch}`);
+    }
+    try {
+      const key = await deriveSharedTopicKey(topic, meta.epoch);
+      const plaintext = xchacha20(key, meta.nonce, meta.ciphertext);
+      return { plaintext, keyEpoch: meta.epoch, format: 'shared' };
+    } catch (err) {
+      if (err instanceof TenantKeyUnavailableError) {
+        throw new WakuDecryptError('TENANT_KEY_UNAVAILABLE', err.message);
+      }
+      if (err instanceof WakuDecryptError) {
+        throw err;
+      }
+      throw new WakuDecryptError(
+        'KEY_DERIVATION_FAILED',
+        err instanceof Error ? err.message : 'Failed to derive shared key',
+      );
+    }
+  }
+
+  const legacyPlaintext = decryptLegacyEnvelope(topic, payload);
+  return { plaintext: legacyPlaintext, keyEpoch: null, format: 'legacy' };
+}
+
+export default { encrypt, decrypt, getCurrentKeyEpoch, getSupportedKeyEpochs };


### PR DESCRIPTION
## Summary
- derive deterministic Waku shared keys via tenant/admin ECDH, HKDF, and key epochs with legacy dual-write support
- tag envelopes with keyEpoch, accept current/previous epochs during decrypt, and count decrypt errors in Ops drawer metrics
- gate rollout with a wakuSharedKeys feature flag, expose key epoch config, and update validation/tests accordingly

## Testing
- node scripts/multi-peer-sync.js
- Tests not run: npm/yarn dependencies are not installed in the environment

------
https://chatgpt.com/codex/tasks/task_e_68ca2326736c8326a55988a1e659da3f