### PR TITLE
refactor stores repository diff broadcasting

### DIFF
--- a/agents/stores-agent.ts
+++ b/agents/stores-agent.ts
@@ -2,7 +2,7 @@ import type { WakuMessage } from '@/types/waku';
 import type { Store } from '@/types';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { buildTopic } from '@/utils/wakuTopics';
-import storeRepository from '@/services/storeRepository';
+import storeRepository, { type StoreRepositoryDiff } from '@/services/storeRepository';
 import reputationService, { type ScoreUpdateListener } from './reputation-service';
 
 const getTransportCrypto = () =>
@@ -43,17 +43,8 @@ type StoreChangeType = 'store.created' | 'store.updated';
 
 class StoresAgent {
   constructor() {
-    storeRepository.on('store.created', ({ store }) => {
-      reputationService.hydrate(store.id, store);
-      void this.broadcastStoreChange('store.created', store);
-    });
-    storeRepository.on('store.updated', ({ store }) => {
-      reputationService.hydrate(store.id, store);
-      void this.broadcastStoreChange('store.updated', store);
-    });
-    storeRepository.on('store.removed', ({ id, store }) => {
-      reputationService.clear(id);
-      void this.broadcastStoreRemoval({ id, store });
+    storeRepository.on('store.diff', (change) => {
+      this.handleRepositoryDiff(change);
     });
   }
 
@@ -142,7 +133,16 @@ class StoresAgent {
     return storeRepository.list('default');
   }
 
-  private async broadcastStoreChange(type: StoreChangeType, store: Store): Promise<void> {
+  private handleRepositoryDiff(change: StoreRepositoryDiff): void {
+    if (change.op === 'remove') {
+      reputationService.clear(change.id);
+    } else {
+      reputationService.hydrate(change.id, change.store);
+    }
+    void this.broadcastStoreDiff(change);
+  }
+
+  private async broadcastStoreDiff(change: StoreRepositoryDiff): Promise<void> {
     try {
       const { publish, makeSignedWakuMessage } = await loadWakuDeps();
       const transportCrypto = getTransportCrypto();
@@ -150,7 +150,25 @@ class StoresAgent {
         transportCrypto && typeof transportCrypto.randomUUID === 'function'
           ? transportCrypto.randomUUID()
           : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const msg: WakuMessage<Store> = await makeSignedWakuMessage(type, store, 'store-owner', {
+      if (change.op === 'remove') {
+        const payload: StoreRemovalPayload = {
+          id: change.id,
+          store: change.previous ?? null,
+        };
+        const msg: WakuMessage<StoreRemovalPayload> = await makeSignedWakuMessage(
+          'store.removed',
+          payload,
+          'store-owner',
+          {
+            ts: Date.now(),
+            nonce,
+          },
+        );
+        await publish(buildTopic('stores', '1'), msg);
+        return;
+      }
+      const type: StoreChangeType = change.op === 'create' ? 'store.created' : 'store.updated';
+      const msg: WakuMessage<Store> = await makeSignedWakuMessage(type, change.store, 'store-owner', {
         ts: Date.now(),
         nonce,
       });
@@ -160,28 +178,6 @@ class StoresAgent {
     }
   }
 
-  private async broadcastStoreRemoval(payload: StoreRemovalPayload): Promise<void> {
-    try {
-      const { publish, makeSignedWakuMessage } = await loadWakuDeps();
-      const transportCrypto = getTransportCrypto();
-      const nonce =
-        transportCrypto && typeof transportCrypto.randomUUID === 'function'
-          ? transportCrypto.randomUUID()
-          : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const msg: WakuMessage<StoreRemovalPayload> = await makeSignedWakuMessage(
-        'store.removed',
-        payload,
-        'store-owner',
-        {
-          ts: Date.now(),
-          nonce,
-        },
-      );
-      await publish(buildTopic('stores', '1'), msg);
-    } catch {
-      // non-fatal
-    }
-  }
 }
 
 const storesAgent = new StoresAgent();

--- a/services/storeRepository.ts
+++ b/services/storeRepository.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import type { Store } from '@/types';
 
 import type { StoreListStream } from '@/features/stores/services/nearStores';
+import type { DiffMessage } from '@/services/warmCache';
 
 type NearStoresModule = typeof import('@/features/stores/services/nearStores');
 type StoreService = ReturnType<NearStoresModule['createStoreService']>;
@@ -24,6 +25,7 @@ export type StoreRepositoryEventMap = {
   'store.created': { store: Store; namespace: string; previous: Store | null };
   'store.updated': { store: Store; namespace: string; previous: Store | null };
   'store.removed': { id: string; namespace: string; store: Store | null };
+  'store.diff': StoreRepositoryDiff;
 };
 
 type StoreRepositoryEvent = keyof StoreRepositoryEventMap;
@@ -36,11 +38,35 @@ function cloneStore(store: Store): Store {
   return { ...store };
 }
 
+type StoreRepositoryDiffBase = {
+  id: string;
+  namespace: string;
+  cacheDiff: DiffMessage<Store> | null;
+};
+
+export type StoreRepositoryDiff =
+  | (StoreRepositoryDiffBase & {
+      op: 'create';
+      store: Store;
+      previous: null;
+    })
+  | (StoreRepositoryDiffBase & {
+      op: 'update';
+      store: Store;
+      previous: Store;
+    })
+  | (StoreRepositoryDiffBase & {
+      op: 'remove';
+      store: null;
+      previous: Store | null;
+    });
+
 export interface SaveStoreResult {
   store: Store;
   namespace: string;
   previous: Store | null;
   created: boolean;
+  diff: StoreRepositoryDiff;
 }
 
 export class StoreRepository {
@@ -75,6 +101,10 @@ export class StoreRepository {
     this.emitter.emit(event, payload);
   }
 
+  private emitDiff(diff: StoreRepositoryDiff): void {
+    this.emit('store.diff', diff);
+  }
+
   on<T extends StoreRepositoryEvent>(
     event: T,
     listener: StoreRepositoryListener<T>,
@@ -106,17 +136,35 @@ export class StoreRepository {
 
     if (previous) {
       const previousRecord = cloneStore(previous);
-      await service.updateStore(record, namespace);
+      const cacheDiff = await service.updateStore(record, namespace);
+      const diff: StoreRepositoryDiff = {
+        op: 'update',
+        id: record.id,
+        namespace,
+        store: record,
+        previous: previousRecord,
+        cacheDiff: cacheDiff ?? null,
+      };
       this.emit('store.updated', { store: record, namespace, previous: previousRecord });
-      return { store: record, namespace, previous: previousRecord, created: false };
+      this.emitDiff(diff);
+      return { store: record, namespace, previous: previousRecord, created: false, diff };
     }
 
-    await service.addStore(record, namespace);
+    const cacheDiff = await service.addStore(record, namespace);
+    const diff: StoreRepositoryDiff = {
+      op: 'create',
+      id: record.id,
+      namespace,
+      store: record,
+      previous: null,
+      cacheDiff: cacheDiff ?? null,
+    };
     this.emit('store.created', { store: record, namespace, previous: null });
-    return { store: record, namespace, previous: null, created: true };
+    this.emitDiff(diff);
+    return { store: record, namespace, previous: null, created: true, diff };
   }
 
-  async remove(id: string): Promise<{ id: string; namespace: string; store: Store | null } | null> {
+  async remove(id: string): Promise<StoreRepositoryDiff | null> {
     const service = await getStoreService();
     let existing: Store | null = null;
     try {
@@ -125,9 +173,18 @@ export class StoreRepository {
     if (!existing) return null;
     const namespace = this.getNamespace(existing);
     const snapshot = cloneStore(existing);
-    await service.removeStore(namespace, id);
+    const cacheDiff = await service.removeStore(namespace, id);
+    const diff: StoreRepositoryDiff = {
+      op: 'remove',
+      id,
+      namespace,
+      store: null,
+      previous: snapshot,
+      cacheDiff: cacheDiff ?? null,
+    };
     this.emit('store.removed', { id, namespace, store: snapshot });
-    return { id, namespace, store: snapshot };
+    this.emitDiff(diff);
+    return diff;
   }
 
   async select(id: string): Promise<Store | null> {

--- a/services/warmCache.ts
+++ b/services/warmCache.ts
@@ -300,10 +300,6 @@ export function createWarmCache<T>(
   };
 }
 
-<<<<<<< HEAD
-
-=======
->>>>>>> d216adbb8dbc37b3b9c4757b53aba85da3b76ceb
 export function getCacheHitRatio(topic: string): number {
   const s = getHitStats().get(topic);
   if (!s || s.total === 0) return 0;

--- a/src/features/products/hooks/useStore.ts
+++ b/src/features/products/hooks/useStore.ts
@@ -1,6 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import chain from '@/services/chain';
 import { Store } from '@/types';
+import storeRepository, { type StoreRepositoryDiff } from '@/services/storeRepository';
 
 let getStore: ((storeId: string, id: string) => Promise<Store | null>) | undefined;
 if (chain === 'near') {
@@ -12,6 +14,33 @@ if (chain === 'near') {
 }
 
 export function useStore(id?: string, storeId: string = 'default') {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!id) return;
+    if (!storeRepository || typeof storeRepository.on !== 'function') return;
+    const updateQuery = (ns: string, value: Store | null) => {
+      queryClient.setQueryData(['store', ns, id], value);
+    };
+    const unsubscribe = storeRepository.on('store.diff', (change: StoreRepositoryDiff) => {
+      if (change.id !== id) return;
+      if (change.op === 'remove') {
+        updateQuery(change.namespace, null);
+        updateQuery('default', null);
+        updateQuery(storeId, null);
+        return;
+      }
+      updateQuery(change.namespace, change.store);
+      updateQuery('default', change.store);
+      updateQuery(storeId, change.store);
+    });
+    return () => {
+      try {
+        unsubscribe();
+      } catch {}
+    };
+  }, [id, storeId, queryClient]);
+
   return useQuery({
     queryKey: ['store', storeId, id],
     queryFn: () => (getStore && id ? getStore(storeId, id) : Promise.resolve(null)),

--- a/src/features/stores/components/StoreCreation.tsx
+++ b/src/features/stores/components/StoreCreation.tsx
@@ -9,7 +9,6 @@ import {
   I18nManager,
 } from 'react-native';
 import { useAppRouter } from '@/services';
-import { useQueryClient } from '@tanstack/react-query';
 import { useLanguage } from '@/ui/ThemeProvider';
 import storesAgent from '@/agents/stores-agent';
 import DatabaseService from '@/services/database';
@@ -25,7 +24,6 @@ const storeServiceDeps = createDefaultStoreServiceDeps();
 
 const StoreCreation: React.FC = () => {
   const [name, setName] = useState('');
-  const queryClient = useQueryClient();
   const { t } = useLanguage();
   const { replace } = useAppRouter();
   const { showNotification } = useNotificationActions();
@@ -80,11 +78,6 @@ const StoreCreation: React.FC = () => {
       } else {
         Alert.alert(t('common.success'), t('stores.createSuccess'));
       }
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['home'] }),
-        queryClient.invalidateQueries({ queryKey: ['store'] }),
-        queryClient.invalidateQueries({ queryKey: ['product'] }),
-      ]);
       replace(`/store/${id}/admin`);
     } catch (err: any) {
       Alert.alert(t('stores.transactionCancelled'));

--- a/src/features/stores/services/nearStores.ts
+++ b/src/features/stores/services/nearStores.ts
@@ -19,7 +19,7 @@ import {
   storeCacheIndexKey,
   storeCacheKey,
 } from './storeCache';
-
+import type { DiffMessage } from '@/services/warmCache';
 
 const defaultDeps = createDefaultStoreServiceDeps();
 
@@ -80,13 +80,15 @@ export async function mintStore(
   return resolved.storeChainClient.mintStore(name);
 }
 
-async function persistStore(store: Store, sid: string) {
+async function persistStore(store: Store, sid: string): Promise<DiffMessage<Store> | null> {
   const json = canonicalJson(store);
   await setValue(STORE_CACHE_ADDRESS, storeCacheKey(store.id, sid), json);
   await setValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(store.id), json);
+  let diff: DiffMessage<Store> | null = null;
   try {
-    storeCacheRepository.mutate({ id: store.id, value: store });
+    diff = storeCacheRepository.mutate({ id: store.id, value: store }) ?? null;
   } catch {}
+  return diff;
 }
 
 export function selectStore(
@@ -391,36 +393,36 @@ export async function addStore(
   store: Store,
   sid?: string,
   deps?: StoreServiceDeps,
-): Promise<void> {
+): Promise<DiffMessage<Store> | null> {
   const resolved = resolveDeps(deps);
   await resolved.storeChainClient.submitMutation('add', { store });
-  await persistStore(store, sid ?? requireStoreId(store.id));
+  return persistStore(store, sid ?? requireStoreId(store.id));
 }
 
 export async function updateStore(
   store: Store,
   sid?: string,
   deps?: StoreServiceDeps,
-): Promise<void> {
+): Promise<DiffMessage<Store> | null> {
   const resolved = resolveDeps(deps);
   await resolved.storeChainClient.submitMutation('update', { store });
-  await persistStore(store, sid ?? requireStoreId(store.id));
+  return persistStore(store, sid ?? requireStoreId(store.id));
 }
 
 export function removeStore(
   id: string,
   deps?: StoreServiceDeps,
-): Promise<void>;
+): Promise<DiffMessage<Store> | null>;
 export function removeStore(
   arg1: string,
   arg2: string,
   deps?: StoreServiceDeps,
-): Promise<void>;
+): Promise<DiffMessage<Store> | null>;
 export async function removeStore(
   arg1: string,
   arg2OrDeps?: string | StoreServiceDeps,
   maybeDeps?: StoreServiceDeps,
-): Promise<void> {
+): Promise<DiffMessage<Store> | null> {
   const id = typeof arg2OrDeps === 'string' ? arg2OrDeps : arg1;
   const sid =
     typeof arg2OrDeps === 'string'
@@ -434,9 +436,11 @@ export async function removeStore(
   await resolved.storeChainClient.submitMutation('remove', { id });
   await removeValue(STORE_CACHE_ADDRESS, storeCacheKey(id, sid));
   await removeValue(STORE_CACHE_ADDRESS, storeCacheIndexKey(id));
+  let diff: DiffMessage<Store> | null = null;
   try {
-    storeCacheRepository.mutate({ id, op: 'delete' });
+    diff = storeCacheRepository.mutate({ id, op: 'delete' }) ?? null;
   } catch {}
+  return diff;
 }
 
 export const getStore = selectStore;
@@ -445,14 +449,13 @@ export async function setStore(
   storeId: string,
   store: Store,
   deps?: StoreServiceDeps,
-) {
+): Promise<DiffMessage<Store> | null> {
   const resolved = resolveDeps(deps);
   const existing = await selectStore(storeId, store.id, resolved);
   if (existing) {
-    await updateStore(store, storeId, resolved);
-  } else {
-    await addStore(store, storeId, resolved);
+    return updateStore(store, storeId, resolved);
   }
+  return addStore(store, storeId, resolved);
 }
 
 export function createStoreService(
@@ -461,10 +464,10 @@ export function createStoreService(
   mintStore: (name: string) => Promise<MintStoreResult>;
   selectStore: (arg1: string, arg2?: string) => Promise<Store | null>;
   listStores: (storeId: string) => StoreListStream;
-  addStore: (store: Store, sid?: string) => Promise<void>;
-  updateStore: (store: Store, sid?: string) => Promise<void>;
-  removeStore: (arg1: string, arg2?: string) => Promise<void>;
-  setStore: (storeId: string, store: Store) => Promise<void>;
+  addStore: (store: Store, sid?: string) => Promise<DiffMessage<Store> | null>;
+  updateStore: (store: Store, sid?: string) => Promise<DiffMessage<Store> | null>;
+  removeStore: (arg1: string, arg2?: string) => Promise<DiffMessage<Store> | null>;
+  setStore: (storeId: string, store: Store) => Promise<DiffMessage<Store> | null>;
   createStoreOnChain: (args: { id: string; name: string; owner: string }) => Promise<string>;
 } {
   const resolved = resolveDeps(deps);

--- a/src/services/useStores.ts
+++ b/src/services/useStores.ts
@@ -2,10 +2,15 @@ import { useCallback, useEffect, useState } from 'react';
 import chain from '@/services/chain';
 import type { Store } from '@/types';
 import type { StoreListStream } from '@/features/stores/services/nearStores';
+import type { DiffMessage } from '@/services/warmCache';
 
 let listStores: ((storeId: string) => StoreListStream) | undefined;
-let setStore: ((storeId: string, store: Store) => Promise<void>) | undefined;
-let removeStore: ((storeId: string, id: string) => Promise<void>) | undefined;
+let setStore:
+  | ((storeId: string, store: Store) => Promise<DiffMessage<Store> | null>)
+  | undefined;
+let removeStore:
+  | ((storeId: string, id: string) => Promise<DiffMessage<Store> | null>)
+  | undefined;
 if (chain === 'near') {
   const nearStores = require('@/features/stores/services/nearStores');
   const storeService = nearStores.createStoreService(

--- a/tests/storeCreation.snapshot.test.tsx
+++ b/tests/storeCreation.snapshot.test.tsx
@@ -6,12 +6,6 @@ jest.mock('@/services', () => ({
   useAppRouter: () => ({ replace: jest.fn() }),
 }));
 
-jest.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({
-    invalidateQueries: jest.fn(),
-  }),
-}));
-
 jest.mock('@/ui/ThemeProvider', () => ({
   useLanguage: () => ({
     t: (key: string, fallback?: string) => fallback ?? key,

--- a/tests/storesAgentReputation.test.ts
+++ b/tests/storesAgentReputation.test.ts
@@ -75,6 +75,14 @@ describe('storesAgent reputation integration', () => {
       namespace: 'default',
       previous: baseStore,
       created: false,
+      diff: {
+        op: 'update',
+        id: baseStore.id,
+        namespace: 'default',
+        store: { ...baseStore, reputation: 3.4 },
+        previous: baseStore,
+        cacheDiff: null,
+      },
     });
 
     const callback = jest.fn();
@@ -112,6 +120,14 @@ describe('storesAgent reputation integration', () => {
       namespace: 'default',
       previous: baseStore,
       created: false,
+      diff: {
+        op: 'update',
+        id: baseStore.id,
+        namespace: 'default',
+        store: { ...baseStore, reputation: 3 },
+        previous: baseStore,
+        cacheDiff: null,
+      },
     });
 
     const callback = jest.fn();


### PR DESCRIPTION
## Summary
- emit structured store diffs from the repository, returning diff metadata from save/remove
- have the stores agent listen for those diffs to hydrate reputation data and broadcast a unified Waku payload
- propagate diff-aware cache updates through the Near store service, hooks, and tests while dropping manual query invalidations

## Testing
- yarn typecheck *(fails: missing expo base config and dependencies because install is blocked by @waku/core requiring Node >=22)*
- yarn install --ignore-scripts --no-progress *(fails: @waku/core requires Node >=22 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4e9ae8b4832696824d0d3194f80d