### PR TITLE
Refactor store chain interactions into dedicated client

### DIFF
--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -12,6 +12,7 @@ import {
   createDefaultStoreServiceDeps,
   type StoreServiceDeps,
 } from './storeServiceDeps';
+import type { MintStoreResult } from './storeChainClient';
 import {
   STORE_CACHE_ADDRESS,
   storeCacheRepository,
@@ -26,39 +27,6 @@ const defaultDeps = createDefaultStoreServiceDeps();
 
 function resolveDeps(deps?: StoreServiceDeps): StoreServiceDeps {
   return deps ?? defaultDeps;
-}
-
-function decodeBase64String(value: string): string {
-  const globalObj: any = globalThis as any;
-  const BufferCtor = globalObj?.Buffer;
-  if (BufferCtor?.from) {
-    try {
-      return BufferCtor.from(value, 'base64').toString('utf-8');
-    } catch {
-      // fall through
-    }
-  }
-  if (typeof globalObj?.atob === 'function') {
-    try {
-      const binary = globalObj.atob(value);
-      if (typeof globalObj.TextDecoder === 'function') {
-        const decoder = new globalObj.TextDecoder();
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i += 1) {
-          bytes[i] = binary.charCodeAt(i);
-        }
-        return decoder.decode(bytes);
-      }
-      return binary;
-    } catch {
-      try {
-        return globalObj.atob(value);
-      } catch {
-        // continue to fallback
-      }
-    }
-  }
-  return value;
 }
 
 export const storesWarmCache = {
@@ -98,50 +66,9 @@ function fromChain(data: any): Store {
 export async function mintStore(
   name: string,
   deps?: StoreServiceDeps,
-): Promise<{ id: string; nftId: string; txHash: string }> {
+): Promise<MintStoreResult> {
   const resolved = resolveDeps(deps);
-  resolved.chain.assertNearChain();
-  const { contractId } = resolved.config.nearConfig();
-  if (!contractId) throw new Error('CONTRACT_ID required');
-  const selector = resolved.walletSelector.getSelector();
-  if (!selector) throw new Error('Wallet not initialized');
-  const wallet = await selector.wallet();
-  const res: any = await wallet.signAndSendTransactions({
-    transactions: [
-      {
-        receiverId: contractId,
-        actions: [
-          {
-            type: 'FunctionCall',
-            params: {
-              methodName: 'mint_store',
-              args: { name },
-              gas: '30000000000000',
-              deposit: '0',
-            },
-          },
-        ],
-      },
-    ],
-  });
-
-  const outcome = Array.isArray(res) ? res[0] : res;
-  const txHash: string = outcome?.transaction?.hash || '';
-  let id = '';
-  let nftId = '';
-  try {
-    const val =
-      outcome?.status?.SuccessValue ||
-      outcome?.transaction_outcome?.outcome?.status?.SuccessValue;
-    if (val) {
-      const decoded = decodeBase64String(val);
-      const parsed = JSON.parse(decoded);
-      id = parsed.store_id || parsed.storeId || parsed.id || '';
-      nftId = parsed.nft_id || parsed.nftId || '';
-    }
-  } catch {}
-  if (!id) throw new Error('mint_store failed');
-  return { id, nftId, txHash };
+  return resolved.storeChainClient.mintStore(name);
 }
 
 async function persistStore(store: Store, sid: string) {
@@ -150,17 +77,6 @@ async function persistStore(store: Store, sid: string) {
   await setValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(store.id), json);
 }
 
-async function sendTx(action: string, data: any, deps: StoreServiceDeps) {
-  if (process.env.JEST_WORKER_ID || process.env.NODE_ENV === 'test') {
-    return;
-  }
-  const payload = canonicalJson({ action, ...data });
-  deps.chain.assertNearChain();
-  const tx = await deps.chain.chainAdapter.signMessage?.(payload);
-  if (!tx) {
-    throw new Error('Transaction failed');
-  }
-}
 export function selectStore(
   arg1: string,
   deps?: StoreServiceDeps,
@@ -239,7 +155,7 @@ export async function addStore(
   deps?: StoreServiceDeps,
 ): Promise<void> {
   const resolved = resolveDeps(deps);
-  await sendTx('add', { store }, resolved);
+  await resolved.storeChainClient.submitMutation('add', { store });
   await persistStore(store, sid ?? requireStoreId(store.id));
 }
 
@@ -249,7 +165,7 @@ export async function updateStore(
   deps?: StoreServiceDeps,
 ): Promise<void> {
   const resolved = resolveDeps(deps);
-  await sendTx('update', { store }, resolved);
+  await resolved.storeChainClient.submitMutation('update', { store });
   await persistStore(store, sid ?? requireStoreId(store.id));
 }
 
@@ -277,7 +193,7 @@ export async function removeStore(
       ? arg2OrDeps
       : maybeDeps;
   const resolved = resolveDeps(deps);
-  await sendTx('remove', { id }, resolved);
+  await resolved.storeChainClient.submitMutation('remove', { id });
   await removeValue(STORE_CACHE_ADDRESS, storeCacheKey(id, sid));
   await removeValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(id));
 }
@@ -301,7 +217,7 @@ export async function setStore(
 export function createStoreService(
   deps: StoreServiceDeps = defaultDeps,
 ): {
-  mintStore: (name: string) => Promise<{ id: string; nftId: string; txHash: string }>;
+  mintStore: (name: string) => Promise<MintStoreResult>;
   selectStore: (arg1: string, arg2?: string) => Promise<Store | null>;
   listStores: (storeId: string) => Promise<Store[]>;
   addStore: (store: Store, sid?: string) => Promise<void>;
@@ -341,42 +257,12 @@ export async function createStoreOnChain(args: {
   owner: string;
 }, deps?: StoreServiceDeps): Promise<string> {
   const resolved = resolveDeps(deps);
-  const appConfig = await resolved.config.loadAppConfig();
-  const relayerUrl = appConfig.EXPO_PUBLIC_RELAYER_URL;
-  if (!relayerUrl) throw new Error('EXPO_PUBLIC_RELAYER_URL not configured');
-  resolved.chain.assertNearChain();
-  const { chainAdapter } = resolved.chain;
-  const publicKey = chainAdapter.getPublicKey();
-  if (!publicKey) throw new Error('Wallet not connected');
-  const body = {
-    action: 'create_store',
-    args: { store_id: args.id, name: args.name },
-    ownerId: args.owner,
-  } as const;
-  const toSign = new TextEncoder().encode(
-    JSON.stringify({ action: body.action, args: body.args })
-  );
-  const signature = await chainAdapter.signMessage?.(toSign);
-  const res = await fetch(`${relayerUrl}/meta-tx`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: canonicalJson({ ...body, publicKey, signature }),
-  });
-  if (!res.ok) {
-    let msg = `${res.status} ${res.statusText}`;
-    try {
-      const j = await res.json();
-      msg = (j && (j.error || j.message)) || msg;
-    } catch {}
-    throw new Error(`Relayer error: ${msg}`);
-  }
-  const json = await res.json();
-  if (json?.error) throw new Error(String(json.error));
-  return json?.tx || '';
+  return resolved.storeChainClient.createStoreOnChain(args);
 }
 
 export { createDefaultStoreServiceDeps } from './storeServiceDeps';
 export { seedStoreCache, setStoreCacheSeedEnabled } from './storeCache';
+export type { MintStoreResult } from './storeChainClient';
 
 
 

--- a/src/features/stores/services/storeChainClient.ts
+++ b/src/features/stores/services/storeChainClient.ts
@@ -1,0 +1,179 @@
+import type { WalletSelector } from '@near-wallet-selector/core';
+import type { chainAdapter as ChainAdapter } from '@/services/chain';
+import type { getSelector } from '@/services/walletSelector';
+import type { nearConfig } from '@/services/config';
+import { canonicalJson } from '@/utils/serialization';
+
+export interface MintStoreResult {
+  id: string;
+  nftId: string;
+  txHash: string;
+}
+
+export interface StoreChainClientDeps {
+  assertNearChain: () => void;
+  getSelector: typeof getSelector;
+  nearConfig: typeof nearConfig;
+  chainAdapter: typeof ChainAdapter;
+  loadAppConfig: () => Promise<typeof import('@/config').default>;
+  fetchFn?: typeof fetch;
+}
+
+function decodeBase64String(value: string): string {
+  const globalObj: any = globalThis as any;
+  const BufferCtor = globalObj?.Buffer;
+  if (BufferCtor?.from) {
+    try {
+      return BufferCtor.from(value, 'base64').toString('utf-8');
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof globalObj?.atob === 'function') {
+    try {
+      const binary = globalObj.atob(value);
+      if (typeof globalObj.TextDecoder === 'function') {
+        const decoder = new globalObj.TextDecoder();
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        return decoder.decode(bytes);
+      }
+      return binary;
+    } catch {
+      try {
+        return globalObj.atob(value);
+      } catch {
+        // continue to fallback
+      }
+    }
+  }
+  return value;
+}
+
+function ensureWalletSelector(selector: WalletSelector | null | undefined) {
+  if (!selector) {
+    throw new Error('Wallet not initialized');
+  }
+  return selector;
+}
+
+function isTestEnvironment(): boolean {
+  return Boolean(process.env.JEST_WORKER_ID || process.env.NODE_ENV === 'test');
+}
+
+export class StoreChainClient {
+  private readonly fetchFn: typeof fetch;
+
+  constructor(private readonly deps: StoreChainClientDeps) {
+    this.fetchFn = deps.fetchFn ?? globalThis.fetch?.bind(globalThis) ?? fetch;
+  }
+
+  async mintStore(name: string): Promise<MintStoreResult> {
+    this.deps.assertNearChain();
+    const { contractId } = this.deps.nearConfig();
+    if (!contractId) throw new Error('CONTRACT_ID required');
+    const selector = ensureWalletSelector(this.deps.getSelector());
+    const wallet = await selector.wallet();
+    const signer: any = wallet;
+    if (!signer?.signAndSendTransactions) {
+      throw new Error('Wallet not initialized');
+    }
+    const res: any = await signer.signAndSendTransactions({
+      transactions: [
+        {
+          receiverId: contractId,
+          actions: [
+            {
+              type: 'FunctionCall',
+              params: {
+                methodName: 'mint_store',
+                args: { name },
+                gas: '30000000000000',
+                deposit: '0',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const outcome = Array.isArray(res) ? res[0] : res;
+    const txHash: string = outcome?.transaction?.hash || '';
+    let id = '';
+    let nftId = '';
+    try {
+      const val =
+        outcome?.status?.SuccessValue ||
+        outcome?.transaction_outcome?.outcome?.status?.SuccessValue;
+      if (val) {
+        const decoded = decodeBase64String(val);
+        const parsed = JSON.parse(decoded);
+        id = parsed.store_id || parsed.storeId || parsed.id || '';
+        nftId = parsed.nft_id || parsed.nftId || '';
+      }
+    } catch {}
+    if (!id) throw new Error('mint_store failed');
+    return { id, nftId, txHash };
+  }
+
+  async submitMutation(
+    action: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    if (isTestEnvironment()) return;
+    const payload = canonicalJson({ action, ...data });
+    this.deps.assertNearChain();
+    const tx = await this.deps.chainAdapter.signMessage?.(payload);
+    if (!tx) {
+      throw new Error('Transaction failed');
+    }
+  }
+
+  async createStoreOnChain(args: {
+    id: string;
+    name: string;
+    owner: string;
+  }): Promise<string> {
+    const appConfig = await this.deps.loadAppConfig();
+    const relayerUrl = appConfig.EXPO_PUBLIC_RELAYER_URL;
+    if (!relayerUrl) throw new Error('EXPO_PUBLIC_RELAYER_URL not configured');
+    this.deps.assertNearChain();
+    const { chainAdapter } = this.deps;
+    const publicKey = chainAdapter.getPublicKey();
+    if (!publicKey) throw new Error('Wallet not connected');
+    const body = {
+      action: 'create_store' as const,
+      args: { store_id: args.id, name: args.name },
+      ownerId: args.owner,
+    };
+    const encoder = new TextEncoder();
+    const toSign = encoder.encode(
+      JSON.stringify({ action: body.action, args: body.args }),
+    );
+    const signature = await chainAdapter.signMessage?.(toSign);
+    const response = await this.fetchFn(`${relayerUrl}/meta-tx`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: canonicalJson({ ...body, publicKey, signature }),
+    });
+    if (!response.ok) {
+      let msg = `${response.status} ${response.statusText}`;
+      try {
+        const json = await response.json();
+        msg = (json && (json.error || json.message)) || msg;
+      } catch {}
+      throw new Error(`Relayer error: ${msg}`);
+    }
+    const json = await response.json();
+    if (json?.error) throw new Error(String(json.error));
+    return json?.tx || '';
+  }
+}
+
+export function createStoreChainClient(
+  deps: StoreChainClientDeps,
+): StoreChainClient {
+  return new StoreChainClient(deps);
+}

--- a/src/features/stores/services/storeServiceDeps.ts
+++ b/src/features/stores/services/storeServiceDeps.ts
@@ -2,6 +2,10 @@ import { assertNearChain, chainAdapter } from '@/services/chain';
 import { listStores as contractListStores } from '@/services/nearStoreContract';
 import { getSelector } from '@/services/walletSelector';
 import { nearConfig } from '@/services/config';
+import {
+  createStoreChainClient,
+  type StoreChainClient,
+} from './storeChainClient';
 
 export interface StoreServiceDeps {
   chain: {
@@ -18,16 +22,25 @@ export interface StoreServiceDeps {
     nearConfig: typeof nearConfig;
     loadAppConfig: () => Promise<typeof import('@/config').default>;
   };
+  storeChainClient: StoreChainClient;
 }
 
 export function createDefaultStoreServiceDeps(): StoreServiceDeps {
+  const config = {
+    nearConfig,
+    loadAppConfig: async () => (await import('@/config')).default,
+  } as const;
   return {
     chain: { assertNearChain, chainAdapter },
     contract: { listStores: contractListStores },
     walletSelector: { getSelector },
-    config: {
+    config,
+    storeChainClient: createStoreChainClient({
+      assertNearChain,
+      getSelector,
       nearConfig,
-      loadAppConfig: async () => (await import('@/config')).default,
-    },
+      chainAdapter,
+      loadAppConfig: config.loadAppConfig,
+    }),
   };
 }

--- a/tests/storeIsolation.test.ts
+++ b/tests/storeIsolation.test.ts
@@ -19,7 +19,20 @@ jest.mock('@/services/nearKvStore', () => {
   };
 });
 
-const storeServiceDeps = createDefaultStoreServiceDeps();
+const baseStoreServiceDeps = createDefaultStoreServiceDeps();
+const mockStoreChainClient = {
+  mintStore: jest.fn(),
+  submitMutation: jest.fn().mockResolvedValue(undefined),
+  createStoreOnChain: jest.fn(),
+};
+const storeServiceDeps = {
+  ...baseStoreServiceDeps,
+  storeChainClient: mockStoreChainClient,
+};
+
+beforeEach(() => {
+  mockStoreChainClient.submitMutation.mockClear();
+});
 
 describe('store data isolation', () => {
   it('separates products by storeId', async () => {
@@ -49,6 +62,9 @@ describe('store data isolation', () => {
     const s2: Store = { id: 'b', name: 'B', owner: '', nftId: '' };
     await setStore('s1', s1, storeServiceDeps);
     await setStore('s2', s2, storeServiceDeps);
+    expect(mockStoreChainClient.submitMutation).toHaveBeenCalledTimes(2);
+    expect(mockStoreChainClient.submitMutation).toHaveBeenCalledWith('add', { store: s1 });
+    expect(mockStoreChainClient.submitMutation).toHaveBeenCalledWith('add', { store: s2 });
     const l1 = await listStores('s1', storeServiceDeps);
     const l2 = await listStores('s2', storeServiceDeps);
     expect(l1.map(s => s.id)).toEqual(['a']);


### PR DESCRIPTION
## Summary
- add a StoreChainClient to wrap wallet selector calls, message signing, and relayer submissions
- update the store service dependencies and nearStores helpers to delegate to the client and return typed mint results
- adjust the store isolation test to inject a mocked chain client so cache logic can be verified without hitting the chain

## Testing
- `npx jest tests/storeIsolation.test.ts` *(fails: preset ts-jest/presets/default-esm missing in environment)*
- `npm run lint` *(fails: missing @typescript-eslint/parser in environment)*
- `npm run typecheck` *(fails: existing merge-conflict markers and missing expo tsconfig in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3b86c4dc83269f2492581c66f0f0