### PR TITLE
Wrap homepage content in layout container

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 // TOUCHPOINT: pages/index.tsx — MVP network homepage (hero + 4 cards)
 import React, { Suspense } from 'react';
-import { View, StyleSheet } from 'react-native';
-import { ScrollArea, Stack } from '@/ui/layout';
+import { StyleSheet } from 'react-native';
+import { Container, ScrollArea, Stack } from '@/ui/layout';
 import { Spinner } from '@/ui/primitives';
 import HeroCallout from '@/features/home/components/HeroCallout';
 import HomeOptions from '@/features/home/components/HomeOptions';
@@ -15,7 +15,7 @@ export default function IndexPage() {
   return (
     <ErrorBoundary>
       <ScrollArea backgroundColor={colors.canvas}>
-        <View style={[styles.wrapper, { backgroundColor: colors.canvas }]}>
+        <Container backgroundColor={colors.canvas} style={styles.wrapper}>
           <Stack gap="spacer24">
             <Suspense fallback={<Spinner />}>
               <HeroCallout />
@@ -24,7 +24,7 @@ export default function IndexPage() {
               <HomeOptions />
             </Suspense>
           </Stack>
-        </View>
+        </Container>
       </ScrollArea>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- wrap the homepage hero and option sections in the shared `Container` layout for consistent responsive side padding
- retain the existing vertical spacing while delegating horizontal padding to the layout wrapper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1473614cc832693860dd769e6b264