### PR TITLE
Refactor stores agent to use shared store repository

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -2,25 +2,10 @@ import type { WakuMessage } from '@/types/waku';
 import type { Store } from '@/types';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { buildTopic } from '@/utils/wakuTopics';
+import storeRepository from '@/services/storeRepository';
 
-const getTransportCrypto = () => (typeof globalThis !== 'undefined' && globalThis.crypto ? globalThis.crypto : undefined);
-
-type NearStoresModule = typeof import('@/features/stores/services/nearStores');
-type StoreService = ReturnType<NearStoresModule['createStoreService']>;
-
-let nearStoresModule: NearStoresModule | null = null;
-let nearStoreService: StoreService | null = null;
-
-async function getStoreServices(): Promise<StoreService> {
-  if (!nearStoresModule) {
-    nearStoresModule = await import('@/features/stores/services/nearStores');
-  }
-  if (!nearStoreService) {
-    const deps = nearStoresModule.createDefaultStoreServiceDeps();
-    nearStoreService = nearStoresModule.createStoreService(deps);
-  }
-  return nearStoreService;
-}
+const getTransportCrypto = () =>
+  typeof globalThis !== 'undefined' && globalThis.crypto ? globalThis.crypto : undefined;
 
 type EnsureNearWalletFn = typeof import('@/utils/ensureNearWallet').default;
 let ensureNearWalletFn: EnsureNearWalletFn | null = null;
@@ -58,36 +43,30 @@ interface Metrics {
   score: number;
 }
 
+type StoreRemovalPayload = { id: string; store: Store | null };
+
+type StoreChangeType = 'store.created' | 'store.updated';
+
 class StoresAgent {
   private reputation: Record<string, Metrics> = {};
   private subscribers: Set<(id: string, score: number) => void> = new Set();
 
+  constructor() {
+    storeRepository.on('store.created', ({ store }) => {
+      void this.broadcastStoreChange('store.created', store);
+    });
+    storeRepository.on('store.updated', ({ store }) => {
+      void this.broadcastStoreChange('store.updated', store);
+    });
+    storeRepository.on('store.removed', ({ id, store }) => {
+      delete this.reputation[id];
+      void this.broadcastStoreRemoval({ id, store });
+    });
+  }
+
   private async ensureWallet(): Promise<{ address: string; publicKey: string }> {
     const ensureWallet = await loadEnsureNearWallet();
     return ensureWallet('Please connect your NEAR wallet to manage stores.');
-  }
-
-  private getNamespace(store: Store): string {
-    const owner = typeof store.owner === 'string' ? store.owner.trim() : '';
-    return owner || 'default';
-  }
-
-  private async persistStore(store: Store): Promise<Store> {
-    const services = await getStoreServices();
-    const record = this.toRecord(store);
-    const namespace = this.getNamespace(record);
-    const existing = await services.selectStore(namespace, record.id);
-    if (existing) {
-      await services.updateStore(record, namespace);
-    } else {
-      await services.addStore(record, namespace);
-    }
-    return record;
-  }
-
-  private toRecord(item: Store) {
-    const { id, name, owner, nftId, reputation = 0, plan, createdAt } = item;
-    return { id, name, owner, nftId, reputation, plan, createdAt } as Store;
   }
 
   private calculateScore(id: string): number {
@@ -104,16 +83,13 @@ class StoresAgent {
     m.reviewSum += rating;
     m.reviewCount += 1;
     const newScore = this.calculateScore(storeId);
-    const services = await getStoreServices();
-    const store = await services.selectStore(storeId);
+    const store = await storeRepository.select(storeId);
     if (store) {
       try {
-        await this.persistStore({ ...store, reputation: newScore });
-        const confirmed = await services.selectStore(storeId);
-        if (confirmed) {
-          m.score = confirmed.reputation || newScore;
-          this.subscribers.forEach((cb) => cb(storeId, m.score));
-        }
+        const result = await storeRepository.save({ ...store, reputation: newScore });
+        const confirmed = result.store.reputation ?? newScore;
+        m.score = confirmed;
+        this.subscribers.forEach((cb) => cb(storeId, confirmed));
       } catch {
         m.reviewSum -= rating;
         m.reviewCount -= 1;
@@ -122,13 +98,7 @@ class StoresAgent {
   }
 
   async updateReputationByOwner(owner: string, reliability: number): Promise<void> {
-    const services = await getStoreServices();
-    const stream = services.listStores('default');
-    let stores = stream.getSnapshot();
-    if (stores.length === 0) {
-      stores = await stream.read();
-    }
-    const store = stores.find((s) => s.owner === owner);
+    const store = await storeRepository.findByOwner(owner);
     if (store) {
       const id = store.id;
       if (!this.reputation[id]) {
@@ -138,12 +108,10 @@ class StoresAgent {
       this.reputation[id].reliability = reliability;
       const newScore = this.calculateScore(id);
       try {
-        await this.persistStore({ ...store, reputation: newScore });
-        const confirmed = await services.selectStore(id);
-        if (confirmed) {
-          this.reputation[id].score = confirmed.reputation || newScore;
-          this.subscribers.forEach((cb) => cb(id, this.reputation[id].score));
-        }
+        const result = await storeRepository.save({ ...store, reputation: newScore });
+        const confirmed = result.store.reputation ?? newScore;
+        this.reputation[id].score = confirmed;
+        this.subscribers.forEach((cb) => cb(id, confirmed));
       } catch {
         this.reputation[id].reliability = prev;
       }
@@ -165,58 +133,72 @@ class StoresAgent {
   async add(item: Store): Promise<void> {
     await this.ensureWallet();
     const normalized = normalizeMessage<Store>('Store', item);
-    const record = await this.persistStore({
+    await storeRepository.save({
       createdAt: normalized.createdAt || new Date().toISOString(),
       ...normalized,
     });
-    await this.broadcastCreated(record);
   }
 
   async update(item: Store): Promise<void> {
     await this.ensureWallet();
     const normalized = normalizeMessage<Store>('Store', item);
-    await this.persistStore(normalized);
+    await storeRepository.save(normalized);
   }
 
   async remove(id: string): Promise<void> {
     await this.ensureWallet();
-    const services = await getStoreServices();
-    await services.removeStore(id);
+    await storeRepository.remove(id);
   }
 
   /**
    * Returns a defensive copy of a store by id.
    */
   async selectStore(id: string): Promise<Store | null> {
-    const services = await getStoreServices();
-    const store = await services.selectStore(id);
-    return store ? { ...store } : null;
+    return storeRepository.select(id);
   }
 
   /**
    * Returns defensive copies of all stores.
    */
   async getStores(): Promise<Store[]> {
-    const services = await getStoreServices();
-    const stream = services.listStores('default');
-    let list = stream.getSnapshot();
-    if (list.length === 0) {
-      list = await stream.read();
-    }
-    return list.map((s) => ({ ...s }));
+    return storeRepository.list('default');
   }
 
-  private async broadcastCreated(store: Store): Promise<void> {
+  private async broadcastStoreChange(type: StoreChangeType, store: Store): Promise<void> {
     try {
       const { publish, makeSignedWakuMessage } = await loadWakuDeps();
       const transportCrypto = getTransportCrypto();
-      const nonce = transportCrypto && typeof transportCrypto.randomUUID === 'function'
-        ? transportCrypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const msg: WakuMessage<Store> = await makeSignedWakuMessage('store.created', store, 'store-owner', {
+      const nonce =
+        transportCrypto && typeof transportCrypto.randomUUID === 'function'
+          ? transportCrypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const msg: WakuMessage<Store> = await makeSignedWakuMessage(type, store, 'store-owner', {
         ts: Date.now(),
         nonce,
       });
+      await publish(buildTopic('stores', '1'), msg);
+    } catch {
+      // non-fatal
+    }
+  }
+
+  private async broadcastStoreRemoval(payload: StoreRemovalPayload): Promise<void> {
+    try {
+      const { publish, makeSignedWakuMessage } = await loadWakuDeps();
+      const transportCrypto = getTransportCrypto();
+      const nonce =
+        transportCrypto && typeof transportCrypto.randomUUID === 'function'
+          ? transportCrypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const msg: WakuMessage<StoreRemovalPayload> = await makeSignedWakuMessage(
+        'store.removed',
+        payload,
+        'store-owner',
+        {
+          ts: Date.now(),
+          nonce,
+        },
+      );
       await publish(buildTopic('stores', '1'), msg);
     } catch {
       // non-fatal
@@ -227,7 +209,6 @@ class StoresAgent {
 const storesAgent = new StoresAgent();
 
 export const getStores = (): Promise<Store[]> => storesAgent.getStores();
-export const selectStore = (id: string): Promise<Store | null> =>
-  storesAgent.selectStore(id);
+export const selectStore = (id: string): Promise<Store | null> => storesAgent.selectStore(id);
 
 export default storesAgent;

--- a/services/storeRepository.ts
+++ b/services/storeRepository.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from 'events';
+import type { Store } from '@/types';
+
+import type { StoreListStream } from '@/features/stores/services/nearStores';
+
+type NearStoresModule = typeof import('@/features/stores/services/nearStores');
+type StoreService = ReturnType<NearStoresModule['createStoreService']>;
+
+let nearStoresModule: NearStoresModule | null = null;
+let storeService: StoreService | null = null;
+
+async function getStoreService(): Promise<StoreService> {
+  if (!nearStoresModule) {
+    nearStoresModule = await import('@/features/stores/services/nearStores');
+  }
+  if (!storeService) {
+    const deps = nearStoresModule.createDefaultStoreServiceDeps();
+    storeService = nearStoresModule.createStoreService(deps);
+  }
+  return storeService;
+}
+
+export type StoreRepositoryEventMap = {
+  'store.created': { store: Store; namespace: string; previous: Store | null };
+  'store.updated': { store: Store; namespace: string; previous: Store | null };
+  'store.removed': { id: string; namespace: string; store: Store | null };
+};
+
+type StoreRepositoryEvent = keyof StoreRepositoryEventMap;
+
+type StoreRepositoryListener<T extends StoreRepositoryEvent> = (
+  payload: StoreRepositoryEventMap[T],
+) => void;
+
+function cloneStore(store: Store): Store {
+  return { ...store };
+}
+
+export interface SaveStoreResult {
+  store: Store;
+  namespace: string;
+  previous: Store | null;
+  created: boolean;
+}
+
+export class StoreRepository {
+  private emitter = new EventEmitter();
+
+  constructor() {
+    this.emitter.setMaxListeners(this.emitter.getMaxListeners() + 10);
+  }
+
+  private toRecord(store: Store): Store {
+    const { id, name, owner, nftId, reputation = 0, plan, createdAt } = store;
+    return {
+      id,
+      name,
+      owner,
+      nftId,
+      reputation,
+      plan,
+      createdAt,
+    } as Store;
+  }
+
+  private getNamespace(store: Store): string {
+    const owner = typeof store.owner === 'string' ? store.owner.trim() : '';
+    return owner || 'default';
+  }
+
+  private emit<T extends StoreRepositoryEvent>(
+    event: T,
+    payload: StoreRepositoryEventMap[T],
+  ): void {
+    this.emitter.emit(event, payload);
+  }
+
+  on<T extends StoreRepositoryEvent>(
+    event: T,
+    listener: StoreRepositoryListener<T>,
+  ): () => void {
+    this.emitter.on(event, listener as (...args: unknown[]) => void);
+    return () => {
+      this.emitter.off(event, listener as (...args: unknown[]) => void);
+    };
+  }
+
+  once<T extends StoreRepositoryEvent>(
+    event: T,
+    listener: StoreRepositoryListener<T>,
+  ): () => void {
+    this.emitter.once(event, listener as (...args: unknown[]) => void);
+    return () => {
+      this.emitter.off(event, listener as (...args: unknown[]) => void);
+    };
+  }
+
+  async save(store: Store): Promise<SaveStoreResult> {
+    const service = await getStoreService();
+    const record = this.toRecord(store);
+    const namespace = this.getNamespace(record);
+    let previous: Store | null = null;
+    try {
+      previous = await service.selectStore(namespace, record.id);
+    } catch {}
+
+    if (previous) {
+      const previousRecord = cloneStore(previous);
+      await service.updateStore(record, namespace);
+      this.emit('store.updated', { store: record, namespace, previous: previousRecord });
+      return { store: record, namespace, previous: previousRecord, created: false };
+    }
+
+    await service.addStore(record, namespace);
+    this.emit('store.created', { store: record, namespace, previous: null });
+    return { store: record, namespace, previous: null, created: true };
+  }
+
+  async remove(id: string): Promise<{ id: string; namespace: string; store: Store | null } | null> {
+    const service = await getStoreService();
+    let existing: Store | null = null;
+    try {
+      existing = await service.selectStore(id);
+    } catch {}
+    if (!existing) return null;
+    const namespace = this.getNamespace(existing);
+    const snapshot = cloneStore(existing);
+    await service.removeStore(namespace, id);
+    this.emit('store.removed', { id, namespace, store: snapshot });
+    return { id, namespace, store: snapshot };
+  }
+
+  async select(id: string): Promise<Store | null> {
+    const service = await getStoreService();
+    const store = await service.selectStore(id);
+    return store ? cloneStore(store) : null;
+  }
+
+  async selectInNamespace(namespace: string, id: string): Promise<Store | null> {
+    const service = await getStoreService();
+    const store = await service.selectStore(namespace, id);
+    return store ? cloneStore(store) : null;
+  }
+
+  private async resolveList(namespace: string): Promise<StoreListStream> {
+    const service = await getStoreService();
+    return service.listStores(namespace);
+  }
+
+  async list(namespace = 'default'): Promise<Store[]> {
+    const stream = await this.resolveList(namespace);
+    let list = stream.getSnapshot();
+    if (list.length === 0) {
+      list = await stream.read();
+    }
+    return list.map(cloneStore);
+  }
+
+  async findByOwner(owner: string): Promise<Store | null> {
+    const stores = await this.list('default');
+    const store = stores.find((s) => s.owner === owner);
+    return store ? cloneStore(store) : null;
+  }
+}
+
+export const storeRepository = new StoreRepository();
+
+export const saveStore = (store: Store) => storeRepository.save(store);
+export const removeStore = (id: string) => storeRepository.remove(id);
+export const selectStore = (id: string) => storeRepository.select(id);
+export const listStores = (namespace?: string) => storeRepository.list(namespace);
+export const findStoreByOwner = (owner: string) => storeRepository.findByOwner(owner);
+
+export default storeRepository;


### PR DESCRIPTION
## Summary
- add a centralized `StoreRepository` that exposes save/remove/select/list helpers and emits change events for store lifecycle updates
- refactor the stores agent to use the repository operations, react to change events, and publish the appropriate Waku messages without extra lookups

## Testing
- yarn typecheck *(fails: `services/warmCache.ts` contains merge conflict markers and `tsconfig.json` extends missing `expo/tsconfig.base.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68cf445d0ab483268136ef5de6dadcfb