### PR TITLE
chore: remove react-native-worklets plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,9 +15,6 @@ module.exports = function (api) {
     // SDK 50+: expo-router/babel is built into the preset; don't add it here.
     // Enable support for static class blocks in dependencies like @smithy/core
     // by transforming them during compilation.
-    plugins: [
-      '@babel/plugin-transform-class-static-block',
-      'react-native-worklets/plugin',
-    ],
+    plugins: ['@babel/plugin-transform-class-static-block'],
   };
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,6 @@ const cfg = {
         '@noble/ed25519',
         'react-native',
         'react-native-reanimated',
-        'react-native-worklets',
         'expo',
         'expo-linear-gradient',
         'react-native-svg',


### PR DESCRIPTION
## Summary
- drop the react-native-worklets Babel plugin that is no longer required
- remove the matching transformIgnorePatterns entry from the Jest config

## Testing
- yarn lint
- yarn test --config jest.config.js *(fails: Cannot find module 'react-native-reanimated' from 'tests/setupEnv.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68d0f14e4f588326988da3d3c3c45115