### PR TITLE
Add TTL-based dedupe tracking for Waku subscribe

### DIFF
--- a/services/waku.ts
+++ b/services/waku.ts
@@ -54,7 +54,9 @@ const PUB =
   '';
 
 let cachedNode: LightNode | null = null;
-const receivedIds = new Set<string>();
+export const RECEIVED_ID_TTL_MS = 5 * 60 * 1000;
+const RECEIVED_ID_MAX_ENTRIES = 1024;
+const receivedIds = new Map<string, number>();
 let reconnectAttempt = 0;
 let lakeStarted = false;
 
@@ -90,6 +92,28 @@ async function persistStore(storeId: string, store: Store): Promise<void> {
   } catch (err) {
     errorLog('Failed to persist store from lake event', err);
   }
+}
+
+function pruneReceivedIds(now: number): void {
+  if (receivedIds.size === 0) return;
+  for (const [id, seenAt] of receivedIds) {
+    if (now - seenAt > RECEIVED_ID_TTL_MS) {
+      receivedIds.delete(id);
+    } else {
+      break;
+    }
+  }
+}
+
+function rememberMessageId(id: string, now: number): boolean {
+  if (receivedIds.has(id)) return false;
+  receivedIds.set(id, now);
+  while (receivedIds.size > RECEIVED_ID_MAX_ENTRIES) {
+    const oldest = receivedIds.keys().next().value;
+    if (oldest === undefined) break;
+    receivedIds.delete(oldest);
+  }
+  return true;
 }
 
 function computeKeyEpoch(ts: number): number {
@@ -316,8 +340,9 @@ export async function subscribeWithAck(
         wakuDecryptErrorCounter.inc({ reason: 'decode_failure' });
         return;
       }
-      if (msg.id && receivedIds.has(msg.id)) return;
-      if (msg.id) receivedIds.add(msg.id);
+      const now = Date.now();
+      pruneReceivedIds(now);
+      if (msg.id && !rememberMessageId(msg.id, now)) return;
       cb(msg);
       if (msg.id) await sendAck(topic, msg.id);
     } catch (err) {

--- a/tests/waku/subscribeWithAck.test.ts
+++ b/tests/waku/subscribeWithAck.test.ts
@@ -1,0 +1,129 @@
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const mockCreateDecoder = jest.fn(() => ({}));
+const mockBytesToUtf8 = jest.fn((bytes: Uint8Array) => textDecoder.decode(bytes));
+const mockUtf8ToBytes = jest.fn((value: string) => textEncoder.encode(value));
+const mockCreateEncoder = jest.fn(() => ({}));
+
+const mockClient = {
+  createDecoder: mockCreateDecoder,
+  bytesToUtf8: mockBytesToUtf8,
+  utf8ToBytes: mockUtf8ToBytes,
+  createEncoder: mockCreateEncoder,
+};
+
+jest.mock('@/utils/transport', () => ({
+  __esModule: true,
+  getClient: jest.fn(),
+}));
+
+jest.mock('@/utils/wakuCrypto', () => {
+  class MockWakuDecryptError extends Error {}
+  return {
+    __esModule: true,
+    decrypt: jest.fn(),
+    encrypt: jest.fn(),
+    getCurrentKeyEpoch: jest.fn(),
+    getSupportedKeyEpochs: jest.fn(),
+    WakuDecryptError: MockWakuDecryptError,
+  };
+});
+
+jest.mock('@blue-ocean/utils', () => ({
+  __esModule: true,
+  topicFor: jest.fn(() => '/mock/topic'),
+}));
+
+jest.mock('@/services/monitoring', () => ({
+  __esModule: true,
+  wakuDecryptErrorCounter: { inc: jest.fn() },
+}));
+
+jest.mock('@/utils/serialization', () => ({
+  __esModule: true,
+  canonicalJson: (value: unknown) => JSON.stringify(value),
+}));
+
+describe('subscribeWithAck', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+
+    mockCreateDecoder.mockImplementation(() => ({}));
+    mockBytesToUtf8.mockImplementation((bytes: Uint8Array) => textDecoder.decode(bytes));
+    mockUtf8ToBytes.mockImplementation((value: string) => textEncoder.encode(value));
+    mockCreateEncoder.mockImplementation(() => ({}));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('suppresses duplicate ids but expires them after the TTL', async () => {
+    const transport = await import('@/utils/transport');
+    const getClientMock = transport.getClient as jest.Mock;
+    getClientMock.mockResolvedValue(mockClient);
+
+    const crypto = await import('@/utils/wakuCrypto');
+    const decryptMock = crypto.decrypt as jest.Mock;
+    const getSupportedKeyEpochsMock = crypto.getSupportedKeyEpochs as jest.Mock;
+    getSupportedKeyEpochsMock.mockReturnValue([0]);
+
+    const messages = [
+      { id: 'msg-1', seq: 1 },
+      { id: 'msg-1', seq: 2 },
+      { id: 'msg-1', seq: 3 },
+    ];
+    let callIndex = 0;
+    decryptMock.mockImplementation(async () => {
+      const message = messages[Math.min(callIndex, messages.length - 1)];
+      callIndex += 1;
+      return { plaintext: mockUtf8ToBytes(JSON.stringify(message)) };
+    });
+
+    const callback = jest.fn();
+    const unsubscribe = jest.fn();
+    let observer: ((msg: any) => Promise<void>) | undefined;
+
+    const mockRelay = {
+      addObserver: jest.fn((handler: (msg: any) => Promise<void>) => {
+        observer = handler;
+        return unsubscribe;
+      }),
+    };
+    const mockLightPush = {
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+    const node = { relay: mockRelay, lightPush: mockLightPush } as const;
+
+    const wakuModule = await import('@/services/waku');
+    const ensureNodeSpy = jest.spyOn(wakuModule, 'ensureNode').mockResolvedValue(node as any);
+
+    try {
+      await wakuModule.subscribeWithAck('/blue-ocean/test', callback);
+      expect(mockRelay.addObserver).toHaveBeenCalledTimes(1);
+      expect(observer).toBeDefined();
+
+      await observer!({ payload: mockUtf8ToBytes('first') });
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ seq: 1 }));
+      expect(mockLightPush.send).toHaveBeenCalledTimes(1);
+
+      await observer!({ payload: mockUtf8ToBytes('second') });
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockLightPush.send).toHaveBeenCalledTimes(1);
+
+      jest.setSystemTime(wakuModule.RECEIVED_ID_TTL_MS + 1);
+
+      await observer!({ payload: mockUtf8ToBytes('third') });
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ seq: 3 }));
+      expect(mockLightPush.send).toHaveBeenCalledTimes(2);
+    } finally {
+      ensureNodeSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- track received Waku message IDs with timestamps and bounded capacity so stale entries expire before re-processing
- prune duplicate IDs inside subscribeWithAck using the timestamped cache
- add a focused subscribeWithAck test that exercises duplicate suppression and TTL expiry with mocked dependencies

## Testing
- npx -y -p jest@29.7.0 -p ts-jest@29.1.2 -p typescript@5.9.2 -p @types/jest@29.5.12 -p jest-environment-jsdom@30.1.2 -p babel-jest@29.7.0 -p @babel/core@7.27.1 jest tests/waku/subscribeWithAck.test.ts *(fails: preset ts-jest/presets/default-esm not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d117a810b88326a613f970fcc4212a