### PR TITLE
Require configured cache secret

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -45,7 +45,10 @@ const envSchema = z.object({
   AWS_ACCESS_KEY_ID: z.string().optional().default(''),
   AWS_SECRET_ACCESS_KEY: z.string().optional().default(''),
   CACHE_DIR: z.string().optional().default(''),
-  CACHE_SECRET: z.string().optional().default('blue-ocean'),
+  CACHE_SECRET: z
+    .string()
+    .min(1, 'CACHE_SECRET must not be empty')
+    .optional(),
 });
 
 export type Config = z.infer<typeof envSchema>;

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -113,6 +113,7 @@ Use this checklist before inviting shoppers. Mark each line once validated and r
 - [ ] `EXPO_PUBLIC_NEAR_WALLET_URL` and `EXPO_PUBLIC_NEAR_WALLET_REDIRECT_URL` are correct for the chosen network
 - [ ] `EXPO_PUBLIC_NEAR_RPC_URL` (optional) overrides the RPC endpoint if you run your own node
 - [ ] `EXPO_PUBLIC_DEBUG_LOGS` is set appropriately for the environment (`false` in production)
+- [ ] `CACHE_SECRET` is a random 32+ character value stored in your secrets manager for cache encryption
 
 ### Contract deployment & relayer
 

--- a/docs/secure-key-management.md
+++ b/docs/secure-key-management.md
@@ -3,3 +3,13 @@
 Sensitive configuration values such as `NEAR_RPC_URL` must be supplied via environment variables. In production environments, load these variables from a dedicated secrets manager (AWS Secrets Manager, Hashicorp Vault, Docker secrets, etc.) rather than committing them to source control. The OrderPayment factory contract address is managed by admins through the dashboard and does not require an environment variable.
 
 At runtime the app validates that required keys are present and will throw an error if any are missing. Development-only flags are automatically ignored when `NODE_ENV` is set to `production`.
+
+## Cache encryption secret
+
+`CACHE_SECRET` encrypts persisted snapshot files using AES-GCM. Set this to a high-entropy value for every deployment and store it in the same secrets manager you use for other credentials. Operators can generate a suitable secret with:
+
+```sh
+openssl rand -hex 32
+```
+
+Expose the value as the `CACHE_SECRET` environment variable (or through Vault injection during bootstrap) before starting the relayer or any other Node.js runtime that touches the on-disk cache. The services layer now fails fast when the secret is undefined so CI and production pipelines surface misconfigurations immediately.

--- a/services/cache/index.ts
+++ b/services/cache/index.ts
@@ -23,8 +23,16 @@ const memorySnapshots = new Map<string, { hash: string; version: number; data: u
 const CACHE_DIR = isNodeRuntime && pathModule && typeof process.cwd === 'function'
   ? config.CACHE_DIR || pathModule.join(process.cwd(), '.cache')
   : '.cache';
-const SECRET = config.CACHE_SECRET || 'blue-ocean';
-const KEY = cryptoModule ? cryptoModule.createHash('sha256').update(SECRET).digest() : null;
+const SECRET = config.CACHE_SECRET;
+const hasSecret = typeof SECRET === 'string' && SECRET.trim().length > 0;
+
+if (isNodeRuntime && !hasSecret) {
+  throw new Error(
+    'CACHE_SECRET is required when running the persistent cache. Provide a secure random value via the CACHE_SECRET environment variable or config.CACHE_SECRET.',
+  );
+}
+
+const KEY = hasSecret && cryptoModule ? cryptoModule.createHash('sha256').update(SECRET!).digest() : null;
 
 function filePath(key: string): string {
   if (!pathModule) return key;

--- a/tests/cacheSnapshotVersion.test.ts
+++ b/tests/cacheSnapshotVersion.test.ts
@@ -25,3 +25,27 @@ describe('cache snapshot schema version', () => {
     expect(data).toEqual({ foo: 'bar' });
   });
 });
+
+describe('cache secret configuration', () => {
+  const originalSecret = process.env.CACHE_SECRET;
+
+  afterEach(() => {
+    jest.resetModules();
+    if (originalSecret === undefined) {
+      delete process.env.CACHE_SECRET;
+    } else {
+      process.env.CACHE_SECRET = originalSecret;
+    }
+  });
+
+  it('throws a descriptive error when secret is missing in Node runtimes', () => {
+    jest.resetModules();
+    delete process.env.CACHE_SECRET;
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('@/services/cache');
+      });
+    }).toThrowError(/CACHE_SECRET is required/);
+  });
+});

--- a/tests/initGlobals.ts
+++ b/tests/initGlobals.ts
@@ -5,6 +5,9 @@
 process.env.EXPO_PUBLIC_CHAIN = 'near';
 process.env.EXPO_PUBLIC_CONTRACT_ID = 'EQtestcontract';
 process.env.EXPO_PUBLIC_NETWORK = 'testnet';
+if (!process.env.CACHE_SECRET) {
+  process.env.CACHE_SECRET = 'test-cache-secret';
+}
 
 // Provide minimal polyfills for Node environments lacking Web APIs.
 // `fetch` is undefined in older Node versions which makes `jest.spyOn`
@@ -25,39 +28,52 @@ import { createRequire } from 'module';
 
 const baseRequire = createRequire(`${process.cwd()}/jest.config.js`);
 
-const configStub = {
-  default: {
-    EXPO_PUBLIC_TRANSPORT: '',
-    EXPO_PUBLIC_CONTRACT_ID: '',
-    WAKU_PUBLISHER_KEY: '',
-    EXPO_PUBLIC_WAKU_PUBLISHER_KEY: '',
-    WAKU_DISABLE: '',
-    EXPO_PUBLIC_WAKU_DISABLE: '',
-    WAKU_STRICT: '',
-    EXPO_PUBLIC_RELAYER_URL: '',
-    EXPO_PUBLIC_INDEXER_URL: '',
-    EXPO_PUBLIC_DEBUG_LOGS: '',
-    EXPO_PUBLIC_CHAIN: '',
-    NEAR_NETWORK: '',
-    NEAR_RPC_URL: '',
-    NEAR_RPC_FALLBACK_URLS: '',
-    ENABLE_UNSAFE_NEAR_PRIVATE_KEY: '',
-    EXPO_PUBLIC_PINATA_API_KEY: '',
-    EXPO_PUBLIC_PINATA_SECRET_API_KEY: '',
-    EXPO_PUBLIC_PINATA_JWT: '',
-    EXPO_PUBLIC_MOONPAY_PUBLISHABLE_KEY: '',
-    NEAR_LAKE_BUCKET: '',
-    NEAR_LAKE_REGION: 'eu-central-1',
-    NEAR_LAKE_DIR: '',
-    NEAR_LAKE_START_BLOCK: '0',
-    NEAR_LAKE_ENDPOINT: '',
-    NEAR_ACCESS_KEY: '',
-    NEAR_SECRET_KEY: '',
-    AWS_ACCESS_KEY_ID: '',
-    AWS_SECRET_ACCESS_KEY: '',
-    CACHE_DIR: '',
-    CACHE_SECRET: 'blue-ocean',
+const configValues = {
+  EXPO_PUBLIC_TRANSPORT: '',
+  EXPO_PUBLIC_CONTRACT_ID: '',
+  WAKU_PUBLISHER_KEY: '',
+  EXPO_PUBLIC_WAKU_PUBLISHER_KEY: '',
+  WAKU_DISABLE: '',
+  EXPO_PUBLIC_WAKU_DISABLE: '',
+  WAKU_STRICT: '',
+  EXPO_PUBLIC_RELAYER_URL: '',
+  EXPO_PUBLIC_INDEXER_URL: '',
+  EXPO_PUBLIC_DEBUG_LOGS: '',
+  EXPO_PUBLIC_CHAIN: '',
+  NEAR_NETWORK: '',
+  NEAR_RPC_URL: '',
+  NEAR_RPC_FALLBACK_URLS: '',
+  ENABLE_UNSAFE_NEAR_PRIVATE_KEY: '',
+  EXPO_PUBLIC_PINATA_API_KEY: '',
+  EXPO_PUBLIC_PINATA_SECRET_API_KEY: '',
+  EXPO_PUBLIC_PINATA_JWT: '',
+  EXPO_PUBLIC_MOONPAY_PUBLISHABLE_KEY: '',
+  NEAR_LAKE_BUCKET: '',
+  NEAR_LAKE_REGION: 'eu-central-1',
+  NEAR_LAKE_DIR: '',
+  NEAR_LAKE_START_BLOCK: '0',
+  NEAR_LAKE_ENDPOINT: '',
+  NEAR_ACCESS_KEY: '',
+  NEAR_SECRET_KEY: '',
+  AWS_ACCESS_KEY_ID: '',
+  AWS_SECRET_ACCESS_KEY: '',
+  CACHE_DIR: '',
+  CACHE_SECRET: '',
+};
+
+Object.defineProperty(configValues, 'CACHE_SECRET', {
+  configurable: true,
+  enumerable: true,
+  get() {
+    return process.env.CACHE_SECRET ?? 'test-cache-secret';
   },
+  set(value) {
+    process.env.CACHE_SECRET = value as string;
+  },
+});
+
+const configStub = {
+  default: configValues,
   reloadConfig: () => {},
 };
 


### PR DESCRIPTION
## Summary
- remove the default fallback for `CACHE_SECRET` and validate the value is non-empty during config parsing
- prevent the cache service from deriving an AES-GCM key without a configured secret and document the new runtime requirement for operators
- update the Jest environment and cache snapshot tests to cover missing-secret failures so CI highlights misconfiguration

## Testing
- ⚠️ `yarn install --ignore-scripts` *(fails: workspace package "@blue-ocean/sdk-near" is not published to the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d127d034bc832691743fd38a6969f4