### PR TITLE
Refactor NEAR store service dependencies

### DIFF
--- a/agents/products-agent.ts
+++ b/agents/products-agent.ts
@@ -37,12 +37,20 @@ async function loadNearProducts(): Promise<NearProductsModule> {
 }
 
 type NearStoresModule = typeof import('@/features/stores/services/nearStores');
+type StoreService = ReturnType<NearStoresModule['createStoreService']>;
+
 let nearStoresModule: NearStoresModule | null = null;
-async function loadNearStores(): Promise<NearStoresModule> {
+let storeService: StoreService | null = null;
+
+async function loadNearStores(): Promise<StoreService> {
   if (!nearStoresModule) {
     nearStoresModule = await import('@/features/stores/services/nearStores');
   }
-  return nearStoresModule;
+  if (!storeService) {
+    const deps = nearStoresModule.createDefaultStoreServiceDeps();
+    storeService = nearStoresModule.createStoreService(deps);
+  }
+  return storeService;
 }
 
 let ensureNearWalletFn: (typeof import('@/utils/ensureNearWallet').default) | null = null;
@@ -209,8 +217,8 @@ class ProductsAgent {
 
   private async assertStoreOwner(storeId: string) {
     const { address } = await this.ensureWallet();
-    const { getStore } = await loadNearStores();
-    const store = await getStore(storeId, storeId);
+    const storeService = await loadNearStores();
+    const store = await storeService.selectStore(storeId, storeId);
     const admin = await isAdmin();
     if (!store || store.owner !== address || !admin) {
       throw new AgentError(

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -6,12 +6,20 @@ import { buildTopic } from '@/utils/wakuTopics';
 const getTransportCrypto = () => (typeof globalThis !== 'undefined' && globalThis.crypto ? globalThis.crypto : undefined);
 
 type NearStoresModule = typeof import('@/features/stores/services/nearStores');
+type StoreService = ReturnType<NearStoresModule['createStoreService']>;
+
 let nearStoresModule: NearStoresModule | null = null;
-async function getStoreServices(): Promise<NearStoresModule> {
+let nearStoreService: StoreService | null = null;
+
+async function getStoreServices(): Promise<StoreService> {
   if (!nearStoresModule) {
     nearStoresModule = await import('@/features/stores/services/nearStores');
   }
-  return nearStoresModule;
+  if (!nearStoreService) {
+    const deps = nearStoresModule.createDefaultStoreServiceDeps();
+    nearStoreService = nearStoresModule.createStoreService(deps);
+  }
+  return nearStoreService;
 }
 
 type EnsureNearWalletFn = typeof import('@/utils/ensureNearWallet').default;

--- a/app/store/[storeId]/admin/dashboard.tsx
+++ b/app/store/[storeId]/admin/dashboard.tsx
@@ -9,7 +9,10 @@ import { useAuth } from '@/features/auth/AuthContext';
 import OrderRevenueMetrics from '@/features/stores/components/OrderRevenueMetrics';
 import FeeDashboard from '@/features/billing/components/FeeDashboard';
 import { routes } from '@/utils/routes';
-import { getStore as getNearStore } from '@/features/stores/services/nearStores';
+import {
+  getStore as getNearStore,
+  createDefaultStoreServiceDeps,
+} from '@/features/stores/services/nearStores';
 import { listProducts as listNearProducts } from '@/features/products/services/nearProducts';
 
 // Avoid React.lazy in Jest to reduce transform/mapping complexity
@@ -18,6 +21,8 @@ const DashboardScreen: any = isTest
   ? // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('./_DashboardScreen').default
   : React.lazy(() => import('./_DashboardScreen'));
+
+const storeServiceDeps = createDefaultStoreServiceDeps();
 
 export default function DashboardRoute(props: any) {
   if (isTest) {
@@ -32,7 +37,7 @@ export default function DashboardRoute(props: any) {
       useEffect(() => {
         (async () => {
           if (!storeId) return;
-          const s = await getNearStore(storeId as string, storeId as string);
+          const s = await getNearStore(storeId as string, storeId as string, storeServiceDeps);
           setOwner(s?.owner || null);
           const ps = await listNearProducts(storeId as string);
           setCount((ps || []).filter((p: any) => p.storeId === storeId).length);

--- a/services/nearStoreLake.ts
+++ b/services/nearStoreLake.ts
@@ -1,6 +1,11 @@
 import { types } from 'near-lake-framework';
 import { initLake } from './nearLake';
-import { setStore } from '@/features/stores/services/nearStores';
+import {
+  createDefaultStoreServiceDeps,
+  createStoreService,
+} from '@/features/stores/services/nearStores';
+
+const storeService = createStoreService(createDefaultStoreServiceDeps());
 
 let started = false;
 
@@ -31,8 +36,8 @@ export function startNearStoreLake() {
                 if (evt?.event === 'store_created') {
                   const s = toStore(evt);
                   if (s) {
-                    await setStore(s.id, s);
-                    await setStore('default', s);
+                    await storeService.setStore(s.id, s);
+                    await storeService.setStore('default', s);
                   }
                 }
               } catch {

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -23,7 +23,10 @@ import {
   User,
 } from '../types';
 import { sha256 } from '@noble/hashes/sha256';
-import { getStore } from '@/features/stores/services/nearStores';
+import {
+  createDefaultStoreServiceDeps,
+  createStoreService,
+} from '@/features/stores/services/nearStores';
 import { getProduct, setProduct } from '@/features/products/services/nearProducts';
 import { chainAdapter } from '@/services/chain';
 import { getAccountId as getNearAuthAccountId } from '@/features/auth/services/nearAuth';
@@ -48,6 +51,8 @@ import {
   forgetCheckoutNonce,
   clearExpiredKycNonceUsage,
 } from '@/utils/nonceStore';
+
+const storeService = createStoreService(createDefaultStoreServiceDeps());
 
 // TODO:CORE-001 thin wrapper; instrument, do not inline deployEscrow
 export async function deployOrderPayment(orderDraft: any, opts: { fee?: any; nonce: string }) {
@@ -324,7 +329,7 @@ class OrderService {
     buyerId: string,
     storeId: string,
   ): Promise<KycVerificationResult> {
-    const store = await getStore(storeId, storeId);
+    const store = await storeService.selectStore(storeId, storeId);
     const requiresKyc = this.storeRequiresKyc(store);
 
     // TODO:CORE-004 Angle 1 - Swap to the tenant KYC verification microservice once its API contract is finalized.
@@ -711,7 +716,7 @@ class OrderService {
       const orders: Order[] = [];
       for (const [storeId, items] of Object.entries(grouped)) {
         const verifiedKyc = kycResults.get(storeId) ?? { ok: true, hash: null };
-        const store = await getStore(storeId, storeId);
+        const store = await storeService.selectStore(storeId, storeId);
         const payment =
           paymentMethod === 'near'
             ? {

--- a/services/waku.ts
+++ b/services/waku.ts
@@ -78,7 +78,8 @@ async function persistStore(storeId: string, store: Store): Promise<void> {
   if (!persistStoreImpl) {
     try {
       const mod = await import('@/features/stores/services/nearStores');
-      persistStoreImpl = mod.setStore as PersistStoreFn;
+      const service = mod.createStoreService(mod.createDefaultStoreServiceDeps());
+      persistStoreImpl = service.setStore.bind(service) as PersistStoreFn;
     } catch (err) {
       errorLog('Failed to load store persistence module', err);
       return;

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -37,7 +37,11 @@ let getStore:
   | ((storeId: string, id: string) => Promise<Store | null>)
   | undefined;
 if (chain === 'near') {
-  ({ getStore } = require('@/features/stores/services/nearStores'));
+  const nearStores = require('@/features/stores/services/nearStores');
+  const service = nearStores.createStoreService(
+    nearStores.createDefaultStoreServiceDeps(),
+  );
+  getStore = service.selectStore;
 }
 
 import OrderService from '@/services/orders';

--- a/src/features/cart/hooks/useCartStores.ts
+++ b/src/features/cart/hooks/useCartStores.ts
@@ -5,7 +5,11 @@ import { CartItem, Store } from '@/types';
 
 let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
 if (chain === 'near') {
-  ({ getStore } = require('@/features/stores/services/nearStores'));
+  const nearStores = require('@/features/stores/services/nearStores');
+  const service = nearStores.createStoreService(
+    nearStores.createDefaultStoreServiceDeps(),
+  );
+  getStore = service.selectStore;
 }
 
 export default function useCartStores(cartItems: CartItem[]) {

--- a/src/features/products/hooks/useStore.ts
+++ b/src/features/products/hooks/useStore.ts
@@ -4,7 +4,11 @@ import { Store } from '@/types';
 
 let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
 if (chain === 'near') {
-  ({ getStore } = require('@/features/stores/services/nearStores'));
+  const nearStores = require('@/features/stores/services/nearStores');
+  const service = nearStores.createStoreService(
+    nearStores.createDefaultStoreServiceDeps(),
+  );
+  getStore = service.selectStore;
 }
 
 export function useStore(id?: string, storeId: string = 'default') {

--- a/src/features/profile/components/ProfileOverview.tsx
+++ b/src/features/profile/components/ProfileOverview.tsx
@@ -6,7 +6,10 @@ import { useWallet } from '@/contexts/WalletProvider';
 import { chainAdapter } from '@/services/chain';
 import { Heading, Text, Card, Button } from '@/ui/primitives';
 import { Stack } from '@/ui/layout';
-import { listStores } from '@/features/stores/services/nearStores';
+import {
+  listStores,
+  createDefaultStoreServiceDeps,
+} from '@/features/stores/services/nearStores';
 import { Store } from '@/types';
 import { useNotificationActions } from '@/components/NotificationContext';
 import { prefetchStoreBundle } from '@/features/stores/services/prefetch';
@@ -29,6 +32,8 @@ function formatNearYocto(yocto: string): string {
   return `${whole}.${frac}`;
 }
 
+const storeServiceDeps = createDefaultStoreServiceDeps();
+
 export default function ProfileOverview() {
   const { colors } = useTheme();
   const { t } = useLanguage();
@@ -46,7 +51,7 @@ export default function ProfileOverview() {
     try {
       const amt = await chainAdapter.getBalance(address);
       setBalance(amt);
-      const all = await listStores('default');
+      const all = await listStores('default', storeServiceDeps);
       const owner = address?.toLowerCase() || '';
       setStores(all.filter((s) => (s.owner || '').toLowerCase() === owner));
       // NFTs: disabled by default to avoid web bundle issues. Enable behind a flag in the future.

--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -14,9 +14,14 @@ import { useLanguage } from '@/ui/ThemeProvider';
 import storesAgent from '@/agents/stores-agent';
 import DatabaseService from '@/services/database';
 import { useNotificationActions } from '@/components/NotificationContext';
-import { createStoreOnChain } from '@/features/stores/services/nearStores';
+import {
+  createStoreOnChain,
+  createDefaultStoreServiceDeps,
+} from '@/features/stores/services/nearStores';
 import { useWallet } from '@/contexts/WalletProvider';
 import { errorLog } from '@/utils/logger';
+
+const storeServiceDeps = createDefaultStoreServiceDeps();
 
 const StoreCreation: React.FC = () => {
   const [name, setName] = useState('');
@@ -42,7 +47,7 @@ const StoreCreation: React.FC = () => {
     let onChainError: any = null;
     // Try on-chain first, but do not block local creation in dev
     try {
-      const tx = await createStoreOnChain({ id, name: finalName, owner });
+      const tx = await createStoreOnChain({ id, name: finalName, owner }, storeServiceDeps);
       if (tx) {
         try {
           showNotification('Store Minted', `tx: ${tx}`, 'success');

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -8,83 +8,31 @@ import {
   removeValue,
 } from '@/services/nearKvStore';
 import { errorLog } from '@/utils/logger';
-import type { CacheMutation, DiffMessage, WarmCache as WarmCacheType } from '@/services/warmCache';
+import {
+  createWarmCache,
+  type CacheMutation,
+  type DiffMessage,
+} from '@/services/warmCache';
+import {
+  createDefaultStoreServiceDeps,
+  type StoreServiceDeps,
+} from './storeServiceDeps';
 
 
 const ADDRESS = 'stores';
 const STORE_CACHE_TOPIC = '/blue-ocean/stores/1';
 const DISABLED = false;
 let SEEDED = false;
-let chainEnsured = false;
-type ChainModule = typeof import('@/services/chain');
-let chainModule: ChainModule | null = null;
-async function loadChainModule(): Promise<ChainModule> {
-  if (!chainModule) {
-    chainModule = await import('@/services/chain');
-  }
-  return chainModule;
+
+const defaultDeps = createDefaultStoreServiceDeps();
+
+function resolveDeps(deps?: StoreServiceDeps): StoreServiceDeps {
+  return deps ?? defaultDeps;
 }
 
-async function ensureChain(): Promise<void> {
-  if (chainEnsured) return;
-  const { assertNearChain } = await loadChainModule();
-  assertNearChain();
-  chainEnsured = true;
-}
-
-type NearStoreContractModule = typeof import('@/services/nearStoreContract');
-let nearStoreContractModule: NearStoreContractModule | null = null;
-async function loadNearStoreContract(): Promise<NearStoreContractModule> {
-  await ensureChain();
-  if (!nearStoreContractModule) {
-    nearStoreContractModule = await import('@/services/nearStoreContract');
-  }
-  return nearStoreContractModule;
-}
-
-type WalletSelectorModule = typeof import('@/services/walletSelector');
-let walletSelectorModule: WalletSelectorModule | null = null;
-async function loadWalletSelector(): Promise<WalletSelectorModule> {
-  if (!walletSelectorModule) {
-    walletSelectorModule = await import('@/services/walletSelector');
-  }
-  return walletSelectorModule;
-}
-
-type ConfigModule = typeof import('@/services/config');
-let configModule: ConfigModule | null = null;
-async function loadConfigModule(): Promise<ConfigModule> {
-  if (!configModule) {
-    configModule = await import('@/services/config');
-  }
-  return configModule;
-}
-
-type AppConfig = typeof import('@/config').default;
-let cachedAppConfig: AppConfig | null = null;
-type WarmCacheModule = typeof import('@/services/warmCache');
-let warmCacheModule: WarmCacheModule | null = null;
-let storeCacheInstance: WarmCacheType<Store> | null = null;
-
-function ensureStoreCache(): WarmCacheType<Store> {
-  if (!storeCacheInstance) {
-    const mod: WarmCacheModule =
-      warmCacheModule ??
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      (require('@/services/warmCache') as WarmCacheModule);
-    warmCacheModule = mod;
-    storeCacheInstance = mod.createWarmCache<Store>(STORE_CACHE_TOPIC, {
-      hydrateLake: hydrateStoreLake,
-    });
-  }
-  return storeCacheInstance;
-}
-async function loadAppConfig(): Promise<AppConfig> {
-  if (!cachedAppConfig) {
-    cachedAppConfig = (await import('@/config')).default;
-  }
-  return cachedAppConfig;
-}
+const storeCache = createWarmCache<Store>(STORE_CACHE_TOPIC, {
+  hydrateLake: hydrateStoreLake,
+});
 
 function decodeBase64String(value: string): string {
   const globalObj: any = globalThis as any;
@@ -155,22 +103,22 @@ async function hydrateStoreLake(): Promise<Array<DiffMessage<Store>>> {
 
 export const storesWarmCache = {
   getById(id: string) {
-    return ensureStoreCache().getById(id);
+    return storeCache.getById(id);
   },
   list(filter?: (id: string, value: Store) => boolean) {
-    return ensureStoreCache().list(filter);
+    return storeCache.list(filter);
   },
   subscribe(
     filter: (id: string, value: Store | undefined) => boolean,
     cb: (id: string, value: Store | undefined) => void,
   ) {
-    return ensureStoreCache().subscribe(filter, cb);
+    return storeCache.subscribe(filter, cb);
   },
   mutate(cmd: CacheMutation<Store>) {
-    return ensureStoreCache().mutate(cmd);
+    return storeCache.mutate(cmd);
   },
   onSynced(cb: (event?: { cache: string }) => void) {
-    return ensureStoreCache().onSynced(cb);
+    return storeCache.onSynced(cb);
   },
 };
 
@@ -205,14 +153,14 @@ function fromChain(data: any): Store {
 }
 
 export async function mintStore(
-  name: string
+  name: string,
+  deps?: StoreServiceDeps,
 ): Promise<{ id: string; nftId: string; txHash: string }> {
-  await ensureChain();
-  const { nearConfig } = await loadConfigModule();
-  const { contractId } = nearConfig();
+  const resolved = resolveDeps(deps);
+  resolved.chain.assertNearChain();
+  const { contractId } = resolved.config.nearConfig();
   if (!contractId) throw new Error('CONTRACT_ID required');
-  const { getSelector } = await loadWalletSelector();
-  const selector = getSelector();
+  const selector = resolved.walletSelector.getSelector();
   if (!selector) throw new Error('Wallet not initialized');
   const wallet = await selector.wallet();
   const res: any = await wallet.signAndSendTransactions({
@@ -267,29 +215,46 @@ async function persistStore(store: Store, sid: string) {
   await setValue(ADDRESS, indexKey(store.id), json);
 }
 
-async function sendTx(action: string, data: any) {
+async function sendTx(action: string, data: any, deps: StoreServiceDeps) {
   if (process.env.JEST_WORKER_ID || process.env.NODE_ENV === 'test') {
     return;
   }
   const payload = canonicalJson({ action, ...data });
-  await ensureChain();
-  const { chainAdapter } = await loadChainModule();
-  const tx = await chainAdapter.signMessage?.(payload);
+  deps.chain.assertNearChain();
+  const tx = await deps.chain.chainAdapter.signMessage?.(payload);
   if (!tx) {
     throw new Error('Transaction failed');
   }
 }
+export function selectStore(
+  arg1: string,
+  deps?: StoreServiceDeps,
+): Promise<Store | null>;
+export function selectStore(
+  arg1: string,
+  arg2: string,
+  deps?: StoreServiceDeps,
+): Promise<Store | null>;
 export async function selectStore(
   arg1: string,
-  arg2?: string
+  arg2OrDeps?: string | StoreServiceDeps,
+  maybeDeps?: StoreServiceDeps,
 ): Promise<Store | null> {
   ensureSeed();
-  const id = arg2 ?? arg1;
+  const id = typeof arg2OrDeps === 'string' ? arg2OrDeps : arg1;
+  const deps =
+    (typeof arg2OrDeps === 'object' && arg2OrDeps)
+      ? arg2OrDeps
+      : maybeDeps;
+  resolveDeps(deps);
   try {
     const cached = storesWarmCache.getById(id);
     if (cached) return cached;
   } catch {}
-  const key = arg2 ? storeKey(id, requireStoreId(arg1)) : indexKey(id);
+  const key =
+    typeof arg2OrDeps === 'string'
+      ? storeKey(id, requireStoreId(arg1))
+      : indexKey(id);
   const res = await getValue(ADDRESS, key);
   if (!res) return null;
   try {
@@ -299,11 +264,14 @@ export async function selectStore(
     return null;
   }
 }
-export async function listStores(storeId: string): Promise<Store[]> {
+export async function listStores(
+  storeId: string,
+  deps?: StoreServiceDeps,
+): Promise<Store[]> {
   ensureSeed();
   const sid = requireStoreId(storeId);
   try {
-    const values = ensureStoreCache().list();
+    const values = storeCache.list();
     if (sid === 'default') return values;
     const filtered = values.filter((store) => requireStoreId(store.id) === sid);
     if (filtered.length > 0) return filtered;
@@ -318,9 +286,9 @@ export async function listStores(storeId: string): Promise<Store[]> {
   }
   if (res.length > 0 || DISABLED) return res;
   try {
-    await ensureChain();
-    const { listStores: contractListStores } = await loadNearStoreContract();
-    const chainRes = await contractListStores();
+    const resolved = resolveDeps(deps);
+    resolved.chain.assertNearChain();
+    const chainRes = await resolved.contract.listStores();
     const mapped = chainRes.map(fromChain);
     for (const s of mapped) {
       await persistStore(s, requireStoreId(s.id));
@@ -332,33 +300,101 @@ export async function listStores(storeId: string): Promise<Store[]> {
   return res;
 }
 
-export async function addStore(store: Store, sid?: string): Promise<void> {
-  await sendTx('add', { store });
+export async function addStore(
+  store: Store,
+  sid?: string,
+  deps?: StoreServiceDeps,
+): Promise<void> {
+  const resolved = resolveDeps(deps);
+  await sendTx('add', { store }, resolved);
   await persistStore(store, sid ?? requireStoreId(store.id));
 }
 
-export async function updateStore(store: Store, sid?: string): Promise<void> {
-  await sendTx('update', { store });
+export async function updateStore(
+  store: Store,
+  sid?: string,
+  deps?: StoreServiceDeps,
+): Promise<void> {
+  const resolved = resolveDeps(deps);
+  await sendTx('update', { store }, resolved);
   await persistStore(store, sid ?? requireStoreId(store.id));
 }
 
-export async function removeStore(arg1: string, arg2?: string): Promise<void> {
-  const id = arg2 ?? arg1;
-  const sid = arg2 ? requireStoreId(arg1) : requireStoreId(id);
-  await sendTx('remove', { id });
+export function removeStore(
+  id: string,
+  deps?: StoreServiceDeps,
+): Promise<void>;
+export function removeStore(
+  arg1: string,
+  arg2: string,
+  deps?: StoreServiceDeps,
+): Promise<void>;
+export async function removeStore(
+  arg1: string,
+  arg2OrDeps?: string | StoreServiceDeps,
+  maybeDeps?: StoreServiceDeps,
+): Promise<void> {
+  const id = typeof arg2OrDeps === 'string' ? arg2OrDeps : arg1;
+  const sid =
+    typeof arg2OrDeps === 'string'
+      ? requireStoreId(arg1)
+      : requireStoreId(id);
+  const deps =
+    (typeof arg2OrDeps === 'object' && arg2OrDeps)
+      ? arg2OrDeps
+      : maybeDeps;
+  const resolved = resolveDeps(deps);
+  await sendTx('remove', { id }, resolved);
   await removeValue(ADDRESS, storeKey(id, sid));
   await removeValue(ADDRESS, indexKey(id));
 }
 
 export const getStore = selectStore;
 
-export async function setStore(storeId: string, store: Store) {
-  const existing = await selectStore(storeId, store.id);
+export async function setStore(
+  storeId: string,
+  store: Store,
+  deps?: StoreServiceDeps,
+) {
+  const resolved = resolveDeps(deps);
+  const existing = await selectStore(storeId, store.id, resolved);
   if (existing) {
-    await updateStore(store, storeId);
+    await updateStore(store, storeId, resolved);
   } else {
-    await addStore(store, storeId);
+    await addStore(store, storeId, resolved);
   }
+}
+
+export function createStoreService(
+  deps: StoreServiceDeps = defaultDeps,
+): {
+  mintStore: (name: string) => Promise<{ id: string; nftId: string; txHash: string }>;
+  selectStore: (arg1: string, arg2?: string) => Promise<Store | null>;
+  listStores: (storeId: string) => Promise<Store[]>;
+  addStore: (store: Store, sid?: string) => Promise<void>;
+  updateStore: (store: Store, sid?: string) => Promise<void>;
+  removeStore: (arg1: string, arg2?: string) => Promise<void>;
+  setStore: (storeId: string, store: Store) => Promise<void>;
+  createStoreOnChain: (args: { id: string; name: string; owner: string }) => Promise<string>;
+} {
+  const resolved = resolveDeps(deps);
+  return {
+    mintStore: (name: string) => mintStore(name, resolved),
+    selectStore: (arg1: string, arg2?: string) =>
+      typeof arg2 === 'string'
+        ? selectStore(arg1, arg2, resolved)
+        : selectStore(arg1, resolved),
+    listStores: (storeId: string) => listStores(storeId, resolved),
+    addStore: (store: Store, sid?: string) => addStore(store, sid, resolved),
+    updateStore: (store: Store, sid?: string) => updateStore(store, sid, resolved),
+    removeStore: (arg1: string, arg2?: string) =>
+      typeof arg2 === 'string'
+        ? removeStore(arg1, arg2, resolved)
+        : removeStore(arg1, resolved),
+    setStore: (storeId: string, store: Store) => setStore(storeId, store, resolved),
+    createStoreOnChain: (args: { id: string; name: string; owner: string }) =>
+      createStoreOnChain(args, resolved),
+  };
 }
 
 /**
@@ -370,12 +406,13 @@ export async function createStoreOnChain(args: {
   id: string;
   name: string;
   owner: string;
-}): Promise<string> {
-  const appConfig = await loadAppConfig();
+}, deps?: StoreServiceDeps): Promise<string> {
+  const resolved = resolveDeps(deps);
+  const appConfig = await resolved.config.loadAppConfig();
   const relayerUrl = appConfig.EXPO_PUBLIC_RELAYER_URL;
   if (!relayerUrl) throw new Error('EXPO_PUBLIC_RELAYER_URL not configured');
-  await ensureChain();
-  const { chainAdapter } = await loadChainModule();
+  resolved.chain.assertNearChain();
+  const { chainAdapter } = resolved.chain;
   const publicKey = chainAdapter.getPublicKey();
   if (!publicKey) throw new Error('Wallet not connected');
   const body = {
@@ -404,6 +441,8 @@ export async function createStoreOnChain(args: {
   if (json?.error) throw new Error(String(json.error));
   return json?.tx || '';
 }
+
+export { createDefaultStoreServiceDeps } from './storeServiceDeps';
 
 
 

--- a/src/features/stores/services/prefetch.ts
+++ b/src/features/stores/services/prefetch.ts
@@ -1,13 +1,15 @@
 /* Lightweight prefetcher for store bundles (store + products + categories).
  * Starts network/kv reads ahead of navigation to reduce first render latency.
  */
-import { getStore } from './nearStores';
+import { getStore, createDefaultStoreServiceDeps } from './nearStores';
 import { listProducts } from '@/features/products/services/nearProducts';
 import { listCategories } from '@/features/products/services/nearCategories';
 
 type Entry = { ts: number; promise: Promise<void> };
 const cache = new Map<string, Entry>();
 const TTL_MS = 30000;
+
+const storeServiceDeps = createDefaultStoreServiceDeps();
 
 export function prefetchStoreBundle(storeId: string | null | undefined): Promise<void> {
   const id = (storeId || '').trim();
@@ -19,7 +21,7 @@ export function prefetchStoreBundle(storeId: string | null | undefined): Promise
   const promise = (async () => {
     try {
       await Promise.allSettled([
-        getStore(id, id),
+        getStore(id, id, storeServiceDeps),
         listProducts(id),
         listCategories(id),
       ]);

--- a/src/features/stores/services/storeServiceDeps.ts
+++ b/src/features/stores/services/storeServiceDeps.ts
@@ -1,0 +1,33 @@
+import { assertNearChain, chainAdapter } from '@/services/chain';
+import { listStores as contractListStores } from '@/services/nearStoreContract';
+import { getSelector } from '@/services/walletSelector';
+import { nearConfig } from '@/services/config';
+
+export interface StoreServiceDeps {
+  chain: {
+    assertNearChain: () => void;
+    chainAdapter: typeof chainAdapter;
+  };
+  contract: {
+    listStores: typeof contractListStores;
+  };
+  walletSelector: {
+    getSelector: typeof getSelector;
+  };
+  config: {
+    nearConfig: typeof nearConfig;
+    loadAppConfig: () => Promise<typeof import('@/config').default>;
+  };
+}
+
+export function createDefaultStoreServiceDeps(): StoreServiceDeps {
+  return {
+    chain: { assertNearChain, chainAdapter },
+    contract: { listStores: contractListStores },
+    walletSelector: { getSelector },
+    config: {
+      nearConfig,
+      loadAppConfig: async () => (await import('@/config')).default,
+    },
+  };
+}

--- a/src/services/openDM.ts
+++ b/src/services/openDM.ts
@@ -8,7 +8,11 @@ let getUser: ((id: string) => Promise<User | null>) | undefined;
 
 if (chain === 'near') {
   try {
-    ({ getStore } = require('@/features/stores/services/nearStores'));
+    const nearStores = require('@/features/stores/services/nearStores');
+    const service = nearStores.createStoreService(
+      nearStores.createDefaultStoreServiceDeps(),
+    );
+    getStore = service.selectStore;
   } catch (err) {
     errorLog('Failed to load store service for messaging', err);
   }

--- a/src/services/useStores.ts
+++ b/src/services/useStores.ts
@@ -6,7 +6,19 @@ let listStores: ((storeId: string) => Promise<Store[]>) | undefined;
 let setStore: ((storeId: string, store: Store) => Promise<void>) | undefined;
 let removeStore: ((storeId: string, id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
-  ({ listStores, setStore, removeStore } = require('@/features/stores/services/nearStores'));
+  const nearStores = require('@/features/stores/services/nearStores');
+  const storeService = nearStores.createStoreService(
+    nearStores.createDefaultStoreServiceDeps(),
+  );
+  ({
+    listStores,
+    setStore,
+    removeStore,
+  } = {
+    listStores: storeService.listStores,
+    setStore: storeService.setStore,
+    removeStore: storeService.removeStore,
+  });
 }
 
 export function useStores(storeId: string) {

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -105,14 +105,41 @@ jest.mock('@/features/auth/services/nearAuth', () => ({
   signIn: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@/features/stores/services/nearStores', () => ({
-  getStore: jest.fn(async (id: string) => ({
+jest.mock('@/features/stores/services/nearStores', () => {
+  const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
     owner: `seller_${id}`,
     policies: { kycRequired: true },
-  })),
-}));
+  }));
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores: jest.fn(),
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    getStore: selectStore,
+    setStore,
+    listStores: service.listStores,
+    createStoreOnChain: service.createStoreOnChain,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 
 const mockUsersAgent = {
   get: jest.fn(),

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -81,15 +81,42 @@ jest.mock('@/agents/users-agent', () => ({
   default: mockUsersAgent,
 }));
 
-jest.mock('@/features/stores/services/nearStores', () => ({
-  getStore: jest.fn(async (id: string) => ({
+jest.mock('@/features/stores/services/nearStores', () => {
+  const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
     owner: `seller_${id}`,
     nftId: id,
     policies: { kycRequired: true },
-  })),
-}));
+  }));
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores: jest.fn(),
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    getStore: selectStore,
+    setStore,
+    listStores: service.listStores,
+    createStoreOnChain: service.createStoreOnChain,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 
 jest.mock('@/features/products/services/nearProducts', () => ({
   getProduct: jest.fn(async (id: string) => mockProducts[id] || null),

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -99,15 +99,42 @@ jest.mock('@/agents/users-agent', () => ({
   default: mockUsersAgent,
 }));
 
-jest.mock('@/features/stores/services/nearStores', () => ({
-  getStore: jest.fn(async (id: string) => ({
+jest.mock('@/features/stores/services/nearStores', () => {
+  const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
     owner: `seller_${id}`,
     nftId: id,
     policies: { kycRequired: true },
-  })),
-}));
+  }));
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores: jest.fn(),
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    getStore: selectStore,
+    setStore,
+    listStores: service.listStores,
+    createStoreOnChain: service.createStoreOnChain,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 
 jest.mock('@/features/products/services/nearProducts', () => ({
   getProduct: jest.fn(async (id: string) => mockProducts[id] || null),

--- a/tests/orderServiceKyc.test.ts
+++ b/tests/orderServiceKyc.test.ts
@@ -30,9 +30,36 @@ jest.mock('@/services/kycReceipts', () => ({
 }));
 
 const mockGetStore = jest.fn();
-jest.mock('@/features/stores/services/nearStores', () => ({
-  getStore: (...args: any[]) => mockGetStore(...args),
-}));
+jest.mock('@/features/stores/services/nearStores', () => {
+  const selectStore = jest.fn((...args: any[]) => mockGetStore(...args));
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores: jest.fn(),
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    getStore: selectStore,
+    setStore,
+    listStores: service.listStores,
+    createStoreOnChain: service.createStoreOnChain,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 
 jest.mock('@/agents/orders-agent', () => ({
   __esModule: true,

--- a/tests/storeCreation.snapshot.test.tsx
+++ b/tests/storeCreation.snapshot.test.tsx
@@ -37,9 +37,37 @@ jest.mock('@/components/NotificationContext', () => ({
   useNotificationActions: () => ({ showNotification: jest.fn() }),
 }));
 
-jest.mock('@/features/stores/services/nearStores', () => ({
-  createStoreOnChain: jest.fn(),
-}));
+jest.mock('@/features/stores/services/nearStores', () => {
+  const createStoreOnChain = jest.fn();
+  const selectStore = jest.fn();
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores: jest.fn(),
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain,
+  };
+  return {
+    __esModule: true,
+    createStoreOnChain,
+    getStore: selectStore,
+    listStores: service.listStores,
+    setStore,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 
 jest.mock('@/services/chain', () => ({ __esModule: true,
   chainAdapter: { getAccountId: jest.fn() },

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -31,7 +31,37 @@ jest.mock('@/ui/ThemeProvider', () => ({
   }),
 }));
 
-jest.mock('@/features/stores/services/nearStores', () => ({ getStore: jest.fn() }));
+jest.mock('@/features/stores/services/nearStores', () => {
+  const selectStore = jest.fn();
+  const listStores = jest.fn();
+  const setStore = jest.fn();
+  const service = {
+    mintStore: jest.fn(),
+    selectStore,
+    listStores,
+    addStore: jest.fn(),
+    updateStore: jest.fn(),
+    removeStore: jest.fn(),
+    setStore,
+    createStoreOnChain: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    getStore: selectStore,
+    listStores,
+    setStore,
+    createStoreOnChain: service.createStoreOnChain,
+    createDefaultStoreServiceDeps: jest.fn(() => ({})),
+    createStoreService: jest.fn(() => service),
+    storesWarmCache: {
+      getById: jest.fn(),
+      list: jest.fn(() => []),
+      subscribe: jest.fn(() => jest.fn()),
+      mutate: jest.fn(),
+      onSynced: jest.fn(() => jest.fn()),
+    },
+  };
+});
 jest.mock('@/features/products/services/nearProducts', () => ({ listProducts: jest.fn() }));
 
 jest.mock('@/features/auth/AuthContext', () => ({ useAuth: jest.fn() }));

--- a/tests/storeIsolation.test.ts
+++ b/tests/storeIsolation.test.ts
@@ -1,6 +1,10 @@
 import { setProduct, listProducts } from '@/features/products/services/nearProducts';
 import { setOrder, listOrders } from '@/services/nearOrders';
-import { setStore, listStores } from '@/features/stores/services/nearStores';
+import {
+  setStore,
+  listStores,
+  createDefaultStoreServiceDeps,
+} from '@/features/stores/services/nearStores';
 import { Product, Order, Store, ShippingAddress } from '../types';
 
 jest.mock('@/services/nearKvStore', () => {
@@ -14,6 +18,8 @@ jest.mock('@/services/nearKvStore', () => {
     removeValue: async (_addr: string, key: string) => { store.delete(key); },
   };
 });
+
+const storeServiceDeps = createDefaultStoreServiceDeps();
 
 describe('store data isolation', () => {
   it('separates products by storeId', async () => {
@@ -41,10 +47,10 @@ describe('store data isolation', () => {
   it('separates stores by storeId', async () => {
     const s1: Store = { id: 'a', name: 'A', owner: '', nftId: '' };
     const s2: Store = { id: 'b', name: 'B', owner: '', nftId: '' };
-    await setStore('s1', s1);
-    await setStore('s2', s2);
-    const l1 = await listStores('s1');
-    const l2 = await listStores('s2');
+    await setStore('s1', s1, storeServiceDeps);
+    await setStore('s2', s2, storeServiceDeps);
+    const l1 = await listStores('s1', storeServiceDeps);
+    const l2 = await listStores('s2', storeServiceDeps);
     expect(l1.map(s => s.id)).toEqual(['a']);
     expect(l2.map(s => s.id)).toEqual(['b']);
   });


### PR DESCRIPTION
## Summary
- introduce a StoreServiceDeps contract and default factory so NEAR store helpers can share their chain, contract, wallet, and config wiring
- refactor nearStores to accept injected dependencies, expose a createStoreService helper, and remove the old module-level singletons
- update agents, services, UI hooks/components, and Jest mocks to construct store services or pass dependency bundles explicitly

## Testing
- npm run typecheck *(fails: services/warmCache.ts still contains merge markers and Expo tsconfig base is missing)*
- npm run lint *(fails: project lacks @typescript-eslint/parser in this environment)*
- npx jest tests/storeIsolation.test.ts tests/storeDashboard.test.tsx *(fails: npm could not install jest interactively in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf34de67a88326bf090e7dc12eae35