### PR TITLE
Simplify provider composition and bootstrap logic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,29 +3,48 @@ import './polyfills';
 import { AppRegistry } from 'react-native';
 import App from './App';
 
-// Ensure root has height even without +html Document and mount manually
-  try {
-  if (typeof document !== 'undefined') {
-    const style = document.createElement('style');
-    style.innerHTML = `
-      html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; }
-      html { min-height: 100%; }
-      body { background: #0b0b0b; }
-    `;
-    document.head.appendChild(style);
-    let root = document.getElementById('root') || document.getElementById('app-root');
-    if (!root) {
-      root = document.createElement('div');
-      root.id = 'root';
-      document.body.appendChild(root);
-    }
-    AppRegistry.registerComponent('main', () => App);
-    AppRegistry.runApplication('main', {
-      rootTag: root,
-      initialProps: {},
-      hydrate: false,
-    } as any);
+const GLOBAL_STYLE_RULES = `
+  html, body, #root, #app-root { height: 100% !important; margin: 0; padding: 0; }
+  html { min-height: 100%; }
+  body { background: #0b0b0b; }
+`;
+
+function injectGlobalStyles() {
+  const style = document.createElement('style');
+  style.innerHTML = GLOBAL_STYLE_RULES;
+  document.head.appendChild(style);
+}
+
+function ensureRootContainer(): HTMLElement {
+  const rootElement =
+    document.getElementById('root') ?? document.getElementById('app-root');
+  if (rootElement instanceof HTMLElement) {
+    return rootElement;
   }
+
+  const root = document.createElement('div');
+  root.id = 'root';
+  document.body.appendChild(root);
+  return root;
+}
+
+function bootstrap() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  injectGlobalStyles();
+  const root = ensureRootContainer();
+  AppRegistry.registerComponent('main', () => App);
+  AppRegistry.runApplication('main', {
+    rootTag: root,
+    initialProps: {},
+    hydrate: false,
+  } as any);
+}
+
+try {
+  bootstrap();
 } catch (err) {
   console.error('Failed to start app', err);
 }

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -14,6 +14,7 @@ import { CurrencyProvider } from '@/contexts/CurrencyContext';
 import { NotificationProvider } from '@/components/NotificationContext';
 import { reportError } from '@/services/errorReporter';
 import { LaunchGateProvider } from '@/features/launchGate';
+import { composeProviders, type ProviderConfig } from './composeProviders';
 
 /**
  * Composes the core providers used across the app.
@@ -73,34 +74,28 @@ export default function AppProviders({ children }: React.PropsWithChildren) {
     },
     [showNotification],
   );
-  return (
-    <ThemeProvider>
-      <LanguageProvider>
-        <CheckedQueryClientProvider client={queryClient}>
-          <WalletProvider>
-            <AppInfoProvider>
-              <ConfigProvider>
-                <ErrorBoundary onError={handleBoundaryError}>
-                  <WakuProvider>
-                    <AuthProvider>
-                      <AuthModalProvider>
-                        <CurrencyProvider>
-                          <NotificationProvider>
-                            <NotificationActionsRegistrar
-                              onReady={handleNotificationReady}
-                            />
-                            <LaunchGateProvider>{children}</LaunchGateProvider>
-                          </NotificationProvider>
-                        </CurrencyProvider>
-                      </AuthModalProvider>
-                    </AuthProvider>
-                  </WakuProvider>
-                </ErrorBoundary>
-              </ConfigProvider>
-            </AppInfoProvider>
-          </WalletProvider>
-        </CheckedQueryClientProvider>
-      </LanguageProvider>
-    </ThemeProvider>
+  const providerTree = React.useMemo<ProviderConfig[]>(
+    () => [
+      { component: ThemeProvider },
+      { component: LanguageProvider },
+      { component: CheckedQueryClientProvider, props: { client: queryClient } },
+      { component: WalletProvider },
+      { component: AppInfoProvider },
+      { component: ConfigProvider },
+      { component: ErrorBoundary, props: { onError: handleBoundaryError } },
+      { component: WakuProvider },
+      { component: AuthProvider },
+      { component: AuthModalProvider },
+      { component: CurrencyProvider },
+      { component: NotificationProvider },
+    ],
+    [handleBoundaryError],
   );
+
+  return composeProviders(providerTree, (
+    <>
+      <NotificationActionsRegistrar onReady={handleNotificationReady} />
+      <LaunchGateProvider>{children}</LaunchGateProvider>
+    </>
+  ));
 }

--- a/src/providers/composeProviders.tsx
+++ b/src/providers/composeProviders.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface ProviderConfig {
+  readonly component: React.ComponentType<React.PropsWithChildren<any>>;
+  readonly props?: Record<string, unknown>;
+}
+
+export function composeProviders(
+  providers: readonly ProviderConfig[],
+  children: React.ReactNode,
+): React.ReactElement {
+  return providers.reduceRight<React.ReactElement>(
+    (acc, { component: Component, props }) =>
+      React.createElement(Component, props ?? {}, acc),
+    React.createElement(React.Fragment, null, children),
+  );
+}


### PR DESCRIPTION
## Summary
- flatten the React provider tree by composing providers through a reusable helper
- add a small composeProviders utility to share the wrapping logic across the app
- refactor the web bootstrap entry to isolated helpers for DOM setup to reduce inline complexity

## Testing
- npm install --ignore-scripts *(fails: npm does not understand workspace protocol)*
- yarn install --ignore-scripts *(fails: workspace package @blue-ocean/sdk-near is not published)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a98fb8188326bfea55619469d8ea