### PR TITLE
Refactor store listing to stream cache updates

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -123,7 +123,11 @@ class StoresAgent {
 
   async updateReputationByOwner(owner: string, reliability: number): Promise<void> {
     const services = await getStoreServices();
-    const stores = await services.listStores('default');
+    const stream = services.listStores('default');
+    let stores = stream.getSnapshot();
+    if (stores.length === 0) {
+      stores = await stream.read();
+    }
     const store = stores.find((s) => s.owner === owner);
     if (store) {
       const id = store.id;
@@ -186,7 +190,7 @@ class StoresAgent {
   async selectStore(id: string): Promise<Store | null> {
     const services = await getStoreServices();
     const store = await services.selectStore(id);
-    return store ? JSON.parse(JSON.stringify(store)) : null;
+    return store ? { ...store } : null;
   }
 
   /**
@@ -194,8 +198,12 @@ class StoresAgent {
    */
   async getStores(): Promise<Store[]> {
     const services = await getStoreServices();
-    const list = await services.listStores('default');
-    return list.map((s) => JSON.parse(JSON.stringify(s)));
+    const stream = services.listStores('default');
+    let list = stream.getSnapshot();
+    if (list.length === 0) {
+      list = await stream.read();
+    }
+    return list.map((s) => ({ ...s }));
   }
 
   private async broadcastCreated(store: Store): Promise<void> {

--- a/src/features/profile/components/ProfileOverview.tsx
+++ b/src/features/profile/components/ProfileOverview.tsx
@@ -51,7 +51,11 @@ export default function ProfileOverview() {
     try {
       const amt = await chainAdapter.getBalance(address);
       setBalance(amt);
-      const all = await listStores('default', storeServiceDeps);
+      const stream = listStores('default', storeServiceDeps);
+      let all = stream.getSnapshot();
+      if (all.length === 0) {
+        all = await stream.read();
+      }
       const owner = address?.toLowerCase() || '';
       setStores(all.filter((s) => (s.owner || '').toLowerCase() === owner));
       // NFTs: disabled by default to avoid web bundle issues. Enable behind a flag in the future.

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -21,12 +21,21 @@ import {
 } from './storeCache';
 
 
-const DISABLED = false;
-
 const defaultDeps = createDefaultStoreServiceDeps();
 
 function resolveDeps(deps?: StoreServiceDeps): StoreServiceDeps {
   return deps ?? defaultDeps;
+}
+
+type StoreListener = (stores: ReadonlyArray<Store>) => void;
+type StoreErrorListener = (error: unknown) => void;
+
+export interface StoreListStream {
+  read(): Promise<ReadonlyArray<Store>>;
+  getSnapshot(): ReadonlyArray<Store>;
+  subscribe(listener: StoreListener): () => void;
+  onError(listener: StoreErrorListener): () => void;
+  [Symbol.asyncIterator](): AsyncIterator<ReadonlyArray<Store>>;
 }
 
 export const storesWarmCache = {
@@ -75,6 +84,9 @@ async function persistStore(store: Store, sid: string) {
   const json = canonicalJson(store);
   await setValue(STORE_CACHE_ADDRESS, storeCacheKey(store.id, sid), json);
   await setValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(store.id), json);
+  try {
+    storeCacheRepository.mutate({ id: store.id, value: store });
+  } catch {}
 }
 
 export function selectStore(
@@ -114,39 +126,265 @@ export async function selectStore(
     return null;
   }
 }
-export async function listStores(
-  storeId: string,
-  deps?: StoreServiceDeps,
-): Promise<Store[]> {
-  const sid = requireStoreId(storeId);
-  try {
-    const values = storeCacheRepository.list();
-    if (sid === 'default') return values;
-    const filtered = values.filter((store) => requireStoreId(store.id) === sid);
-    if (filtered.length > 0) return filtered;
-  } catch {}
-  const items = await listValues(STORE_CACHE_ADDRESS);
-  const res: Store[] = [];
-  for (const i of items) {
-    if (!i.key.startsWith(`${STORE_CACHE_ADDRESS}:${sid}:`)) continue;
+const storeStreams = new WeakMap<StoreServiceDeps, Map<string, StoreListStream>>();
+const chainSyncTasks = new WeakMap<StoreServiceDeps, Promise<void>>();
+
+function scheduleChainSync(deps: StoreServiceDeps): void {
+  if (chainSyncTasks.has(deps)) return;
+  const task = (async () => {
     try {
-      res.push(JSON.parse(i.value) as Store);
-    } catch {}
-  }
-  if (res.length > 0 || DISABLED) return res;
-  try {
-    const resolved = resolveDeps(deps);
-    resolved.chain.assertNearChain();
-    const chainRes = await resolved.contract.listStores();
-    const mapped = chainRes.map(fromChain);
-    for (const s of mapped) {
-      await persistStore(s, requireStoreId(s.id));
+      try {
+        deps.chain.assertNearChain();
+      } catch {
+        return;
+      }
+      const chainRes = await deps.contract.listStores();
+      const mapped = chainRes.map(fromChain);
+      await Promise.all(
+        mapped.map(async (store) => {
+          try {
+            await persistStore(store, requireStoreId(store.id));
+          } catch (err) {
+            errorLog('Failed to persist store from chain sync', err);
+          }
+        }),
+      );
+    } catch (err) {
+      errorLog('Failed to sync stores from chain', err);
+    } finally {
+      chainSyncTasks.delete(deps);
     }
-    return mapped;
-  } catch {
-    return res;
+  })();
+  chainSyncTasks.set(deps, task);
+}
+
+function createStoreListStream(
+  storeId: string,
+  deps: StoreServiceDeps,
+): StoreListStream {
+  const sid = requireStoreId(storeId);
+  const listeners = new Set<StoreListener>();
+  const errorListeners = new Set<StoreErrorListener>();
+  const state = new Map<string, Store>();
+  let current: ReadonlyArray<Store> = [];
+  let hasValue = false;
+
+  function cloneStore(store: Store): Store {
+    return { ...store };
   }
-  return res;
+
+  function emitError(err: unknown) {
+    for (const listener of errorListeners) {
+      try {
+        listener(err);
+      } catch {}
+    }
+  }
+
+  function snapshot(): ReadonlyArray<Store> {
+    return Array.from(state.values());
+  }
+
+  function notify() {
+    const value = snapshot();
+    current = value;
+    hasValue = true;
+    for (const listener of listeners) {
+      try {
+        listener(value);
+      } catch (err) {
+        emitError(err);
+      }
+    }
+  }
+
+  function replaceState(list: Store[]) {
+    state.clear();
+    for (const item of list) {
+      if (!item || typeof item.id !== 'string' || item.id.length === 0) continue;
+      state.set(item.id, cloneStore(item));
+    }
+    notify();
+  }
+
+  const filter = (id: string, value: Store | undefined) => {
+    if (sid === 'default') return true;
+    if (value) return requireStoreId(value.id) === sid;
+    return state.has(id);
+  };
+
+  try {
+    storeCacheRepository.subscribe(filter, (id, value) => {
+      if (value) {
+        state.set(id, cloneStore(value));
+      } else if (!state.has(id)) {
+        return;
+      } else {
+        state.delete(id);
+      }
+      notify();
+    });
+  } catch (err) {
+    emitError(err);
+  }
+
+  (async () => {
+    try {
+      const cached = storeCacheRepository.list((id, value) => filter(id, value));
+      replaceState(cached);
+    } catch {
+      // ignore cache hydration errors
+    }
+    if (state.size === 0) {
+      try {
+        const items = await listValues(STORE_CACHE_ADDRESS);
+        const res: Store[] = [];
+        const specificPrefix = `${STORE_CACHE_ADDRESS}:${sid}:`;
+        for (const item of items) {
+          if (sid !== 'default' && !item.key.startsWith(specificPrefix)) continue;
+          if (sid === 'default' && !item.key.startsWith(`${STORE_CACHE_ADDRESS}:default:`)) continue;
+          try {
+            const parsed = JSON.parse(item.value) as Store;
+            if (sid !== 'default' && requireStoreId(parsed.id) !== sid) continue;
+            res.push(parsed);
+          } catch (err) {
+            errorLog('Invalid store data', err);
+          }
+        }
+        if (res.length > 0) {
+          replaceState(res);
+        }
+      } catch (err) {
+        errorLog('Failed to load stores from KV', err);
+      }
+    }
+    if (!hasValue) {
+      replaceState([]);
+    }
+  })().catch((err) => emitError(err));
+
+  scheduleChainSync(deps);
+
+  return {
+    async read() {
+      if (hasValue) return current;
+      return new Promise<ReadonlyArray<Store>>((resolve, reject) => {
+        let unsub: (() => void) | null = null;
+        let offError: (() => void) | null = null;
+        const handleValue = (value: ReadonlyArray<Store>) => {
+          if (unsub) unsub();
+          if (offError) offError();
+          resolve(value);
+        };
+        const handleError = (err: unknown) => {
+          if (unsub) unsub();
+          if (offError) offError();
+          reject(err);
+        };
+        unsub = this.subscribe(handleValue);
+        offError = this.onError(handleError);
+      });
+    },
+    getSnapshot() {
+      return current;
+    },
+    subscribe(listener: StoreListener) {
+      listeners.add(listener);
+      if (hasValue) {
+        try {
+          listener(current);
+        } catch (err) {
+          emitError(err);
+        }
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    onError(listener: StoreErrorListener) {
+      errorListeners.add(listener);
+      return () => {
+        errorListeners.delete(listener);
+      };
+    },
+    [Symbol.asyncIterator]() {
+      let done = false;
+      const queue: ReadonlyArray<Store>[] = [];
+      const pending: Array<{
+        resolve: (value: IteratorResult<ReadonlyArray<Store>>) => void;
+        reject: (reason?: unknown) => void;
+      }> = [];
+
+      const push = (value: ReadonlyArray<Store>) => {
+        if (pending.length > 0) {
+          const waiter = pending.shift();
+          waiter?.resolve({ value, done: false });
+          return;
+        }
+        queue.length = 0;
+        queue.push(value);
+      };
+
+      const fail = (err: unknown) => {
+        while (pending.length > 0) {
+          const waiter = pending.shift();
+          waiter?.reject(err);
+        }
+      };
+
+      const stop = () => {
+        if (done) return;
+        done = true;
+        valueUnsub();
+        errorUnsub();
+      };
+
+      const valueUnsub = this.subscribe((value) => {
+        push(value);
+      });
+      const errorUnsub = this.onError((err) => {
+        fail(err);
+      });
+
+      return {
+        next: () => {
+          if (done) return Promise.resolve({ value: undefined, done: true });
+          if (queue.length > 0) {
+            const value = queue.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          return new Promise<IteratorResult<ReadonlyArray<Store>>>((resolve, reject) => {
+            pending.push({ resolve, reject });
+          });
+        },
+        return: () => {
+          stop();
+          return Promise.resolve({ value: undefined, done: true });
+        },
+        throw: (err?: unknown) => {
+          stop();
+          return Promise.reject(err);
+        },
+      };
+    },
+  };
+}
+
+export function listStores(storeId: string, deps?: StoreServiceDeps): StoreListStream {
+  const resolved = resolveDeps(deps);
+  const sid = requireStoreId(storeId);
+  let perDeps = storeStreams.get(resolved);
+  if (!perDeps) {
+    perDeps = new Map();
+    storeStreams.set(resolved, perDeps);
+  }
+  let stream = perDeps.get(sid);
+  if (!stream) {
+    stream = createStoreListStream(sid, resolved);
+    perDeps.set(sid, stream);
+  }
+  scheduleChainSync(resolved);
+  return stream;
 }
 
 export async function addStore(
@@ -196,6 +434,9 @@ export async function removeStore(
   await resolved.storeChainClient.submitMutation('remove', { id });
   await removeValue(STORE_CACHE_ADDRESS, storeCacheKey(id, sid));
   await removeValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(id));
+  try {
+    storeCacheRepository.mutate({ id, op: 'delete' });
+  } catch {}
 }
 
 export const getStore = selectStore;
@@ -219,7 +460,7 @@ export function createStoreService(
 ): {
   mintStore: (name: string) => Promise<MintStoreResult>;
   selectStore: (arg1: string, arg2?: string) => Promise<Store | null>;
-  listStores: (storeId: string) => Promise<Store[]>;
+  listStores: (storeId: string) => StoreListStream;
   addStore: (store: Store, sid?: string) => Promise<void>;
   updateStore: (store: Store, sid?: string) => Promise<void>;
   removeStore: (arg1: string, arg2?: string) => Promise<void>;

--- a/src/services/useStores.ts
+++ b/src/services/useStores.ts
@@ -1,8 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
 import chain from '@/services/chain';
-import { Store } from '@/types';
+import type { Store } from '@/types';
+import type { StoreListStream } from '@/features/stores/services/nearStores';
 
-let listStores: ((storeId: string) => Promise<Store[]>) | undefined;
+let listStores: ((storeId: string) => StoreListStream) | undefined;
 let setStore: ((storeId: string, store: Store) => Promise<void>) | undefined;
 let removeStore: ((storeId: string, id: string) => Promise<void>) | undefined;
 if (chain === 'near') {
@@ -22,37 +23,88 @@ if (chain === 'near') {
 }
 
 export function useStores(storeId: string) {
-  return useQuery({
-    queryKey: ['stores', storeId],
-    queryFn: () => (listStores ? listStores(storeId) : Promise.resolve([])),
-    select: (data) => data ?? [],
-    staleTime: 5 * 60 * 1000,
-    gcTime: 30 * 60 * 1000,
-  });
+  const [data, setData] = useState<Store[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    if (!listStores) {
+      setData([]);
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const stream = listStores(storeId);
+    setError(null);
+    const snapshot = stream.getSnapshot();
+    if (snapshot.length > 0) {
+      setData([...snapshot]);
+      setIsLoading(false);
+    } else {
+      setData([]);
+      setIsLoading(true);
+    }
+    stream
+      .read()
+      .then((value) => {
+        if (cancelled) return;
+        setData([...value]);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err);
+        setIsLoading(false);
+      });
+    const unsubscribe = stream.subscribe((value) => {
+      if (cancelled) return;
+      setData([...value]);
+    });
+    const offError = stream.onError((err) => {
+      if (cancelled) return;
+      setError(err);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      offError();
+    };
+  }, [storeId]);
+
+  return { data, isLoading, error };
 }
 
 export function useStoreMutations(storeId: string) {
-  const queryClient = useQueryClient();
+  const [pending, setPending] = useState(0);
 
-  const upsert = useMutation({
-    mutationFn: (store: Store) =>
-      setStore ? setStore(storeId, store) : Promise.resolve(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['stores', storeId] });
-    },
-  });
+  const run = useCallback(async <T>(action: () => Promise<T>): Promise<T> => {
+    setPending((count) => count + 1);
+    try {
+      return await action();
+    } finally {
+      setPending((count) => Math.max(0, count - 1));
+    }
+  }, []);
 
-  const remove = useMutation({
-    mutationFn: (id: string) =>
-      removeStore ? removeStore(storeId, id) : Promise.resolve(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['stores', storeId] });
+  const upsert = useCallback(
+    (store: Store) => {
+      if (!setStore) return Promise.resolve();
+      return run(() => setStore(storeId, store));
     },
-  });
+    [run, storeId],
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      if (!removeStore) return Promise.resolve();
+      return run(() => removeStore(storeId, id));
+    },
+    [run, storeId],
+  );
 
   return {
-    setStore: upsert.mutateAsync,
-    removeStore: remove.mutateAsync,
-    isPending: upsert.isPending || remove.isPending,
+    setStore: upsert,
+    removeStore: remove,
+    isPending: pending > 0,
   };
 }

--- a/tests/auth/checkoutSessionToken.test.ts
+++ b/tests/auth/checkoutSessionToken.test.ts
@@ -106,6 +106,20 @@ jest.mock('@/features/auth/services/nearAuth', () => ({
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
@@ -116,7 +130,7 @@ jest.mock('@/features/stores/services/nearStores', () => {
   const service = {
     mintStore: jest.fn(),
     selectStore,
-    listStores: jest.fn(),
+    listStores: jest.fn(() => createStream()),
     addStore: jest.fn(),
     updateStore: jest.fn(),
     removeStore: jest.fn(),

--- a/tests/cardCheckoutFee.test.ts
+++ b/tests/cardCheckoutFee.test.ts
@@ -82,6 +82,20 @@ jest.mock('@/agents/users-agent', () => ({
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
@@ -93,7 +107,7 @@ jest.mock('@/features/stores/services/nearStores', () => {
   const service = {
     mintStore: jest.fn(),
     selectStore,
-    listStores: jest.fn(),
+    listStores: jest.fn(() => createStream()),
     addStore: jest.fn(),
     updateStore: jest.fn(),
     removeStore: jest.fn(),

--- a/tests/multiSellerCheckout.test.ts
+++ b/tests/multiSellerCheckout.test.ts
@@ -100,6 +100,20 @@ jest.mock('@/agents/users-agent', () => ({
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const selectStore = jest.fn(async (id: string) => ({
     id,
     name: id,
@@ -111,7 +125,7 @@ jest.mock('@/features/stores/services/nearStores', () => {
   const service = {
     mintStore: jest.fn(),
     selectStore,
-    listStores: jest.fn(),
+    listStores: jest.fn(() => createStream()),
     addStore: jest.fn(),
     updateStore: jest.fn(),
     removeStore: jest.fn(),

--- a/tests/orderServiceKyc.test.ts
+++ b/tests/orderServiceKyc.test.ts
@@ -31,12 +31,26 @@ jest.mock('@/services/kycReceipts', () => ({
 
 const mockGetStore = jest.fn();
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const selectStore = jest.fn((...args: any[]) => mockGetStore(...args));
   const setStore = jest.fn();
   const service = {
     mintStore: jest.fn(),
     selectStore,
-    listStores: jest.fn(),
+    listStores: jest.fn(() => createStream()),
     addStore: jest.fn(),
     updateStore: jest.fn(),
     removeStore: jest.fn(),

--- a/tests/storeCreation.snapshot.test.tsx
+++ b/tests/storeCreation.snapshot.test.tsx
@@ -38,13 +38,27 @@ jest.mock('@/components/NotificationContext', () => ({
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const createStoreOnChain = jest.fn();
   const selectStore = jest.fn();
   const setStore = jest.fn();
   const service = {
     mintStore: jest.fn(),
     selectStore,
-    listStores: jest.fn(),
+    listStores: jest.fn(() => createStream()),
     addStore: jest.fn(),
     updateStore: jest.fn(),
     removeStore: jest.fn(),

--- a/tests/storeDashboard.test.tsx
+++ b/tests/storeDashboard.test.tsx
@@ -32,8 +32,22 @@ jest.mock('@/ui/ThemeProvider', () => ({
 }));
 
 jest.mock('@/features/stores/services/nearStores', () => {
+  const createStream = (stores: any[] = []) => {
+    const stream: any = {
+      read: jest.fn().mockResolvedValue(stores),
+      getSnapshot: jest.fn(() => stores),
+      subscribe: jest.fn(() => jest.fn()),
+      onError: jest.fn(() => jest.fn()),
+    };
+    stream[Symbol.asyncIterator] = jest.fn(() => ({
+      next: jest.fn().mockResolvedValue({ value: stores, done: false }),
+      return: jest.fn().mockResolvedValue({ value: undefined, done: true }),
+      throw: jest.fn(),
+    }));
+    return stream;
+  };
   const selectStore = jest.fn();
-  const listStores = jest.fn();
+  const listStores = jest.fn(() => createStream());
   const setStore = jest.fn();
   const service = {
     mintStore: jest.fn(),

--- a/tests/storeIsolation.test.ts
+++ b/tests/storeIsolation.test.ts
@@ -65,8 +65,8 @@ describe('store data isolation', () => {
     expect(mockStoreChainClient.submitMutation).toHaveBeenCalledTimes(2);
     expect(mockStoreChainClient.submitMutation).toHaveBeenCalledWith('add', { store: s1 });
     expect(mockStoreChainClient.submitMutation).toHaveBeenCalledWith('add', { store: s2 });
-    const l1 = await listStores('s1', storeServiceDeps);
-    const l2 = await listStores('s2', storeServiceDeps);
+    const l1 = await listStores('s1', storeServiceDeps).read();
+    const l2 = await listStores('s2', storeServiceDeps).read();
     expect(l1.map(s => s.id)).toEqual(['a']);
     expect(l2.map(s => s.id)).toEqual(['b']);
   });


### PR DESCRIPTION
## Summary
- replace the NEAR store service listStores implementation with a shared StoreListStream that streams cache, KV, and chain sync updates via the warm cache repository
- update the stores agent, profile overview, and React hook utilities to consume the new stream API and avoid manual JSON cloning or react-query invalidation
- adjust Jest store mocks and tests to work with the new streaming contract

## Testing
- npm run lint *(fails: requires @typescript-eslint/parser which is unavailable in the environment)*
- npm run typecheck *(fails: existing TypeScript issues – warmCache merge markers and missing expo/tsconfig.base.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e9b02d08326bc67524c9d041ec6