### PR TITLE
Wire admin agent subscription and approvals

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,11 @@ import AppProviders from '@/providers/AppProviders';
 import { isRouterEnabled } from '@/services/config';
 import { initSessionTokens } from '@/services/session';
 import { initErrorReporter } from '@/services/errorReporter';
-import { setDebugLogsEnabled } from '@/utils/logger';
+import { errorLog, setDebugLogsEnabled } from '@/utils/logger';
+import {
+  ensureAdminAgentSubscription,
+  stopAdminAgentSubscription,
+} from '@/services/adminSubscription';
 
 const USE_ROUTER = isRouterEnabled();
 
@@ -42,6 +46,14 @@ function MainApp() {
       },
     });
     return cleanupReporter;
+  }, []);
+  useEffect(() => {
+    void ensureAdminAgentSubscription().catch((err) => {
+      errorLog('Failed to initialize admin agent subscription', err);
+    });
+    return () => {
+      stopAdminAgentSubscription();
+    };
   }, []);
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/agents/admin-agent.ts
+++ b/agents/admin-agent.ts
@@ -11,7 +11,7 @@ import {
 } from '@/services/monitoring';
 import flags from '@/utils/flags';
 
-interface AdminRecord {
+export interface AdminRecord {
   address: string;
   publicKey: string;
   requestedAt?: number;
@@ -241,6 +241,35 @@ export class AdminAgent extends EventEmitter {
       this.emit('admin.rejected', { address: pending.address });
     }
     return 'admin.rejected';
+  }
+
+  async handleMessage(msg: WakuMessage<any>): Promise<void> {
+    if (!msg || typeof msg !== 'object') return;
+    const type = msg.type;
+    switch (type) {
+      case 'admin.joinRequested':
+        await this.requestAdmin(
+          msg as WakuMessage<{
+            address: string;
+            displayName?: string;
+            nonce: string;
+            ts: number;
+          }>,
+        );
+        break;
+      case 'admin.approve':
+        await this.approveAdmin(
+          msg as WakuMessage<{ address: string; nonce: string; ts: number }>,
+        );
+        break;
+      case 'admin.reject':
+        await this.rejectAdmin(
+          msg as WakuMessage<{ address: string; nonce: string; ts: number }>,
+        );
+        break;
+      default:
+        break;
+    }
   }
 }
 

--- a/app/store/[storeId]/admin/_SettingsScreen.tsx
+++ b/app/store/[storeId]/admin/_SettingsScreen.tsx
@@ -1,11 +1,12 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import { useAppRouter } from '@/services';
 import { ArrowLeft, Save, Settings as SettingsIcon } from 'lucide-react-native';
 import { useAuth } from '@/features/auth/AuthContext';
+import { publish as publishWaku } from '@/services/waku';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useCurrency } from '../../../../contexts/CurrencyContext';
 import { useLanguage } from '@/ui/ThemeProvider';
@@ -14,6 +15,7 @@ import InfoModal from '../../../../components/InfoModal';
 import { useAppInfo } from '../../../../contexts/AppInfoContext';
 import commonStyles from '@/constants/styles';
 import SettingsAgent from '../../../../agents/settings-agent';
+import adminAgent, { type AdminRecord } from '../../../../agents/admin-agent';
 import BrandingSettings from '../../../../components/settings/BrandingSettings';
 import CurrencySettings from '../../../../components/settings/CurrencySettings';
 import EnvironmentSettings from '../../../../components/settings/EnvironmentSettings';
@@ -24,6 +26,11 @@ import MoonPaySettings from '../../../../components/settings/MoonPaySettings';
 import PaymentFactorySettings from '../../../../components/settings/PaymentFactorySettings';
 import eventBus from '@/services/eventBus';
 import { isMoonPayEnabled } from '@/config/featureFlags';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import uuid from '@/utils/uuid';
+
+type PendingRequest = Pick<AdminRecord, 'address' | 'requestedAt'>;
+const USERS_TOPIC = '/blue-ocean/users/1';
 
 export default function SettingsScreen() {
   const { replace, back } = useAppRouter();
@@ -37,7 +44,7 @@ export default function SettingsScreen() {
   const [paymentFactoryAddress, setPaymentFactoryAddress] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const { isAdmin, isDriver } = useAuth();
+  const { isAdmin, isDriver, checkAuthState } = useAuth();
   const { colors } = useTheme();
   const { currencySymbol: contextCurrencySymbol, setCurrencySymbol } = useCurrency();
   const { currentLanguage, t } = useLanguage();
@@ -53,7 +60,7 @@ export default function SettingsScreen() {
   } = useAppInfo();
   const [admins, setAdmins] = useState<string[]>([]);
   const [inviteAddress, setInviteAddress] = useState('');
-  const [pendingInvites, setPendingInvites] = useState<string[]>([]);
+  const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([]);
   const [inviteLoading, setInviteLoading] = useState(false);
   const moonPayEnabled = useMemo(() => isMoonPayEnabled(), []);
   const storeTopic = useMemo(() => `/blue-ocean/stores/${storeId ?? '1'}`, [storeId]);
@@ -64,6 +71,17 @@ export default function SettingsScreen() {
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
+
+  const refreshPendingRequests = useCallback(async () => {
+    try {
+      const requests = await adminAgent.getPendingRequests();
+      setPendingRequests(
+        requests.map(({ address, requestedAt }) => ({ address, requestedAt })),
+      );
+    } catch (error) {
+      errorLog('Failed to load pending admin requests:', error);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isAdmin && !isDriver) {
@@ -78,6 +96,55 @@ export default function SettingsScreen() {
       .getAdmins()
       .then(setAdmins)
       .catch((err) => errorLog('Failed to load admins:', err));
+  }, []);
+
+  useEffect(() => {
+    void refreshPendingRequests();
+  }, [refreshPendingRequests]);
+
+  useEffect(() => {
+    const handleRequested = ({
+      address,
+      requestedAt,
+    }: {
+      address: string;
+      requestedAt: number;
+    }) => {
+      const lower = address.toLowerCase();
+      setPendingRequests((prev) => {
+        if (prev.some((req) => req.address.toLowerCase() === lower)) {
+          return prev.map((req) =>
+            req.address.toLowerCase() === lower ? { address, requestedAt } : req,
+          );
+        }
+        return [...prev, { address, requestedAt }];
+      });
+    };
+    const handleRegistered = ({ address }: { address: string }) => {
+      const lower = address.toLowerCase();
+      setPendingRequests((prev) =>
+        prev.filter((req) => req.address.toLowerCase() !== lower),
+      );
+      setAdmins((prev) =>
+        prev.some((admin) => admin.toLowerCase() === lower)
+          ? prev
+          : [...prev, address],
+      );
+    };
+    const handleRejected = ({ address }: { address: string }) => {
+      const lower = address.toLowerCase();
+      setPendingRequests((prev) =>
+        prev.filter((req) => req.address.toLowerCase() !== lower),
+      );
+    };
+    adminAgent.on('admin.requested', handleRequested);
+    adminAgent.on('admin.registered', handleRegistered);
+    adminAgent.on('admin.rejected', handleRejected);
+    return () => {
+      adminAgent.off('admin.requested', handleRequested);
+      adminAgent.off('admin.registered', handleRegistered);
+      adminAgent.off('admin.rejected', handleRejected);
+    };
   }, []);
 
   useEffect(() => {
@@ -159,12 +226,17 @@ export default function SettingsScreen() {
     }
     setInviteLoading(true);
     try {
-      await eventBus.publish(storeTopic, 'admin.joinRequested', {
-        address,
-      });
-      setPendingInvites((prev) =>
-        prev.includes(address) ? prev : [...prev, address],
+      const message = await makeSignedWakuMessage(
+        'admin.joinRequested',
+        {
+          address,
+          nonce: uuid(),
+          ts: Date.now(),
+        },
+        'admin',
       );
+      await publishWaku(USERS_TOPIC, message);
+      await refreshPendingRequests();
       setInviteAddress('');
       setInfoModal({
         visible: true,
@@ -183,16 +255,69 @@ export default function SettingsScreen() {
   const approveInvite = async (address: string) => {
     setInviteLoading(true);
     try {
-      await eventBus.publish(storeTopic, 'admin.registered', {
-        address,
-      });
+      const normalized = address.toLowerCase();
+      const waitForRegistration = () =>
+        new Promise<void>((resolve, reject) => {
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+          const cleanup = () => {
+            if (timeoutHandle) clearTimeout(timeoutHandle);
+            adminAgent.off('admin.registered', handleRegistered);
+            adminAgent.off('admin.rejected', handleRejected);
+          };
+          const handleRegistered = ({ address: approved }: { address: string }) => {
+            if (approved.toLowerCase() !== normalized) return;
+            cleanup();
+            resolve();
+          };
+          const handleRejected = ({ address: rejected }: { address: string }) => {
+            if (rejected.toLowerCase() !== normalized) return;
+            cleanup();
+            reject(new Error('rejected'));
+          };
+          adminAgent.on('admin.registered', handleRegistered);
+          adminAgent.on('admin.rejected', handleRejected);
+          timeoutHandle = setTimeout(() => {
+            cleanup();
+            reject(new Error('timeout'));
+          }, 5000);
+        });
+
+      const resultPromise = waitForRegistration();
+      const message = await makeSignedWakuMessage(
+        'admin.approve',
+        {
+          address,
+          nonce: uuid(),
+          ts: Date.now(),
+        },
+        'admin',
+      );
+      await publishWaku(USERS_TOPIC, message);
+      await resultPromise;
       const nextAdmins = Array.from(new Set([...admins, address]));
       await SettingsAgent.getInstance().setAdmins(nextAdmins);
       setAdmins(nextAdmins);
-      setPendingInvites((prev) => prev.filter((item) => item !== address));
+      setPendingRequests((prev) =>
+        prev.filter((item) => item.address.toLowerCase() !== normalized),
+      );
+      await refreshPendingRequests();
+      await checkAuthState();
+      await eventBus.publish(storeTopic, 'admin.registered', {
+        address,
+      });
+      setInfoModal({
+        visible: true,
+        title: 'אישור מנהל',
+        message: 'המנהל החדש אושר בהצלחה.',
+        type: 'success',
+      });
     } catch (error) {
       errorLog('Failed to approve admin invite', error);
-      Alert.alert('שגיאה', 'אישור ההזמנה נכשל');
+      const message =
+        error instanceof Error && error.message === 'timeout'
+          ? 'האישור לא התקבל בזמן. נסה שוב.'
+          : 'אישור ההזמנה נכשל';
+      Alert.alert('שגיאה', message);
     } finally {
       setInviteLoading(false);
     }
@@ -288,15 +413,31 @@ export default function SettingsScreen() {
             הזמנה חדשה דורשת אישור מנהל קיים לפני כניסה למערכת.
           </Text>
           <Text style={[styles.cardTitle, { color: colors.text.primary }]}>הזמנות בהמתנה</Text>
-          {pendingInvites.length === 0 ? (
+          {pendingRequests.length === 0 ? (
             <Text style={{ color: colors.text.secondary }}>אין הזמנות ממתינות.</Text>
           ) : (
-            pendingInvites.map((address) => (
+            pendingRequests.map(({ address, requestedAt }) => (
               <View
                 key={address}
                 style={[styles.inviteItem, { borderColor: colors.border.primary }]}
               >
-                <Text style={{ color: colors.text.primary }}>{address}</Text>
+                <View style={styles.inviteInfo}>
+                  <Text
+                    style={{ color: colors.text.primary, textAlign: 'right' }}
+                  >
+                    {address}
+                  </Text>
+                  {requestedAt ? (
+                    <Text
+                      style={[
+                        styles.pendingMeta,
+                        { color: colors.text.secondary, textAlign: 'right' },
+                      ]}
+                    >
+                      {new Date(requestedAt).toLocaleString()}
+                    </Text>
+                  ) : null}
+                </View>
                 <TouchableOpacity
                   style={[styles.approveInviteButton, { borderColor: colors.status.success }]}
                   onPress={() => approveInvite(address)}
@@ -427,10 +568,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 8,
   },
+  inviteInfo: {
+    flex: 1,
+    alignItems: 'flex-end',
+    gap: 4,
+  },
   approveInviteButton: {
     borderWidth: 1,
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 6,
+  },
+  pendingMeta: {
+    fontSize: 12,
   },
 });

--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -82,8 +82,18 @@ export function createWarmCache<T>(
   const metricLabels = { cache: topic } as const;
   cacheLagGauge.set(metricLabels, 0);
 
+  function isValidDiff(msg: Partial<DiffMessage<T>>): msg is DiffMessage<T> {
+    if (!msg || typeof msg !== 'object') return false;
+    if (typeof msg.id !== 'string' || msg.id.length === 0) return false;
+    if (typeof msg.rev !== 'number' || !Number.isFinite(msg.rev)) return false;
+    if (msg.op !== 'set' && msg.op !== 'delete' && msg.op !== 'merge') return false;
+    return true;
+  }
+
   function apply(raw: DiffMessage<T>, source: MessageSource): DiffMessage<T> | null {
+    if (!isValidDiff(raw)) return null;
     const msg = normalizeMessage(raw, source);
+    if (!isValidDiff(msg)) return null;
     const currentRev = revisions.get(msg.id) ?? 0;
     const expected = currentRev === 0 ? msg.rev : currentRev + 1;
     if (currentRev !== 0) {
@@ -176,7 +186,9 @@ export function createWarmCache<T>(
     let unsub: (() => void) | null = null;
     try {
       unsub = await subscribeWithAck(topic, (msg: DiffMessage<T>) => {
+        if (!isValidDiff(msg)) return;
         const normalized = normalizeMessage(msg, 'live');
+        if (!isValidDiff(normalized)) return;
         if (!synced) buffer.push({ msg: normalized, source: 'live' });
         else apply(normalized, 'live');
       });

--- a/src/services/adminSubscription.ts
+++ b/src/services/adminSubscription.ts
@@ -1,0 +1,51 @@
+import adminAgent from '@/agents/admin-agent';
+import { subscribeWithAck } from '@/services/waku';
+import { errorLog } from '@/utils/logger';
+import type { WakuMessage } from '@/types/waku';
+
+const USERS_TOPIC = '/blue-ocean/users/1';
+
+let subscriptionPromise: Promise<void> | null = null;
+let unsubscribe: (() => void) | null = null;
+
+function toWakuMessage(raw: any): WakuMessage<any> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const { type, payload, sender, signature } = raw as Record<string, unknown>;
+  if (typeof type !== 'string' || !type.startsWith('admin.')) return null;
+  if (!payload || typeof payload !== 'object') return null;
+  if (!sender || typeof sender !== 'object') return null;
+  return {
+    type,
+    payload,
+    sender: sender as WakuMessage<any>['sender'],
+    signature: typeof signature === 'string' ? signature : '',
+  };
+}
+
+export async function ensureAdminAgentSubscription(): Promise<void> {
+  if (subscriptionPromise) {
+    await subscriptionPromise;
+    return;
+  }
+  subscriptionPromise = (async () => {
+    unsubscribe = await subscribeWithAck(USERS_TOPIC, (raw: unknown) => {
+      const message = toWakuMessage(raw);
+      if (!message) return;
+      void adminAgent.handleMessage(message).catch((err) => {
+        errorLog('admin-agent.handleMessage failed', err);
+      });
+    });
+  })().catch((err) => {
+    subscriptionPromise = null;
+    unsubscribe = null;
+    errorLog('Failed to subscribe admin agent', err);
+    throw err;
+  });
+  await subscriptionPromise;
+}
+
+export function stopAdminAgentSubscription(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  subscriptionPromise = null;
+}

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -205,6 +205,15 @@ describe('AdminAgent', () => {
     expect(end).toBe(start + 1);
   });
 
+  it('routes messages through handleMessage dispatcher', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const join = await createJoinRequest(priv, pub, 'addr-dispatch');
+    await agent.handleMessage(join);
+    const admins = await agent.getAdmins();
+    expect(admins.map((a) => a.address)).toEqual(['addr-dispatch']);
+  });
+
   it('rejects approvals with bad signatures', async () => {
     const priv1 = utils.randomPrivateKey();
     const pub1 = await getPublicKey(priv1);


### PR DESCRIPTION
## Summary
- add a dedicated admin subscription service that forwards `/blue-ocean/users/1` Waku traffic to the admin agent and bootstrap it during app startup
- publish signed `admin.joinRequested` and `admin.approve` messages from the settings screen, load pending requests from the agent, and update the UI accordingly
- harden the warm cache against non-diff payloads and expose `AdminAgent.handleMessage` with test coverage for the dispatcher

## Testing
- not run (node modules are not installed in the container; `yarn install` would create a new lockfile and exceeds the environment limits)


------
https://chatgpt.com/codex/tasks/task_e_68ca2368bf30832690b38a1d276c6cd7