### PR TITLE
feat(auth): bootstrap admin join request

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -5,8 +5,10 @@ import React, {
   useEffect,
   useState,
   useCallback,
+  useRef,
 } from 'react';
 import { Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Spinner } from '@/ui';
 import { User } from '@/types';
 import { errorLog } from '@/utils/logger';
@@ -16,6 +18,10 @@ import usersAgent from '@/agents/users-agent';
 import { getEd25519KeyPair } from '@/services/localIdentity';
 import { t } from '@/i18n';
 import { Buffer } from 'buffer';
+import SettingsAgent from '@/agents/settings-agent';
+import { makeSignedWakuMessage } from '@/utils/wakuSigning';
+import { publish as publishWaku } from '@/services/waku';
+import uuid from '@/utils/uuid';
 import { getUser as getChainUser, setUser as setChainUser } from './services/nearUsers';
 import { sessionEvents, revokeToken, listSessions } from '@/services/session';
 import {
@@ -65,12 +71,15 @@ interface AuthProviderProps {
 
 const SESSION_EXP_TOLERANCE_MS = 60_000;
 const BROWSE_SCOPE = 'read';
+const USERS_TOPIC = '/blue-ocean/users/1';
+const ADMIN_BOOTSTRAP_FLAG_PREFIX = 'auth.adminBootstrap:';
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const { address, connect, disconnect } = useWallet();
   const [user, setUser] = useState<User | null>(null);
   const [initialized, setInitialized] = useState(false);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const adminBootstrapRequests = useRef<Set<string>>(new Set());
 
   const syncSessionToken = useCallback(() => {
     const records = listSessions();
@@ -85,6 +94,71 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const nextToken = preferred?.token ?? null;
     setSessionToken((current) => (current === nextToken ? current : nextToken));
   }, []);
+
+  const maybeRequestAdminBootstrap = useCallback(
+    async (profile: User) => {
+      const id = profile.address || profile.id;
+      if (!id) return;
+      const normalizedId = id.toLowerCase();
+      const attempts = adminBootstrapRequests.current;
+      if (attempts.has(normalizedId)) return;
+      attempts.add(normalizedId);
+      const release = () => {
+        attempts.delete(normalizedId);
+      };
+
+      const storageKey = `${ADMIN_BOOTSTRAP_FLAG_PREFIX}${normalizedId}`;
+      try {
+        const stored = await AsyncStorage.getItem(storageKey);
+        if (stored === '1') {
+          return;
+        }
+      } catch (err) {
+        errorLog('Failed to read admin bootstrap flag', err);
+      }
+
+      let admins: string[] = [];
+      try {
+        admins = await SettingsAgent.getInstance().getAdmins();
+      } catch (err) {
+        errorLog('Failed to fetch admin list for bootstrap', err);
+        release();
+        return;
+      }
+
+      if (admins.length > 0 || profile.role !== 'user') {
+        try {
+          await AsyncStorage.setItem(storageKey, '1');
+        } catch (err) {
+          errorLog('Failed to persist admin bootstrap flag', err);
+        }
+        return;
+      }
+
+      try {
+        const message = await makeSignedWakuMessage(
+          'admin.joinRequested',
+          {
+            address: profile.address || profile.id,
+            displayName: profile.displayName,
+            nonce: uuid(),
+            ts: Date.now(),
+          },
+          'user',
+        );
+        await publishWaku(USERS_TOPIC, message);
+        try {
+          await AsyncStorage.setItem(storageKey, '1');
+        } catch (err) {
+          errorLog('Failed to persist admin bootstrap flag', err);
+        }
+      } catch (err) {
+        errorLog('Failed to publish admin bootstrap request', err);
+        release();
+      }
+    },
+    [adminBootstrapRequests],
+  );
 
   useEffect(() => {
     const handleTokenChange = () => {
@@ -162,6 +236,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
           // Ignore agent propagation errors in non-wallet test environments
         }
         setUser(profile);
+      }
+
+      if (profile) {
+        void maybeRequestAdminBootstrap(profile);
       }
     } catch {
       // Best-effort: keep existing stored profile if available

--- a/tests/auth/adminBootstrap.test.tsx
+++ b/tests/auth/adminBootstrap.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { AuthProvider, useAuth } from '@/features/auth/AuthContext';
+
+const mockPublish = jest.fn();
+const mockMakeSignedWakuMessage = jest.fn();
+const mockUseWallet = jest.fn();
+const mockUsersAgentAdd = jest.fn();
+const mockGetAccountId = jest.fn();
+const mockUseAccount = jest.fn();
+const nearUsersStore: Record<string, any> = {};
+const mockGetChainUser = jest.fn(async (id: string) => nearUsersStore[id] ?? null);
+const mockSetChainUser = jest.fn(async (user: any) => {
+  nearUsersStore[user.id] = user;
+});
+const mockGetAdmins = jest.fn();
+const mockSettingsInstance = {
+  getAdmins: (...args: Parameters<typeof mockGetAdmins>) => mockGetAdmins(...args),
+};
+const storage: Record<string, string> = {};
+const mockGetItem = jest.fn(async (key: string) => storage[key] ?? null);
+const mockSetItem = jest.fn(async (key: string, value: string) => {
+  storage[key] = value;
+  return Promise.resolve();
+});
+const mockRemoveItem = jest.fn(async (key: string) => {
+  delete storage[key];
+});
+
+jest.mock('@/services/waku', () => ({
+  __esModule: true,
+  publish: (...args: Parameters<typeof mockPublish>) => mockPublish(...args),
+}));
+
+jest.mock('@/utils/wakuSigning', () => ({
+  makeSignedWakuMessage: (
+    ...args: Parameters<typeof mockMakeSignedWakuMessage>
+  ) => mockMakeSignedWakuMessage(...args),
+}));
+
+jest.mock('@/contexts/WalletProvider', () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+jest.mock('@/agents/users-agent', () => ({
+  __esModule: true,
+  default: {
+    add: (...args: Parameters<typeof mockUsersAgentAdd>) => mockUsersAgentAdd(...args),
+    update: jest.fn(),
+  },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (key: string) => mockGetItem(key),
+    setItem: (key: string, value: string) => mockSetItem(key, value),
+    removeItem: (key: string) => mockRemoveItem(key),
+  },
+}));
+
+jest.mock('@/agents/settings-agent', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => mockSettingsInstance,
+  },
+}));
+
+jest.mock('@/services/localIdentity', () => ({
+  getEd25519KeyPair: jest.fn(async () => ({
+    publicKey: new Uint8Array([1, 2, 3, 4]),
+  })),
+}));
+
+jest.mock('@/services/chain', () => ({
+  chainAdapter: {
+    getAccountId: (...args: Parameters<typeof mockGetAccountId>) =>
+      mockGetAccountId(...args),
+    useAccount: (...args: Parameters<typeof mockUseAccount>) => mockUseAccount(...args),
+  },
+}));
+
+jest.mock('@/features/auth/services/nearUsers', () => ({
+  getUser: (id: string) => mockGetChainUser(id),
+  setUser: (user: any) => mockSetChainUser(user),
+}));
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function Capture() {
+  useAuth();
+  return null;
+}
+
+describe('AuthProvider admin bootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(nearUsersStore).forEach((key) => delete nearUsersStore[key]);
+    Object.keys(storage).forEach((key) => delete storage[key]);
+    mockGetAdmins.mockResolvedValue([]);
+    mockUsersAgentAdd.mockResolvedValue(undefined);
+    mockUseWallet.mockReturnValue({
+      address: 'alice.near',
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+    });
+    mockGetAccountId.mockReturnValue('alice.near');
+    mockUseAccount.mockReturnValue('alice.near');
+    mockMakeSignedWakuMessage.mockImplementation(async (type, payload, role) => ({
+      type,
+      payload,
+      sender: { publicKey: 'pub-key', role },
+      signature: 'sig',
+      ts: 123,
+      nonce: 'nonce',
+    }));
+    mockPublish.mockResolvedValue('message-1');
+  });
+
+  it('publishes admin.joinRequested for the first wallet profile', async () => {
+    await act(async () => {
+      renderer.create(
+        <AuthProvider>
+          <Capture />
+        </AuthProvider>,
+      );
+      await flushPromises();
+    });
+    await flushPromises();
+
+    expect(mockGetAdmins).toHaveBeenCalledTimes(1);
+    const [type, payload, role] = mockMakeSignedWakuMessage.mock.calls[0];
+    expect(type).toBe('admin.joinRequested');
+    expect(payload).toMatchObject({ address: 'alice.near' });
+    expect(role).toBe('user');
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      '/blue-ocean/users/1',
+      expect.objectContaining({
+        type: 'admin.joinRequested',
+        sender: expect.objectContaining({ role: 'user' }),
+      }),
+    );
+    expect(mockSetItem).toHaveBeenCalledWith(
+      expect.stringMatching(/^auth\.adminBootstrap:/),
+      '1',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fetch admin roster after provisioning a wallet profile and store a bootstrap guard flag
- emit an `admin.joinRequested` message for the first wallet using the local identity signature
- cover the bootstrap behaviour with a dedicated auth unit test

## Testing
- yarn run jest --config tests/jest.unit.config.js tests/auth/adminBootstrap.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca3844610083269015b0995c4d2d2d