### PR TITLE
Fix stores agent wallet guard and import KYC receipt helpers

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -10,7 +10,6 @@ import {
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { publish } from '@/services/waku';
 import { buildTopic } from '@/utils/wakuTopics';
-import type { WakuMessage } from '@/types/waku';
 import ensureNearWallet from '@/utils/ensureNearWallet';
 import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 
@@ -116,12 +115,8 @@ class StoresAgent {
     this.subscribers.delete(cb);
   }
 
-  private async ensureWallet(): Promise<void> {
-    await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
-  }
-
   async add(item: Store): Promise<void> {
-    await this.ensureWallet();
+    await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
     const normalized = normalizeMessage<Store>('Store', item);
     const record = await this.persistStore({
       createdAt: normalized.createdAt || new Date().toISOString(),
@@ -131,13 +126,13 @@ class StoresAgent {
   }
 
   async update(item: Store): Promise<void> {
-    await this.ensureWallet();
+    await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
     const normalized = normalizeMessage<Store>('Store', item);
     await this.persistStore(normalized);
   }
 
   async remove(id: string): Promise<void> {
-    await this.ensureWallet();
+    await ensureNearWallet('Please connect your NEAR wallet to manage stores.');
     await removeStore(id);
   }
 
@@ -159,7 +154,7 @@ class StoresAgent {
 
   private async broadcastCreated(store: Store): Promise<void> {
     try {
-      const msg = await makeSignedMessage('store.created', store);
+      const msg = await makeSignedWakuMessage<Store>('store.created', store, 'store-owner');
       await publish(buildTopic('stores', '1'), msg);
     } catch {
       // non-fatal
@@ -174,7 +169,3 @@ export const selectStore = (id: string): Promise<Store | null> =>
   storesAgent.selectStore(id);
 
 export default storesAgent;
-
-async function makeSignedMessage(type: string, payload: any): Promise<WakuMessage<any>> {
-  return await makeSignedWakuMessage(type, payload, 'store-owner');
-}

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -18,6 +18,11 @@ import { t } from '@/i18n';
 import { Buffer } from 'buffer';
 import { getUser as getChainUser, setUser as setChainUser } from './services/nearUsers';
 import { sessionEvents, revokeToken, listSessions } from '@/services/session';
+import {
+  loadKycReceipt,
+  subscribeToKycReceipts,
+  type KycReceipt,
+} from '@/services/kycReceipts';
 
 
 interface AuthContextType {
@@ -251,10 +256,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       try {
         unsubscribe = await subscribeToKycReceipts(buyerPublicKey, {
           fetchHistory: false,
-          onReceipt: async (receipt) => {
+          onReceipt: async (receipt: KycReceipt) => {
             await applyReceipt(receipt);
           },
-          onError: (err) => {
+          onError: (err: unknown) => {
             errorLog('kyc.receipt subscription error', err);
           },
         });


### PR DESCRIPTION
## Summary
- ensure store mutations call the shared NEAR wallet guard directly
- use the signed Waku message helper when broadcasting store creation events
- wire AuthContext up to the KYC receipt helpers and tighten callback typings

## Testing
- yarn typecheck *(fails: expo/tsconfig.base.json missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2b4db56c832690d581802d8b9f8c