### PR TITLE
Enable Android Proguard and resource shrinking

### DIFF
--- a/SHIP_REPORT.md
+++ b/SHIP_REPORT.md
@@ -6,7 +6,7 @@
 - **Entry strategy**: Platform-specific bootstrap (Expo register on native, direct `AppRegistry` on web) with lazy tab screens.
 
 ## Performance hardening
-- Hermes enabled for iOS/Android; Proguard + resource shrink active on Android builds (`app.json`).
+- Hermes runtime remains enabled on iOS/Android via Expo SDK 54 defaults; `app.json` now explicitly enables Proguard and resource shrinking for Android release builds.
 - Metro minifier tuned for aggressive compression (inline requires, drop console/debugger, toplevel mangling, pure getters).
 - Web builds alias React/React DOM to Preact and React Native Web to react-native-web-lite.
 - Tab screens lazy-loaded via `React.lazy` + Suspense skeleton fallbacks.

--- a/app.json
+++ b/app.json
@@ -12,6 +12,10 @@
     "ios": {
       "supportsTablet": true
     },
+    "android": {
+      "enableProguardInReleaseBuilds": true,
+      "enableShrinkResources": true
+    },
     "web": {
       "bundler": "metro",
       "output": "single"


### PR DESCRIPTION
## Summary
- enable Android release builds to run Proguard and resource shrinking in app.json
- document the Android hardening and Hermes runtime defaults in the ship report

## Testing
- `npx expo prebuild` *(fails: PluginError resolving expo-router plugin even though node modules are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ef98c1dc832690e372acf38b680c