### PR TITLE
Handle delayed Waku subscriptions

### DIFF
--- a/contexts/WakuContext.tsx
+++ b/contexts/WakuContext.tsx
@@ -72,7 +72,91 @@ const NOTIFICATION_TOPIC = '/blue-ocean/notifications/1';
 
 export function WakuProvider({ children }: { children: React.ReactNode }) {
   const nodeRef = useRef<LightNode>();
+  const nodeWaitersRef = useRef<((node: LightNode) => void)[]>([]);
+  const subscriptionsRef = useRef(
+    new Map<symbol, {
+      id: symbol;
+      active: boolean;
+      cleanup?: (() => void) | undefined;
+      setup: (node: LightNode) => Promise<(() => void) | void> | (() => void);
+    }>(),
+  );
   const [status, setStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
+
+  const resolveNodeWaiters = useCallback((node: LightNode) => {
+    if (nodeWaitersRef.current.length === 0) return;
+    const waiters = [...nodeWaitersRef.current];
+    nodeWaitersRef.current = [];
+    for (const resolve of waiters) {
+      try {
+        resolve(node);
+      } catch (err) {
+        errorLog('Failed to resolve Waku waiter', err);
+      }
+    }
+  }, []);
+
+  const awaitNode = useCallback(async (): Promise<LightNode> => {
+    if (nodeRef.current) return nodeRef.current;
+    return await new Promise<LightNode>((resolve) => {
+      nodeWaitersRef.current.push(resolve);
+    });
+  }, []);
+
+  const bindSubscription = useCallback(
+    async (id: symbol, nodeOverride?: LightNode) => {
+      const entry = subscriptionsRef.current.get(id);
+      if (!entry || !entry.active) return;
+      const node = nodeOverride ?? (await awaitNode());
+      if (!entry.active) return;
+      if (entry.cleanup) {
+        try {
+          entry.cleanup();
+        } catch (err) {
+          errorLog('Failed to cleanup Waku subscription', err);
+        }
+        entry.cleanup = undefined;
+      }
+      try {
+        const cleanup = await entry.setup(node);
+        if (!entry.active) {
+          if (typeof cleanup === 'function') cleanup();
+          return;
+        }
+        entry.cleanup = typeof cleanup === 'function' ? cleanup : undefined;
+      } catch (err) {
+        errorLog('Failed to bind Waku subscription', err);
+      }
+    },
+    [awaitNode],
+  );
+
+  const registerSubscription = useCallback(
+    async (
+      setup: (node: LightNode) => Promise<(() => void) | void> | (() => void),
+    ): Promise<() => void> => {
+      const id = Symbol('waku-sub');
+      const entry = { id, active: true, setup };
+      subscriptionsRef.current.set(id, entry);
+      void bindSubscription(id);
+      const unsubscribe = () => {
+        const current = subscriptionsRef.current.get(id);
+        if (!current) return;
+        current.active = false;
+        subscriptionsRef.current.delete(id);
+        if (current.cleanup) {
+          try {
+            current.cleanup();
+          } catch (err) {
+            errorLog('Failed to cleanup Waku subscription', err);
+          }
+          current.cleanup = undefined;
+        }
+      };
+      return unsubscribe;
+    },
+    [bindSubscription],
+  );
 
   const connect = useCallback(async () => {
     try {
@@ -86,6 +170,11 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       await waitForRemotePeer(node, [Protocols.Relay, Protocols.Store]);
       nodeRef.current = node;
       setStatus('connected');
+      resolveNodeWaiters(node);
+      for (const entry of subscriptionsRef.current.values()) {
+        if (!entry.active) continue;
+        void bindSubscription(entry.id, node);
+      }
       const client = await getClient();
       void flush(async (topic, payload) => {
         const encoder = client.createEncoder({ contentTopic: topic });
@@ -96,7 +185,7 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
       nodeRef.current = undefined;
       setStatus('disconnected');
     }
-  }, []);
+  }, [bindSubscription, resolveNodeWaiters]);
 
   useEffect(() => {
     void connect();
@@ -144,44 +233,45 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
     peerPublicKey: string,
     cb: (msg: ChatMessage) => void,
   ): Promise<() => void> => {
-    if (!nodeRef.current) return () => {};
-    const client = await getClient();
-    const topic = await chatTopic(roomId, peerPublicKey);
-    const decoder = client.createDecoder({ contentTopic: topic });
-    const handler = async (wakuMsg: DecodedMessage) => {
-      if (!wakuMsg.payload) return;
-      try {
-        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
-        const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema, undefined, topic);
-        if (!signed) return;
-        const text = await decryptMessage(signed.payload, roomId, peerPublicKey);
-        const chat: ChatMessage = {
-          id: Date.now().toString(),
-          senderId: signed.sender.publicKey,
-          senderName: signed.sender.publicKey,
-          message: text,
-          timestamp: Date.now(),
-          isAdmin: false,
-        };
-        const db = DatabaseService.getInstance();
-        await db.sendChatMessage(roomId, { ...chat, message: signed.payload });
-        cb(chat);
-      } catch {
-        /* ignore malformed messages */
-      }
-    };
-    const maybeUnsub = (nodeRef.current.relay as any).addObserver(handler, [decoder]) as
-      | (() => void)
-      | void;
-    return () => {
-      if (typeof maybeUnsub === 'function') {
-        maybeUnsub();
-      } else {
-        (nodeRef.current?.relay as any)?.deleteObserver?.(handler);
-      }
-    };
-  }, []);
+    return registerSubscription(async (node) => {
+      const client = await getClient();
+      const topic = await chatTopic(roomId, peerPublicKey);
+      const decoder = client.createDecoder({ contentTopic: topic });
+      const handler = async (wakuMsg: DecodedMessage) => {
+        if (!wakuMsg.payload) return;
+        try {
+          const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
+          const schema = wakuMessageSchema.extend({ payload: z.string() });
+          const signed = await verifyBeforeWrite(raw, schema, undefined, topic);
+          if (!signed) return;
+          const text = await decryptMessage(signed.payload, roomId, peerPublicKey);
+          const chat: ChatMessage = {
+            id: Date.now().toString(),
+            senderId: signed.sender.publicKey,
+            senderName: signed.sender.publicKey,
+            message: text,
+            timestamp: Date.now(),
+            isAdmin: false,
+          };
+          const db = DatabaseService.getInstance();
+          await db.sendChatMessage(roomId, { ...chat, message: signed.payload });
+          cb(chat);
+        } catch {
+          /* ignore malformed messages */
+        }
+      };
+      const maybeUnsub = (node.relay as any).addObserver(handler, [decoder]) as
+        | (() => void)
+        | void;
+      return () => {
+        if (typeof maybeUnsub === 'function') {
+          maybeUnsub();
+        } else {
+          (node.relay as any)?.deleteObserver?.(handler);
+        }
+      };
+    });
+  }, [registerSubscription]);
 
   const fetchHistory = useCallback(async (
     roomId: string,
@@ -249,66 +339,68 @@ export function WakuProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const subscribeSystem = useCallback(async (cb: (msg: string) => void) => {
-    if (!nodeRef.current) return () => {};
-    const client = await getClient();
-    const decoder = client.createDecoder({ contentTopic: SYSTEM_TOPIC });
-    const handler = async (wakuMsg: DecodedMessage) => {
-      if (!wakuMsg.payload) return;
-      try {
-        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
-        const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema, undefined, SYSTEM_TOPIC);
-        if (!signed) {
-          errorLog('Dropping unverified system message', raw);
-          return;
+    return registerSubscription(async (node) => {
+      const client = await getClient();
+      const decoder = client.createDecoder({ contentTopic: SYSTEM_TOPIC });
+      const handler = async (wakuMsg: DecodedMessage) => {
+        if (!wakuMsg.payload) return;
+        try {
+          const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
+          const schema = wakuMessageSchema.extend({ payload: z.string() });
+          const signed = await verifyBeforeWrite(raw, schema, undefined, SYSTEM_TOPIC);
+          if (!signed) {
+            errorLog('Dropping unverified system message', raw);
+            return;
+          }
+          cb(signed.payload);
+        } catch (err) {
+          errorLog('Malformed system message', err);
         }
-        cb(signed.payload);
-      } catch (err) {
-        errorLog('Malformed system message', err);
-      }
-    };
-    const maybeUnsub = (nodeRef.current.relay as any).addObserver(handler, [decoder]) as
-      | (() => void)
-      | void;
-    return () => {
-      if (typeof maybeUnsub === 'function') {
-        maybeUnsub();
-      } else {
-        (nodeRef.current?.relay as any)?.deleteObserver?.(handler);
-      }
-    };
-  }, []);
+      };
+      const maybeUnsub = (node.relay as any).addObserver(handler, [decoder]) as
+        | (() => void)
+        | void;
+      return () => {
+        if (typeof maybeUnsub === 'function') {
+          maybeUnsub();
+        } else {
+          (node.relay as any)?.deleteObserver?.(handler);
+        }
+      };
+    });
+  }, [registerSubscription]);
 
   const subscribeNotifications = useCallback(async (cb: (msg: string) => void) => {
-    if (!nodeRef.current) return () => {};
-    const client = await getClient();
-    const decoder = client.createDecoder({ contentTopic: NOTIFICATION_TOPIC });
-    const handler = async (wakuMsg: DecodedMessage) => {
-      if (!wakuMsg.payload) return;
-      try {
-        const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
-        const schema = wakuMessageSchema.extend({ payload: z.string() });
-        const signed = await verifyBeforeWrite(raw, schema, undefined, NOTIFICATION_TOPIC);
-        if (!signed) {
-          errorLog('Dropping unverified notification message', raw);
-          return;
+    return registerSubscription(async (node) => {
+      const client = await getClient();
+      const decoder = client.createDecoder({ contentTopic: NOTIFICATION_TOPIC });
+      const handler = async (wakuMsg: DecodedMessage) => {
+        if (!wakuMsg.payload) return;
+        try {
+          const raw = JSON.parse(client.bytesToUtf8(wakuMsg.payload));
+          const schema = wakuMessageSchema.extend({ payload: z.string() });
+          const signed = await verifyBeforeWrite(raw, schema, undefined, NOTIFICATION_TOPIC);
+          if (!signed) {
+            errorLog('Dropping unverified notification message', raw);
+            return;
+          }
+          cb(signed.payload);
+        } catch (err) {
+          errorLog('Malformed notification message', err);
         }
-        cb(signed.payload);
-      } catch (err) {
-        errorLog('Malformed notification message', err);
-      }
-    };
-    const maybeUnsub = (nodeRef.current.relay as any).addObserver(handler, [decoder]) as
-      | (() => void)
-      | void;
-    return () => {
-      if (typeof maybeUnsub === 'function') {
-        maybeUnsub();
-      } else {
-        (nodeRef.current?.relay as any)?.deleteObserver?.(handler);
-      }
-    };
-  }, []);
+      };
+      const maybeUnsub = (node.relay as any).addObserver(handler, [decoder]) as
+        | (() => void)
+        | void;
+      return () => {
+        if (typeof maybeUnsub === 'function') {
+          maybeUnsub();
+        } else {
+          (node.relay as any)?.deleteObserver?.(handler);
+        }
+      };
+    });
+  }, [registerSubscription]);
 
   const getPeerSummary = useCallback(() => {
     const node = nodeRef.current as any;

--- a/src/features/notifications/hooks/useNotificationSubscription.ts
+++ b/src/features/notifications/hooks/useNotificationSubscription.ts
@@ -42,24 +42,15 @@ export function useNotificationSubscription(
     }
   }, [isLoggedIn, user]);
 
-  useEffect(() => {
-    if (isLoggedIn && user) {
-      refreshNotifications();
-      setupRealtimeSubscription();
-      setupWakuSubscription();
-    } else {
-      setUnreadCount(0);
-      cleanupSubscription();
-      cleanupWakuSubscription();
+  const cleanupSubscription = useCallback(() => {
+    if (notificationSubscription.current) {
+      const notificationService = NotificationService.getInstance();
+      notificationService.unsubscribeFromNotifications(notificationSubscription.current);
+      notificationSubscription.current = null;
     }
-    return () => {
-      cleanupSubscription();
-      cleanupWakuSubscription();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoggedIn, user, refreshNotifications]);
+  }, []);
 
-  const setupRealtimeSubscription = () => {
+  const setupRealtimeSubscription = useCallback(() => {
     if (!user) return;
     const notificationService = NotificationService.getInstance();
     cleanupSubscription();
@@ -80,23 +71,18 @@ export function useNotificationSubscription(
         );
       },
     );
-  };
+  }, [cleanupSubscription, onNotification, user]);
 
-  const cleanupSubscription = () => {
-    if (notificationSubscription.current) {
-      const notificationService = NotificationService.getInstance();
-      notificationService.unsubscribeFromNotifications(notificationSubscription.current);
-      notificationSubscription.current = null;
-    }
-  };
-
-  const setupWakuSubscription = async () => {
-    if (!user) return;
+  const cleanupWakuSubscription = useCallback(() => {
     if (wakuUnsub.current) {
       wakuUnsub.current();
       wakuUnsub.current = null;
     }
-    wakuUnsub.current = await waku.subscribeNotifications((message) => {
+  }, []);
+
+  const handleWakuNotification = useCallback(
+    (message: string) => {
+      if (!user) return;
       try {
         const payload = parseNotificationWakuPayload(JSON.parse(message));
         if (!payload) return;
@@ -123,15 +109,66 @@ export function useNotificationSubscription(
       } catch (err) {
         errorLog('Failed to parse notification', err);
       }
-    });
-  };
+    },
+    [onNotification, user],
+  );
 
-  const cleanupWakuSubscription = () => {
-    if (wakuUnsub.current) {
-      wakuUnsub.current();
-      wakuUnsub.current = null;
+  useEffect(() => {
+    if (isLoggedIn && user) {
+      void refreshNotifications();
+      setupRealtimeSubscription();
+    } else {
+      setUnreadCount(0);
+      cleanupSubscription();
+      cleanupWakuSubscription();
     }
-  };
+    return () => {
+      cleanupSubscription();
+      cleanupWakuSubscription();
+    };
+  }, [
+    cleanupSubscription,
+    cleanupWakuSubscription,
+    isLoggedIn,
+    refreshNotifications,
+    setupRealtimeSubscription,
+    user,
+  ]);
+
+  useEffect(() => {
+    if (!isLoggedIn || !user) {
+      return;
+    }
+    if (waku.status !== 'connected') {
+      cleanupWakuSubscription();
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      cleanupWakuSubscription();
+      const unsub = await waku.subscribeNotifications((message) => {
+        handleWakuNotification(message);
+      });
+      if (cancelled) {
+        unsub();
+        return;
+      }
+      wakuUnsub.current = unsub;
+    })().catch((err) => {
+      errorLog('Failed to subscribe to Waku notifications', err);
+    });
+    return () => {
+      cancelled = true;
+      cleanupWakuSubscription();
+    };
+  }, [
+    cleanupWakuSubscription,
+    handleWakuNotification,
+    isLoggedIn,
+    user,
+    waku,
+    waku.status,
+  ]);
 
   return { unreadCount, refreshNotifications };
 }

--- a/tests/waku/notificationsResume.test.tsx
+++ b/tests/waku/notificationsResume.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('@/utils/logger', () => ({
+  errorLog: jest.fn(),
+}));
+
+jest.mock('@/services/eventBus', () => ({
+  __esModule: true,
+  default: { track: jest.fn() },
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const notificationServiceMock = {
+  getNotifications: jest.fn().mockResolvedValue([]),
+  subscribeToUserNotifications: jest.fn().mockReturnValue('sub'),
+  unsubscribeFromNotifications: jest.fn(),
+};
+
+jest.mock('@/services/notification', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => notificationServiceMock,
+  },
+}));
+
+const verifyBeforeWriteMock = jest.fn();
+jest.mock('@/utils/verifyMessageSignature', () => ({
+  verifyBeforeWrite: (...args: any[]) => verifyBeforeWriteMock(...args),
+}));
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const mockClient = {
+  Protocols: { Relay: 'relay', Store: 'store' },
+  waitForRemotePeer: jest.fn(),
+  createLightNode: jest.fn(),
+  createDecoder: jest.fn(() => ({})),
+  createEncoder: jest.fn(() => ({})),
+  utf8ToBytes: (input: string) => textEncoder.encode(input),
+  bytesToUtf8: (input: Uint8Array) => textDecoder.decode(input),
+};
+
+jest.mock('@/utils/transport', () => ({
+  getClient: jest.fn(async () => mockClient),
+}));
+
+import { getClient } from '@/utils/transport';
+import { WakuProvider } from '@/contexts/WakuContext';
+import { useNotificationSubscription } from '@/features/notifications';
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve: resolve! };
+}
+
+function TestHarness({ onNotification }: { onNotification: jest.Mock }) {
+  const { unreadCount } = useNotificationSubscription((_, __, ___, ____, id) => {
+    onNotification(id);
+  });
+  return React.createElement('Count', { value: unreadCount });
+}
+
+describe('Waku notifications resume after delayed connect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isLoggedIn: true, user: { id: 'user-1' } });
+  });
+
+  it('delivers queued notification callbacks once the node connects', async () => {
+    const waitForPeer = createDeferred<void>();
+    const observers = new Set<(msg: any) => void>();
+    const addObserver = jest.fn((handler: (msg: any) => void) => {
+      observers.add(handler);
+      return () => {
+        observers.delete(handler);
+      };
+    });
+    const deleteObserver = jest.fn((handler: (msg: any) => void) => {
+      observers.delete(handler);
+    });
+
+    const node = {
+      start: jest.fn(async () => {}),
+      stop: jest.fn(async () => {}),
+      libp2p: new EventTarget(),
+      lightPush: { send: jest.fn() },
+      relay: { addObserver, deleteObserver },
+      store: { queryGenerator: jest.fn() },
+    } as any;
+
+    mockClient.createLightNode.mockResolvedValue(node);
+    mockClient.waitForRemotePeer.mockImplementation(async () => waitForPeer.promise);
+
+    const rawMessage = {
+      type: 'notify.direct',
+      payload: JSON.stringify({
+        type: 'notify.direct',
+        notification: {
+          id: 'notif-1',
+          userId: 'user-1',
+          title: 'Hello',
+          message: 'World',
+          type: 'message',
+          read: false,
+          timestamp: Date.now(),
+        },
+        ts: Date.now(),
+        nonce: 'nonce-1',
+      }),
+      sender: { publicKey: '0xabc' },
+      signature: '0xsig',
+      ts: Date.now(),
+      nonce: 'nonce-1',
+    };
+
+    verifyBeforeWriteMock.mockImplementation(async () => rawMessage as any);
+
+    const onNotification = jest.fn();
+
+    let testRenderer!: ReturnType<typeof renderer.create>;
+    await act(async () => {
+      testRenderer = renderer.create(
+        React.createElement(
+          WakuProvider,
+          null,
+          React.createElement(TestHarness, { onNotification }),
+        ),
+      );
+    });
+
+    expect(addObserver).not.toHaveBeenCalled();
+
+    await act(async () => {
+      waitForPeer.resolve();
+      await Promise.resolve();
+    });
+
+    const getClientMock = getClient as jest.Mock;
+    expect(getClientMock).toHaveBeenCalled();
+
+    // Allow the subscription effect to run after connection resolves
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(addObserver).toHaveBeenCalled();
+
+    const handler = Array.from(observers)[0];
+    expect(handler).toBeDefined();
+
+    await act(async () => {
+      await handler({
+        payload: mockClient.utf8ToBytes(JSON.stringify(rawMessage)),
+      });
+      await Promise.resolve();
+    });
+
+    expect(onNotification).toHaveBeenCalledWith('notif-1');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const countNode = testRenderer!.root.findByType('Count');
+    expect(countNode.props.value).toBe(1);
+
+    await act(async () => {
+      testRenderer.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- queue Waku relay subscriptions until the node is ready and automatically rebind them after reconnects
- ensure notification subscriptions clean up and resubscribe when the Waku connection status changes
- cover delayed node startup with a regression test that verifies notifications resume once connected

## Testing
- `npx jest tests/waku/notificationsResume.test.tsx` *(fails: missing ts-jest preset in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11386de94832681f0964b762f85ec