### PR TITLE
feat(waku): add order purchase proof schema

### DIFF
--- a/schemas/waku/index.ts
+++ b/schemas/waku/index.ts
@@ -14,3 +14,4 @@ export * from './admin.recoveryVerify';
 export * from './store.created';
 export * from './workspace.created';
 export * from './delivery.update';
+export * from './order.purchaseProof';

--- a/schemas/waku/order.purchaseProof.ts
+++ b/schemas/waku/order.purchaseProof.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { wakuMessageSchema } from './message';
+
+// TODO:CORE-011 Replace placeholder property definitions once purchase proof payload is finalized.
+export const orderPurchaseProofPayloadSchema = z.object({
+  orderId: z.unknown(),
+  buyerId: z.unknown(),
+  sellerId: z.unknown(),
+  storeId: z.unknown(),
+  escrowTx: z.unknown(),
+  closedAt: z.unknown(),
+  receiptHash: z.unknown(),
+  ts: z.unknown(),
+  nonce: z.unknown(),
+});
+
+export const orderPurchaseProofMessageSchema = wakuMessageSchema.extend({
+  type: z.literal('order.purchaseProof'),
+  payload: orderPurchaseProofPayloadSchema,
+});
+
+export type OrderPurchaseProofMessage = z.infer<typeof orderPurchaseProofMessageSchema>;


### PR DESCRIPTION
## Summary
- add a placeholder order purchase proof Waku schema exposing the expected payload shape
- re-export the new schema from the Waku schema index for consumers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb1d13dd1c8326af05f7d2d545434d