### PR TITLE
Add TODO tracking annotations across core modules

### DIFF
--- a/agents/admin-agent.ts
+++ b/agents/admin-agent.ts
@@ -11,6 +11,9 @@ import {
 } from '@/services/monitoring';
 import flags from '@/utils/flags';
 
+// TODO:TODO-105 Add structured audit history for admin approvals and rejections to satisfy compliance requirements.
+// TODO:REC-205 Explore moving AdminAgent persistence into a typed repository to avoid repeated manual JSON parsing.
+
 export interface AdminRecord {
   address: string;
   publicKey: string;

--- a/agents/cart-agent.ts
+++ b/agents/cart-agent.ts
@@ -11,6 +11,8 @@ import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
+// TODO:TODO-112 Extend CartAgent to support multi-store contexts without clobbering per-tenant line items.
+// TODO:REC-212 Move wallet prompt handling into a shared UX utility for consistent localization and messaging.
 class CartAgent {
   private async ensureWallet() {
     await ensureNearWallet('Please connect your NEAR wallet to manage your cart.');

--- a/agents/categories-agent.ts
+++ b/agents/categories-agent.ts
@@ -11,6 +11,8 @@ import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
+// TODO:TODO-113 Expand CategoriesAgent to coordinate cross-channel taxonomy sync when stores sell in multiple marketplaces.
+// TODO:REC-213 Share wallet guard copy through localization dictionaries to keep admin prompts consistent.
 class CategoriesAgent {
   private async ensureWallet() {
     await ensureNearWallet('Please connect your NEAR wallet to manage categories.');

--- a/agents/chat-agent.ts
+++ b/agents/chat-agent.ts
@@ -3,6 +3,8 @@ import DatabaseService from '@/services/database';
 import { ChatRoom } from '../types';
 import { normalizeMessage } from '../lib/normalizeMessage';
 
+// TODO:TODO-114 Extend ChatAgent to persist unread state transitions so cross-device inbox views stay in sync.
+// TODO:REC-214 Consider migrating ChatAgent event wiring to typed observables for better composability in React contexts.
 class ChatAgent {
   private emitter = new EventEmitter();
 

--- a/agents/delivery-agent.ts
+++ b/agents/delivery-agent.ts
@@ -32,6 +32,8 @@ type QueueItem =
   | { type: 'order.created'; payload: OrderCreatedPayload; storeId: string; queuedAt: number }
   | { type: 'delivery.assigned'; payload: DeliveryAssignedPayload; storeId: string; queuedAt: number };
 
+// TODO:TODO-115 Teach DeliveryAgent to checkpoint backlog state so restarts do not drop queued delivery notifications.
+// TODO:REC-215 Leverage structured telemetry for pauseReasons to aid incident debugging when Waku pauses drain cycles.
 class DeliveryAgent {
   private backlog: QueueItem[] = [];
   private draining = false;

--- a/agents/moderation-agent.ts
+++ b/agents/moderation-agent.ts
@@ -7,6 +7,8 @@ import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 
+// TODO:TODO-116 Add rate limiting and abuse heuristics to ModerationAgent to prevent automated spam reports.
+// TODO:REC-216 Feed moderation events into analytics topics so trust & safety dashboards stay up to date.
 class ModerationAgent {
   private async ensureWallet() {
     const { address, publicKey } = await ensureNearWallet(

--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -36,6 +36,8 @@ const MESSAGE_TYPE = 'notification.broadcast';
 type PauseReason = 'queue' | 'latency' | 'waku';
 type NotificationBroadcastPayload = NotificationWakuPayload & { storeId?: string };
 
+// TODO:TODO-107 Introduce shard-aware backlog management so NotificationsAgent scales across high-volume tenants without drops.
+// TODO:REC-207 Surface pauseReasons telemetry via monitoring hooks to accelerate production incident triage.
 class NotificationsAgent {
   private subscribers: Set<(n: Notification) => void> = new Set();
   private backlog: Array<{

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -53,6 +53,8 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   refunded: [],
 };
 
+// TODO:TODO-106 Break OrdersAgent into domain submodules for pricing, fulfillment, and notifications to tame the 600+ LOC scope.
+// TODO:REC-206 Introduce typed workflow definitions so status transitions can be validated without manual map maintenance.
 class OrdersAgent {
   private subscribers: Set<(o: Order) => void> = new Set();
   private sellerMetrics: Record<string, { completed: number; refunds: number }> = {};

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -34,6 +34,8 @@ const PAGE_SIZE = 50;
 
 assertNearChain();
 
+// TODO:TODO-108 Separate ProductAgent concerns for cache hydration, Waku broadcasts, and persistence to simplify reasoning.
+// TODO:REC-208 Adopt incremental diff sync for product updates to minimize payload sizes over Waku relays.
 interface ProductSummary {
   rating: number;
   reviews: number;

--- a/agents/review-agent.ts
+++ b/agents/review-agent.ts
@@ -12,6 +12,8 @@ assertNearChain();
 
 const TOPIC = '/blue-ocean/reviews/1';
 
+// TODO:TODO-117 Capture reviewer metadata hashing so duplicate detection survives anonymized Waku relays.
+// TODO:REC-217 Consider streaming review updates over eventBus to avoid polling when storefronts refresh.
 class ReviewAgent {
   private subscribers: Set<(r: Review) => void> = new Set();
 

--- a/agents/settings-agent.ts
+++ b/agents/settings-agent.ts
@@ -22,6 +22,8 @@ if (typeof assertNearChain === 'function') {
   try { assertNearChain(); } catch {}
 }
 
+// TODO:TODO-110 Introduce versioned migrations for tenant settings so schema changes propagate safely across wallets.
+// TODO:REC-210 Move admin scope management into dedicated module with explicit capability contracts.
 type SettingKey =
   | 'tenantId'
   | 'appName'

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -15,6 +15,8 @@ import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 
 assertNearChain();
 
+// TODO:TODO-111 Extend StoresAgent to track multi-tenant metrics and avoid namespace collisions for shared storefronts.
+// TODO:REC-211 Publish reputation score updates via analytics topic so UI dashboards can react in real time.
 interface Metrics {
   reviewSum: number;
   reviewCount: number;

--- a/agents/users-agent.ts
+++ b/agents/users-agent.ts
@@ -31,6 +31,8 @@ export type UsersAgentMessage =
       payload: { userId: string; receipt: KycCallReceiptRecord };
     };
 
+// TODO:TODO-109 Add audit-trail friendly storage of KYC transitions to meet regional compliance requirements.
+// TODO:REC-209 Evaluate using capability tokens instead of wallet prompts for privileged user mutations.
 class UsersAgent {
   private async ensureWallet() {
     const { address, publicKey } = await ensureNearWallet(

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -44,6 +44,8 @@ import eventBus from '@/services/eventBus';
 import { localIndex } from '@/services/localIndex';
 import { isReviewsEnabled } from '@/config/featureFlags';
 
+// TODO:TODO-126 Split HomeScreenContent into route-level chunks so bundle size stays manageable on low-end devices.
+// TODO:REC-226 Prefetch personalization data during warm start to reduce spinner time when resuming the app.
 function HomeScreenContent() {
   const { tenantId, isNetwork } = useTenant();
   const { t } = useLanguage();

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -22,6 +22,8 @@ interface GlobalHeaderProps {
   showSearch?: boolean;
 }
 
+// TODO:TODO-121 Decompose GlobalHeader into presentational and data hooks to improve testability of complex UI state.
+// TODO:REC-221 Preload command palette dependencies when notifications arrive to minimize perceived latency.
 export default function GlobalHeader({ showSearch = true }: GlobalHeaderProps) {
   const isTest = typeof process !== 'undefined' && (process.env.JEST_WORKER_ID || process.env.NODE_ENV === 'test');
   const { t, isRTL, currentLanguage, setLanguage } = useLanguage();

--- a/components/HomeCards.tsx
+++ b/components/HomeCards.tsx
@@ -8,6 +8,8 @@ interface Card {
   image: string;
 }
 
+// TODO:TODO-122 Support skeleton loading states in HomeCards to smooth transitions on slow networks.
+// TODO:REC-222 Prefetch catalog imagery once layout stabilizes to reduce jank when scrolling.
 export default function HomeCards() {
   const [cards, setCards] = useState<Card[]>([]);
   const [loading, setLoading] = useState(true);

--- a/components/NotificationPopup.tsx
+++ b/components/NotificationPopup.tsx
@@ -23,6 +23,8 @@ interface NotificationPopupProps {
 
 const { width } = Dimensions.get('window');
 
+// TODO:TODO-123 Allow stacking multiple NotificationPopup instances with queue prioritization per severity.
+// TODO:REC-223 Normalize animation timing tokens so toast experiences match mobile motion guidelines.
 export default function NotificationPopup({
   title,
   message,

--- a/components/admin/AdminList.tsx
+++ b/components/admin/AdminList.tsx
@@ -15,6 +15,8 @@ export type AdminListItem = {
 
 type Props = { items: AdminListItem[]; emptyText?: string };
 
+// TODO:TODO-124 Allow AdminList to render action badges (approve/deny) inline for pending administrator requests.
+// TODO:REC-224 Memoize list virtualization so large admin rosters don't re-render on each theme change.
 function AdminList({ items, emptyText = 'Nothing yet.' }: Props) {
   const { colors } = useTheme();
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -11,6 +11,8 @@ if (typeof process !== 'undefined' && typeof process.cwd === 'function') {
   loadEnv();
 }
 
+// TODO:TODO-101 Audit envSchema defaults so runtime parity across Expo web and native builds does not drift from documented expectations.
+// TODO:REC-201 Consider lifting envSchema into a shared config module consumed by services and agents to centralize validation.
 const envSchema = z.object({
   EXPO_PUBLIC_TRANSPORT: z.string().optional().default(''),
   EXPO_PUBLIC_CONTRACT_ID: z.string().optional().default(''),

--- a/docs/architecture/topics-waku.md
+++ b/docs/architecture/topics-waku.md
@@ -1,4 +1,6 @@
 # Waku Topics (1 = v1)
+// TODO:TODO-118 Document retention and pruning strategy for each topic to align with data minimization policies.
+// TODO:REC-218 Provide end-to-end encryption walkthroughs for new topic families to accelerate feature onboarding.
 
 - `/blue-ocean/users/1` — users + roles + KYC status
 - `/blue-ocean/stores/1` — store metadata

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,6 @@
 # Configuration
+// TODO:TODO-119 Expand configuration docs with environment-specific examples for mobile vs. server runtimes.
+// TODO:REC-219 Include threat modeling guidance for secrets management to complement the vault workflow.
 
 Use `requireEnv(key, fallback?)` from `src/services/config.ts` to read environment variables. Missing keys will throw unless a fallback is provided.
 

--- a/docs/ui/mvp-app-tree.md
+++ b/docs/ui/mvp-app-tree.md
@@ -1,4 +1,6 @@
 # MVP App Tree (Screens → Components → Buttons)
+// TODO:TODO-120 Layer interaction notes for accessibility states so designers can spot missing focus flows.
+// TODO:REC-220 Cross-link wireframe revisions when new agents introduce screens to keep docs discoverable.
 
 Auth
 - Connect Wallet → [PrimaryCTA: "Connect"] → onSuccess: request `checkout` scope

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,6 +8,8 @@ import HomeOptions from '@/features/home/components/HomeOptions';
 import { useTheme } from '@/ui/ThemeProvider';
 import ErrorBoundary from '@/shared/ErrorBoundary';
 
+// TODO:TODO-125 Introduce above-the-fold personalization on IndexPage based on tenant insights.
+// TODO:REC-225 Prefetch hero assets during idle periods to reduce initial skeleton time.
 export default function IndexPage() {
   const { colors } = useTheme();
   return (

--- a/report.md
+++ b/report.md
@@ -1,0 +1,31 @@
+# TODO & Recommendation Annotation Report
+
+| Path | TODO IDs | REC IDs | Notes |
+| --- | --- | --- | --- |
+| config/index.ts | TODO-101 | REC-201 | Env schema refinement + shared module recommendation. |
+| services/eventBus.ts | TODO-102 | REC-202 | Ensure Waku node resilience and telemetry coverage. |
+| services/waku.ts | TODO-103 | REC-203 | Highlighted need for modularization and streaming compression. |
+| utils/wakuTopics.ts | TODO-104 | REC-204 | Topic validation and caching guidance. |
+| agents/admin-agent.ts | TODO-105 | REC-205 | Admin audit trail + persistence refactor suggestion. |
+| agents/orders-agent.ts | TODO-106 | REC-206 | Work breakdown for large orders agent and workflow typing. |
+| agents/notifications-agent.ts | TODO-107 | REC-207 | Scaling backlog plus monitoring improvements. |
+| agents/products-agent.ts | TODO-108 | REC-208 | Separation of concerns and diff-sync idea. |
+| agents/users-agent.ts | TODO-109 | REC-209 | KYC audit storage and capability tokens advice. |
+| agents/settings-agent.ts | TODO-110 | REC-210 | Settings migrations and scope management module. |
+| agents/stores-agent.ts | TODO-111 | REC-211 | Multi-tenant metrics and analytics streaming. |
+| agents/cart-agent.ts | TODO-112 | REC-212 | Multi-store cart handling and shared UX messaging. |
+| agents/categories-agent.ts | TODO-113 | REC-213 | Taxonomy sync + localization consistency. |
+| agents/chat-agent.ts | TODO-114 | REC-214 | Inbox sync persistence and observable refactor. |
+| agents/delivery-agent.ts | TODO-115 | REC-215 | Backlog checkpointing and telemetry instrumentation. |
+| agents/moderation-agent.ts | TODO-116 | REC-216 | Spam protection and analytics linkage. |
+| agents/review-agent.ts | TODO-117 | REC-217 | Reviewer hashing and event streaming. |
+| docs/architecture/topics-waku.md | TODO-118 | REC-218 | Expand retention guidance and onboarding walkthrough. |
+| docs/config.md | TODO-119 | REC-219 | Environment examples and security guidance. |
+| docs/ui/mvp-app-tree.md | TODO-120 | REC-220 | Accessibility interaction notes and cross-linking updates. |
+| components/GlobalHeader.tsx | TODO-121 | REC-221 | Refactor for testability and preloading suggestions. |
+| components/HomeCards.tsx | TODO-122 | REC-222 | Skeleton loading and image prefetching. |
+| components/NotificationPopup.tsx | TODO-123 | REC-223 | Toast stacking and motion normalization. |
+| components/admin/AdminList.tsx | TODO-124 | REC-224 | Inline approvals and virtualization memoization. |
+| pages/index.tsx | TODO-125 | REC-225 | Personalization enhancements and asset prefetch. |
+| app/index.tsx | TODO-126 | REC-226 | Bundle splitting and warm-start personalization. |
+| tests/adminAgent.test.ts | TODO-127 | REC-227 | Add revocation coverage and browser polyfill parity. |

--- a/services/eventBus.ts
+++ b/services/eventBus.ts
@@ -19,6 +19,8 @@ interface PublishOptions {
   stage?: string;
 }
 
+// TODO:TODO-102 Harden ensureNode to survive mobile background transitions without leaking dangling Waku nodes.
+// TODO:REC-202 Emit structured connectivity metrics from ensureNode so monitoring can alert on relay unavailability.
 async function ensureNode(): Promise<LightNode | null> {
   if (node) return node;
   try {

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -22,6 +22,9 @@ import { setStore as persistStore } from '@/features/stores/services/nearStores'
 import { randomBytes } from '@noble/hashes/utils';
 import { Buffer } from 'buffer';
 
+// TODO:TODO-103 Break the monolithic Waku service into focused modules so subscription, publishing, and sync concerns stay isolated.
+// TODO:REC-203 Investigate streaming compression primitives to mitigate zlib blocking when handling large relay payloads.
+
 declare const logger: any;
 
 const isProd = process.env.NODE_ENV === 'production';

--- a/tests/adminAgent.test.ts
+++ b/tests/adminAgent.test.ts
@@ -58,6 +58,8 @@ async function createJoinRequest(
   );
 }
 
+// TODO:TODO-127 Add regression cases for admin scope revocation to ensure pending approvals can't escalate permissions.
+// TODO:REC-227 Mirror these tests against browser crypto polyfills to catch serialization drift.
 describe('AdminAgent', () => {
   let agent: AdminAgent;
 

--- a/utils/wakuTopics.ts
+++ b/utils/wakuTopics.ts
@@ -1,3 +1,5 @@
+// TODO:TODO-104 Expand buildTopic to validate domain/store identifiers against allowed vocabularies before constructing topics.
+// TODO:REC-204 Consider caching normalized topics to reduce repeated string allocations in hot message loops.
 export function buildTopic(domain: string, storeId: string): string {
   return `/blue-ocean/${domain}/${storeId}`;
 }


### PR DESCRIPTION
## Summary
- add TODO and REC tracking comments across config, services, agents, UI, docs, and tests per assignment IDs
- include a consolidated report.md mapping each annotated path to its identifiers and context

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser before install; install attempt blocked by engine requirement @waku/core >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68caf200058c8326ae7b628f7e6b8433