### PR TITLE
Improve product grid accessibility and loading states

### DIFF
--- a/app/store/[storeId]/_StoreScreen.tsx
+++ b/app/store/[storeId]/_StoreScreen.tsx
@@ -5,7 +5,7 @@ import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Text, Button } from '@/ui/primitives';
 import StoreHeader, { StoreHeaderSkeleton } from '@/features/stores/components/store/StoreHeader';
 import CategoryChips from '@/features/home/components/CategoryChips';
-import { ProductGrid, ProductCardSkeleton } from '@/features/products';
+import { ProductGrid } from '@/features/products';
 import { useProducts, useCategories, useStoreReviews } from '@/services';
 import { useStoreProfile } from '@/features/stores/hooks/useStoreProfile';
 import type { Product } from '@/types';
@@ -272,15 +272,7 @@ export default function StoreScreen() {
       ) : null}
 
       <View style={styles.catalogContainer}>
-        {productsLoading ? (
-          <View style={styles.productSkeletonRow}>
-            {Array.from({ length: 4 }).map((_, index) => (
-              <View key={index} style={styles.productSkeletonWrapper}>
-                <ProductCardSkeleton />
-              </View>
-            ))}
-          </View>
-        ) : loadErrorMessage ? (
+        {loadErrorMessage ? (
           <EmptyState
             icon={AlertTriangle}
             title={t('home.loadErrorTitle', 'Unable to load products')}
@@ -294,6 +286,7 @@ export default function StoreScreen() {
             refreshing={refreshing}
             onRefresh={handleRefresh}
             onProductPress={handleProductPress}
+            loading={productsLoading}
           />
         )}
       </View>
@@ -310,18 +303,6 @@ const styles = StyleSheet.create({
   catalogContainer: {
     flex: 1,
     paddingTop: spacing.spacer8,
-  },
-  productSkeletonRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.spacer16,
-    paddingVertical: spacing.spacer16,
-    gap: spacing.spacer16,
-  },
-  productSkeletonWrapper: {
-    width: '48%',
-    borderRadius: radius.md,
   },
 });
 

--- a/src/features/products/ProductCard.tsx
+++ b/src/features/products/ProductCard.tsx
@@ -24,12 +24,28 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
     originalPrice,
   } = useProductCard(product);
   const reviewsEnabled = isReviewsEnabled();
+  const imageUri = product.images && product.images[0] ? product.images[0] : null;
+  const [imageStatus, setImageStatus] = React.useState<
+    'loading' | 'loaded' | 'error'
+  >(imageUri ? 'loading' : 'error');
+
+  React.useEffect(() => {
+    if (imageUri) {
+      setImageStatus('loading');
+    } else {
+      setImageStatus('error');
+    }
+  }, [imageUri]);
+
   const accessibilityLabel = React.useMemo(() => {
     if (!price) {
       return product.name;
     }
     return `${product.name}, ${price}`;
   }, [price, product.name]);
+
+  const showSkeleton = imageUri && imageStatus !== 'loaded';
+  const shouldShowFallback = !imageUri || imageStatus === 'error';
 
   return (
     <Pressable
@@ -39,10 +55,26 @@ function ProductCard({ product, onPress, onCTAPress, style }: ProductCardProps) 
       style={[styles.card, { backgroundColor: colors.surface.primary }, style]}
     >
       <View style={styles.imageWrapper}>
-        {product.images && product.images[0] ? (
-          <Image source={{ uri: product.images[0] }} style={styles.image} />
-        ) : (
+        {shouldShowFallback ? (
           <View style={[styles.image, { backgroundColor: colors.muted }]} />
+        ) : (
+          <>
+            <Image
+              source={{ uri: imageUri! }}
+              style={[styles.image, showSkeleton && styles.hiddenImage]}
+              accessibilityRole="image"
+              accessibilityLabel={product.name}
+              onLoadStart={() => setImageStatus('loading')}
+              onLoad={() => setImageStatus('loaded')}
+              onError={() => setImageStatus('error')}
+            />
+            {showSkeleton ? (
+              <Skeleton
+                style={styles.imageSkeleton}
+                accessibilityLabel="Loading product image"
+              />
+            ) : null}
+          </>
         )}
         <Pressable
           accessibilityRole="button"
@@ -136,6 +168,12 @@ const styles = StyleSheet.create({
   image: {
     width: '100%',
     aspectRatio: 1,
+  },
+  hiddenImage: {
+    opacity: 0,
+  },
+  imageSkeleton: {
+    ...StyleSheet.absoluteFillObject,
   },
   wishlist: {
     position: 'absolute',

--- a/src/features/products/components/ProductGrid.tsx
+++ b/src/features/products/components/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { FlatList, View, StyleSheet } from 'react-native';
+import { FlatList, View, StyleSheet, I18nManager } from 'react-native';
 import EmptyState from '@/shared/ui/EmptyState';
-import ProductCard from '../ProductCard';
+import ProductCard, { ProductCardSkeleton } from '../ProductCard';
 import { Product } from '@/types';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
 import { Package } from 'lucide-react-native';
@@ -31,11 +31,21 @@ interface ProductGridProps {
   refreshing?: boolean;
   onRefresh?: () => void;
   onProductPress?: (product: Product) => void;
+  loading?: boolean;
+  skeletonCount?: number;
 }
 
-function ProductGrid({ products, refreshing, onRefresh, onProductPress }: ProductGridProps) {
+function ProductGrid({
+  products,
+  refreshing,
+  onRefresh,
+  onProductPress,
+  loading,
+  skeletonCount = 4,
+}: ProductGridProps) {
   const { colors } = useTheme();
   const { t } = useLanguage();
+  const isRTL = I18nManager.isRTL;
 
   const borderColor = colors.border.primary;
   const renderItem = useCallback(
@@ -48,13 +58,42 @@ function ProductGrid({ products, refreshing, onRefresh, onProductPress }: Produc
   const keyExtractor = useCallback((item: Product) => item.id, []);
 
   const columnWrapperStyle = useMemo(
-    () => ({ gap: spacing.spacer12, paddingHorizontal: spacing.spacer16 }),
-    []
+    () => ({
+      gap: spacing.spacer12,
+      paddingHorizontal: spacing.spacer16,
+      flexDirection: isRTL ? 'row-reverse' : 'row',
+    }),
+    [isRTL]
   );
   const contentContainerStyle = useMemo(
-    () => ({ paddingVertical: spacing.spacer16 }),
-    []
+    () => ({
+      paddingVertical: spacing.spacer16,
+      direction: isRTL ? 'rtl' : 'ltr',
+    }),
+    [isRTL]
   );
+  const skeletonItems = useMemo(
+    () => Array.from({ length: skeletonCount }, (_, index) => index),
+    [skeletonCount]
+  );
+
+  if (loading && (!products || products.length === 0)) {
+    return (
+      <View
+        style={[
+          styles.skeletonGrid,
+          { flexDirection: isRTL ? 'row-reverse' : 'row' },
+        ]}
+        accessibilityLabel={t('home.loadingProducts', 'Loading products')}
+      >
+        {skeletonItems.map((index) => (
+          <View key={index} style={styles.skeletonWrapper}>
+            <ProductCardSkeleton />
+          </View>
+        ))}
+      </View>
+    );
+  }
 
   if (!products || products.length === 0) {
     return (
@@ -71,6 +110,7 @@ function ProductGrid({ products, refreshing, onRefresh, onProductPress }: Produc
       data={products}
       keyExtractor={keyExtractor}
       numColumns={2}
+      style={{ direction: isRTL ? 'rtl' : 'ltr' }}
       columnWrapperStyle={columnWrapperStyle}
       contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}
@@ -81,4 +121,18 @@ function ProductGrid({ products, refreshing, onRefresh, onProductPress }: Produc
 }
 
 export default memo(ProductGrid);
+
+const styles = StyleSheet.create({
+  skeletonGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    gap: spacing.spacer12,
+    paddingHorizontal: spacing.spacer16,
+    paddingVertical: spacing.spacer16,
+  },
+  skeletonWrapper: {
+    width: '48%',
+  },
+});
 

--- a/tests/storeScreen.test.tsx
+++ b/tests/storeScreen.test.tsx
@@ -71,12 +71,16 @@ jest.mock('@/features/home/components/CategoryChips', () => ({
 }));
 
 jest.mock('@/features/products', () => ({
-  ProductGrid: ({ products }: any) =>
-    React.createElement(
-      'ProductGrid',
-      null,
-      products.map((p: any) => React.createElement('Product', { key: p.id }, p.name)),
-    ),
+  ProductGrid: ({ products, loading }: any) =>
+    loading
+      ? React.createElement('ProductSkeleton')
+      : React.createElement(
+          'ProductGrid',
+          null,
+          products.map((p: any) =>
+            React.createElement('Product', { key: p.id }, p.name),
+          ),
+        ),
   ProductCardSkeleton: () => React.createElement('ProductSkeleton'),
 }));
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -163,6 +163,7 @@
     "priceLowHigh": "Price: Low to High",
     "priceHighLow": "Price: High to Low",
     "highRating": "High Rating",
+    "loadingProducts": "Loading products",
     "loadErrorMessage": "Failed to load data. Pull to refresh or press Reload.",
     "connectWalletToContinue": "Connect wallet to continue",
     "create_store_prompt_title": "Create your store",

--- a/translations/he.json
+++ b/translations/he.json
@@ -163,6 +163,7 @@
     "priceLowHigh": "מחיר: נמוך לגבוה",
     "priceHighLow": "מחיר: גבוה לנמוך",
     "highRating": "דירוג גבוה",
+    "loadingProducts": "טוען מוצרים",
     "loadErrorMessage": "טעינת הנתונים נכשלה. משוך לרענון או לחץ טען מחדש.",
     "connectWalletToContinue": "חבר ארנק כדי להמשיך",
     "create_store_prompt_title": "צור את החנות שלך",


### PR DESCRIPTION
## Summary
- add image loading skeletons and accessibility labels to product cards
enhancing screen-reader support
- teach the shared product grid to render skeletons when data is loading and
respect RTL layouts
- reuse the new grid loading state on the store screen, update mocks, and add
a loading translation string

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser because dependencies are
not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2aaa55bc83269861dbca63ce29b0