### PR TITLE
Refactor stores agent to use shared reputation service

### DIFF
--- a/agents/reputation-service.ts
+++ b/agents/reputation-service.ts
@@ -1,0 +1,125 @@
+import { Store } from '@/types';
+
+export interface ReputationMetrics {
+  reviewSum: number;
+  reviewCount: number;
+  reliability: number;
+  score: number;
+}
+
+export type ScoreUpdateListener = (
+  id: string,
+  score: number,
+  metrics?: ReputationMetrics,
+) => void;
+
+export class ReputationService {
+  private metrics: Map<string, ReputationMetrics> = new Map();
+
+  private subscribers: Set<ScoreUpdateListener> = new Set();
+
+  private ensureMetrics(id: string): ReputationMetrics {
+    let entry = this.metrics.get(id);
+    if (!entry) {
+      entry = { reviewSum: 0, reviewCount: 0, reliability: 0, score: 0 };
+      this.metrics.set(id, entry);
+    }
+    return entry;
+  }
+
+  private calculateScore(entry: ReputationMetrics): number {
+    const avg = entry.reviewCount > 0 ? entry.reviewSum / entry.reviewCount : 0;
+    return (avg + entry.reliability * 5) / 2;
+  }
+
+  private notify(id: string, metrics: ReputationMetrics): void {
+    const snapshot: ReputationMetrics = { ...metrics };
+    this.subscribers.forEach((cb) => cb(id, snapshot.score, snapshot));
+  }
+
+  recordReview(id: string, rating: number): { score: number; metrics: ReputationMetrics } {
+    const entry = this.ensureMetrics(id);
+    entry.reviewSum += rating;
+    entry.reviewCount += 1;
+    const score = this.calculateScore(entry);
+    entry.score = score;
+    return { score, metrics: { ...entry } };
+  }
+
+  rollbackReview(id: string, rating: number): { score: number; metrics: ReputationMetrics } {
+    const entry = this.ensureMetrics(id);
+    entry.reviewSum -= rating;
+    entry.reviewCount = Math.max(0, entry.reviewCount - 1);
+    if (entry.reviewCount === 0) {
+      entry.reviewSum = 0;
+    }
+    entry.score = this.calculateScore(entry);
+    return { score: entry.score, metrics: { ...entry } };
+  }
+
+  setReliability(
+    id: string,
+    reliability: number,
+  ): {
+    score: number;
+    previousReliability: number;
+    previousScore: number;
+    metrics: ReputationMetrics;
+  } {
+    const entry = this.ensureMetrics(id);
+    const previousReliability = entry.reliability;
+    const previousScore = entry.score;
+    entry.reliability = reliability;
+    entry.score = this.calculateScore(entry);
+    return {
+      score: entry.score,
+      previousReliability,
+      previousScore,
+      metrics: { ...entry },
+    };
+  }
+
+  restoreReliability(
+    id: string,
+    previous: number,
+    previousScore?: number,
+  ): { score: number; metrics: ReputationMetrics } {
+    const entry = this.ensureMetrics(id);
+    entry.reliability = previous;
+    entry.score = typeof previousScore === 'number' ? previousScore : this.calculateScore(entry);
+    return { score: entry.score, metrics: { ...entry } };
+  }
+
+  confirmScore(id: string, score: number): void {
+    const entry = this.ensureMetrics(id);
+    entry.score = score;
+    this.notify(id, entry);
+  }
+
+  clear(id: string): void {
+    this.metrics.delete(id);
+  }
+
+  getScore(id: string): number {
+    return this.metrics.get(id)?.score ?? 0;
+  }
+
+  subscribe(cb: ScoreUpdateListener): () => void {
+    this.subscribers.add(cb);
+    return () => this.unsubscribe(cb);
+  }
+
+  unsubscribe(cb: ScoreUpdateListener): void {
+    this.subscribers.delete(cb);
+  }
+
+  hydrate(id: string, store: Pick<Store, 'reputation'> | null | undefined): void {
+    if (!store || typeof store.reputation !== 'number') return;
+    const entry = this.ensureMetrics(id);
+    entry.score = store.reputation;
+  }
+}
+
+const reputationService = new ReputationService();
+
+export default reputationService;

--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -3,6 +3,7 @@ import type { Store } from '@/types';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { buildTopic } from '@/utils/wakuTopics';
 import storeRepository from '@/services/storeRepository';
+import reputationService, { type ScoreUpdateListener } from './reputation-service';
 
 const getTransportCrypto = () =>
   typeof globalThis !== 'undefined' && globalThis.crypto ? globalThis.crypto : undefined;
@@ -36,30 +37,22 @@ async function loadWakuDeps(): Promise<{ publish: PublishFn; makeSignedWakuMessa
 
 // TODO:TODO-111 Extend StoresAgent to track multi-tenant metrics and avoid namespace collisions for shared storefronts.
 // TODO:REC-211 Publish reputation score updates via analytics topic so UI dashboards can react in real time.
-interface Metrics {
-  reviewSum: number;
-  reviewCount: number;
-  reliability: number;
-  score: number;
-}
-
 type StoreRemovalPayload = { id: string; store: Store | null };
 
 type StoreChangeType = 'store.created' | 'store.updated';
 
 class StoresAgent {
-  private reputation: Record<string, Metrics> = {};
-  private subscribers: Set<(id: string, score: number) => void> = new Set();
-
   constructor() {
     storeRepository.on('store.created', ({ store }) => {
+      reputationService.hydrate(store.id, store);
       void this.broadcastStoreChange('store.created', store);
     });
     storeRepository.on('store.updated', ({ store }) => {
+      reputationService.hydrate(store.id, store);
       void this.broadcastStoreChange('store.updated', store);
     });
     storeRepository.on('store.removed', ({ id, store }) => {
-      delete this.reputation[id];
+      reputationService.clear(id);
       void this.broadcastStoreRemoval({ id, store });
     });
   }
@@ -69,31 +62,19 @@ class StoresAgent {
     return ensureWallet('Please connect your NEAR wallet to manage stores.');
   }
 
-  private calculateScore(id: string): number {
-    const m = this.reputation[id];
-    const avg = m.reviewCount > 0 ? m.reviewSum / m.reviewCount : 0;
-    return (avg + m.reliability * 5) / 2;
-  }
-
   async recordReview(storeId: string, rating: number) {
-    if (!this.reputation[storeId]) {
-      this.reputation[storeId] = { reviewSum: 0, reviewCount: 0, reliability: 0, score: 0 };
-    }
-    const m = this.reputation[storeId];
-    m.reviewSum += rating;
-    m.reviewCount += 1;
-    const newScore = this.calculateScore(storeId);
+    const { score: newScore } = reputationService.recordReview(storeId, rating);
     const store = await storeRepository.select(storeId);
     if (store) {
       try {
         const result = await storeRepository.save({ ...store, reputation: newScore });
         const confirmed = result.store.reputation ?? newScore;
-        m.score = confirmed;
-        this.subscribers.forEach((cb) => cb(storeId, confirmed));
+        reputationService.confirmScore(storeId, confirmed);
       } catch {
-        m.reviewSum -= rating;
-        m.reviewCount -= 1;
+        reputationService.rollbackReview(storeId, rating);
       }
+    } else {
+      reputationService.rollbackReview(storeId, rating);
     }
   }
 
@@ -101,33 +82,30 @@ class StoresAgent {
     const store = await storeRepository.findByOwner(owner);
     if (store) {
       const id = store.id;
-      if (!this.reputation[id]) {
-        this.reputation[id] = { reviewSum: 0, reviewCount: 0, reliability: 0, score: 0 };
-      }
-      const prev = this.reputation[id].reliability;
-      this.reputation[id].reliability = reliability;
-      const newScore = this.calculateScore(id);
+      const { score: newScore, previousReliability, previousScore } = reputationService.setReliability(
+        id,
+        reliability,
+      );
       try {
         const result = await storeRepository.save({ ...store, reputation: newScore });
         const confirmed = result.store.reputation ?? newScore;
-        this.reputation[id].score = confirmed;
-        this.subscribers.forEach((cb) => cb(id, confirmed));
+        reputationService.confirmScore(id, confirmed);
       } catch {
-        this.reputation[id].reliability = prev;
+        reputationService.restoreReliability(id, previousReliability, previousScore);
       }
     }
   }
 
   getReputationScore(id: string): number {
-    return this.reputation[id]?.score || 0;
+    return reputationService.getScore(id);
   }
 
-  subscribe(cb: (id: string, score: number) => void) {
-    this.subscribers.add(cb);
+  subscribe(cb: ScoreUpdateListener): () => void {
+    return reputationService.subscribe(cb);
   }
 
-  unsubscribe(cb: (id: string, score: number) => void) {
-    this.subscribers.delete(cb);
+  unsubscribe(cb: ScoreUpdateListener) {
+    reputationService.unsubscribe(cb);
   }
 
   async add(item: Store): Promise<void> {

--- a/jest.config.js
+++ b/jest.config.js
@@ -158,6 +158,8 @@ const cfg = {
     '<rootDir>/tests/homeServices.test.tsx',
     '<rootDir>/tests/homeSearch.test.tsx',
     '<rootDir>/tests/featuredStoresCarousel.test.tsx',
+    '<rootDir>/tests/reputationService.test.ts',
+    '<rootDir>/tests/storesAgentReputation.test.ts',
     '<rootDir>/tests/navigationLoop.test.tsx',
     '<rootDir>/tests/productCardAccessibility.test.tsx',
     '<rootDir>/tests/productGalleryAccessibility.test.tsx',

--- a/tests/reputationService.test.ts
+++ b/tests/reputationService.test.ts
@@ -1,0 +1,34 @@
+import { ReputationService } from '../agents/reputation-service';
+
+const STORE_ID = 'store-1';
+
+describe('ReputationService', () => {
+  it('calculates blended scores from reviews and reliability', () => {
+    const service = new ReputationService();
+
+    const first = service.recordReview(STORE_ID, 4);
+    expect(first.score).toBeCloseTo(2); // average 4, reliability 0 => score 2
+
+    const second = service.recordReview(STORE_ID, 2);
+    // avg = 3, reliability 0 => score 1.5
+    expect(second.score).toBeCloseTo(1.5);
+
+    const reliabilityUpdate = service.setReliability(STORE_ID, 0.8);
+    // avg = 3, reliability = 0.8 -> score = (3 + 4) / 2 = 3.5
+    expect(reliabilityUpdate.score).toBeCloseTo(3.5);
+
+    service.confirmScore(STORE_ID, reliabilityUpdate.score);
+    expect(service.getScore(STORE_ID)).toBeCloseTo(3.5);
+  });
+
+  it('rolls back review updates when requested', () => {
+    const service = new ReputationService();
+    service.recordReview(STORE_ID, 5);
+    service.recordReview(STORE_ID, 1);
+
+    const rollback = service.rollbackReview(STORE_ID, 1);
+    expect(rollback.metrics.reviewCount).toBe(1);
+    expect(rollback.metrics.reviewSum).toBe(5);
+    expect(rollback.score).toBeCloseTo(2.5);
+  });
+});

--- a/tests/storesAgentReputation.test.ts
+++ b/tests/storesAgentReputation.test.ts
@@ -1,0 +1,134 @@
+const listeners: Record<string, Array<(payload: any) => void>> = {};
+
+type StoreRepositoryMock = {
+  on: jest.Mock<() => void, [string, (payload: any) => void]>;
+  select: jest.Mock;
+  save: jest.Mock;
+  findByOwner: jest.Mock;
+  list: jest.Mock;
+  remove: jest.Mock;
+  emit: (event: string, payload: any) => void;
+};
+
+function createStoreRepositoryMock(): StoreRepositoryMock {
+  return {
+    on: jest.fn((event: string, cb: (payload: any) => void) => {
+      listeners[event] = listeners[event] || [];
+      listeners[event]!.push(cb);
+      return () => {
+        listeners[event] = (listeners[event] || []).filter((fn) => fn !== cb);
+      };
+    }),
+    select: jest.fn(),
+    save: jest.fn(),
+    findByOwner: jest.fn(),
+    list: jest.fn(),
+    remove: jest.fn(),
+    emit: (event: string, payload: any) => {
+      (listeners[event] || []).forEach((cb) => cb(payload));
+    },
+  };
+}
+
+let storeRepositoryMock: StoreRepositoryMock;
+
+const loadStoresAgent = () => {
+  jest.resetModules();
+  jest.doMock('@/services/storeRepository', () => {
+    storeRepositoryMock = createStoreRepositoryMock();
+    return {
+      __esModule: true,
+      default: storeRepositoryMock,
+    };
+  });
+  let agent: typeof import('../agents/stores-agent').default;
+  jest.isolateModules(() => {
+    agent = require('../agents/stores-agent').default;
+  });
+  if (!storeRepositoryMock) {
+    throw new Error('store repository mock not initialized');
+  }
+  return { storesAgent: agent!, storeRepository: storeRepositoryMock };
+};
+
+describe('storesAgent reputation integration', () => {
+  const baseStore = {
+    id: 'store-1',
+    name: 'Store One',
+    owner: 'owner-1',
+    nftId: 'nft-1',
+    reputation: 0,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(listeners).forEach((event) => {
+      listeners[event] = [];
+    });
+  });
+
+  it('persists review scores and notifies subscribers', async () => {
+    const { storesAgent, storeRepository } = loadStoresAgent();
+    storeRepository.select.mockResolvedValue({ ...baseStore });
+    storeRepository.save.mockResolvedValue({
+      store: { ...baseStore, reputation: 3.4 },
+      namespace: 'default',
+      previous: baseStore,
+      created: false,
+    });
+
+    const callback = jest.fn();
+    storesAgent.subscribe(callback);
+
+    await storesAgent.recordReview(baseStore.id, 4);
+
+    expect(storeRepository.save).toHaveBeenCalledWith({
+      ...baseStore,
+      reputation: 2,
+    });
+    expect(callback).toHaveBeenCalledWith(baseStore.id, 3.4, expect.any(Object));
+    expect(storesAgent.getReputationScore(baseStore.id)).toBeCloseTo(3.4);
+  });
+
+  it('rolls back failed review updates', async () => {
+    const { storesAgent, storeRepository } = loadStoresAgent();
+    storeRepository.select.mockResolvedValue({ ...baseStore });
+    storeRepository.save.mockRejectedValue(new Error('network error'));
+
+    const callback = jest.fn();
+    storesAgent.subscribe(callback);
+
+    await storesAgent.recordReview(baseStore.id, 5);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(storesAgent.getReputationScore(baseStore.id)).toBe(0);
+  });
+
+  it('updates reliability by owner and restores on failure', async () => {
+    const { storesAgent, storeRepository } = loadStoresAgent();
+    storeRepository.findByOwner.mockResolvedValue({ ...baseStore });
+    storeRepository.save.mockResolvedValue({
+      store: { ...baseStore, reputation: 3 },
+      namespace: 'default',
+      previous: baseStore,
+      created: false,
+    });
+
+    const callback = jest.fn();
+    storesAgent.subscribe(callback);
+
+    await storesAgent.updateReputationByOwner(baseStore.owner, 0.6);
+
+    expect(storeRepository.save).toHaveBeenCalledWith({
+      ...baseStore,
+      reputation: 1.5,
+    });
+    expect(callback).toHaveBeenCalledWith(baseStore.id, 3, expect.any(Object));
+    expect(storesAgent.getReputationScore(baseStore.id)).toBeCloseTo(3);
+
+    storeRepository.save.mockRejectedValueOnce(new Error('write failed'));
+    await storesAgent.updateReputationByOwner(baseStore.owner, 0.2);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(storesAgent.getReputationScore(baseStore.id)).toBeCloseTo(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated reputation service to track store review metrics and emit score updates
- refactor the stores agent to hydrate via the service and confirm persisted score updates
- register new unit tests and cover reputation calculations and store update flows

## Testing
- npx jest --config tests/jest.unit.config.js --runTestsByPath tests/reputationService.test.ts tests/storesAgentReputation.test.ts --runInBand --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cf492efca083269c6570982fb42d2e