### PR TITLE
Fix AppProviders notification error handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -152,6 +152,7 @@ const cfg = {
     '<rootDir>/tests/navigation.test.ts',
     '<rootDir>/tests/CheckedQueryClientProvider.test.tsx',
     '<rootDir>/tests/appProvidersSingleQueryClient.test.tsx',
+    '<rootDir>/tests/appProvidersErrorNotifications.test.tsx',
     '<rootDir>/tests/signupLogic.test.ts',
     '<rootDir>/tests/nearKvPersistence.test.ts',
     '<rootDir>/tests/homeScreenRender.test.tsx',

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -32,11 +32,40 @@ import { LaunchGateProvider } from '@/features/launchGate';
  * 11. `CurrencyProvider` – stores selected currency.
  * 12. `NotificationProvider` – listens for notifications and displays popups.
  */
-export default function AppProviders({ children }: React.PropsWithChildren) {
+type ShowNotification = ReturnType<typeof useNotificationActions>['showNotification'];
+
+interface NotificationRegistrarProps {
+  onReady: (showNotification: ShowNotification | null) => void;
+}
+
+function NotificationActionsRegistrar({ onReady }: NotificationRegistrarProps) {
   const { showNotification } = useNotificationActions();
+
+  React.useEffect(() => {
+    onReady(showNotification);
+    return () => onReady(null);
+  }, [onReady, showNotification]);
+
+  return null;
+}
+
+export default function AppProviders({ children }: React.PropsWithChildren) {
+  const [showNotification, setShowNotification] = React.useState<
+    ShowNotification | null
+  >(null);
+
+  const handleNotificationReady = React.useCallback(
+    (notification: ShowNotification | null) => {
+      // Defer binding the error handler until the NotificationProvider has
+      // mounted so the boundary always uses a live `showNotification` ref.
+      setShowNotification(() => notification);
+    },
+    [],
+  );
+
   const handleBoundaryError = React.useCallback(
     (error: Error, info: React.ErrorInfo) => {
-      showNotification('Error', error.message, 'error');
+      showNotification?.('Error', error.message, 'error');
       void reportError(error, {
         context: 'error-boundary',
         componentStack: info?.componentStack,
@@ -57,6 +86,9 @@ export default function AppProviders({ children }: React.PropsWithChildren) {
                       <AuthModalProvider>
                         <CurrencyProvider>
                           <NotificationProvider>
+                            <NotificationActionsRegistrar
+                              onReady={handleNotificationReady}
+                            />
                             <LaunchGateProvider>{children}</LaunchGateProvider>
                           </NotificationProvider>
                         </CurrencyProvider>

--- a/tests/appProvidersErrorNotifications.test.tsx
+++ b/tests/appProvidersErrorNotifications.test.tsx
@@ -1,0 +1,233 @@
+jest.mock('@/services/waku', () => ({
+  ensureNode: jest.fn(async () => null),
+  isWakuDisabled: jest.fn(() => true),
+  subscribeWithAck: jest.fn(async () => () => {}),
+  fetchHistory: jest.fn(async () => undefined),
+  publish: jest.fn(async () => 'mock-id'),
+}));
+
+jest.mock('@/providers/WalletProvider', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    WalletProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@/contexts/WakuContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    WakuProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useWaku: () => ({
+      subscribeNotifications: jest.fn(async () => () => {}),
+    }),
+  };
+});
+
+jest.mock('@/contexts/AppInfoContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    AppInfoProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useAppInfo: () => ({ themeColor: '#0055ff' }),
+  };
+});
+
+jest.mock('@/contexts/ConfigContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    ConfigProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@/features/auth/AuthContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    AuthProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useAuth: () => ({ isLoggedIn: true, user: { id: 'user-1' } }),
+  };
+});
+
+jest.mock('@/features/auth/AuthModalContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    AuthModalProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@/contexts/CurrencyContext', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    CurrencyProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@/features/launchGate', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    LaunchGateProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('@/ui/ThemeProvider', () => {
+  const React = require('react');
+  const colors = {
+    status: { success: '#0f0', warning: '#ff0', error: '#f00', info: '#00f' },
+    text: { inverse: '#fff', primary: '#111', secondary: '#666' },
+    background: '#000',
+    interactive: { primary: '#00f', primaryHover: '#00f' },
+    border: { focus: '#00f' },
+    tabBar: { active: '#00f' },
+  };
+  return {
+    __esModule: true,
+    ThemeProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    LanguageProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useTheme: () => ({
+      theme: 'dark',
+      colors,
+      tokens: {},
+      getColor: (path: string) => {
+        switch (path) {
+          case 'text.primary':
+            return colors.text.primary;
+          case 'text.secondary':
+            return colors.text.secondary;
+          case 'text.inverse':
+            return colors.text.inverse;
+          default:
+            return '#000';
+        }
+      },
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+    useLanguage: () => ({
+      t: (key: string, fallback?: string) => fallback ?? key,
+      isRTL: false,
+    }),
+  };
+});
+
+jest.mock('@/features/notifications', () => ({
+  useNotificationSubscription: () => ({
+    unreadCount: 0,
+    refreshNotifications: jest.fn(),
+  }),
+}));
+
+jest.mock('@/services/notification', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      setLastOpenedNotificationId: jest.fn(),
+      subscribeToUserNotifications: jest.fn(() => 'sub'),
+      unsubscribeFromNotifications: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('@/services/eventBus', () => ({
+  track: jest.fn(),
+}));
+
+jest.mock('@/services/useAppRouter', () => ({
+  useAppRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock('@/services/errorReporter', () => ({
+  reportError: jest.fn(),
+}));
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import AppProviders from '@/providers/AppProviders';
+
+describe('AppProviders error notifications', () => {
+  it('renders a notification popup when a descendant throws', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    let updateThrow: React.Dispatch<React.SetStateAction<boolean>> = () => {};
+
+    function ThrowAfterReady({
+      onReady,
+    }: {
+      onReady: (setter: React.Dispatch<React.SetStateAction<boolean>>) => void;
+    }) {
+      const [shouldThrow, setShouldThrow] = React.useState(false);
+
+      React.useEffect(() => {
+        onReady(setShouldThrow);
+      }, [onReady]);
+
+      if (shouldThrow) {
+        throw new Error('Kaboom');
+      }
+
+      return React.createElement('Safe', null, 'safe');
+    }
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          AppProviders,
+          null,
+          React.createElement(ThrowAfterReady, {
+            onReady: (setter) => {
+              updateThrow = setter;
+            },
+          }),
+        ),
+      );
+    });
+
+    // Allow NotificationProvider effects to register actions
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      updateThrow(true);
+    });
+
+    const headings = Array.from(document.body.querySelectorAll('Heading'));
+    const notificationHeading = headings.find(
+      (node) => node.textContent === 'Error',
+    );
+    expect(notificationHeading).toBeTruthy();
+    expect(notificationHeading?.closest('TouchableOpacity')).not.toBeNull();
+
+    const textNodes = Array.from(document.body.querySelectorAll('Text'));
+    const messageNode = textNodes.find((node) => node.textContent === 'Kaboom');
+    expect(messageNode?.closest('TouchableOpacity')).not.toBeNull();
+
+    consoleErrorSpy.mockRestore();
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- register the notification actions for the AppProviders error boundary after the provider mounts
- ensure the boundary callback guards against a missing notification handler
- add a regression test that verifies errors under AppProviders surface a notification toast

## Testing
- ⚠️ `yarn jest tests/appProvidersErrorNotifications.test.tsx` *(fails before running because private packages such as @blue-ocean/sdk-near are unavailable in the environment)*
- ⚠️ `yarn install` *(fails because @blue-ocean/sdk-near cannot be resolved from the public registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d10fa761608326ade55189919d57aa