### PR TITLE
chore: remove expo cli dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "@babel/plugin-transform-class-static-block": "^7.28.3",
     "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@storybook/react": "^8.5.3",
-    "@expo/cli": "^0.26.9",
     "@faker-js/faker": "^8.4.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.1",


### PR DESCRIPTION
## Summary
- remove the redundant @expo/cli entry from the root devDependencies so the repo relies on the Expo binary that ships with expo

## Testing
- yarn install *(fails: https://registry.yarnpkg.com/@blue-ocean%2fsdk-near returned 404, preventing workspace install)*
- CI=1 yarn dev *(fails: packages/sdk-near build step cannot resolve @waku/sdk and near-api-js without a successful install)*
- CI=1 yarn dev:web *(fails: packages/sdk-near build step cannot resolve @waku/sdk and near-api-js without a successful install)*
- CI=1 yarn build:web *(fails: cross-env binary missing without a successful install)*

------
https://chatgpt.com/codex/tasks/task_e_68d1077994688326909d3334c7e615cf