### PR TITLE
Harden Waku replay protections

### DIFF
--- a/agents/delivery-agent.ts
+++ b/agents/delivery-agent.ts
@@ -7,6 +7,8 @@ import { errorLog } from '@/utils/logger';
 import { deliveryBacklog } from '@/utils/observability';
 import { onBacklog, onDrained } from '@/utils/wakuStore';
 import type { DeliveryJobStatus } from '@/types';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
 
 export const E_BACKLOG = 'E_BACKLOG';
 
@@ -110,6 +112,7 @@ class DeliveryAgent {
     const { type, payload, storeId } = job;
     const topic = buildTopic(DELIVERY_TOPIC_DOMAIN, storeId);
     const timestamp = Date.now();
+    const nonce = Buffer.from(randomBytes(12)).toString('hex');
     if (type === 'order.created') {
       const message = await makeSignedWakuMessage(
         'notify.deliveryUpdate',
@@ -119,8 +122,11 @@ class DeliveryAgent {
           storeId,
           status: 'pending',
           timestamp,
+          ts: timestamp,
+          nonce,
         },
         'deliveries',
+        { ts: timestamp, nonce },
       );
       await publish(topic, message);
       return;
@@ -136,8 +142,11 @@ class DeliveryAgent {
         driverId: assigned.driverId,
         status: assigned.status,
         timestamp,
+        ts: timestamp,
+        nonce,
       },
       'deliveries',
+      { ts: timestamp, nonce },
     );
     await publish(topic, message);
   }

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -26,6 +26,8 @@ import {
 } from '@/config/featureFlags';
 import { canonicalJson } from '@/utils/serialization';
 import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
 
 export const E_BACKLOG = 'E_BACKLOG';
 
@@ -284,11 +286,15 @@ class NotificationsAgent {
         type: event ?? 'notify.direct',
         notification: item,
         storeId,
+        ts: Date.now(),
+        nonce: Buffer.from(randomBytes(12)).toString('hex'),
       };
+      const meta = { ts: payload.ts, nonce: payload.nonce };
       const message = await makeSignedWakuMessage(
         MESSAGE_TYPE,
         canonicalJson(payload),
         'notifications',
+        meta,
       );
       await publish(NOTIFICATION_TOPIC, message);
     } catch (err) {

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -118,12 +118,13 @@ class OrdersAgent {
     const n = await this.ensureNode();
     if (!n) return;
     const client = await getClient();
-    const decoder = client.createDecoder(buildTopic('orders', storeId));
+    const topic = buildTopic('orders', storeId);
+    const decoder = client.createDecoder(topic);
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
-        const signed = await verifyBeforeWrite(raw, orderStatusMessageSchema);
+        const signed = await verifyBeforeWrite(raw, orderStatusMessageSchema, undefined, topic);
         if (!signed) return;
         const { orderId, status } = signed.payload;
         await this.applyRemoteStatus(orderId, status);

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -14,15 +14,14 @@ import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import { verifyBeforeWrite } from '@/utils/verifyMessageSignature';
 import { productUpdatedSchema } from '../schemas/waku/product.updated';
-import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
-import { sign } from '@noble/ed25519';
-import { canonicalJson } from '@/utils/serialization';
-import type { WakuMessage } from '@/types/waku';
 import { errorLog } from '@/utils/logger';
 import { buildTopic } from '@/utils/wakuTopics';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import AgentError from '@/types/AgentError';
 import isAdmin from '@/utils/isAdmin';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
 
 import {
   getProductCache,
@@ -71,12 +70,13 @@ class ProductsAgent {
     const n = await this.ensureNode();
     if (!n) return;
     const client = await getClient();
-    const decoder = client.createDecoder(buildProductTopic(storeId));
+    const topic = buildProductTopic(storeId);
+    const decoder = client.createDecoder(topic);
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
-        const signed = await verifyBeforeWrite(raw, productUpdatedSchema);
+        const signed = await verifyBeforeWrite(raw, productUpdatedSchema, undefined, topic);
         if (!signed) return;
         void this.invalidateCache();
       } catch (err) {
@@ -134,23 +134,14 @@ class ProductsAgent {
     const n = await this.ensureNode();
     if (!n) return;
     try {
-      const priv = await getPrivateKey();
-      const pub = await getPublicKeyHex();
-      const msg: WakuMessage<Product> = {
-        type: 'product.updated',
-        payload: product,
-        sender: { publicKey: pub },
-        signature: '',
-      };
-      const msgBytes = new TextEncoder().encode(
-        canonicalJson({
-          type: msg.type,
-          payload: msg.payload,
-          sender: msg.sender,
-        }),
+      const ts = Date.now();
+      const nonce = Buffer.from(randomBytes(12)).toString('hex');
+      const msg = await makeSignedWakuMessage(
+        'product.updated',
+        { product, ts, nonce },
+        'store-owner',
+        { ts, nonce },
       );
-      const sig = await sign(msgBytes, priv);
-      msg.signature = Buffer.from(sig).toString('hex');
       const client = await getClient();
       const encoder = client.createEncoder({
         contentTopic: buildProductTopic(product.storeId),

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -10,11 +10,9 @@ import {
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { publish } from '@/services/waku';
 import { buildTopic } from '@/utils/wakuTopics';
-import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
-import { sign } from '@noble/ed25519';
-import { canonicalJson } from '@/utils/serialization';
 import type { WakuMessage } from '@/types/waku';
 import ensureNearWallet from '@/utils/ensureNearWallet';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 
 assertNearChain();
 
@@ -178,18 +176,5 @@ export const selectStore = (id: string): Promise<Store | null> =>
 export default storesAgent;
 
 async function makeSignedMessage(type: string, payload: any): Promise<WakuMessage<any>> {
-  const priv = await getPrivateKey();
-  const pub = await getPublicKeyHex();
-  const msg: WakuMessage<any> = {
-    type,
-    payload,
-    sender: { publicKey: pub, role: 'store-owner' },
-    signature: '',
-  };
-  const toSign = new TextEncoder().encode(
-    canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
-  );
-  const sig = await sign(toSign, priv);
-  msg.signature = Buffer.from(sig).toString('hex');
-  return msg;
+  return await makeSignedWakuMessage(type, payload, 'store-owner');
 }

--- a/contexts/WakuContext.tsx
+++ b/contexts/WakuContext.tsx
@@ -153,7 +153,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       try {
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema);
+        const signed = await verifyBeforeWrite(raw, schema, undefined, topic);
         if (!signed) return;
         const text = await decryptMessage(signed.payload, roomId, peerPublicKey);
         const chat: ChatMessage = {
@@ -207,7 +207,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
         try {
           const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
           const schema = wakuMessageSchema.extend({ payload: z.string() });
-          const signed = await verifyBeforeWrite(raw, schema);
+          const signed = await verifyBeforeWrite(raw, schema, undefined, topic);
           if (!signed) continue;
           const text = await decryptMessage(signed.payload, roomId, peerPublicKey);
           const chat: ChatMessage = {
@@ -257,7 +257,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       try {
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema);
+        const signed = await verifyBeforeWrite(raw, schema, undefined, SYSTEM_TOPIC);
         if (!signed) {
           errorLog('Dropping unverified system message', raw);
           return;
@@ -288,7 +288,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       try {
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema);
+        const signed = await verifyBeforeWrite(raw, schema, undefined, NOTIFICATION_TOPIC);
         if (!signed) {
           errorLog('Dropping unverified notification message', raw);
           return;

--- a/schemas/notifications/order.created.ts
+++ b/schemas/notifications/order.created.ts
@@ -7,6 +7,8 @@ export const orderCreatedEventSchema = wakuMessageSchema.extend({
     orderId: z.string(),
     userId: z.string(),
     total: z.number(),
+    ts: z.number(),
+    nonce: z.string(),
   }),
 });
 

--- a/schemas/notifications/order.failed.ts
+++ b/schemas/notifications/order.failed.ts
@@ -8,6 +8,8 @@ export const orderFailedEventSchema = wakuMessageSchema.extend({
     userId: z.string(),
     code: z.string(),
     reason: z.string(),
+    ts: z.number(),
+    nonce: z.string(),
   }),
 });
 

--- a/schemas/waku/delivery.update.ts
+++ b/schemas/waku/delivery.update.ts
@@ -11,6 +11,8 @@ export const deliveryUpdatePayloadSchema = z.object({
   driverId: z.string().optional(),
   status: deliveryStatusSchema,
   timestamp: z.number(),
+  ts: z.number(),
+  nonce: z.string(),
 });
 
 export const deliveryUpdateMessageSchema = wakuMessageSchema.extend({

--- a/schemas/waku/message.ts
+++ b/schemas/waku/message.ts
@@ -8,6 +8,9 @@ export const wakuMessageSchema = z.object({
     role: z.string().optional(),
   }),
   signature: z.string(),
+  ts: z.number(),
+  nonce: z.string(),
+  keyEpoch: z.number().optional(),
 });
 
 export type WakuMessage<T = unknown> = z.infer<typeof wakuMessageSchema> & {

--- a/schemas/waku/notification.ts
+++ b/schemas/waku/notification.ts
@@ -29,6 +29,8 @@ export const notificationWakuPayloadSchema = z.object({
   type: notificationEventSchema,
   notification: notificationSchema,
   storeId: z.string().optional(),
+  ts: z.number(),
+  nonce: z.string(),
 });
 
 export type NotificationWakuPayload = z.infer<typeof notificationWakuPayloadSchema>;

--- a/schemas/waku/order.status.ts
+++ b/schemas/waku/order.status.ts
@@ -17,6 +17,8 @@ export const orderStatusMessageSchema = wakuMessageSchema.extend({
   payload: z.object({
     orderId: z.string(),
     status: z.enum(orderStatuses),
+    ts: z.number(),
+    nonce: z.string(),
   }),
 });
 

--- a/services/kycReceipts.ts
+++ b/services/kycReceipts.ts
@@ -61,7 +61,10 @@ export async function issueKycReceipt(
     ts: Date.now(),
     nonce: randomNonce(),
   };
-  const message = await makeSignedWakuMessage('kyc.receipt', payload, 'admin');
+  const message = await makeSignedWakuMessage('kyc.receipt', payload, 'admin', {
+    ts: payload.ts,
+    nonce: payload.nonce,
+  });
   await persistReceipt(buyerPublicKey, message);
   await publish(receiptTopic(buyerPublicKey), message);
   return message;

--- a/services/nearSettings.ts
+++ b/services/nearSettings.ts
@@ -4,19 +4,19 @@ import { getValue, setValue, listValues } from './nearKvStore';
 import config from '@/config';
 import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
-import type { SettingsWriteEvent, WakuMessage } from '../types/waku';
+import type { SettingsWriteEvent } from '../types/waku';
 import { settingsWriteEventSchema, wakuMessageSchema } from '../schemas/waku';
 import { verifyBeforeWrite } from '../utils/verifyMessageSignature';
 import { z } from 'zod';
-import { sign } from '@noble/ed25519';
 import { canonicalJson } from '@/utils/serialization';
-import { getPrivateKey, getPublicKeyHex } from './localIdentity';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 import type { AdminScope } from '@/types';
 import { ALL_ADMIN_SCOPES } from '@/types';
 
 assertNearChain();
 
 const ADDRESS = 'settings';
+const SETTINGS_TOPIC = '/blue-ocean/settings/1';
 
 async function assertAdmin(actor: string): Promise<void> {
   if (!actor) {
@@ -81,27 +81,11 @@ async function emit(event: SettingsWriteEvent) {
   const n = await ensureNode();
   if (!n) return;
   try {
-    const priv = await getPrivateKey();
-    const pub = await getPublicKeyHex();
-    const msg: WakuMessage<SettingsWriteEvent> = {
-      type: event.type,
-      payload: event,
-      sender: { publicKey: pub },
-      signature: '',
-    };
-    const msgBytes = new TextEncoder().encode(
-      canonicalJson({
-        type: msg.type,
-        payload: msg.payload,
-        sender: msg.sender,
-      }),
-    );
-    const sig = await sign(msgBytes, priv);
-    msg.signature = Buffer.from(sig).toString('hex');
+    const msg = await makeSignedWakuMessage(event.type, event, 'admin');
 
     const client = await getClient();
     const encoder = client.createEncoder({
-      contentTopic: '/blue-ocean/settings/1',
+      contentTopic: SETTINGS_TOPIC,
     } as any);
     await n.lightPush.send(encoder, {
       payload: client.utf8ToBytes(canonicalJson(msg)),
@@ -117,10 +101,7 @@ export async function subscribeToSettingsWrites(
   const n = await ensureNode();
   if (!n) return () => {};
   const client = await getClient();
-  const decoder = client.createDecoder(
-    '/blue-ocean/settings/1',
-    undefined as any,
-  );
+  const decoder = client.createDecoder(SETTINGS_TOPIC, undefined as any);
   const handler = async (wakuMsg: any) => {
     if (!wakuMsg.payload) return;
     try {
@@ -130,7 +111,7 @@ export async function subscribeToSettingsWrites(
         payload: settingsWriteEventSchema,
       });
       const adminKeys = await getAdminPublicKeys();
-      const signed = await verifyBeforeWrite(raw, schema, adminKeys);
+      const signed = await verifyBeforeWrite(raw, schema, adminKeys, SETTINGS_TOPIC);
       if (!signed) return;
       cb(signed.payload);
     } catch (err) {

--- a/services/productEvents.ts
+++ b/services/productEvents.ts
@@ -15,30 +15,36 @@ export async function publishProductUpdated(product: Product) {
     ...product,
     isActive: product.isActive !== false,
   };
+  const ts = Date.now();
+  const nonce = randomNonce();
   const message = await makeSignedWakuMessage(
     'product.updated',
     {
       product: normalized,
-      ts: Date.now(),
-      nonce: randomNonce(),
+      ts,
+      nonce,
     },
     'admin',
+    { ts, nonce },
   );
   await publish(PRODUCT_TOPIC, message);
   return message;
 }
 
 export async function publishProductDeleted(id: string, storeId: string) {
+  const ts = Date.now();
+  const nonce = randomNonce();
   const message = await makeSignedWakuMessage(
     'product.deleted',
     {
       id,
       storeId,
       deletedAt: new Date().toISOString(),
-      ts: Date.now(),
-      nonce: randomNonce(),
+      ts,
+      nonce,
     },
     'admin',
+    { ts, nonce },
   );
   await publish(PRODUCT_TOPIC, message);
   return message;

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -13,6 +13,8 @@ import { initLake } from './nearLake';
 import { topicFor } from '@blue-ocean/utils';
 import { getNetworkId, getContractId } from '@/services/config';
 import { setStore as persistStore } from '@/features/stores/services/nearStores';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
 
 declare const logger: any;
 
@@ -39,6 +41,31 @@ let lakeStarted = false;
 
 const MAX_GZ_PAYLOAD = 200 * 1024; // 200KB
 const PROMPT_TTI_MS = 2500; // 2.5s
+const NONCE_BYTE_LENGTH = 12;
+const KEY_EPOCH_INTERVAL_MS = 10 * 60 * 1000;
+
+function randomHex(byteLength = NONCE_BYTE_LENGTH): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
+
+function computeKeyEpoch(ts: number): number {
+  if (!Number.isFinite(ts)) return 0;
+  return Math.floor(ts / KEY_EPOCH_INTERVAL_MS);
+}
+
+function enrichEnvelope(message: unknown): Record<string, unknown> {
+  const base: Record<string, unknown> = {};
+  if (message && typeof message === 'object' && !Array.isArray(message)) {
+    Object.assign(base, message as Record<string, unknown>);
+  } else if (message !== undefined) {
+    base.payload = message;
+  }
+  const ts = typeof base.ts === 'number' ? base.ts : Date.now();
+  const nonce = typeof base.nonce === 'string' ? base.nonce : randomHex();
+  const keyEpoch =
+    typeof base.keyEpoch === 'number' ? base.keyEpoch : computeKeyEpoch(ts);
+  return { ...base, ts, nonce, keyEpoch };
+}
 
 function getPublisherKey(): string {
   if (PUB) return PUB;
@@ -175,7 +202,9 @@ async function sendAck(topic: string, id: string): Promise<void> {
 export async function publish(topic: string, message: any): Promise<string> {
   const client = await getClient();
   const id = message?.id || Date.now().toString();
-  const payload = client.utf8ToBytes(canonicalJson({ ...message, id }));
+  const enriched = enrichEnvelope(message);
+  const envelope = { ...enriched, id };
+  const payload = client.utf8ToBytes(canonicalJson(envelope));
   const gzSize = gzipSync(Buffer.from(payload)).length;
   if (gzSize > MAX_GZ_PAYLOAD) {
     throw new Error('Payload exceeds 200KB gz limit');

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,6 +4,8 @@ import { connectWallet } from '@/auth/wallet';
 import { publish, subscribeWithAck } from '@/services/waku';
 import { requestScopes, validateToken, refreshToken, SessionToken } from '@/services/session';
 import { canonicalJson } from '@/utils/serialization';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
 import { uuid } from '@/utils/uuid';
 import { parseWorkspaceCreatedMessage } from '@/schemas/waku/workspace.created';
 import type { WorkspaceCreatedMessage, WorkspaceCreatedPayload } from '@/types/waku';
@@ -219,11 +221,15 @@ async function buildWorkspaceMessage(
     timestamp: Date.now(),
   };
   const senderPublicKey = getPublicKey?.() ?? `workspace:${session.workspaceId}`;
+  const ts = Date.now();
+  const nonce = Buffer.from(randomBytes(12)).toString('hex');
   const message: WorkspaceCreatedMessage = {
     type: 'workspace.created',
     payload,
     sender: { publicKey: senderPublicKey, role: 'workspace' },
     signature: '',
+    ts,
+    nonce,
   };
   const canonical = canonicalJson({
     type: message.type,

--- a/src/features/opsDrawer/OpsDrawer.tsx
+++ b/src/features/opsDrawer/OpsDrawer.tsx
@@ -49,6 +49,12 @@ interface OpsSnapshot {
     notificationsBacklog: number | null;
     deliveryBacklog: number | null;
     cacheLagMs: number | null;
+    replayDrops: {
+      total: number;
+      duplicate: number;
+      skew: number;
+      missing: number;
+    };
   };
   session: {
     token: string | null;
@@ -69,10 +75,33 @@ interface GaugeEntry {
   value: number;
 }
 
+interface CounterEntry {
+  value: number;
+  labels: Record<string, string>;
+}
+
 function readGauge(snapshot: RegistrySnapshot, name: string): number | null {
   const entries = snapshot.gauges[name] as GaugeEntry[] | undefined;
   if (!entries || entries.length === 0) return null;
   return entries.reduce((max, entry) => Math.max(max, entry.value), Number.NEGATIVE_INFINITY);
+}
+
+function summarizeReplayDrops(snapshot: RegistrySnapshot) {
+  const entries = snapshot.counters['waku_replay_drops_total'] as CounterEntry[] | undefined;
+  const summary = { total: 0, duplicate: 0, skew: 0, missing: 0 };
+  if (!entries) return summary;
+  for (const entry of entries) {
+    summary.total += entry.value;
+    const reason = entry.labels.reason;
+    if (reason === 'duplicate') {
+      summary.duplicate += entry.value;
+    } else if (reason === 'skew') {
+      summary.skew += entry.value;
+    } else {
+      summary.missing += entry.value;
+    }
+  }
+  return summary;
 }
 
 function formatNumber(value: number | null, suffix = ''): string {
@@ -222,6 +251,7 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
     const notificationsBacklog = readGauge(observability, 'notifications_backlog');
     const deliveryBacklog = readGauge(observability, 'delivery_notifications_backlog');
     const cacheLagMs = readGauge(monitoring, 'cache_sync_lag_ms');
+    const replayDrops = summarizeReplayDrops(observability);
     const record = sessionToken ? getSession(sessionToken) : undefined;
     const scopes = Array.isArray(record?.scopes) ? record!.scopes : [];
     return {
@@ -231,6 +261,7 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
         notificationsBacklog,
         deliveryBacklog,
         cacheLagMs,
+        replayDrops,
       },
       session: {
         token: sessionToken ?? null,
@@ -396,6 +427,11 @@ export default function OpsDrawer({ open, onClose }: OpsDrawerProps) {
                   )}
                 </Section>
                 <Section title="Security">
+                  <MetricRow
+                    label="Replay drops"
+                    value={formatNumber(snapshot.metrics.replayDrops.total)}
+                    detail={`dup ${formatNumber(snapshot.metrics.replayDrops.duplicate)} • skew ${formatNumber(snapshot.metrics.replayDrops.skew)} • miss ${formatNumber(snapshot.metrics.replayDrops.missing)}`}
+                  />
                   <MetricRow label="PIN enrolled" value={snapshot.security.pinSet ? 'Yes' : 'No'} />
                   <View style={styles.toggleRow}>
                     <Text style={[styles.metricLabel, { flex: 1 }]}>Biometric unlock</Text>

--- a/tests/__mocks__/utils/observability.ts
+++ b/tests/__mocks__/utils/observability.ts
@@ -6,6 +6,8 @@ const notificationsBacklog = { set: jest.fn() };
 const notificationDeliveryLatency = {
   observe: jest.fn(),
 };
+const deliveryBacklog = { set: jest.fn() };
+const wakuReplayDrops = { inc: jest.fn() };
 module.exports = {
   serviceLatency,
   serviceFailures,
@@ -13,4 +15,6 @@ module.exports = {
   startMetricsServer,
   notificationsBacklog,
   notificationDeliveryLatency,
+  deliveryBacklog,
+  wakuReplayDrops,
 };

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -19,15 +19,20 @@ async function createSignedMessage<T>(
   pub: Uint8Array,
   meta?: { nonce?: string; ts?: number },
 ): Promise<WakuMessage<T & { nonce: string; ts: number }>> {
+  const ts = meta?.ts ?? Date.now();
+  const nonce =
+    meta?.nonce ?? Buffer.from(utils.randomPrivateKey()).toString('hex');
   const message: WakuMessage<any> = {
     type,
     payload: {
       ...payload,
-      nonce: meta?.nonce ?? Buffer.from(utils.randomPrivateKey()).toString('hex'),
-      ts: meta?.ts ?? Date.now(),
+      nonce,
+      ts,
     },
     sender: { publicKey: Buffer.from(pub).toString('hex') },
     signature: '',
+    ts,
+    nonce,
   };
   const bytes = new TextEncoder().encode(
     canonicalJson({ type: message.type, payload: message.payload, sender: message.sender }),

--- a/tests/verifyBeforeWrite.test.ts
+++ b/tests/verifyBeforeWrite.test.ts
@@ -19,6 +19,8 @@ describe('verifyBeforeWrite', () => {
       payload: 'hi',
       sender: { publicKey: pubHex },
       signature: '',
+      ts: Date.now(),
+      nonce: 'nonce-allowed',
     };
     const bytes = new TextEncoder().encode(
       canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
@@ -50,6 +52,8 @@ describe('verifyBeforeWrite', () => {
         payload: { timestamp: ts },
         sender: { publicKey: pubHex },
         signature: '',
+        ts,
+        nonce: `nonce-${ts}`,
       };
       const bytes = new TextEncoder().encode(
         canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
@@ -64,5 +68,31 @@ describe('verifyBeforeWrite', () => {
 
     const future = await makeMsg(Date.now() + TIMESTAMP_TOLERANCE_MS + 1000);
     await expect(verifyBeforeWrite(future, schema)).resolves.toBeNull();
+  });
+
+  it('rejects duplicate nonces on the same topic', async () => {
+    const priv = utils.randomPrivateKey();
+    const pub = await getPublicKey(priv);
+    const pubHex = Buffer.from(pub).toString('hex');
+    const schema = wakuMessageSchema.extend({
+      type: z.literal('test'),
+      payload: z.string(),
+    });
+    const ts = Date.now();
+    const msg: WakuMessage<string> = {
+      type: 'test',
+      payload: 'hello',
+      sender: { publicKey: pubHex },
+      signature: '',
+      ts,
+      nonce: 'replay-nonce',
+    };
+    const bytes = new TextEncoder().encode(
+      canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),
+    );
+    const sig = await sign(bytes, priv);
+    msg.signature = Buffer.from(sig).toString('hex');
+    await expect(verifyBeforeWrite(msg, schema, undefined, 'topic-1')).resolves.not.toBeNull();
+    await expect(verifyBeforeWrite(msg, schema, undefined, 'topic-1')).resolves.toBeNull();
   });
 });

--- a/tests/verifyMessageSignature.test.ts
+++ b/tests/verifyMessageSignature.test.ts
@@ -14,6 +14,8 @@ describe('verifyMessageSignature', () => {
       payload: 'hello',
       sender: { publicKey: pubHex },
       signature: '',
+      ts: Date.now(),
+      nonce: 'nonce-verify',
     };
     const bytes = new TextEncoder().encode(
       canonicalJson({ type: msg.type, payload: msg.payload, sender: msg.sender }),

--- a/tests/wakuSchemas.test.ts
+++ b/tests/wakuSchemas.test.ts
@@ -12,6 +12,8 @@ describe('Waku schemas', () => {
       payload: 'hello',
       sender: { publicKey: '0xabc' },
       signature: '0xdef',
+      ts: Date.now(),
+      nonce: 'nonce-schema',
     };
     const parsed = parseWakuMessage(msg, z.string());
     expect(parsed).toEqual(msg);
@@ -35,6 +37,8 @@ describe('Waku schemas', () => {
         read: false,
         timestamp: 1,
       },
+      ts: Date.now(),
+      nonce: 'notification-nonce',
     };
     expect(parseNotificationWakuPayload(payload)).toEqual(payload);
   });

--- a/utils/observability.ts
+++ b/utils/observability.ts
@@ -41,6 +41,13 @@ export const deliveryBacklog = registry.createGauge({
   help: 'Number of delivery updates pending broadcast',
 });
 
+export const wakuReplayDrops = registry.createCounter({
+  name: 'waku_replay_drops_total',
+  help: 'Number of Waku messages dropped by replay protection',
+  labelNames: ['reason'],
+  anonymizeLabels: false,
+});
+
 export function startMetricsServer(): void {
   logger.debug('Central metrics server disabled; metrics stay local.');
 }

--- a/utils/verifyMessageSignature.ts
+++ b/utils/verifyMessageSignature.ts
@@ -3,8 +3,70 @@ import type { WakuMessage } from '../types/waku';
 import { canonicalJson } from './serialization';
 import { z } from 'zod';
 import { errorLog } from './logger';
+import { wakuReplayDrops } from './observability';
 
-export const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
+export const TIMESTAMP_TOLERANCE_MS = 2 * 60 * 1000; // 2 minutes
+const REPLAY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const REPLAY_CACHE_MAX = 2048;
+
+type ReplayEntry = { seenAt: number };
+
+const replayCache = new Map<string, ReplayEntry>();
+
+function pruneReplayCache(now: number): void {
+  for (const [key, entry] of replayCache) {
+    if (now - entry.seenAt > REPLAY_CACHE_TTL_MS) {
+      replayCache.delete(key);
+    } else {
+      break;
+    }
+  }
+}
+
+function storeReplayKey(key: string, now: number): void {
+  replayCache.delete(key);
+  replayCache.set(key, { seenAt: now });
+  if (replayCache.size > REPLAY_CACHE_MAX) {
+    const oldest = replayCache.keys().next().value;
+    if (oldest) replayCache.delete(oldest);
+  }
+}
+
+function extractPayloadObject(payload: unknown): Record<string, unknown> | null {
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>;
+  }
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function extractReplayMetadata(message: WakuMessage<unknown>): {
+  ts: number | null;
+  nonce: string | null;
+} {
+  const payload = extractPayloadObject(message.payload);
+  const payloadTs = payload && typeof payload.ts === 'number'
+    ? payload.ts
+    : payload && typeof payload.timestamp === 'number'
+      ? payload.timestamp
+      : null;
+  const payloadNonce = payload && typeof payload.nonce === 'string' ? payload.nonce : null;
+  const envelopeTs = typeof (message as any).ts === 'number' ? (message as any).ts : null;
+  const envelopeNonce = typeof (message as any).nonce === 'string' ? (message as any).nonce : null;
+  return {
+    ts: payloadTs ?? envelopeTs,
+    nonce: payloadNonce ?? envelopeNonce,
+  };
+}
 
 export async function verifyMessageSignature<T>(
   message: WakuMessage<T>,
@@ -34,6 +96,7 @@ export async function verifyBeforeWrite<T>(
   data: unknown,
   schema: z.ZodType<WakuMessage<T>>,
   allowedPublicKeys?: string[],
+  topic?: string,
 ): Promise<WakuMessage<T> | null> {
   const res = schema.safeParse(data);
   if (!res.success) {
@@ -46,17 +109,38 @@ export async function verifyBeforeWrite<T>(
     errorLog('E_SIGNATURE_INVALID');
     return null;
   }
-  const ts = (msg.payload as any)?.timestamp;
+  if (allowedPublicKeys && !allowedPublicKeys.includes(msg.sender.publicKey)) {
+    errorLog('E_UNAUTHORIZED');
+    return null;
+  }
+  const { ts, nonce } = extractReplayMetadata(msg);
   if (typeof ts === 'number') {
     const skew = Math.abs(Date.now() - ts);
     if (skew > TIMESTAMP_TOLERANCE_MS) {
       errorLog('E_TIMESTAMP_SKEW');
+      wakuReplayDrops.inc({ reason: 'skew' });
       return null;
     }
-  }
-  if (allowedPublicKeys && !allowedPublicKeys.includes(msg.sender.publicKey)) {
-    errorLog('E_UNAUTHORIZED');
+  } else {
+    wakuReplayDrops.inc({ reason: 'missing_ts' });
+    errorLog('E_TIMESTAMP_SKEW');
     return null;
+  }
+  if (!nonce) {
+    wakuReplayDrops.inc({ reason: 'missing_nonce' });
+    errorLog('E_REPLAY');
+    return null;
+  }
+  if (topic) {
+    const now = Date.now();
+    pruneReplayCache(now);
+    const key = `${topic}|${msg.sender.publicKey}|${nonce}`;
+    if (replayCache.has(key)) {
+      wakuReplayDrops.inc({ reason: 'duplicate' });
+      errorLog('E_REPLAY');
+      return null;
+    }
+    storeReplayKey(key, now);
   }
   return msg;
 }

--- a/utils/wakuSigning.ts
+++ b/utils/wakuSigning.ts
@@ -2,6 +2,14 @@ import { canonicalJson } from '@/utils/serialization';
 import { getPrivateKey, getPublicKeyHex } from '@/services/localIdentity';
 import type { WakuMessage } from '@/types/waku';
 import { sign } from '@noble/ed25519';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
+
+const NONCE_BYTE_LENGTH = 12;
+
+function randomNonce(byteLength = NONCE_BYTE_LENGTH): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
 
 const textEncoder = new TextEncoder();
 
@@ -9,14 +17,19 @@ export async function makeSignedWakuMessage<T>(
   type: string,
   payload: T,
   role: string,
+  options: { ts?: number; nonce?: string } = {},
 ): Promise<WakuMessage<T>> {
   const priv = await getPrivateKey();
   const pub = await getPublicKeyHex();
+  const ts = options.ts ?? Date.now();
+  const nonce = options.nonce ?? randomNonce();
   const message: WakuMessage<T> = {
     type,
     payload,
     sender: { publicKey: pub, role },
     signature: '',
+    ts,
+    nonce,
   };
   const toSign = textEncoder.encode(
     canonicalJson({ type: message.type, payload: message.payload, sender: message.sender }),


### PR DESCRIPTION
## Summary
- require timestamp/nonce metadata on Waku envelopes and domain payloads while updating signing helpers
- auto-populate ts/nonce/keyEpoch during publish flows and propagate metadata across notification, delivery, product, KYC, and workspace broadcasters
- add replay-cache validation with metrics and surface replay counters within the Ops drawer telemetry

## Testing
- ⚠️ `npx --yes jest verifyBeforeWrite` *(fails: preset ts-jest/presets/default-esm not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2372ab608326877979983f428daa