### PR TITLE
Expand KYC capture with liveness video and artifact bundle

### DIFF
--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -34,7 +34,9 @@ type SettingKey =
   | 'rpcUrl'
   | 'rpcFallbackUrls'
   | 'paymentFactoryAddress'
-  | 'kyc.required';
+  | 'kyc.required'
+  | 'kyc.requireSocialProof'
+  | 'kyc.requireWhatsappCall';
 
 class SettingsAgent {
   private static instance: SettingsAgent;

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -1,4 +1,4 @@
-import { User } from '@/types';
+import { User, type KycArtifactBundle, type KycCallReceiptRecord } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { getUser, setUser, listUsers, removeUser } from '@/features/auth/services/nearUsers';
 import { getPublicKeyHex } from '@/services/localIdentity';
@@ -20,11 +20,15 @@ export type UsersAgentMessage =
   | { type: 'user.remove'; payload: { id: string } }
   | {
       type: 'kyc.request';
-      payload: { userId: string; document: { uri: string; hash: string } };
+      payload: { userId: string; bundle: KycArtifactBundle };
     }
   | {
       type: 'kyc.update';
       payload: { userId: string; status: 'verified' | 'rejected'; adminId?: string };
+    }
+  | {
+      type: 'kyc.call';
+      payload: { userId: string; receipt: KycCallReceiptRecord };
     };
 
 class UsersAgent {
@@ -108,10 +112,7 @@ class UsersAgent {
   }
 
   // kyc.request
-  async requestKyc(
-    userId: string,
-    document: { uri: string; hash: string },
-  ): Promise<void> {
+  async requestKyc(userId: string, bundle: KycArtifactBundle): Promise<void> {
     const { address, publicKey } = await this.ensureWallet();
     const user = await getUser(userId);
     if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
@@ -132,7 +133,12 @@ class UsersAgent {
       address,
       kycStatus: 'pending',
       kycRequestedAt: new Date().toISOString(),
-      kycDocument: document,
+      kycRequestNotes: bundle.notes ?? user.kycRequestNotes,
+      kycDocument: bundle.document,
+      kycArtifacts: bundle.artifacts,
+      kycBundleNonce: bundle.nonce,
+      kycBundleSig: bundle.sig,
+      kycWhatsappNumber: bundle.whatsappNumber ?? user.kycWhatsappNumber,
     });
     await setUser(enriched);
   }
@@ -170,6 +176,8 @@ class UsersAgent {
         : status === 'rejected'
         ? undefined
         : user.kycReceiptHash;
+    const callReceipts =
+      status === 'verified' ? user.kycCallReceipts ?? [] : user.kycCallReceipts;
     const enriched: User = normalizeMessage<User>('User', {
       ...user,
       publicKey,
@@ -178,6 +186,32 @@ class UsersAgent {
       kycReceiptHash: nextHash,
       kycApprovedBy: status === 'verified' ? approvedBy : user.kycApprovedBy,
       kycApprovedAt: status === 'verified' ? now : user.kycApprovedAt,
+      kycCallReceipts: callReceipts,
+    });
+    await setUser(enriched);
+  }
+
+  async logKycCallReceipt(userId: string, receipt: KycCallReceiptRecord): Promise<void> {
+    const { address, publicKey } = await this.ensureWallet();
+    const hasScope = await SettingsAgent.getInstance().hasAdminScope(
+      address,
+      'admin:users',
+    );
+    if (!hasScope) {
+      throw new AgentError(
+        'UNAUTHORIZED',
+        'Only admins with scope admin:users can log call receipts',
+        'users-agent',
+      );
+    }
+    const user = await getUser(userId);
+    if (!user) throw new AgentError('USER_NOT_FOUND', 'User not found', 'users-agent');
+    const nextReceipts = [...(user.kycCallReceipts ?? []), receipt];
+    const enriched: User = normalizeMessage<User>('User', {
+      ...user,
+      publicKey,
+      address,
+      kycCallReceipts: nextReceipts,
     });
     await setUser(enriched);
   }
@@ -212,7 +246,7 @@ class UsersAgent {
         await this.remove(msg.payload.id);
         break;
       case 'kyc.request':
-        await this.requestKyc(msg.payload.userId, msg.payload.document);
+        await this.requestKyc(msg.payload.userId, msg.payload.bundle);
         break;
       case 'kyc.update':
         await this.updateKyc(
@@ -220,6 +254,9 @@ class UsersAgent {
           msg.payload.status,
           msg.payload.adminId,
         );
+        break;
+      case 'kyc.call':
+        await this.logKycCallReceipt(msg.payload.userId, msg.payload.receipt);
         break;
     }
   }

--- a/app/kyc/components/VideoCapture.tsx
+++ b/app/kyc/components/VideoCapture.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Camera, CameraType } from 'expo-camera';
+import { Spinner } from '@/ui/primitives';
+import WatermarkOverlay from './WatermarkOverlay';
+import type { CaptureArtifact } from '../hooks/useKycCapture';
+
+interface VideoCaptureProps {
+  appName: string;
+  livenessPrompt: string | null;
+  livenessNonce: string | null;
+  prepareLiveness: () => { prompt: string; challenge: string; nonce: string };
+  recordLiveness: (camera: Camera) => Promise<CaptureArtifact>;
+  onRecorded: (artifact: CaptureArtifact) => void;
+  onCancel?: () => void;
+}
+
+export default function VideoCapture({
+  appName,
+  livenessPrompt,
+  livenessNonce,
+  prepareLiveness,
+  recordLiveness,
+  onRecorded,
+  onCancel,
+}: VideoCaptureProps): React.ReactElement {
+  const cameraRef = useRef<Camera | null>(null);
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionTs, setSessionTs] = useState(() => Date.now());
+  const [promptState, setPromptState] = useState(() =>
+    livenessPrompt && livenessNonce ? { prompt: livenessPrompt, nonce: livenessNonce } : null,
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      if (mounted) {
+        setHasPermission(status === 'granted');
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    if (!cameraRef.current) {
+      setError('מצלמה אינה זמינה');
+      return;
+    }
+    setError(null);
+    const state = promptState ?? prepareLiveness();
+    setPromptState({ prompt: state.prompt, nonce: state.nonce });
+    setSessionTs(Date.now());
+    try {
+      setRecording(true);
+      const artifact = await recordLiveness(cameraRef.current);
+      onRecorded(artifact);
+    } catch (err) {
+      setError('לא ניתן להקליט את הוידאו. נסה/י שוב.');
+    } finally {
+      setRecording(false);
+    }
+  }, [onRecorded, prepareLiveness, promptState, recordLiveness]);
+
+  const overlayNonce = promptState?.nonce ?? livenessNonce ?? '';
+  const overlayPrompt = promptState?.prompt ?? livenessPrompt ?? '';
+
+  const permissionDenied = useMemo(() => hasPermission === false, [hasPermission]);
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.centered}>
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (permissionDenied) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.permissionText}>יש לאשר גישה למצלמה לצורך בדיקת חיות.</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={() => setHasPermission(null)}>
+          <Text style={styles.retryLabel}>נסה/י שוב</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Camera
+        ref={(ref) => {
+          cameraRef.current = ref;
+        }}
+        style={styles.camera}
+        type={CameraType.front}
+        ratio="16:9"
+      >
+        <WatermarkOverlay appName={appName} timestamp={sessionTs} nonce={overlayNonce} />
+        <View style={styles.promptContainer} pointerEvents="none">
+          <Text style={styles.prompt}>{overlayPrompt}</Text>
+        </View>
+      </Camera>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <View style={styles.actions}>
+        {onCancel ? (
+          <TouchableOpacity style={styles.secondaryButton} onPress={onCancel} disabled={recording}>
+            <Text style={styles.secondaryLabel}>ביטול</Text>
+          </TouchableOpacity>
+        ) : null}
+        <TouchableOpacity
+          style={[styles.primaryButton, recording && styles.primaryButtonDisabled]}
+          onPress={() => void startRecording()}
+          disabled={recording}
+        >
+          <Text style={styles.primaryLabel}>{recording ? 'מקליט…' : 'התחל/י הקלטה'}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { width: '100%', height: 320, borderRadius: 16, overflow: 'hidden', position: 'relative' },
+  camera: { flex: 1 },
+  promptContainer: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    right: 16,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  prompt: { color: '#fff', fontSize: 16, fontWeight: '600', textAlign: 'center' },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 12,
+  },
+  primaryButton: {
+    flex: 1,
+    backgroundColor: '#1f2937',
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonDisabled: { opacity: 0.6 },
+  primaryLabel: { color: '#fff', fontWeight: '600', fontSize: 16 },
+  secondaryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    marginRight: 12,
+  },
+  secondaryLabel: { color: '#1f2937', fontWeight: '600' },
+  error: { color: '#ef4444', marginTop: 8, textAlign: 'center' },
+  centered: { alignItems: 'center', justifyContent: 'center', padding: 32 },
+  permissionText: { textAlign: 'center', marginBottom: 16 },
+  retryButton: {
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  retryLabel: { color: '#1f2937', fontWeight: '600' },
+});

--- a/app/kyc/components/WatermarkOverlay.tsx
+++ b/app/kyc/components/WatermarkOverlay.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+interface WatermarkOverlayProps {
+  appName: string;
+  timestamp: number;
+  nonce: string;
+}
+
+export default function WatermarkOverlay({
+  appName,
+  timestamp,
+  nonce,
+}: WatermarkOverlayProps): React.ReactElement {
+  const timeLabel = new Date(timestamp).toLocaleString('he-IL');
+  const nonceLabel = nonce.slice(0, 12);
+  return (
+    <View style={styles.overlay} pointerEvents="none">
+      <Text style={styles.text}>{appName}</Text>
+      <Text style={styles.text}>{timeLabel}</Text>
+      <Text style={styles.text}>nonce {nonceLabel}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    bottom: 16,
+    left: 16,
+    right: 16,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    padding: 12,
+    borderRadius: 12,
+    alignItems: 'flex-start',
+    gap: 4,
+  },
+  text: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/app/kyc/hooks/useKycCapture.ts
+++ b/app/kyc/hooks/useKycCapture.ts
@@ -1,0 +1,341 @@
+import { useCallback, useMemo, useState } from 'react';
+import * as ImagePicker from 'expo-image-picker';
+import { Camera } from 'expo-camera';
+import { Platform } from 'react-native';
+import { randomBytes } from '@noble/hashes/utils';
+import { Buffer } from 'buffer';
+import type { KycArtifactType } from '@/types';
+import {
+  trackKycCapturedPath,
+  untrackKycCapturedPath,
+} from '@/utils/kycTemp';
+
+export type CaptureSource = 'camera' | 'library';
+
+export interface CaptureArtifact {
+  type: KycArtifactType;
+  uri: string;
+  mimeType?: string;
+  name: string;
+  capturedAt: number;
+  nonce: string;
+  size?: number;
+  metadata?: Record<string, unknown>;
+  durationMs?: number;
+}
+
+interface UseKycCaptureOptions {
+  requireSocialProof?: boolean;
+  requireWhatsapp?: boolean;
+}
+
+interface CaptureStep {
+  key: 'id-front' | 'id-back' | 'selfie-with-id' | 'selfie-video' | 'social-proof' | 'review';
+  title: string;
+  description: string;
+  required: boolean;
+}
+
+interface LivenessState {
+  prompt: string;
+  challenge: string;
+  nonce: string;
+}
+
+const MAX_FILE_BYTES = 15 * 1024 * 1024;
+
+function randomNonce(byteLength = 16): string {
+  return Buffer.from(randomBytes(byteLength)).toString('hex');
+}
+
+function ensureSizeWithinLimit(size?: number): boolean {
+  if (typeof size !== 'number') return true;
+  return size <= MAX_FILE_BYTES;
+}
+
+function resolveFileName(type: KycArtifactType): string {
+  const stamp = Date.now();
+  switch (type) {
+    case 'id-front':
+      return `id-front-${stamp}.jpg`;
+    case 'id-back':
+      return `id-back-${stamp}.jpg`;
+    case 'selfie-with-id':
+      return `selfie-id-${stamp}.jpg`;
+    case 'selfie-video':
+      return `liveness-${stamp}.mp4`;
+    case 'social-proof':
+      return `social-${stamp}.jpg`;
+    case 'whatsapp-call':
+    default:
+      return `artifact-${stamp}`;
+  }
+}
+
+export function useKycCapture(options: UseKycCaptureOptions = {}) {
+  const { requireSocialProof = false, requireWhatsapp = false } = options;
+  const [artifacts, setArtifacts] = useState<CaptureArtifact[]>([]);
+  const [whatsappNumber, setWhatsappNumber] = useState('');
+  const [livenessState, setLivenessState] = useState<LivenessState | null>(null);
+
+  const steps = useMemo<CaptureStep[]>(() => {
+    const base: CaptureStep[] = [
+      {
+        key: 'id-front',
+        title: 'צילום תעודה - צד קדמי',
+        description: 'צלם/י את הצד הקדמי של התעודה בעזרת מצלמת הגב.',
+        required: true,
+      },
+      {
+        key: 'id-back',
+        title: 'צילום תעודה - צד אחורי',
+        description: 'צלם/י את הצד האחורי של התעודה.',
+        required: true,
+      },
+      {
+        key: 'selfie-with-id',
+        title: 'סלפי עם התעודה',
+        description: 'החזק/י את התעודה ליד הפנים וצור/י סלפי ברור.',
+        required: true,
+      },
+      {
+        key: 'selfie-video',
+        title: 'וידאו בדיקת חיות',
+        description: 'צלם/י וידאו קצר לפי ההוראות על המסך.',
+        required: true,
+      },
+    ];
+    if (requireSocialProof) {
+      base.push({
+        key: 'social-proof',
+        title: 'צילום פרופיל רשת חברתית',
+        description: 'העלה/י צילום מסך של פרופיל חברתי לפי הדרישות.',
+        required: true,
+      });
+    }
+    base.push({
+      key: 'review',
+      title: 'סקירה ושליחה',
+      description: 'בדקו שהכל נראה טוב ושלחו לאדמין.',
+      required: true,
+    });
+    return base;
+  }, [requireSocialProof]);
+
+  const currentStepIndex = useMemo(() => {
+    const orderedKeys = steps.map((step) => step.key);
+    for (let index = 0; index < orderedKeys.length; index += 1) {
+      const key = orderedKeys[index];
+      if (key === 'review') {
+        return index;
+      }
+      const artifact = artifacts.find((item) => item.type === key);
+      if (!artifact) {
+        return index;
+      }
+    }
+    return steps.length - 1;
+  }, [artifacts, steps]);
+
+  const setArtifact = useCallback((artifact: CaptureArtifact) => {
+    setArtifacts((prev) => {
+      const existing = prev.find((item) => item.type === artifact.type);
+      if (existing) {
+        if (existing.uri !== artifact.uri) {
+          untrackKycCapturedPath(existing.uri);
+        }
+        return prev.map((item) => (item.type === artifact.type ? artifact : item));
+      }
+      return [...prev, artifact];
+    });
+    trackKycCapturedPath(artifact.uri);
+  }, []);
+
+  const removeArtifact = useCallback((type: KycArtifactType) => {
+    setArtifacts((prev) => {
+      const next = prev.filter((item) => item.type !== type);
+      const removed = prev.find((item) => item.type === type);
+      if (removed) {
+        untrackKycCapturedPath(removed.uri);
+      }
+      return next;
+    });
+  }, []);
+
+  const pickPhoto = useCallback(
+    async (
+      type: Extract<KycArtifactType, 'id-front' | 'id-back' | 'selfie-with-id' | 'social-proof'>,
+      source: CaptureSource,
+      cameraType: ImagePicker.CameraType = ImagePicker.CameraType.back,
+      metadata: Record<string, unknown> = {},
+    ): Promise<CaptureArtifact | null> => {
+      if (Platform.OS !== 'web') {
+        if (source === 'camera') {
+          const { status } = await ImagePicker.requestCameraPermissionsAsync();
+          if (status !== 'granted') {
+            throw new Error('camera-permission-denied');
+          }
+        } else {
+          const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (status !== 'granted') {
+            throw new Error('library-permission-denied');
+          }
+        }
+      }
+
+      const now = Date.now();
+      const nonce = randomNonce();
+
+      let picked: ImagePicker.ImagePickerAsset | null = null;
+      if (source === 'camera') {
+        const result = await ImagePicker.launchCameraAsync({
+          quality: 0.8,
+          allowsEditing: true,
+          cameraType,
+        });
+        if (result.canceled || !result.assets?.length) {
+          return null;
+        }
+        picked = result.assets[0];
+      } else {
+        const result = await ImagePicker.launchImageLibraryAsync({
+          quality: 0.8,
+          allowsEditing: true,
+        });
+        if (result.canceled || !result.assets?.length) {
+          return null;
+        }
+        picked = result.assets[0];
+      }
+
+      if (!picked?.uri) {
+        return null;
+      }
+
+      const size =
+        typeof picked.fileSize === 'number'
+          ? picked.fileSize
+          : typeof picked.size === 'number'
+          ? picked.size
+          : undefined;
+      if (!ensureSizeWithinLimit(size)) {
+        throw new Error('file-too-large');
+      }
+
+      const mimeType = picked.mimeType || (picked as any).type;
+      const name =
+        picked.fileName || picked.name || `${resolveFileName(type)}.${mimeType?.split('/')?.[1] ?? 'jpg'}`;
+
+      const artifact: CaptureArtifact = {
+        type,
+        uri: picked.uri,
+        mimeType,
+        name,
+        capturedAt: now,
+        nonce,
+        size,
+        metadata,
+      };
+
+      setArtifact(artifact);
+      return artifact;
+    },
+    [setArtifact],
+  );
+
+  const prepareLiveness = useCallback((): LivenessState => {
+    const promptOptions = [
+      { prompt: 'המצמץ פעמיים', challenge: 'blink-twice' },
+      { prompt: 'סובב/י את הראש לצד שמאל', challenge: 'turn-left' },
+      { prompt: 'אמר/י את שם האפליקציה ואת התאריך', challenge: 'speak-phrase' },
+    ];
+    const chosen = promptOptions[Math.floor(Math.random() * promptOptions.length)];
+    const nonce = randomNonce();
+    const state: LivenessState = { ...chosen, nonce };
+    setLivenessState(state);
+    return state;
+  }, []);
+
+  const livenessVideoCapture = useCallback(
+    async (camera: Camera): Promise<CaptureArtifact> => {
+      if (!camera) {
+        throw new Error('camera-not-ready');
+      }
+      const state = livenessState ?? prepareLiveness();
+      const start = Date.now();
+      const recording = await camera.recordAsync({
+        maxDuration: 5,
+        quality: Camera.Constants.VideoQuality['480p'],
+        mute: false,
+      });
+      const durationMs = recording.durationMs ?? Date.now() - start;
+      const artifact: CaptureArtifact = {
+        type: 'selfie-video',
+        uri: recording.uri,
+        mimeType: 'video/mp4',
+        name: resolveFileName('selfie-video'),
+        capturedAt: start,
+        nonce: state.nonce,
+        durationMs,
+        metadata: {
+          prompt: state.prompt,
+          challenge: state.challenge,
+          overlay: {
+            nonce: state.nonce,
+            ts: start,
+          },
+        },
+      };
+      setArtifact(artifact);
+      return artifact;
+    },
+    [livenessState, prepareLiveness, setArtifact],
+  );
+
+  const getArtifact = useCallback(
+    (type: KycArtifactType) => artifacts.find((item) => item.type === type),
+    [artifacts],
+  );
+
+  const reset = useCallback(() => {
+    artifacts.forEach((artifact) => {
+      untrackKycCapturedPath(artifact.uri);
+    });
+    setArtifacts([]);
+    setWhatsappNumber('');
+    setLivenessState(null);
+  }, [artifacts]);
+
+  const canSubmit = useMemo(() => {
+    const requiredTypes: KycArtifactType[] = ['id-front', 'id-back', 'selfie-with-id', 'selfie-video'];
+    if (requireSocialProof) {
+      requiredTypes.push('social-proof');
+    }
+    const missing = requiredTypes.some((type) => !artifacts.find((item) => item.type === type));
+    if (missing) return false;
+    if (requireWhatsapp) {
+      return whatsappNumber.trim().length >= 6;
+    }
+    return true;
+  }, [artifacts, requireSocialProof, requireWhatsapp, whatsappNumber]);
+
+  return {
+    steps,
+    currentStepIndex,
+    artifacts,
+    capturePhoto: pickPhoto,
+    prepareLiveness,
+    livenessState,
+    livenessVideoCapture,
+    removeArtifact,
+    getArtifact,
+    whatsappNumber,
+    setWhatsappNumber,
+    requireSocialProof,
+    requireWhatsapp,
+    canSubmit,
+    reset,
+  };
+}
+
+export type UseKycCaptureResult = ReturnType<typeof useKycCapture>;

--- a/app/kyc/index.tsx
+++ b/app/kyc/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Image, Platform, StyleSheet, TextInput } from 'react-native';
+import { Image, StyleSheet, TextInput, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import * as DocumentPicker from 'expo-document-picker';
 import { ScrollArea, Container, Stack } from '@/ui/layout';
 import { Heading, Text, Button, Card, Badge } from '@/ui/primitives';
 import { useTheme, useLanguage } from '@/ui/ThemeProvider';
@@ -9,55 +8,69 @@ import { spacing, radius } from '@/ui/tokens';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useTenant } from '@/contexts/TenantContext';
 import SettingsAgent from '@/agents/settings-agent';
+import { useKycCapture } from './hooks/useKycCapture';
+import VideoCapture from './components/VideoCapture';
 import { encryptForTenant, type KycUploadFile } from '@/services/kycUpload';
 import { sendDM } from '@/services/dm';
-import {
-  cleanupTrackedKycCapturedPaths,
-  trackKycCapturedPath,
-  untrackKycCapturedPath,
-} from '@/utils/kycTemp';
-import HelperText from '@/ui/form/HelperText';
-import Label from '@/ui/form/Label';
+import { cleanupTrackedKycCapturedPaths } from '@/utils/kycTemp';
 import type { User } from '@/types';
 import { setUser as persistUser } from '@/features/auth/services/nearUsers';
 
-interface CapturedAsset {
-  uri: string;
-  name: string;
-  type?: string;
-  size?: number;
+interface PolicyState {
+  requireSocialProof: boolean;
+  requireWhatsapp: boolean;
+  appName: string;
 }
 
-type CaptureSlot = 'id' | 'selfie';
-
-type PickerSource = 'camera' | 'library' | 'document';
-
-const MAX_FILE_BYTES = 10 * 1024 * 1024;
-const MAX_FILE_SIZE_MB = Math.round(MAX_FILE_BYTES / (1024 * 1024));
-
-function isImage(type?: string): boolean {
-  return typeof type === 'string' && type.startsWith('image/');
-}
+const INITIAL_POLICY: PolicyState = {
+  requireSocialProof: false,
+  requireWhatsapp: false,
+  appName: 'Blue Ocean',
+};
 
 export default function KycVerificationScreen(): React.ReactElement {
   const { colors } = useTheme();
   const { t } = useLanguage();
   const { user, checkAuthState } = useAuth();
   const { tenantId } = useTenant();
-
-  const [idAsset, setIdAsset] = useState<CapturedAsset | null>(null);
-  const [selfieAsset, setSelfieAsset] = useState<CapturedAsset | null>(null);
-  const [notes, setNotes] = useState<string>(user?.kycRequestNotes ?? '');
+  const [policy, setPolicy] = useState<PolicyState>(INITIAL_POLICY);
+  const [notes, setNotes] = useState(user?.kycRequestNotes ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-
-  const kycStatus = user?.kycStatus ?? 'none';
-  const isLocked = !user || kycStatus === 'pending';
+  const capture = useKycCapture({
+    requireSocialProof: policy.requireSocialProof,
+    requireWhatsapp: policy.requireWhatsapp,
+  });
+  const { steps, currentStepIndex, artifacts, requireWhatsapp } = capture;
+  const [activeStep, setActiveStep] = useState(currentStepIndex);
 
   useEffect(() => {
+    setActiveStep(currentStepIndex);
+  }, [currentStepIndex]);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const instance = SettingsAgent.getInstance();
+        const [social, whatsapp, name] = await Promise.all([
+          instance.getSettingValue('kyc.requireSocialProof'),
+          instance.getSettingValue('kyc.requireWhatsappCall'),
+          instance.getSettingValue('appName'),
+        ]);
+        if (!mounted) return;
+        setPolicy({
+          requireSocialProof: (social || '').toLowerCase() === 'on',
+          requireWhatsapp: (whatsapp || '').toLowerCase() === 'on',
+          appName: name || INITIAL_POLICY.appName,
+        });
+      } catch (err) {
+        // Ignore policy fetch errors and fall back to defaults
+      }
+    })();
     return () => {
-      void cleanupTrackedKycCapturedPaths();
+      mounted = false;
     };
   }, []);
 
@@ -66,6 +79,9 @@ export default function KycVerificationScreen(): React.ReactElement {
       setNotes(user.kycRequestNotes);
     }
   }, [user?.kycRequestNotes]);
+
+  const kycStatus = user?.kycStatus ?? 'none';
+  const isLocked = !user || kycStatus === 'pending';
 
   const statusLabel = useMemo(() => {
     switch (kycStatus) {
@@ -94,132 +110,78 @@ export default function KycVerificationScreen(): React.ReactElement {
       default:
         return t(
           'kyc.instructionsIntro',
-          'Submit a photo ID and a selfie so we can verify your identity before you place an order.',
+          'Submit the requested captures so we can verify your identity before you place an order.',
         );
     }
   }, [kycStatus, t]);
 
-  const ensureWithinLimit = useCallback(
-    (asset: Partial<CapturedAsset> & { size?: number }): boolean => {
-      if (typeof asset.size === 'number' && asset.size > MAX_FILE_BYTES) {
-        setError(t('kyc.fileTooLarge', 'Files must be {size} MB or smaller.', { size: MAX_FILE_SIZE_MB }));
-        return false;
-      }
-      return true;
-    },
-    [t],
-  );
-
-  const requestPermission = useCallback(
-    async (source: PickerSource): Promise<boolean> => {
-      if (Platform.OS === 'web') return true;
-      try {
-        if (source === 'camera') {
-          const { status } = await ImagePicker.requestCameraPermissionsAsync();
-          if (status !== 'granted') {
-            setError(t('kyc.permissionDenied', 'Camera access is required to continue.'));
-            return false;
-          }
-          return true;
-        }
-        const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-        if (status !== 'granted') {
-          setError(t('kyc.permissionDenied', 'Media library access is required to continue.'));
-          return false;
-        }
-        return true;
-      } catch (err) {
-        setError(t('kyc.permissionDenied', 'Camera access is required to continue.'));
-        return false;
-      }
-    },
-    [t],
-  );
-
-  const handlePick = useCallback(
-    async (slot: CaptureSlot, source: PickerSource) => {
-      setError(null);
-      setSuccessMessage(null);
-      if (source !== 'document' && !(await requestPermission(source))) {
-        return;
-      }
-
-      try {
-        let picked: ImagePicker.ImagePickerAsset | DocumentPicker.DocumentPickerAsset | null = null;
-        if (source === 'document') {
-          const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: false });
-          if (result.canceled || !result.assets?.length) return;
-          picked = result.assets[0];
-        } else if (source === 'camera') {
-          const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, quality: 0.8 });
-          if (result.canceled || !result.assets?.length) return;
-          picked = result.assets[0];
-        } else {
-          const result = await ImagePicker.launchImageLibraryAsync({ allowsEditing: true, quality: 0.8 });
-          if (result.canceled || !result.assets?.length) return;
-          picked = result.assets[0];
-        }
-
-        if (!picked?.uri) return;
-
-        const size =
-          typeof (picked as any).fileSize === 'number'
-            ? (picked as any).fileSize
-            : typeof (picked as any).size === 'number'
-            ? (picked as any).size
-            : undefined;
-
-        const prepared: CapturedAsset = {
-          uri: picked.uri,
-          name:
-            picked.name ||
-            (picked as any).fileName ||
-            `${slot}-${Date.now()}.${picked.mimeType?.split('/')[1] ?? 'jpg'}`,
-          type: picked.mimeType || (picked as any).type,
-          size,
-        };
-
-        if (!ensureWithinLimit(prepared)) {
+  const handleError = useCallback(
+    (err: unknown) => {
+      if (err instanceof Error) {
+        if (err.message === 'file-too-large') {
+          setError(t('kyc.fileTooLarge', 'Files must be 15 MB or smaller.'));
           return;
         }
-
-        trackKycCapturedPath(prepared.uri);
-        if (slot === 'id') {
-          if (idAsset) untrackKycCapturedPath(idAsset.uri);
-          setIdAsset(prepared);
-        } else {
-          if (selfieAsset) untrackKycCapturedPath(selfieAsset.uri);
-          setSelfieAsset(prepared);
+        if (err.message === 'camera-permission-denied') {
+          setError(t('kyc.permissionDenied', 'Camera access is required to continue.'));
+          return;
         }
-      } catch (err) {
-        setError(t('kyc.selectionError', 'We could not open that file. Try again.'));
+        if (err.message === 'library-permission-denied') {
+          setError(t('kyc.permissionDenied', 'Media library access is required to continue.'));
+          return;
+        }
       }
+      setError(t('kyc.selectionError', 'We could not open that file. Try again.'));
     },
-    [ensureWithinLimit, idAsset, requestPermission, selfieAsset, t],
+    [t],
   );
 
-  const removeAsset = useCallback(
-    (slot: CaptureSlot) => {
-      if (slot === 'id' && idAsset) {
-        untrackKycCapturedPath(idAsset.uri);
-        setIdAsset(null);
+  const captureId = useCallback(
+    async (type: 'id-front' | 'id-back') => {
+      try {
+        setError(null);
+        await capture.capturePhoto(
+          type,
+          'camera',
+          type === 'id-front' ? ImagePicker.CameraType.back : ImagePicker.CameraType.back,
+          { side: type === 'id-front' ? 'front' : 'back' },
+        );
+      } catch (err) {
+        handleError(err);
       }
-      if (slot === 'selfie' && selfieAsset) {
-        untrackKycCapturedPath(selfieAsset.uri);
-        setSelfieAsset(null);
-      }
-      setSuccessMessage(null);
     },
-    [idAsset, selfieAsset],
+    [capture, handleError],
   );
+
+  const captureSelfieWithId = useCallback(async () => {
+    try {
+      setError(null);
+      await capture.capturePhoto('selfie-with-id', 'camera', ImagePicker.CameraType.front, {
+        pose: 'hold-id',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }, [capture, handleError]);
+
+  const captureSocialProof = useCallback(async () => {
+    try {
+      setError(null);
+      await capture.capturePhoto('social-proof', 'library', ImagePicker.CameraType.back, {
+        source: 'social-screenshot',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }, [capture, handleError]);
 
   const handleSubmit = useCallback(async () => {
     if (!user) {
       setError(t('kyc.loginRequired', 'Connect your wallet to submit verification.'));
       return;
     }
-    if (!idAsset || !selfieAsset) {
-      setError(t('kyc.missingDocuments', 'Add both an ID image and a selfie before submitting.'));
+    if (!capture.canSubmit) {
+      setError(t('kyc.missingDocuments', 'Complete all required steps before submitting.'));
       return;
     }
 
@@ -234,18 +196,33 @@ export default function KycVerificationScreen(): React.ReactElement {
         throw new Error('TENANT_PUBLIC_KEY_MISSING');
       }
 
-      const files: KycUploadFile[] = [
-        { uri: idAsset.uri, name: idAsset.name, type: idAsset.type },
-        { uri: selfieAsset.uri, name: selfieAsset.name, type: selfieAsset.type },
-      ];
+      const files: KycUploadFile[] = artifacts.map((artifact) => ({
+        uri: artifact.uri,
+        name: artifact.name,
+        type: artifact.mimeType,
+        artifactType: artifact.type,
+        capturedAt: artifact.capturedAt,
+        nonce: artifact.nonce,
+        metadata: {
+          ...(artifact.metadata ?? {}),
+          size: artifact.size,
+          durationMs: artifact.durationMs,
+        },
+      }));
 
       const encrypted = await encryptForTenant(tenantPublicKey, files);
+      const bundle = {
+        ...encrypted,
+        notes: notes.trim() ? notes.trim() : undefined,
+        whatsappNumber: capture.requireWhatsapp
+          ? capture.whatsappNumber.trim() || undefined
+          : undefined,
+      };
 
       await sendDM(tenantPublicKey, 'kyc.request', {
         userId: user.id,
         tenantId: tenantId ?? 'default',
-        document: encrypted,
-        notes: notes.trim() ? notes.trim() : undefined,
+        bundle,
       });
 
       const updated: User = {
@@ -253,13 +230,15 @@ export default function KycVerificationScreen(): React.ReactElement {
         kycStatus: 'pending',
         kycRequestedAt: new Date().toISOString(),
         kycRequestNotes: notes.trim() ? notes.trim() : undefined,
-        kycDocument: encrypted,
+        kycDocument: encrypted.document,
+        kycArtifacts: encrypted.artifacts,
+        kycBundleNonce: encrypted.nonce,
+        kycBundleSig: encrypted.sig,
+        kycWhatsappNumber: bundle.whatsappNumber ?? undefined,
       };
       await persistUser(updated);
       await checkAuthState();
-
-      setIdAsset(null);
-      setSelfieAsset(null);
+      capture.reset();
       setNotes('');
       setSuccessMessage(t('kyc.requestSubmittedMessage', 'Your verification request has been submitted.'));
     } catch (err) {
@@ -273,17 +252,32 @@ export default function KycVerificationScreen(): React.ReactElement {
       setSubmitting(false);
     }
   }, [
+    artifacts,
+    capture,
     checkAuthState,
-    idAsset,
     notes,
-    selfieAsset,
     t,
     tenantId,
     user,
   ]);
 
-  const canSubmit =
-    !isLocked && !!idAsset && !!selfieAsset && (kycStatus === 'none' || kycStatus === 'rejected');
+  const canSubmit = capture.canSubmit && !isLocked && (kycStatus === 'none' || kycStatus === 'rejected');
+
+  const handleCaptureIdFront = useCallback(() => {
+    void captureId('id-front');
+  }, [captureId]);
+
+  const handleCaptureIdBack = useCallback(() => {
+    void captureId('id-back');
+  }, [captureId]);
+
+  const handleCaptureSelfieStep = useCallback(() => {
+    void captureSelfieWithId();
+  }, [captureSelfieWithId]);
+
+  const handleCaptureSocialStep = useCallback(() => {
+    void captureSocialProof();
+  }, [captureSocialProof]);
 
   return (
     <ScrollArea backgroundColor={colors.canvas}>
@@ -294,7 +288,7 @@ export default function KycVerificationScreen(): React.ReactElement {
             <Card style={[styles.statusCard, { backgroundColor: colors.surface.primary }]}>
               <Stack gap="spacer8">
                 <Stack direction="horizontal" gap="spacer12" align="center">
-                  <Text style={[styles.statusLabel, { color: colors.text.secondary }]}>
+                  <Text style={[styles.statusLabel, { color: colors.text.secondary }]}> 
                     {t('kyc.viewStatusLabel', 'Current status')}
                   </Text>
                   <Badge label={statusLabel} accessibilityLabel={statusLabel} />
@@ -305,192 +299,268 @@ export default function KycVerificationScreen(): React.ReactElement {
           </Stack>
 
           {kycStatus !== 'verified' ? (
-            <Stack gap="spacer16">
-              <Card style={[styles.instructionsCard, { backgroundColor: colors.surface.primary }]}>
-                <Stack gap="spacer8">
-                  <Text style={styles.instructionsTitle}>{t('kyc.instructionsTitle', 'What you will need')}</Text>
-                  <Text>{t('kyc.instructionsId', 'A clear photo or scan of your government-issued ID.')}</Text>
-                  <Text>{t('kyc.instructionsSelfie', 'A selfie that matches your ID and shows your face clearly.')}</Text>
-                  <Text>{t('kyc.instructionsTip', 'Use good lighting and avoid glare or blurry images.')}</Text>
-                </Stack>
+            <Stack gap="spacer24">
+              <Stack gap="spacer16">
+                <Heading size="lg">{t('kyc.stepsTitle', 'Verification steps')}</Heading>
+                <View style={styles.stepper}>
+                  {steps.map((step, index) => {
+                    const isComplete = index < currentStepIndex;
+                    const isActive = index === activeStep;
+                    return (
+                      <View key={step.key} style={styles.stepItem}>
+                        <Button
+                          title={`${index + 1}. ${step.title}`}
+                          onPress={() => setActiveStep(index)}
+                          disabled={index > currentStepIndex}
+                          style={() => [
+                            styles.stepButton,
+                            isActive && styles.stepButtonActive,
+                            isComplete && styles.stepButtonComplete,
+                          ]}
+                          textStyle={styles.stepButtonText}
+                        />
+                        {index === currentStepIndex && !isComplete ? (
+                          <Text style={[styles.stepDescription, { color: colors.text.secondary }]}>
+                            {step.description}
+                          </Text>
+                        ) : null}
+                      </View>
+                    );
+                  })}
+                </View>
+              </Stack>
+
+              <Card style={[styles.stepCard, { backgroundColor: colors.surface.primary }]}> 
+                {renderStepContent({
+                  activeStep,
+                  capture,
+                  appName: policy.appName,
+                  onCaptureIdFront: handleCaptureIdFront,
+                  onCaptureIdBack: handleCaptureIdBack,
+                  onCaptureSelfie: handleCaptureSelfieStep,
+                  onCaptureSocial: handleCaptureSocialStep,
+                })}
               </Card>
 
-              <Stack gap="spacer16">
-                <Stack gap="spacer8">
-                  <Text style={styles.sectionTitle}>{t('kyc.idSectionTitle', 'Identity document')}</Text>
-                  {idAsset ? (
-                    <Card style={[styles.assetCard, { backgroundColor: colors.surface.primary }]}>
-                      <Stack gap="spacer12">
-                        {isImage(idAsset.type) ? (
-                          <Image
-                            source={{ uri: idAsset.uri }}
-                            style={styles.previewImage}
-                            accessibilityLabel={t('kyc.idPreviewAlt', 'Selected ID preview')}
-                          />
-                        ) : (
-                          <Text>{idAsset.name}</Text>
-                        )}
-                        <Button
-                          title={t('kyc.removeAttachment', 'Remove')}
-                          onPress={() => removeAsset('id')}
-                          testID="kyc-remove-id"
-                          accessibilityRole="button"
-                        />
-                      </Stack>
-                    </Card>
-                  ) : (
-                    <Stack direction="horizontal" gap="spacer12" style={styles.actionRow}>
-                      <Button
-                        title={t('kyc.captureId', 'Capture ID photo')}
-                        onPress={() => void handlePick('id', 'camera')}
-                        testID="kyc-id-camera"
-                        accessibilityRole="button"
-                      />
-                      <Button
-                        title={t('kyc.uploadId', 'Upload from library')}
-                        onPress={() => void handlePick('id', 'library')}
-                        testID="kyc-id-library"
-                        accessibilityRole="button"
-                      />
-                      <Button
-                        title={t('kyc.uploadIdFile', 'Upload a file')}
-                        onPress={() => void handlePick('id', 'document')}
-                        testID="kyc-id-document"
-                        accessibilityRole="button"
-                      />
-                    </Stack>
-                  )}
-                </Stack>
+              {activeStep >= steps.length - 1 ? (
+                <Card style={[styles.reviewCard, { backgroundColor: colors.surface.primary }]}> 
+                  {renderReviewSection({
+                    artifacts,
+                    colors,
+                    t,
+                    capture,
+                    notes,
+                    setNotes,
+                    requireWhatsapp,
+                    whatsappNumber: capture.whatsappNumber,
+                    setWhatsappNumber: capture.setWhatsappNumber,
+                  })}
+                </Card>
+              ) : null}
 
-                <Stack gap="spacer8">
-                  <Text style={styles.sectionTitle}>{t('kyc.selfieSectionTitle', 'Selfie')}</Text>
-                  {selfieAsset ? (
-                    <Card style={[styles.assetCard, { backgroundColor: colors.surface.primary }]}>
-                      <Stack gap="spacer12">
-                        {isImage(selfieAsset.type) ? (
-                          <Image
-                            source={{ uri: selfieAsset.uri }}
-                            style={styles.previewImage}
-                            accessibilityLabel={t('kyc.selfiePreviewAlt', 'Selected selfie preview')}
-                          />
-                        ) : (
-                          <Text>{selfieAsset.name}</Text>
-                        )}
-                        <Button
-                          title={t('kyc.removeAttachment', 'Remove')}
-                          onPress={() => removeAsset('selfie')}
-                          testID="kyc-remove-selfie"
-                          accessibilityRole="button"
-                        />
-                      </Stack>
-                    </Card>
-                  ) : (
-                    <Stack direction="horizontal" gap="spacer12" style={styles.actionRow}>
-                      <Button
-                        title={t('kyc.captureSelfie', 'Capture selfie')}
-                        onPress={() => void handlePick('selfie', 'camera')}
-                        testID="kyc-selfie-camera"
-                        accessibilityRole="button"
-                      />
-                      <Button
-                        title={t('kyc.uploadSelfie', 'Upload from library')}
-                        onPress={() => void handlePick('selfie', 'library')}
-                        testID="kyc-selfie-library"
-                        accessibilityRole="button"
-                      />
-                    </Stack>
-                  )}
-                </Stack>
+              {error ? <Text style={[styles.errorText, { color: colors.status.error }]}>{error}</Text> : null}
+              {successMessage ? (
+                <Text style={[styles.successText, { color: colors.status.success }]}>{successMessage}</Text>
+              ) : null}
 
-                <Stack gap="spacer4">
-                  <Label>{t('kyc.notesForAdmin', 'Notes for Admin (Optional)')}</Label>
-                  <TextInput
-                    value={notes}
-                    onChangeText={setNotes}
-                    placeholder={t(
-                      'kyc.notesPlaceholder',
-                      "Share any context that helps us verify your identity",
-                    )}
-                    style={[styles.notesInput, { borderColor: colors.border.primary, color: colors.text.primary }]}
-                    placeholderTextColor={colors.text.tertiary}
-                    multiline
-                    numberOfLines={4}
-                    accessible
-                    accessibilityLabel={t('kyc.notesForAdmin', 'Notes for Admin (Optional)')}
-                  />
-                </Stack>
-
-                {error ? (
-                  <HelperText error>{error}</HelperText>
-                ) : null}
-                {!user ? (
-                  <HelperText error>
-                    {t('kyc.loginRequired', 'Connect your wallet to submit verification.')}
-                  </HelperText>
-                ) : null}
-                {successMessage ? (
-                  <HelperText>{successMessage}</HelperText>
-                ) : null}
-
-                <Button
-                  title={t('kyc.requestVerification', 'Request Verification')}
-                  onPress={() => void handleSubmit()}
-                  loading={submitting}
-                  disabled={!canSubmit || submitting}
-                  testID="kyc-submit"
-                  accessibilityRole="button"
-                />
-              </Stack>
+              <Button
+                title={t('kyc.submit', 'Submit for review')}
+                onPress={() => void handleSubmit()}
+                disabled={!canSubmit || submitting}
+                testID="kyc-submit"
+              />
             </Stack>
-          ) : (
-            <Card style={[styles.instructionsCard, { backgroundColor: colors.surface.primary }]}>
-              <Text>{t('kyc.verifiedMessage', 'Your account is verified. You can now place orders.')}</Text>
-            </Card>
-          )}
+          ) : null}
         </Stack>
       </Container>
     </ScrollArea>
   );
 }
 
+function renderStepContent(params: {
+  activeStep: number;
+  capture: ReturnType<typeof useKycCapture>;
+  appName: string;
+  onCaptureIdFront: () => void;
+  onCaptureIdBack: () => void;
+  onCaptureSelfie: () => void;
+  onCaptureSocial: () => void;
+}): React.ReactElement {
+  const { activeStep, capture, appName, onCaptureIdFront, onCaptureIdBack, onCaptureSelfie, onCaptureSocial } = params;
+  const step = capture.steps[activeStep];
+  const artifact = capture.getArtifact(step.key as any);
+  switch (step.key) {
+    case 'id-front':
+    case 'id-back': {
+      return (
+        <Stack gap="spacer16">
+          <Text>{step.description}</Text>
+          {artifact ? (
+            <Image source={{ uri: artifact.uri }} style={styles.previewImage} />
+          ) : null}
+          <Button
+            title={artifact ? 'צלם/י מחדש' : 'צלם/י'}
+            onPress={() => {
+              if (step.key === 'id-front') {
+                onCaptureIdFront();
+              } else {
+                onCaptureIdBack();
+              }
+            }}
+            testID={step.key === 'id-front' ? 'kyc-capture-id-front' : 'kyc-capture-id-back'}
+          />
+        </Stack>
+      );
+    }
+    case 'selfie-with-id':
+      return (
+        <Stack gap="spacer16">
+          <Text>החזיקו את התעודה מול הפנים וצילמו סלפי ברור.</Text>
+          {artifact ? <Image source={{ uri: artifact.uri }} style={styles.previewImage} /> : null}
+          <Button
+            title={artifact ? 'צלם/י מחדש' : 'צלם/י סלפי'}
+            onPress={onCaptureSelfie}
+            testID="kyc-capture-selfie-id"
+          />
+        </Stack>
+      );
+    case 'selfie-video':
+      return (
+        <Stack gap="spacer16">
+          <Text>עיינו בהנחיות על המסך והקליטו וידאו של 3-5 שניות.</Text>
+          <VideoCapture
+            appName={appName}
+            livenessPrompt={capture.livenessState?.prompt ?? null}
+            livenessNonce={capture.livenessState?.nonce ?? null}
+            prepareLiveness={capture.prepareLiveness}
+            recordLiveness={capture.livenessVideoCapture}
+            onRecorded={() => {}}
+          />
+        </Stack>
+      );
+    case 'social-proof':
+      return (
+        <Stack gap="spacer16">
+          <Text>העלה/י צילום מסך של הפרופיל החברתי המבוקש.</Text>
+          {artifact ? <Image source={{ uri: artifact.uri }} style={styles.previewImage} /> : null}
+          <Button
+            title={artifact ? 'העלה/י מחדש' : 'בחר/י צילום מסך'}
+            onPress={onCaptureSocial}
+            testID="kyc-upload-social"
+          />
+        </Stack>
+      );
+    case 'review':
+    default:
+      return (
+        <Stack gap="spacer16">
+          <Text>עברו על הפרטים לפני השליחה.</Text>
+        </Stack>
+      );
+  }
+}
+
+function renderReviewSection(params: {
+  artifacts: ReturnType<typeof useKycCapture>['artifacts'];
+  colors: any;
+  t: (key: string, fallback: string, params?: Record<string, unknown>) => string;
+  capture: ReturnType<typeof useKycCapture>;
+  notes: string;
+  setNotes: (value: string) => void;
+  requireWhatsapp: boolean;
+  whatsappNumber: string;
+  setWhatsappNumber: (value: string) => void;
+}): React.ReactElement {
+  const { artifacts, colors, t, capture, notes, setNotes, requireWhatsapp, whatsappNumber, setWhatsappNumber } = params;
+  return (
+    <Stack gap="spacer16">
+      <Heading size="md">{t('kyc.reviewArtifacts', 'Captured artifacts')}</Heading>
+      <Stack gap="spacer12">
+        {artifacts.map((artifact) => (
+          <Card key={`${artifact.type}-${artifact.nonce}`} style={[styles.artifactCard, { backgroundColor: colors.surface.secondary }]}> 
+            <Stack gap="spacer8">
+              <Text style={{ fontWeight: '600' }}>{artifactLabel(artifact.type)}</Text>
+              <Text style={{ color: colors.text.secondary }}>
+                {new Date(artifact.capturedAt).toLocaleString('he-IL')} · nonce {artifact.nonce}
+              </Text>
+              <Text style={styles.hashText} numberOfLines={1}>
+                {artifact.uri}
+              </Text>
+              <Button title={t('kyc.removeAttachment', 'Remove')} onPress={() => capture.removeArtifact(artifact.type)} />
+            </Stack>
+          </Card>
+        ))}
+      </Stack>
+      <View>
+        <Text style={{ marginBottom: spacing['spacer8'] }}>{t('kyc.additionalNotes', 'Additional notes')}</Text>
+        <TextInput
+          value={notes}
+          onChangeText={setNotes}
+          multiline
+          placeholder={t('kyc.notesPlaceholder', 'Anything the admin should know?')}
+          style={[styles.textArea, { borderColor: colors.border.primary, color: colors.text.primary }]}
+        />
+      </View>
+      {requireWhatsapp ? (
+        <View>
+          <Text style={{ marginBottom: spacing['spacer8'] }}>מספר WhatsApp לבדיקת וידאו</Text>
+          <TextInput
+            value={whatsappNumber}
+            onChangeText={setWhatsappNumber}
+            keyboardType="phone-pad"
+            placeholder="050-000-0000"
+            style={[styles.input, { borderColor: colors.border.primary, color: colors.text.primary }]}
+          />
+        </View>
+      ) : null}
+    </Stack>
+  );
+}
+
+function artifactLabel(type: string): string {
+  switch (type) {
+    case 'id-front':
+      return 'תעודה - צד קדמי';
+    case 'id-back':
+      return 'תעודה - צד אחורי';
+    case 'selfie-with-id':
+      return 'סלפי עם תעודה';
+    case 'selfie-video':
+      return 'וידאו בדיקת חיות';
+    case 'social-proof':
+      return 'צילום מסך רשת חברתית';
+    case 'whatsapp-call':
+      return 'רשומת שיחת WhatsApp';
+    default:
+      return type;
+  }
+}
+
 const styles = StyleSheet.create({
-  page: {
-    paddingVertical: spacing.spacer24,
-  },
-  statusCard: {
-    padding: spacing.spacer16,
-  },
-  statusLabel: {
-    fontWeight: '600',
-  },
-  instructionsCard: {
-    padding: spacing.spacer16,
-  },
-  instructionsTitle: {
-    fontWeight: '600',
-  },
-  sectionTitle: {
-    fontWeight: '600',
-    fontSize: 16,
-  },
-  assetCard: {
-    padding: spacing.spacer16,
-    borderRadius: radius.lg,
-  },
-  actionRow: {
-    flexWrap: 'wrap',
-  },
-  previewImage: {
-    width: '100%',
-    height: 200,
-    borderRadius: radius.md,
-    backgroundColor: '#0001',
-  },
-  notesInput: {
+  page: { paddingVertical: spacing['spacer24'] },
+  statusCard: { padding: spacing['spacer16'], borderRadius: radius.lg },
+  statusLabel: { fontWeight: '600' },
+  stepper: { gap: spacing['spacer12'] },
+  stepItem: { gap: spacing['spacer8'] },
+  stepDescription: { fontSize: 14 },
+  stepButton: { marginBottom: spacing['spacer4'] },
+  stepButtonActive: { opacity: 1 },
+  stepButtonComplete: { opacity: 0.8 },
+  stepButtonText: { fontWeight: '600' },
+  stepCard: { padding: spacing['spacer16'], borderRadius: radius.lg },
+  reviewCard: { padding: spacing['spacer16'], borderRadius: radius.lg, gap: spacing['spacer16'] },
+  previewImage: { width: '100%', height: 220, borderRadius: radius.md, backgroundColor: '#000' },
+  artifactCard: { padding: spacing['spacer12'], borderRadius: radius.md },
+  hashText: { fontSize: 12, fontFamily: 'Courier', color: '#555' },
+  textArea: {
     borderWidth: 1,
     borderRadius: radius.md,
-    padding: spacing.spacer12,
+    padding: spacing['spacer12'],
     minHeight: 100,
     textAlignVertical: 'top',
   },
+  input: { borderWidth: 1, borderRadius: radius.md, padding: spacing['spacer12'] },
+  errorText: { fontWeight: '600' },
+  successText: { fontWeight: '600' },
 });
+

--- a/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
+++ b/app/store/[storeId]/admin/_KycApprovalsScreen.tsx
@@ -10,34 +10,54 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ArrowLeft, FileText, ShieldCheck, XCircle } from 'lucide-react-native';
+import {
+  ArrowLeft,
+  FileText,
+  ShieldCheck,
+  Smartphone,
+  Video,
+  XCircle,
+} from 'lucide-react-native';
 import { useTheme } from '@/ui/ThemeProvider';
 import { useAppRouter } from '@/services';
 import SettingsAgent from '@/agents/settings-agent';
 import usersAgent from '@/agents/users-agent';
-import type { User } from '@/types';
+import type { User, KycArtifact } from '@/types';
 import { Spinner } from '@/ui/primitives';
-import { issueKycReceipt, loadKycReceipt } from '@/services/kycReceipts';
+import {
+  issueKycReceipt,
+  issueKycCallReceipt,
+  loadKycReceipt,
+} from '@/services/kycReceipts';
 
 const POLICY_SETTING_KEY = 'kyc.required';
+const POLICY_SOCIAL_KEY = 'kyc.requireSocialProof';
+const POLICY_WHATSAPP_KEY = 'kyc.requireWhatsappCall';
 
 export default function KycApprovalsScreen(): React.ReactElement {
   const { colors } = useTheme();
   const { back } = useAppRouter();
   const [policyRequired, setPolicyRequired] = useState(false);
+  const [policySocialProof, setPolicySocialProof] = useState(false);
+  const [policyWhatsapp, setPolicyWhatsapp] = useState(false);
   const [pending, setPending] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [policySaving, setPolicySaving] = useState(false);
   const [processingId, setProcessingId] = useState<string | null>(null);
+  const [callInFlight, setCallInFlight] = useState<string | null>(null);
 
   const refreshData = useCallback(async () => {
     setLoading(true);
     try {
-      const [policyValue, users] = await Promise.all([
+      const [policyValue, socialValue, whatsappValue, users] = await Promise.all([
         SettingsAgent.getInstance().getSettingValue(POLICY_SETTING_KEY),
+        SettingsAgent.getInstance().getSettingValue(POLICY_SOCIAL_KEY),
+        SettingsAgent.getInstance().getSettingValue(POLICY_WHATSAPP_KEY),
         usersAgent.getAll(),
       ]);
       setPolicyRequired((policyValue || '').toLowerCase() === 'on');
+      setPolicySocialProof((socialValue || '').toLowerCase() === 'on');
+      setPolicyWhatsapp((whatsappValue || '').toLowerCase() === 'on');
       setPending(users.filter((user) => user.kycStatus === 'pending'));
     } catch (error) {
       Alert.alert('שגיאה', 'טעינת בקשות KYC נכשלה');
@@ -66,18 +86,92 @@ export default function KycApprovalsScreen(): React.ReactElement {
     }
   }, [policyRequired]);
 
+  const toggleSocialPolicy = useCallback(async () => {
+    const next = !policySocialProof;
+    setPolicySaving(true);
+    try {
+      await SettingsAgent.getInstance().updateSettingValue(
+        POLICY_SOCIAL_KEY,
+        next ? 'on' : 'off',
+      );
+      setPolicySocialProof(next);
+    } catch (error) {
+      Alert.alert('שגיאה', 'עדכון מדיניות צילום רשתות חברתיות נכשל');
+    } finally {
+      setPolicySaving(false);
+    }
+  }, [policySocialProof]);
+
+  const toggleWhatsappPolicy = useCallback(async () => {
+    const next = !policyWhatsapp;
+    setPolicySaving(true);
+    try {
+      await SettingsAgent.getInstance().updateSettingValue(
+        POLICY_WHATSAPP_KEY,
+        next ? 'on' : 'off',
+      );
+      setPolicyWhatsapp(next);
+    } catch (error) {
+      Alert.alert('שגיאה', 'עדכון דרישת שיחת WhatsApp נכשל');
+    } finally {
+      setPolicySaving(false);
+    }
+  }, [policyWhatsapp]);
+
   const handlePreview = useCallback((user: User) => {
     const uri = user.kycDocument?.uri;
     if (uri) {
       Linking.openURL(uri).catch(() =>
         Alert.alert('שגיאה', 'לא ניתן לפתוח את מסמך ה-KYC'),
       );
-    } else if (user.kycRequestNotes) {
-      Alert.alert('הערות משתמש', user.kycRequestNotes);
-    } else {
-      Alert.alert('מידע חסר', 'לא נמצאו מסמכי אימות עבור משתמש זה.');
+      return;
     }
+    if (user.kycRequestNotes) {
+      Alert.alert('הערות משתמש', user.kycRequestNotes);
+      return;
+    }
+    Alert.alert('מידע חסר', 'לא נמצאו מסמכי אימות עבור משתמש זה.');
   }, []);
+
+  const hasWhatsappReceipt = useCallback((user: User) => {
+    if (!user.kycCallReceipts?.length) return false;
+    return user.kycCallReceipts.some((receipt) => receipt.whatsappNumber);
+  }, []);
+
+  const completeWhatsappVerification = useCallback(
+    async (user: User) => {
+      if (!user.publicKey) {
+        Alert.alert('שגיאה', 'לא נמצא מפתח ציבורי של הלקוח לצורך חתימה.');
+        return;
+      }
+      if (!user.kycWhatsappNumber) {
+        Alert.alert('שגיאה', 'לא הוזן מספר WhatsApp אצל הלקוח.');
+        return;
+      }
+      setCallInFlight(user.id);
+      try {
+        const receipt = await issueKycCallReceipt(user.publicKey, {
+          userId: user.id,
+          whatsappNumber: user.kycWhatsappNumber,
+        });
+        await usersAgent.logKycCallReceipt(user.id, {
+          receiptId: receipt.payload.receiptId,
+          issuedAt: receipt.payload.issuedAt,
+          issuerPublicKey: receipt.payload.issuerPublicKey,
+          ts: receipt.payload.ts,
+          nonce: receipt.payload.nonce,
+          whatsappNumber: user.kycWhatsappNumber,
+        });
+        Alert.alert('עודכן', 'אישור שיחת ה-WhatsApp נשמר ונחתם.');
+        await refreshData();
+      } catch (error) {
+        Alert.alert('שגיאה', 'שמירת אישור השיחה נכשלה');
+      } finally {
+        setCallInFlight(null);
+      }
+    },
+    [refreshData],
+  );
 
   const approveRequest = useCallback(
     async (user: User) => {
@@ -149,18 +243,37 @@ export default function KycApprovalsScreen(): React.ReactElement {
         <View style={{ width: 24 }} /> 
       </View> 
 
-      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}> 
-        <View style={[styles.policyCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
-          <View style={styles.policyHeader}> 
-            <ShieldCheck size={20} color={colors.gold} /> 
-            <Text style={[styles.policyTitle, { color: colors.text.primary }]}>מדיניות אימות</Text> 
-          </View> 
-          <View style={styles.policyToggle}> 
-            <Text style={{ color: colors.text.primary }}>דרוש KYC לפני רכישה</Text> 
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View
+          style={[styles.policyCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}
+          <View style={styles.policyHeader}>
+            <ShieldCheck size={20} color={colors.gold} />
+            <Text style={[styles.policyTitle, { color: colors.text.primary }]}>מדיניות אימות</Text>
+          </View>
+          <View style={styles.policyToggle}>
+            <Text style={{ color: colors.text.primary }}>דרוש KYC לפני רכישה</Text>
             <Switch
               value={policyRequired}
               onValueChange={togglePolicy}
               thumbColor={policyRequired ? colors.gold : colors.border.primary}
+              disabled={policySaving}
+            />
+          </View>
+          <View style={styles.policyToggle}>
+            <Text style={{ color: colors.text.primary }}>דרוש צילום פרופיל חברתי</Text>
+            <Switch
+              value={policySocialProof}
+              onValueChange={toggleSocialPolicy}
+              thumbColor={policySocialProof ? colors.gold : colors.border.primary}
+              disabled={policySaving}
+            />
+          </View>
+          <View style={styles.policyToggle}>
+            <Text style={{ color: colors.text.primary }}>דרוש אימות שיחת WhatsApp</Text>
+            <Switch
+              value={policyWhatsapp}
+              onValueChange={toggleWhatsappPolicy}
+              thumbColor={policyWhatsapp ? colors.gold : colors.border.primary}
               disabled={policySaving}
             />
           </View>
@@ -177,12 +290,17 @@ export default function KycApprovalsScreen(): React.ReactElement {
           pending.map((user) => (
             <View
               key={user.id}
-              style={[styles.requestCard, { borderColor: colors.border.primary, backgroundColor: colors.surface.primary }]}> 
-              <View style={styles.requestHeader}> 
-                <View> 
-                  <Text style={[styles.requestName, { color: colors.text.primary }]}>{user.displayName || user.username}</Text> 
-                  <Text style={{ color: colors.text.secondary }}>{user.email}</Text> 
-                </View> 
+              style={[
+                styles.requestCard,
+                { borderColor: colors.border.primary, backgroundColor: colors.surface.primary },
+              ]}>
+              <View style={styles.requestHeader}>
+                <View>
+                  <Text style={[styles.requestName, { color: colors.text.primary }]}>
+                    {user.displayName || user.username}
+                  </Text>
+                  <Text style={{ color: colors.text.secondary }}>{user.email}</Text>
+                </View>
                 <TouchableOpacity
                   style={styles.previewButton}
                   onPress={() => handlePreview(user)}
@@ -194,10 +312,49 @@ export default function KycApprovalsScreen(): React.ReactElement {
               <Text style={{ color: colors.text.secondary }}>
                 בקשה: {formatDate(user.kycRequestedAt)}
               </Text>
+              {user.kycWhatsappNumber ? (
+                <Text style={{ color: colors.text.secondary }}>
+                  מספר WhatsApp: {user.kycWhatsappNumber}
+                </Text>
+              ) : null}
               {user.kycRequestNotes ? (
                 <Text style={[styles.notes, { color: colors.text.secondary }]}>{user.kycRequestNotes}</Text>
               ) : null}
+              {Array.isArray(user.kycArtifacts) && user.kycArtifacts.length > 0 ? (
+                <View style={styles.artifactList}>
+                  {user.kycArtifacts.map((artifact) => (
+                    <View
+                      key={`${artifact.type}-${artifact.hash}`}
+                      style={[styles.artifactRow, { borderColor: colors.border.primary }]}
+                    >
+                      <View style={styles.artifactIcon}>
+                        {renderArtifactIcon(artifact.type, colors.text.primary)}
+                      </View>
+                      <View style={styles.artifactBody}>
+                        <Text style={[styles.artifactTitle, { color: colors.text.primary }]}>
+                          {artifactLabel(artifact.type)}
+                        </Text>
+                        <Text style={{ color: colors.text.secondary }}>
+                          {new Date(artifact.ts).toLocaleString('he-IL')} · nonce {artifact.nonce}
+                        </Text>
+                        <Text style={styles.artifactHash} numberOfLines={1}>
+                          {artifact.hash}
+                        </Text>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
               <View style={styles.actionsRow}>
+                {policyWhatsapp && !hasWhatsappReceipt(user) ? (
+                  <TouchableOpacity
+                    style={[styles.whatsappButton, { borderColor: colors.gold }]}
+                    onPress={() => completeWhatsappVerification(user)}
+                    disabled={callInFlight === user.id}>
+                    <Smartphone size={18} color={colors.gold} />
+                    <Text style={{ color: colors.gold }}>סמן שיחת וידאו</Text>
+                  </TouchableOpacity>
+                ) : null}
                 <TouchableOpacity
                   style={[styles.approveButton, { borderColor: colors.status.success }]}
                   onPress={() => approveRequest(user)}
@@ -259,7 +416,75 @@ const styles = StyleSheet.create({
   requestName: { fontSize: 16, fontWeight: '600' },
   previewButton: { flexDirection: 'row', gap: 6, alignItems: 'center' },
   notes: { fontStyle: 'italic' },
-  actionsRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
-  approveButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
-  rejectButton: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', gap: 6 },
+  artifactList: { gap: 10 },
+  artifactRow: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 10,
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'center',
+  },
+  artifactIcon: { width: 32, alignItems: 'center' },
+  artifactBody: { flex: 1, gap: 4 },
+  artifactTitle: { fontWeight: '600' },
+  artifactHash: { fontSize: 12, color: '#777' },
+  actionsRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' },
+  approveButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  rejectButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  whatsappButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
 });
+
+function artifactLabel(type: KycArtifact['type']): string {
+  switch (type) {
+    case 'id-front':
+      return 'תעודה - צד קדמי';
+    case 'id-back':
+      return 'תעודה - צד אחורי';
+    case 'selfie-with-id':
+      return 'סלפי עם תעודה';
+    case 'selfie-video':
+      return 'וידאו בדיקת חיות';
+    case 'social-proof':
+      return 'צילום רשת חברתית';
+    case 'whatsapp-call':
+      return 'אישור שיחת וידאו';
+    default:
+      return type;
+  }
+}
+
+function renderArtifactIcon(type: KycArtifact['type'], color: string): React.ReactElement {
+  switch (type) {
+    case 'selfie-video':
+      return <Video size={18} color={color} />;
+    case 'whatsapp-call':
+      return <Smartphone size={18} color={color} />;
+    default:
+      return <FileText size={18} color={color} />;
+  }
+}

--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -4,6 +4,7 @@ export * from './notification';
 export * from './product.updated';
 export * from './product.deleted';
 export * from './kyc.receipt';
+export * from './kyc.call.receipt';
 export * from './order.status';
 export * from './admin.joinRequested';
 export * from './admin.approve';

--- a/schemas/waku/kyc.call.receipt.ts
+++ b/schemas/waku/kyc.call.receipt.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+export const kycCallReceiptPayloadSchema = z.object({
+  receiptId: z.string(),
+  buyerPublicKey: z.string(),
+  issuerPublicKey: z.string(),
+  issuedAt: z.string(),
+  data: z.record(z.unknown()).optional().default({}),
+  ts: z.number(),
+  nonce: z.string(),
+});
+
+export const kycCallReceiptSchema = wakuMessageSchema.extend({
+  type: z.literal('kyc.call.receipt'),
+  payload: kycCallReceiptPayloadSchema,
+});
+
+export type KycCallReceiptMessage = z.infer<typeof kycCallReceiptSchema>;
+
+export function parseKycCallReceiptMessage(
+  data: unknown,
+): KycCallReceiptMessage | null {
+  const result = kycCallReceiptSchema.safeParse(data);
+  return result.success ? result.data : null;
+}

--- a/services/kycReceipts.ts
+++ b/services/kycReceipts.ts
@@ -6,10 +6,11 @@ import { canonicalJson } from '@/utils/serialization';
 import { fetchHistory, publish, subscribeWithAck } from '@/services/waku';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import { makeSignedWakuMessage } from '@/utils/wakuSigning';
-import type { KycReceiptMessage } from '@/types/waku';
-import { kycReceiptSchema } from '@/schemas/waku';
+import type { KycReceiptMessage, KycCallReceiptMessage } from '@/types/waku';
+import { kycReceiptSchema, kycCallReceiptSchema } from '@/schemas/waku';
 
 const RECEIPT_STORAGE_PREFIX = 'kyc.receipt:';
+const CALL_RECEIPT_STORAGE_PREFIX = 'kyc.call.receipt:';
 const DM_TOPIC_PREFIX = '/blue-ocean/dm';
 
 function randomNonce(byteLength = 12): string {
@@ -21,6 +22,7 @@ function receiptTopic(buyerPublicKey: string): string {
 }
 
 export type KycReceipt = KycReceiptMessage;
+export type KycCallReceipt = KycCallReceiptMessage;
 
 async function persistReceipt(
   buyerPublicKey: string,
@@ -68,6 +70,58 @@ export async function issueKycReceipt(
   await persistReceipt(buyerPublicKey, message);
   await publish(receiptTopic(buyerPublicKey), message);
   return message;
+}
+
+async function persistCallReceipt(
+  buyerPublicKey: string,
+  message: KycCallReceipt,
+): Promise<void> {
+  await AsyncStorage.setItem(
+    `${CALL_RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`,
+    canonicalJson(message),
+  );
+}
+
+export async function issueKycCallReceipt(
+  buyerPublicKey: string,
+  data: Record<string, unknown>,
+): Promise<KycCallReceipt> {
+  const receiptId = uuid();
+  const issuedAt = new Date().toISOString();
+  const issuerPublicKey = await getPublicKeyHex();
+  const payload = {
+    receiptId,
+    buyerPublicKey,
+    issuerPublicKey,
+    issuedAt,
+    data,
+    ts: Date.now(),
+    nonce: randomNonce(),
+  };
+  const message = await makeSignedWakuMessage('kyc.call.receipt', payload, 'admin', {
+    ts: payload.ts,
+    nonce: payload.nonce,
+  });
+  await persistCallReceipt(buyerPublicKey, message);
+  await publish(receiptTopic(buyerPublicKey), message);
+  return message;
+}
+
+export async function loadKycCallReceipt(
+  buyerPublicKey: string,
+): Promise<KycCallReceipt | null> {
+  if (!buyerPublicKey) return null;
+  try {
+    const raw = await AsyncStorage.getItem(
+      `${CALL_RECEIPT_STORAGE_PREFIX}${buyerPublicKey}`,
+    );
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const validated = kycCallReceiptSchema.parse(parsed);
+    return validated;
+  } catch {
+    return null;
+  }
 }
 
 export interface KycReceiptSubscriptionOptions {

--- a/services/kycUpload.ts
+++ b/services/kycUpload.ts
@@ -4,6 +4,9 @@ import { canonicalJson } from '@/utils/serialization';
 import { deriveSharedKey, deriveChatSalt, aesEncrypt } from '@/utils/encryption';
 import { cleanupTrackedKycCapturedPaths } from '@/utils/kycTemp';
 import { getEd25519KeyPair } from './localIdentity';
+import { sign } from '@noble/ed25519';
+import { randomBytes } from '@noble/hashes/utils';
+import type { KycArtifact, KycArtifactType } from '@/types';
 import PinataService from './pinata';
 import * as FileSystem from 'expo-file-system';
 
@@ -22,6 +25,10 @@ export interface KycUploadFile {
   uri: string;
   name?: string;
   type?: string;
+  artifactType: KycArtifactType;
+  capturedAt: number;
+  nonce: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface EncryptedKycDocument {
@@ -29,7 +36,15 @@ export interface EncryptedKycDocument {
   hash: string;
 }
 
-const INFO_LABEL = 'kyc.v1';
+export interface EncryptedKycBundle {
+  document: EncryptedKycDocument;
+  artifacts: KycArtifact[];
+  ts: number;
+  nonce: string;
+  sig: string;
+}
+
+const INFO_LABEL = 'kyc.v2';
 
 function toFilePath(uri: string): string {
   return uri.startsWith('file://') ? uri.replace('file://', '') : uri;
@@ -129,7 +144,7 @@ function ensureIpfs(uri: string, fallback: string): string {
 export async function encryptForTenant(
   tenantPublicKey: string,
   files: KycUploadFile[],
-): Promise<EncryptedKycDocument> {
+): Promise<EncryptedKycBundle> {
   if (!tenantPublicKey) {
     throw new Error('tenant public key required');
   }
@@ -149,6 +164,10 @@ export async function encryptForTenant(
     hash: string;
     data: string;
     sourceUri: string;
+    artifactType: KycArtifactType;
+    capturedAt: number;
+    nonce: string;
+    metadata?: Record<string, unknown>;
   }>;
 
   for (const file of files) {
@@ -165,12 +184,23 @@ export async function encryptForTenant(
       hash,
       data: base64,
       sourceUri: file.uri,
+      artifactType: file.artifactType,
+      capturedAt: file.capturedAt,
+      nonce: file.nonce,
+      metadata: file.metadata,
     });
   }
 
   const manifest = {
-    version: 1,
+    version: 2,
     files: enriched.map(({ name, type, size, hash }) => ({ name, type, size, hash })),
+    artifacts: enriched.map(({ artifactType, capturedAt, nonce, metadata, hash }) => ({
+      type: artifactType,
+      ts: capturedAt,
+      nonce,
+      hash,
+      metadata: metadata ?? {},
+    })),
   };
 
   const manifestBytes = Buffer.from(canonicalJson(manifest));
@@ -180,12 +210,16 @@ export async function encryptForTenant(
     ...manifest,
     createdAt: new Date().toISOString(),
     from: myPubHex,
-    files: enriched.map(({ name, type, size, hash, data }) => ({
+    files: enriched.map(({ name, type, size, hash, data, artifactType, capturedAt, nonce, metadata }) => ({
       name,
       type,
       size,
       hash,
       data,
+      artifactType,
+      capturedAt,
+      nonce,
+      metadata,
     })),
   };
 
@@ -214,7 +248,44 @@ export async function encryptForTenant(
     finalUri = ensureIpfs(uploaded, `ipfs://${encryptedBodyHash}`);
   }
 
-  return { uri: finalUri, hash: manifestHash };
+  const artifacts: KycArtifact[] = enriched.map(({
+    artifactType,
+    capturedAt,
+    nonce,
+    metadata,
+    hash,
+  }) => ({
+    type: artifactType,
+    ts: capturedAt,
+    nonce,
+    metadata,
+    uri: finalUri,
+    hash,
+  }));
+
+  const bundleTs = Date.now();
+  const bundleNonce = Buffer.from(randomBytes(16)).toString('hex');
+  const signaturePayload = canonicalJson({
+    artifacts: artifacts.map(({ type, ts, nonce, hash, metadata }) => ({
+      type,
+      ts,
+      nonce,
+      hash,
+      metadata: metadata ?? {},
+    })),
+    ts: bundleTs,
+    nonce: bundleNonce,
+  });
+  const sigBytes = await sign(Buffer.from(signaturePayload), privateKey);
+  const sig = Buffer.from(sigBytes).toString('hex');
+
+  return {
+    document: { uri: finalUri, hash: manifestHash },
+    artifacts,
+    ts: bundleTs,
+    nonce: bundleNonce,
+    sig,
+  };
 }
 
 export default {

--- a/tests/auth/kycRoute.test.tsx
+++ b/tests/auth/kycRoute.test.tsx
@@ -36,11 +36,13 @@ jest.mock('@/ui/ThemeProvider', () => ({
 }));
 
 const getAdminPublicKeysMock = jest.fn();
+const getSettingValueMock = jest.fn();
 jest.mock('@/agents/settings-agent', () => ({
   __esModule: true,
   default: {
     getInstance: () => ({
       getAdminPublicKeys: (...args: any[]) => getAdminPublicKeysMock(...args),
+      getSettingValue: (...args: any[]) => getSettingValueMock(...args),
     }),
   },
 }));
@@ -69,22 +71,33 @@ jest.mock('@/features/auth/services/nearUsers', () => ({
   setUser: (...args: any[]) => persistUserMock(...args),
 }));
 
-const documentPickerMock = jest.fn();
-jest.mock('expo-document-picker', () => ({
-  getDocumentAsync: (...args: any[]) => documentPickerMock(...args),
-}));
+const recordAsyncMock = jest.fn();
+const requestExpoCameraPermissionMock = jest.fn(() => Promise.resolve({ status: 'granted' }));
+jest.mock('expo-camera', () => {
+  const React = require('react');
+  const View = require('react-native').View;
+  return {
+    CameraType: { front: 'front', back: 'back' },
+    Constants: { Type: { front: 'front', back: 'back' }, VideoQuality: { '480p': '480p' } },
+    requestCameraPermissionsAsync: (...args: any[]) => requestExpoCameraPermissionMock(...args),
+    Camera: React.forwardRef((props: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        recordAsync: (...recordArgs: any[]) => recordAsyncMock(...recordArgs),
+      }));
+      return React.createElement(View, props, props.children);
+    }),
+  };
+});
 
 const requestCameraPermissionsAsync = jest.fn();
 const requestMediaLibraryPermissionsAsync = jest.fn();
 const launchCameraAsync = jest.fn();
-const launchImageLibraryAsync = jest.fn();
 
 jest.mock('expo-image-picker', () => ({
   requestCameraPermissionsAsync: (...args: any[]) => requestCameraPermissionsAsync(...args),
   requestMediaLibraryPermissionsAsync: (...args: any[]) =>
     requestMediaLibraryPermissionsAsync(...args),
   launchCameraAsync: (...args: any[]) => launchCameraAsync(...args),
-  launchImageLibraryAsync: (...args: any[]) => launchImageLibraryAsync(...args),
 }));
 
 const { default: KycScreen } = require('@/app/kyc/index');
@@ -95,12 +108,30 @@ describe('KycVerificationScreen', () => {
     requestCameraPermissionsAsync.mockResolvedValue({ status: 'granted' });
     requestMediaLibraryPermissionsAsync.mockResolvedValue({ status: 'granted' });
     cleanupMock.mockResolvedValue(undefined);
-    encryptForTenantMock.mockResolvedValue({ uri: 'ipfs://encrypted', hash: 'hash123' });
+    recordAsyncMock.mockResolvedValue({ uri: 'file://liveness.mp4', durationMs: 4000 });
+    requestExpoCameraPermissionMock.mockResolvedValue({ status: 'granted' });
+    encryptForTenantMock.mockResolvedValue({
+      document: { uri: 'ipfs://encrypted', hash: 'hash123' },
+      artifacts: [
+        {
+          type: 'selfie-video',
+          uri: 'ipfs://encrypted',
+          hash: 'videohash',
+          ts: 1700,
+          nonce: 'nonce-video',
+        },
+      ],
+      ts: 1700,
+      nonce: 'bundle-nonce',
+      sig: 'sig',
+    });
     sendDMMock.mockResolvedValue(undefined);
-    documentPickerMock.mockResolvedValue({ canceled: true });
     launchCameraAsync.mockResolvedValue({ canceled: true });
-    launchImageLibraryAsync.mockResolvedValue({ canceled: true });
     getAdminPublicKeysMock.mockResolvedValue(['tenant-public']);
+    getSettingValueMock.mockImplementation((key: string) => {
+      if (key === 'appName') return 'Blue Ocean';
+      return 'off';
+    });
   });
 
   const render = () => renderer.create(<KycScreen />);
@@ -127,28 +158,51 @@ describe('KycVerificationScreen', () => {
       checkAuthState: jest.fn(),
     });
 
-    documentPickerMock.mockResolvedValue({
-      canceled: false,
-      assets: [
-        { uri: 'file://id.png', mimeType: 'image/png', size: 2048, name: 'id.png' },
-      ],
-    });
-    launchImageLibraryAsync.mockResolvedValue({
-      canceled: false,
-      assets: [
-        { uri: 'file://selfie.jpg', mimeType: 'image/jpeg', fileSize: 4096, fileName: 'selfie.jpg' },
-      ],
-    });
+    launchCameraAsync
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [
+          { uri: 'file://id-front.jpg', mimeType: 'image/jpeg', fileName: 'front.jpg', fileSize: 2048 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [
+          { uri: 'file://id-back.jpg', mimeType: 'image/jpeg', fileName: 'back.jpg', fileSize: 2048 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [
+          { uri: 'file://selfie-id.jpg', mimeType: 'image/jpeg', fileName: 'selfie-id.jpg', fileSize: 4096 },
+        ],
+      });
+    recordAsyncMock.mockResolvedValue({ uri: 'file://liveness.mp4', durationMs: 3800 });
 
     const tree = render();
 
     await act(async () => {
-      tree.root.findByProps({ testID: 'kyc-id-document' }).props.onPress();
+      tree.root.findByProps({ testID: 'kyc-capture-id-front' }).props.onPress();
       await Promise.resolve();
     });
 
     await act(async () => {
-      tree.root.findByProps({ testID: 'kyc-selfie-library' }).props.onPress();
+      tree.root.findByProps({ testID: 'kyc-capture-id-back' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'kyc-capture-selfie-id' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    const startButtons = tree.root.findAll(
+      (node: any) => node.props?.title === 'התחל/י הקלטה',
+    );
+    expect(startButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      startButtons[0].props.onPress();
       await Promise.resolve();
     });
 
@@ -158,17 +212,24 @@ describe('KycVerificationScreen', () => {
     });
 
     expect(getAdminPublicKeysMock).toHaveBeenCalled();
-    expect(encryptForTenantMock).toHaveBeenCalledWith('tenant-public', [
-      expect.objectContaining({ uri: 'file://id.png' }),
-      expect.objectContaining({ uri: 'file://selfie.jpg' }),
-    ]);
+    expect(encryptForTenantMock).toHaveBeenCalled();
+    const filesArg = encryptForTenantMock.mock.calls[0][1];
+    expect(filesArg).toHaveLength(4);
+    expect(filesArg[0]).toMatchObject({ uri: 'file://id-front.jpg', artifactType: 'id-front' });
+    expect(filesArg[1]).toMatchObject({ uri: 'file://id-back.jpg', artifactType: 'id-back' });
+    expect(filesArg[2]).toMatchObject({ uri: 'file://selfie-id.jpg', artifactType: 'selfie-with-id' });
+    expect(filesArg[3]).toMatchObject({ uri: 'file://liveness.mp4', artifactType: 'selfie-video' });
     expect(sendDMMock).toHaveBeenCalledWith(
       'tenant-public',
       'kyc.request',
-      expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-1' }),
+      expect.objectContaining({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        bundle: expect.objectContaining({ artifacts: expect.any(Array), document: expect.any(Object) }),
+      }),
     );
-    expect(trackMock).toHaveBeenCalledWith('file://id.png');
-    expect(trackMock).toHaveBeenCalledWith('file://selfie.jpg');
+    expect(trackMock).toHaveBeenCalledWith('file://id-front.jpg');
+    expect(trackMock).toHaveBeenCalledWith('file://liveness.mp4');
     expect(cleanupMock).toHaveBeenCalled();
     expect(persistUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ kycStatus: 'pending' }),
@@ -187,17 +248,22 @@ describe('KycVerificationScreen', () => {
       checkAuthState: jest.fn(),
     });
 
-    documentPickerMock.mockResolvedValue({
+    launchCameraAsync.mockResolvedValueOnce({
       canceled: false,
       assets: [
-        { uri: 'file://large.pdf', mimeType: 'application/pdf', size: 50 * 1024 * 1024 },
+        {
+          uri: 'file://too-large.jpg',
+          mimeType: 'image/jpeg',
+          fileName: 'too-large.jpg',
+          fileSize: 50 * 1024 * 1024,
+        },
       ],
     });
 
     const tree = render();
 
     await act(async () => {
-      tree.root.findByProps({ testID: 'kyc-id-document' }).props.onPress();
+      tree.root.findByProps({ testID: 'kyc-capture-id-front' }).props.onPress();
       await Promise.resolve();
     });
 
@@ -228,24 +294,39 @@ describe('KycVerificationScreen', () => {
       checkAuthState,
     });
 
-    documentPickerMock.mockResolvedValue({
-      canceled: false,
-      assets: [{ uri: 'file://id.png', mimeType: 'image/png', size: 2048, name: 'id.png' }],
-    });
-    launchImageLibraryAsync.mockResolvedValue({
-      canceled: false,
-      assets: [{ uri: 'file://selfie.jpg', mimeType: 'image/jpeg', fileSize: 4096 }],
-    });
+    launchCameraAsync
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [{ uri: 'file://id-front.jpg', mimeType: 'image/jpeg', fileName: 'front.jpg', fileSize: 2048 }],
+      })
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [{ uri: 'file://id-back.jpg', mimeType: 'image/jpeg', fileName: 'back.jpg', fileSize: 2048 }],
+      })
+      .mockResolvedValueOnce({
+        canceled: false,
+        assets: [{ uri: 'file://selfie-id.jpg', mimeType: 'image/jpeg', fileName: 'selfie-id.jpg', fileSize: 4096 }],
+      });
+    recordAsyncMock.mockResolvedValue({ uri: 'file://liveness.mp4', durationMs: 3600 });
     sendDMMock.mockRejectedValueOnce(new Error('send failed'));
 
     const tree = render();
 
     await act(async () => {
-      tree.root.findByProps({ testID: 'kyc-id-document' }).props.onPress();
+      tree.root.findByProps({ testID: 'kyc-capture-id-front' }).props.onPress();
       await Promise.resolve();
     });
     await act(async () => {
-      tree.root.findByProps({ testID: 'kyc-selfie-library' }).props.onPress();
+      tree.root.findByProps({ testID: 'kyc-capture-id-back' }).props.onPress();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      tree.root.findByProps({ testID: 'kyc-capture-selfie-id' }).props.onPress();
+      await Promise.resolve();
+    });
+    const startButtons = tree.root.findAll((node: any) => node.props?.title === 'התחל/י הקלטה');
+    await act(async () => {
+      startButtons[0].props.onPress();
       await Promise.resolve();
     });
     await act(async () => {

--- a/tests/kycUpload.test.ts
+++ b/tests/kycUpload.test.ts
@@ -4,7 +4,6 @@ import { sha256 } from '@noble/hashes/sha256';
 import { sha512 } from '@noble/hashes/sha512';
 import { etc, getPublicKey, utils as edUtils } from '@noble/ed25519';
 import { randomBytes, randomUUID } from 'crypto';
-import { canonicalJson } from '@/utils/serialization';
 import PinataService from '@/services/pinata';
 import { encryptForTenant } from '@/services/kycUpload';
 import {
@@ -72,24 +71,30 @@ describe('encryptForTenant', () => {
 
       trackKycCapturedPath(filePath);
       const result = await encryptForTenant(tenantPubHex, [
-        { uri: filePath, name: 'doc.png' },
+        {
+          uri: filePath,
+          name: 'doc.png',
+          artifactType: 'id-front',
+          capturedAt: 1700000000000,
+          nonce: 'nonce123',
+        },
       ]);
 
       expect(uploadSpy).toHaveBeenCalledTimes(1);
       expect(uploadSpy.mock.calls[0][0]).toContain('kyc-');
-      expect(result.uri).toBe('ipfs://cid123');
+      expect(result.document.uri).toBe('ipfs://cid123');
+      expect(typeof result.sig).toBe('string');
+      expect(typeof result.ts).toBe('number');
+      expect(typeof result.nonce).toBe('string');
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0]).toMatchObject({
+        type: 'id-front',
+        uri: 'ipfs://cid123',
+      });
 
       const fileBytes = Buffer.from('hello');
       const fileHash = Buffer.from(sha256(new Uint8Array(fileBytes))).toString('hex');
-      const manifest = {
-        version: 1,
-        files: [
-          { name: 'doc.png', type: 'application/octet-stream', size: 5, hash: fileHash },
-        ],
-      };
-      const manifestBytes = Buffer.from(canonicalJson(manifest));
-      const expectedHash = Buffer.from(sha256(new Uint8Array(manifestBytes))).toString('hex');
-      expect(result.hash).toBe(expectedHash);
+      expect(result.artifacts[0].hash).toBe(fileHash);
 
       expect(fs.existsSync(filePath)).toBe(false);
     } finally {
@@ -115,7 +120,15 @@ describe('encryptForTenant', () => {
       trackKycCapturedPath(filePath);
 
       await expect(
-        encryptForTenant(tenantPubHex, [{ uri: filePath, name: 'doc.png' }]),
+        encryptForTenant(tenantPubHex, [
+          {
+            uri: filePath,
+            name: 'doc.png',
+            artifactType: 'id-front',
+            capturedAt: Date.now(),
+            nonce: 'nonce123',
+          },
+        ]),
       ).rejects.toThrow('upload failed');
 
       expect(fs.existsSync(filePath)).toBe(true);

--- a/tests/usersAgent.test.ts
+++ b/tests/usersAgent.test.ts
@@ -59,10 +59,27 @@ describe('UsersAgent NEAR integration', () => {
     };
     await usersAgent.add(user);
 
-    await usersAgent.requestKyc('u2', { uri: 'ipfs://doc', hash: 'deadbeef' });
+    await usersAgent.requestKyc('u2', {
+      document: { uri: 'ipfs://doc', hash: 'deadbeef' },
+      artifacts: [
+        {
+          type: 'id-front',
+          uri: 'ipfs://doc',
+          hash: 'deadbeef',
+          ts: 1700000000000,
+          nonce: 'nonce123',
+        },
+      ],
+      ts: 1700000000100,
+      nonce: 'bundle-nonce',
+      sig: 'cafebabe',
+    });
     const pending = await usersAgent.get('u2');
     expect(pending?.kycStatus).toBe('pending');
     expect(pending?.kycDocument).toEqual({ uri: 'ipfs://doc', hash: 'deadbeef' });
+    expect(pending?.kycArtifacts?.length).toBe(1);
+    expect(pending?.kycBundleNonce).toBe('bundle-nonce');
+    expect(pending?.kycBundleSig).toBe('cafebabe');
 
     await usersAgent.updateKyc('u2', 'verified', 'admin1', {
       kycReceiptHash: 'beadfeed',
@@ -102,5 +119,27 @@ describe('UsersAgent NEAR integration', () => {
     await expect(usersAgent.updateKyc('u4', 'verified')).rejects.toThrow(
       'Only admins',
     );
+  });
+
+  it('logs WhatsApp call receipts', async () => {
+    const user: any = {
+      id: 'u5',
+      username: 'ellen',
+      displayName: 'Ellen',
+      role: 'user',
+      address: '',
+      publicKey: '',
+    };
+    await usersAgent.add(user);
+    await usersAgent.logKycCallReceipt('u5', {
+      receiptId: 'r1',
+      issuedAt: '2024-01-01T00:00:00Z',
+      issuerPublicKey: 'admin-key',
+      ts: 1700000000000,
+      nonce: 'nonce',
+      whatsappNumber: '+972500000000',
+    });
+    const updated = await usersAgent.get('u5');
+    expect(updated?.kycCallReceipts?.length).toBe(1);
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -138,9 +138,45 @@ export const ALL_ADMIN_SCOPES: AdminScope[] = [
   'admin:orders',
 ];
 
+export type KycArtifactType =
+  | 'id-front'
+  | 'id-back'
+  | 'selfie-with-id'
+  | 'selfie-video'
+  | 'social-proof'
+  | 'whatsapp-call';
+
 export interface KycDocument {
   uri: string;
   hash: string;
+}
+
+export interface KycArtifact {
+  type: KycArtifactType;
+  uri: string;
+  hash: string;
+  ts: number;
+  nonce: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface KycArtifactBundle {
+  document: KycDocument;
+  artifacts: KycArtifact[];
+  ts: number;
+  nonce: string;
+  sig: string;
+  notes?: string;
+  whatsappNumber?: string;
+}
+
+export interface KycCallReceiptRecord {
+  receiptId: string;
+  issuedAt: string;
+  issuerPublicKey: string;
+  ts: number;
+  nonce: string;
+  whatsappNumber?: string;
 }
 
 export interface User {
@@ -167,6 +203,11 @@ export interface User {
   kycApprovedAt?: string;
   kycReceiptHash?: string;
   kycDocument?: KycDocument;
+  kycArtifacts?: KycArtifact[];
+  kycBundleNonce?: string;
+  kycBundleSig?: string;
+  kycWhatsappNumber?: string;
+  kycCallReceipts?: KycCallReceiptRecord[];
 }
 
 export interface Notification {

--- a/types/waku.ts
+++ b/types/waku.ts
@@ -13,4 +13,5 @@ export {
   type WorkspaceCreatedPayload,
   type DeliveryUpdateMessage,
   type KycReceiptMessage,
+  type KycCallReceiptMessage,
 } from '../schemas/waku';


### PR DESCRIPTION
## Summary
- replace the buyer KYC screen with a guided, multi-step capture wizard that enforces rear/front camera usage, introduces a liveness video step with watermark overlay, supports optional social screenshot and WhatsApp number collection, and bundles submissions via the new useKycCapture hook
- add VideoCapture and WatermarkOverlay components plus a revamped encryptForTenant pipeline that signs artifact manifests and persists detailed metadata on the user, including new types for artifacts and call receipts
- extend admin approvals with policy toggles for social proof and WhatsApp verification, expose signed kyc.call.receipt messages, and refresh tests/schemas to cover the expanded artifact flow

## Testing
- not run (project dependencies are not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ca164b14388326a66417be492e1ac8