### PR TITLE
Add Angle 1 TODO scaffolding for orders pipeline

### DIFF
--- a/agents/notifications-agent.ts
+++ b/agents/notifications-agent.ts
@@ -108,6 +108,7 @@ class NotificationsAgent {
     storeId: string,
     options: { persisted?: boolean } = {},
   ) {
+    // TODO:CORE-019 Angle 1 - Emit queue telemetry to the analytics pipeline once the notification metrics schema stabilizes.
     if (!isNotificationsPipelineEnabled(item.userId)) return;
     if (this.backlog.length >= this.backlogLimit) {
       this.pause('queue');

--- a/agents/orders-agent.ts
+++ b/agents/orders-agent.ts
@@ -38,6 +38,7 @@ import { buildTopic } from '../utils/wakuTopics';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import AgentError from '@/types/AgentError';
 import { canonicalJson } from '@/utils/serialization';
+import { buildOrderTimeline } from '@/utils/buildOrderTimeline';
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
 const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
@@ -126,6 +127,7 @@ class OrdersAgent {
     const handler = async (wakuMsg: any) => {
       if (!wakuMsg.payload) return;
       try {
+        // TODO:CORE-018 Angle 1 - Attach Waku ack/resync hooks once the reliability layer contract is rolled out.
         const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
         const signed = await verifyBeforeWrite(raw, orderStatusMessageSchema, undefined, topic);
         if (!signed) return;
@@ -140,30 +142,8 @@ class OrdersAgent {
   }
 
   private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
-    const allSteps: OrderTrackingStep[] = [
-      { status: 'order_received', title: 'הזמנה התקבלה', timestamp: new Date().toISOString(), completed: false },
-      { status: 'courier_found', title: 'נמצא שליח מתאים', timestamp: '', completed: false },
-      { status: 'courier_picked_up', title: 'שליח אסף את ההזמנה', timestamp: '', completed: false },
-      { status: 'courier_on_way', title: 'שליח בדרך אלייך', timestamp: '', completed: false },
-      { status: 'delivered', title: 'הזמנה התקבלה (השאר ביקורת)', timestamp: '', completed: false },
-    ];
-    const statusOrder: OrderStatus[] = [
-      'order_received',
-      'courier_found',
-      'courier_picked_up',
-      'courier_on_way',
-      'delivered',
-    ];
-    const currentIndex = statusOrder.indexOf(status);
-    for (let i = 0; i <= currentIndex; i++) {
-      allSteps[i].completed = true;
-      if (!allSteps[i].timestamp) {
-        const now = new Date();
-        const minutesAgo = (currentIndex - i) * 10;
-        allSteps[i].timestamp = new Date(now.getTime() - minutesAgo * 60000).toISOString();
-      }
-    }
-    return allSteps;
+    // TODO:CORE-017 Angle 1 - Extend the shared timeline builder with agent-specific phases once sync schema expands.
+    return buildOrderTimeline(status);
   }
 
   private async applyRemoteStatus(orderId: string, status: OrderStatus) {

--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -136,6 +136,7 @@ class ProductsAgent {
     const n = await this.ensureNode();
     if (!n) return;
     try {
+      // TODO:CORE-020 Angle 1 - Mirror product updates into the stock analytics stream once the topic contract is finalized.
       const ts = Date.now();
       const nonce = Buffer.from(randomBytes(12)).toString('hex');
       const msg = await makeSignedWakuMessage(

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -34,6 +34,7 @@ class StoresAgent {
   }
 
   private async persistStore(store: Store): Promise<Store> {
+    // TODO:CORE-021 Angle 1 - Emit store persistence events to the analytics topic once tenant metrics schema ships.
     const record = this.toRecord(store);
     const namespace = this.getNamespace(record);
     const existing = await fetchStore(namespace, record.id);

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -29,6 +29,13 @@ import { getFeeSettings } from '@/constants/tenant';
 import { loadKycReceipt } from '@/services/kycReceipts';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
+import { buildOrderTimeline } from '@/utils/buildOrderTimeline';
+import {
+  recordKycNonceUsage,
+  rememberCheckoutNonce,
+  forgetCheckoutNonce,
+  clearExpiredKycNonceUsage,
+} from '@/utils/nonceStore';
 
 const ORDER_TOPIC_PREFIX = '/blue-ocean/orders';
 const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
@@ -53,6 +60,7 @@ function recordOrderStageDuration(
   stage: string,
   durationMs: number,
 ): void {
+  // TODO:CORE-003 Angle 1 - Replace direct histogram writes with the shared pipeline metrics client once it is available.
   latencyHistogram.observe(
     {
       service: ORDER_PIPELINE_SERVICE,
@@ -80,6 +88,12 @@ type KycVerificationResult = {
   hash: string | null;
   receiptId?: string;
   signature?: string;
+};
+
+type ExternalKycVerification = {
+  hash?: string | null;
+  signature?: string | null;
+  receiptId?: string | null;
 };
 
 interface OrderDraft {
@@ -117,6 +131,7 @@ export async function emitOrderEvents(
   const deterministicTimestamp = parseDeterministicTimestamp();
 
   const orderTopic = `${ORDER_TOPIC_PREFIX}/${storeId}`;
+  // TODO:CORE-001 Angle 1 - Mirror order lifecycle events into the analytics stream once the schema handshake is finalized.
   const baseEvent = {
     id: order.id,
     orderId: order.id,
@@ -261,6 +276,8 @@ class OrderService {
     }
     this.checkoutNonceLocks.set(sessionToken, nonce);
     setSessionCheckoutNonce(sessionToken, nonce);
+    // TODO:CORE-007 Angle 1 - Bridge checkout nonce reservations to the shared store once it's online.
+    rememberCheckoutNonce(sessionToken, nonce);
   }
 
   private releaseCheckoutNonce(sessionToken: string, nonce: string): void {
@@ -268,6 +285,7 @@ class OrderService {
     if (active === nonce) {
       this.checkoutNonceLocks.delete(sessionToken);
       setSessionCheckoutNonce(sessionToken, null);
+      forgetCheckoutNonce(sessionToken, nonce);
     }
   }
 
@@ -278,6 +296,7 @@ class OrderService {
     const store = await getStore(storeId, storeId);
     const requiresKyc = this.storeRequiresKyc(store);
 
+    // TODO:CORE-004 Angle 1 - Swap to the tenant KYC verification microservice once its API contract is finalized.
     let user: User | null = null;
     if (buyerId) {
       try {
@@ -301,6 +320,20 @@ class OrderService {
 
     let canonicalHash = storedHash ?? computedHash ?? null;
     let canonicalSignature = storedSig ?? receipt?.signature ?? null;
+    let resolvedReceiptId = receipt?.payload?.receiptId ?? undefined;
+
+    const ledgerResult = await this.verifyKycReceiptWithLedger(buyerId, storeId);
+    if (ledgerResult) {
+      if (ledgerResult.hash) {
+        canonicalHash = ledgerResult.hash;
+      }
+      if (ledgerResult.signature) {
+        canonicalSignature = ledgerResult.signature;
+      }
+      if (ledgerResult.receiptId) {
+        resolvedReceiptId = ledgerResult.receiptId;
+      }
+    }
 
     if (requiresKyc) {
       if (!user || user.kycStatus !== 'verified') {
@@ -350,6 +383,7 @@ class OrderService {
         throw new Error('{E_REPLAY}');
       }
       this.kycReceiptReplayGuards.set(replayKey, now);
+      recordKycNonceUsage(replayKey, now);
       canonicalHash = storedHash;
       canonicalSignature = storedSig;
     }
@@ -357,9 +391,19 @@ class OrderService {
     return {
       ok: true,
       hash: canonicalHash,
-      receiptId: receipt?.payload?.receiptId,
+      receiptId: resolvedReceiptId,
       signature: canonicalSignature ?? undefined,
     };
+  }
+
+  private async verifyKycReceiptWithLedger(
+    buyerId: string,
+    storeId: string,
+  ): Promise<ExternalKycVerification | null> {
+    // TODO:CORE-005 Angle 1 - Replace stub with the ledger-backed verifier when the compliance service is wired in.
+    void buyerId;
+    void storeId;
+    return null;
   }
 
   private pruneKycReceiptReplayGuards(now: number): void {
@@ -368,6 +412,7 @@ class OrderService {
         this.kycReceiptReplayGuards.delete(key);
       }
     }
+    clearExpiredKycNonceUsage(now - KYC_RECEIPT_REPLAY_TTL_MS);
   }
 
   private async deployEscrow(
@@ -388,16 +433,12 @@ class OrderService {
       itemsHash: draft.itemsHash,
     });
     try {
+      // TODO:CORE-010 Angle 1 - Route escrow deployments through the contract wrapper once multi-chain support lands.
       const { feeAddress, feeBps } = await getFeeSettings();
-      const result = await nearDeployEscrow({
-        total: draft.total,
+      const result = await this.deployEscrowViaWrapper({
+        draft,
         feeAddress,
         feeBps,
-        buyerAddress: draft.buyerAddress,
-        sellerAddress: draft.sellerAddress,
-        kycReceiptHash: draft.kycReceiptHash,
-        nonce: draft.nonce,
-        sessionToken: draft.sessionToken,
       });
       debugLog('orders.escrow.deploy.success', {
         orderId,
@@ -423,29 +464,32 @@ class OrderService {
     }
   }
 
+  private async deployEscrowViaWrapper({
+    draft,
+    feeAddress,
+    feeBps,
+  }: {
+    draft: OrderDraft;
+    feeAddress: string;
+    feeBps: number;
+  }): Promise<{ contractAddress: string; txHash: string }> {
+    // TODO:CORE-011 Angle 1 - Replace this placeholder with the deploy wrapper once contract router endpoints are exposed.
+    return nearDeployEscrow({
+      total: draft.total,
+      feeAddress,
+      feeBps,
+      buyerAddress: draft.buyerAddress,
+      sellerAddress: draft.sellerAddress,
+      kycReceiptHash: draft.kycReceiptHash,
+      nonce: draft.nonce,
+      sessionToken: draft.sessionToken,
+    });
+  }
+
   private getTrackingSteps(status: OrderStatus): OrderTrackingStep[] {
-    const allSteps: OrderTrackingStep[] = [
-      { status: 'order_received', title: 'הזמנה התקבלה', timestamp: new Date().toISOString(), completed: false },
-      { status: 'courier_found', title: 'נמצא שליח מתאים', timestamp: '', completed: false },
-      { status: 'courier_picked_up', title: 'שליח אסף את ההזמנה', timestamp: '', completed: false },
-      { status: 'courier_on_way', title: 'שליח בדרך אלייך', timestamp: '', completed: false },
-      { status: 'delivered', title: 'הזמנה התקבלה (השאר ביקורת)', timestamp: '', completed: false },
-    ];
+    return buildOrderTimeline(status);
+  }
 
-    const statusOrder: OrderStatus[] = [
-      'order_received',
-      'courier_found',
-      'courier_picked_up',
-      'courier_on_way',
-      'delivered',
-    ];
-
-    const currentIndex = statusOrder.indexOf(status);
-    for (let i = 0; i <= currentIndex; i++) {
-      allSteps[i].completed = true;
-      if (!allSteps[i].timestamp) {
-        const now = new Date();
-        const minutesAgo = (currentIndex - i) * 10;
   private async createOrder(
     userId: string,
     items: CartItem[],
@@ -531,6 +575,7 @@ class OrderService {
       kycReceiptSignature: kyc.signature,
     };
 
+    await this.applyCheckoutRiskRules(order, storeId);
     await ordersAgent.add(order);
     debugLog('orders.createOrder.persisted', {
       orderId,
@@ -540,6 +585,7 @@ class OrderService {
     });
     await this.decrementProductStock(items);
     this.notifyListeners();
+    await this.trackOrderAnalytics(order, 'order_created');
     return order;
   }
 
@@ -551,6 +597,7 @@ class OrderService {
     sessionToken: string,
     nonce: string,
   ): Promise<Order[]> {
+    // TODO:CORE-016 Angle 1 - Introduce the checkout pipeline orchestrator before fan-out once the aggregator contract lands.
     const grouped: Record<string, CartItem[]> = {};
     for (const item of cartItems) {
       const storeId = item.product.storeId;
@@ -729,6 +776,28 @@ class OrderService {
     }
   }
 
+  private async applyCheckoutRiskRules(order: Order, storeId: string): Promise<void> {
+    // TODO:CORE-012 Angle 1 - Plug in the fraud/risk engine once scoring endpoints are exposed for checkout orchestration.
+    void order;
+    void storeId;
+  }
+
+  private async trackOrderAnalytics(order: Order, stage: string): Promise<void> {
+    // TODO:CORE-013 Angle 1 - Emit structured analytics events after the telemetry pipeline contract is finalized.
+    void order;
+    void stage;
+  }
+
+  private async dispatchDeliveryHook(order: Order): Promise<void> {
+    // TODO:CORE-014 Angle 1 - Call out to the delivery coordination webhook once the logistics integration is staged.
+    void order;
+  }
+
+  private async dispatchRefundHook(order: Order): Promise<void> {
+    // TODO:CORE-015 Angle 1 - Invoke the refund settlement webhook once the treasury service exposes the callback.
+    void order;
+  }
+
   private simulateOrderProgress(orderId: string) {
     const statusProgression: OrderStatus[] = [
       'courier_found',
@@ -764,6 +833,12 @@ class OrderService {
     order.updatedAt = new Date().toISOString();
     await ordersAgent.update(order);
     this.notifyListeners();
+    await this.trackOrderAnalytics(order, 'status_updated');
+    if (status === 'delivered') {
+      await this.dispatchDeliveryHook(order);
+    } else if (status === 'refunded') {
+      await this.dispatchRefundHook(order);
+    }
   }
 
   async resolveDispute(orderId: string, toSeller: boolean): Promise<void> {

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -103,6 +103,7 @@ async function startNode(): Promise<LightNode | null> {
   const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
   let node: LightNode | null = null;
   try {
+    // TODO:CORE-022 Angle 1 - Insert the orders pipeline handshake before node start once the coordination spec is ready.
     node = await createLightNode({} as any);
   } catch (err) {
     errorLog('Failed to start Waku node', err instanceof Error ? err.message : err);

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -590,6 +590,7 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     setLoading(true);
     let resetNonce = false;
     try {
+      // TODO:CORE-024 Angle 1 - Display the Angle 1 checkout timeline once the orchestrator feeds status updates into the UI.
       const orders = await OrderService.getInstance().createOrdersFromCart(
         user?.id || 'guest',
         cartItems,

--- a/src/features/cart/services/cart.ts
+++ b/src/features/cart/services/cart.ts
@@ -176,6 +176,7 @@ class CartService {
       slow: durationMs > 120,
     };
 
+    // TODO:CORE-025 Angle 1 - Forward add-to-cart telemetry to the checkout analytics contract once Angle 1 metrics are live.
     eventBus.track('cart.add.duration', payload).catch((err) => {
       errorLog('Failed to track cart.add.duration', err);
     });

--- a/utils/buildOrderTimeline.ts
+++ b/utils/buildOrderTimeline.ts
@@ -1,0 +1,58 @@
+import { OrderStatus, OrderTrackingStep } from '@/types';
+
+export function buildOrderTimeline(status: OrderStatus): OrderTrackingStep[] {
+  // TODO:CORE-002 Angle 1 - Replace stub timeline builder once cross-network fulfillment milestones are finalized.
+  const base: OrderTrackingStep[] = [
+    {
+      status: 'order_received',
+      title: 'הזמנה התקבלה',
+      timestamp: new Date().toISOString(),
+      completed: false,
+    },
+    {
+      status: 'courier_found',
+      title: 'נמצא שליח מתאים',
+      timestamp: '',
+      completed: false,
+    },
+    {
+      status: 'courier_picked_up',
+      title: 'שליח אסף את ההזמנה',
+      timestamp: '',
+      completed: false,
+    },
+    {
+      status: 'courier_on_way',
+      title: 'שליח בדרך אלייך',
+      timestamp: '',
+      completed: false,
+    },
+    {
+      status: 'delivered',
+      title: 'הזמנה התקבלה (השאר ביקורת)',
+      timestamp: '',
+      completed: false,
+    },
+  ];
+
+  const statusOrder: OrderStatus[] = [
+    'order_received',
+    'courier_found',
+    'courier_picked_up',
+    'courier_on_way',
+    'delivered',
+  ];
+
+  const currentIndex = statusOrder.indexOf(status);
+  for (let i = 0; i <= currentIndex && i < base.length; i++) {
+    base[i].completed = true;
+    if (!base[i].timestamp) {
+      const now = new Date();
+      const minutesAgo = (currentIndex - i) * 10;
+      const ts = new Date(now.getTime() - minutesAgo * 60 * 1000);
+      base[i].timestamp = ts.toISOString();
+    }
+  }
+
+  return base;
+}

--- a/utils/nonceStore.ts
+++ b/utils/nonceStore.ts
@@ -1,0 +1,29 @@
+const checkoutNonceReservations = new Set<string>();
+const kycNonceUsage = new Map<string, number>();
+
+export function recordKycNonceUsage(key: string, timestamp: number): void {
+  // TODO:CORE-006 Angle 1 - Replace in-memory KYC nonce tracking with the shared anti-replay ledger once the service is wired up.
+  kycNonceUsage.set(key, timestamp);
+}
+
+export function rememberCheckoutNonce(sessionToken: string, nonce: string): void {
+  // TODO:CORE-008 Angle 1 - Persist checkout nonce reservations to the tenant nonce store so multi-device sessions stay in sync.
+  checkoutNonceReservations.add(`${sessionToken}:${nonce}`);
+}
+
+export function forgetCheckoutNonce(sessionToken: string, nonce: string): void {
+  // TODO:CORE-009 Angle 1 - Broadcast nonce releases to the shared store so queued checkouts unblock across clients.
+  checkoutNonceReservations.delete(`${sessionToken}:${nonce}`);
+}
+
+export function hasCheckoutNonce(sessionToken: string, nonce: string): boolean {
+  return checkoutNonceReservations.has(`${sessionToken}:${nonce}`);
+}
+
+export function clearExpiredKycNonceUsage(expireBefore: number): void {
+  for (const [key, seenAt] of kycNonceUsage) {
+    if (seenAt < expireBefore) {
+      kycNonceUsage.delete(key);
+    }
+  }
+}

--- a/utils/wakuTopics.ts
+++ b/utils/wakuTopics.ts
@@ -1,5 +1,6 @@
 // TODO:TODO-104 Expand buildTopic to validate domain/store identifiers against allowed vocabularies before constructing topics.
 // TODO:REC-204 Consider caching normalized topics to reduce repeated string allocations in hot message loops.
 export function buildTopic(domain: string, storeId: string): string {
+  // TODO:CORE-023 Angle 1 - Expand topic derivation with analytics namespaces once the Angle 1 contract is defined.
   return `/blue-ocean/${domain}/${storeId}`;
 }


### PR DESCRIPTION
## Summary
- add Angle 1 TODO markers and supporting stubs throughout the order service for KYC, escrow wrapper, analytics, and hooks
- introduce shared utilities for building order timelines and persisting nonce usage used by orders and related agents
- propagate matching TODO placeholders across agents, Waku services, and checkout/cart UI to cover each Angle 1 requirement

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb14ae2bc08326abce130d92804603