### PR TITLE
Handle React Native Waku publisher key storage

### DIFF
--- a/services/waku.ts
+++ b/services/waku.ts
@@ -64,6 +64,8 @@ const MAX_GZ_PAYLOAD = 200 * 1024; // 200KB
 const PROMPT_TTI_MS = 2500; // 2.5s
 const NONCE_BYTE_LENGTH = 12;
 const KEY_EPOCH_INTERVAL_MS = 10 * 60 * 1000;
+const PUBLISHER_KEY_STORAGE_KEY = 'waku_ephemeral_key';
+const PUBLISHER_KEY_GLOBAL_SYMBOL = Symbol.for('waku.publisherKey');
 
 function toHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
@@ -72,6 +74,149 @@ function toHex(bytes: Uint8Array): string {
 function randomHex(byteLength = NONCE_BYTE_LENGTH): string {
   return toHex(randomBytes(byteLength));
 }
+
+function isReactNativeEnv(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.product === 'string' &&
+    navigator.product === 'ReactNative'
+  );
+}
+
+function getGlobalPublisherKey(): string | null {
+  const globalKey = (globalThis as Record<PropertyKey, unknown>)[
+    PUBLISHER_KEY_GLOBAL_SYMBOL
+  ];
+  return typeof globalKey === 'string' ? globalKey : null;
+}
+
+function cachePublisherKey(key: string): string {
+  (globalThis as Record<PropertyKey, unknown>)[
+    PUBLISHER_KEY_GLOBAL_SYMBOL
+  ] = key;
+  cachedPublisherKey = key;
+  return key;
+}
+
+async function randomBytesReactNative(): Promise<Uint8Array> {
+  try {
+    const randomModule: typeof import('expo-random') = await import(
+      'expo-random'
+    );
+    if (typeof randomModule.getRandomBytesAsync === 'function') {
+      const result = await randomModule.getRandomBytesAsync(32);
+      if (result instanceof Uint8Array) return result;
+      if (Array.isArray(result)) return Uint8Array.from(result);
+    }
+  } catch (err) {
+    logger.warn({ err }, 'expo-random unavailable for RN key generation');
+  }
+  try {
+    await import('react-native-get-random-values');
+    const cryptoLike = (
+      globalThis as { crypto?: { getRandomValues?: (arr: Uint8Array) => void } }
+    ).crypto;
+    if (cryptoLike && typeof cryptoLike.getRandomValues === 'function') {
+      const arr = new Uint8Array(32);
+      cryptoLike.getRandomValues(arr);
+      return arr;
+    }
+  } catch (err) {
+    logger.warn(
+      { err },
+      'react-native-get-random-values unavailable for RN key generation'
+    );
+  }
+  return randomBytes(32);
+}
+
+function randomBytesBrowser(): Uint8Array {
+  const cryptoLike = (
+    globalThis as { crypto?: { getRandomValues?: (arr: Uint8Array) => void } }
+  ).crypto;
+  if (cryptoLike && typeof cryptoLike.getRandomValues === 'function') {
+    const arr = new Uint8Array(32);
+    cryptoLike.getRandomValues(arr);
+    return arr;
+  }
+  return randomBytes(32);
+}
+
+function ensureHexKey(bytes: Uint8Array): string {
+  return `hex:${toHex(bytes)}`;
+}
+
+async function loadReactNativePublisherKey(): Promise<string | null> {
+  try {
+    const secureStore: typeof import('expo-secure-store') = await import(
+      'expo-secure-store'
+    );
+    const existing = await secureStore.getItemAsync(PUBLISHER_KEY_STORAGE_KEY);
+    if (existing) return cachePublisherKey(existing);
+    const bytes = await randomBytesReactNative();
+    const key = ensureHexKey(bytes);
+    await secureStore.setItemAsync(PUBLISHER_KEY_STORAGE_KEY, key);
+    return cachePublisherKey(key);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to resolve React Native publisher key');
+    return null;
+  }
+}
+
+function resolveBrowserPublisherKey(): string | null {
+  try {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.localStorage === 'undefined'
+    ) {
+      return null;
+    }
+    const existing = window.localStorage.getItem(PUBLISHER_KEY_STORAGE_KEY);
+    if (existing) return cachePublisherKey(existing);
+    const key = ensureHexKey(randomBytesBrowser());
+    window.localStorage.setItem(PUBLISHER_KEY_STORAGE_KEY, key);
+    return cachePublisherKey(key);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to use localStorage for publisher key');
+    return null;
+  }
+}
+
+function resolveNodePublisherKey(): string | null {
+  try {
+    const nodeCrypto: typeof import('crypto') = require('crypto');
+    const key = `hex:${nodeCrypto.randomBytes(32).toString('hex')}`;
+    return cachePublisherKey(key);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to use node crypto for publisher key');
+    return null;
+  }
+}
+
+function resolveFallbackPublisherKey(): string {
+  const existing = getGlobalPublisherKey();
+  if (existing) return existing;
+  return cachePublisherKey(ensureHexKey(randomBytes(32)));
+}
+
+async function computePublisherKey(): Promise<string> {
+  if (PUB) return cachePublisherKey(PUB);
+  if (strict) throw new Error('WAKU_PUBLISHER_KEY required in strict/prod.');
+  const globalKey = getGlobalPublisherKey();
+  if (globalKey) return cachePublisherKey(globalKey);
+  if (isReactNativeEnv()) {
+    const rnKey = await loadReactNativePublisherKey();
+    if (rnKey) return rnKey;
+  }
+  const browserKey = resolveBrowserPublisherKey();
+  if (browserKey) return browserKey;
+  const nodeKey = resolveNodePublisherKey();
+  if (nodeKey) return nodeKey;
+  return resolveFallbackPublisherKey();
+}
+
+let cachedPublisherKey: string | null = null;
+let publisherKeyPromise: Promise<string> | null = null;
 type PersistStoreFn = (storeId: string, store: Store) => Promise<void>;
 
 let persistStoreImpl: PersistStoreFn | null = null;
@@ -135,30 +280,18 @@ function enrichEnvelope(message: unknown): Record<string, unknown> {
   return { ...base, ts, nonce, keyEpoch };
 }
 
-function getPublisherKey(): string {
-  if (PUB) return PUB;
-  if (strict) throw new Error('WAKU_PUBLISHER_KEY required in strict/prod.');
-  try {
-    const k =
-      typeof window !== 'undefined'
-        ? localStorage.getItem('waku_ephemeral_key') ||
-          (localStorage.setItem(
-            'waku_ephemeral_key',
-            'hex:' +
-              Array.from(crypto.getRandomValues(new Uint8Array(32)))
-                .map((b) => b.toString(16).padStart(2, '0'))
-                .join('')
-          ),
-          localStorage.getItem('waku_ephemeral_key')!)
-        : 'hex:' + require('crypto').randomBytes(32).toString('hex');
-    return k;
-  } catch {
-    return 'hex:' + '0'.repeat(64);
+export async function getPublisherKey(): Promise<string> {
+  if (cachedPublisherKey) return cachedPublisherKey;
+  if (!publisherKeyPromise) {
+    publisherKeyPromise = computePublisherKey();
   }
+  const key = await publisherKeyPromise;
+  cachedPublisherKey = key;
+  return key;
 }
 
 async function startNode(): Promise<LightNode | null> {
-  getPublisherKey();
+  await getPublisherKey();
   const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
   let node: LightNode | null = null;
   try {

--- a/tests/waku/publisherKey.test.ts
+++ b/tests/waku/publisherKey.test.ts
@@ -1,0 +1,227 @@
+const expoRandomMock = {
+  getRandomBytesAsync: jest.fn<Promise<Uint8Array>, [number]>(),
+};
+
+jest.mock('expo-random', () => expoRandomMock, { virtual: true });
+jest.mock('react-native-get-random-values', () => ({}), { virtual: true });
+
+const STORAGE_KEY = 'waku_ephemeral_key';
+const GLOBAL_KEY_SYMBOL = Symbol.for('waku.publisherKey');
+
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'navigator'
+);
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'window'
+);
+const originalWindowLocalStorageDescriptor =
+  typeof window !== 'undefined'
+    ? Object.getOwnPropertyDescriptor(window, 'localStorage')
+    : undefined;
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'localStorage'
+);
+const originalProcess = global.process;
+
+function bytesSequence(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, idx) => (start + idx) & 0xff);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function setReactNativeNavigator(): void {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { product: 'ReactNative' } as unknown,
+  });
+}
+
+function stubFailingLocalStorage(): void {
+  const thrower = () => {
+    throw new Error('localStorage should not be accessed in React Native path');
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    get: thrower,
+  });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: thrower,
+    });
+  }
+}
+
+function clearPublisherKeyGlobal(): void {
+  delete (globalThis as Record<PropertyKey, unknown>)[GLOBAL_KEY_SYMBOL];
+}
+
+afterEach(() => {
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      'navigator',
+      originalNavigatorDescriptor as PropertyDescriptor
+    );
+  } else {
+    delete (globalThis as any).navigator;
+  }
+
+  if (originalWindowDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      'window',
+      originalWindowDescriptor as PropertyDescriptor
+    );
+  } else {
+    delete (globalThis as any).window;
+  }
+
+  if (typeof window !== 'undefined') {
+    if (originalWindowLocalStorageDescriptor) {
+      Object.defineProperty(
+        window,
+        'localStorage',
+        originalWindowLocalStorageDescriptor as PropertyDescriptor
+      );
+    } else {
+      delete (window as any).localStorage;
+    }
+  }
+
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      'localStorage',
+      originalLocalStorageDescriptor as PropertyDescriptor
+    );
+  } else {
+    delete (globalThis as any).localStorage;
+  }
+
+  global.process = originalProcess;
+  expoRandomMock.getRandomBytesAsync.mockReset();
+  clearPublisherKeyGlobal();
+  jest.resetModules();
+});
+
+describe('getPublisherKey React Native handling', () => {
+  it('persists a generated key via SecureStore without touching localStorage', async () => {
+    jest.resetModules();
+    clearPublisherKeyGlobal();
+
+    setReactNativeNavigator();
+    stubFailingLocalStorage();
+
+    const secureStore = await import('expo-secure-store');
+    secureStore.__reset();
+
+    const bytes = bytesSequence(1);
+    expoRandomMock.getRandomBytesAsync.mockResolvedValueOnce(bytes);
+
+    const module = await import('@/services/waku');
+    const key = await module.getPublisherKey();
+    const expected = `hex:${toHex(bytes)}`;
+
+    expect(key).toBe(expected);
+    expect(await module.getPublisherKey()).toBe(expected);
+    expect(secureStore.setItemAsync).toHaveBeenCalledWith(STORAGE_KEY, expected);
+    expect(expoRandomMock.getRandomBytesAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates a unique key for a new install after SecureStore reset', async () => {
+    jest.resetModules();
+    clearPublisherKeyGlobal();
+
+    setReactNativeNavigator();
+    stubFailingLocalStorage();
+
+    let secureStore = await import('expo-secure-store');
+    secureStore.__reset();
+
+    const firstBytes = bytesSequence(11);
+    expoRandomMock.getRandomBytesAsync.mockResolvedValueOnce(firstBytes);
+
+    let module = await import('@/services/waku');
+    const firstKey = await module.getPublisherKey();
+    const expectedFirst = `hex:${toHex(firstBytes)}`;
+    expect(firstKey).toBe(expectedFirst);
+    expect(secureStore.setItemAsync).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expectedFirst
+    );
+
+    // Simulate reinstall by clearing storage and module cache
+    jest.resetModules();
+    clearPublisherKeyGlobal();
+    secureStore = await import('expo-secure-store');
+    secureStore.__reset();
+
+    setReactNativeNavigator();
+    stubFailingLocalStorage();
+
+    const secondBytes = bytesSequence(51);
+    expoRandomMock.getRandomBytesAsync.mockResolvedValueOnce(secondBytes);
+
+    module = await import('@/services/waku');
+    const secondKey = await module.getPublisherKey();
+    const expectedSecond = `hex:${toHex(secondBytes)}`;
+
+    expect(secondKey).toBe(expectedSecond);
+    expect(secondKey).not.toBe(firstKey);
+    expect(secureStore.setItemAsync).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expectedSecond
+    );
+  });
+});
+
+describe('getPublisherKey fallback behavior', () => {
+  it('creates and reuses a random key when no persistent storage exists', async () => {
+    jest.resetModules();
+    clearPublisherKeyGlobal();
+
+    delete (globalThis as any).navigator;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: undefined,
+    });
+
+    const processClone = Object.create(originalProcess);
+    processClone.versions = {} as any;
+    (global as any).process = processClone;
+
+    expoRandomMock.getRandomBytesAsync.mockRejectedValue(
+      new Error('expo random should not be used')
+    );
+
+    const fallbackBytes = bytesSequence(101);
+
+    jest.doMock('@noble/hashes/utils', () => ({
+      randomBytes: () => fallbackBytes,
+    }));
+    jest.doMock('crypto', () => {
+      throw new Error('crypto unavailable');
+    });
+
+    const module = await import('@/services/waku');
+    const key = await module.getPublisherKey();
+    const expected = `hex:${toHex(fallbackBytes)}`;
+
+    expect(key).toBe(expected);
+    expect(await module.getPublisherKey()).toBe(expected);
+    expect(key).not.toBe(`hex:${'0'.repeat(64)}`);
+
+    jest.dontMock('@noble/hashes/utils');
+    jest.dontMock('crypto');
+  });
+});


### PR DESCRIPTION
## Summary
- add React Native aware publisher key handling that persists via SecureStore, caches globally, and avoids deterministic fallback values
- generate browser, node, and final fallback keys using per-install randomness while keeping strict-mode validation intact
- cover React Native and fallback behaviors with new Jest tests that mock secure storage and randomness

## Testing
- attempted `yarn install` *(fails: https://registry.yarnpkg.com/@blue-ocean%2Fsdk-near: Not found)*
- unable to run `jest` due to missing workspace dependencies

------
https://chatgpt.com/codex/tasks/task_e_68d122c7a3f88326bc946162d0f7f4b3