### PR TITLE
Refactor Waku node bootstrap reuse

### DIFF
--- a/src/services/eventBus.ts
+++ b/src/services/eventBus.ts
@@ -1,17 +1,15 @@
 import { errorLog, debugLog } from '@/utils/logger';
 import { withMonitoring } from './monitoring';
-import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import { uuid } from '../utils/uuid';
 import { sha256 } from '@noble/hashes/sha256';
 import { chainAdapter } from '@/services/chain';
-import config from '@/config';
 import { canonicalJson } from '@/utils/serialization';
+import { ensureRelayNode } from '@/services/wakuNode';
 
 const ANALYTICS_TOPIC = '/blue-ocean/analytics/1';
 const sessionId = uuid();
-
-let node: LightNode | null = null;
+const ensureNode = ensureRelayNode;
 
 interface PublishOptions {
   orderId?: string;
@@ -21,26 +19,6 @@ interface PublishOptions {
 
 // TODO:TODO-102 Harden ensureNode to survive mobile background transitions without leaking dangling Waku nodes.
 // TODO:REC-202 Emit structured connectivity metrics from ensureNode so monitoring can alert on relay unavailability.
-async function ensureNode(): Promise<LightNode | null> {
-  if (node) return node;
-  try {
-    if ((config.EXPO_PUBLIC_TRANSPORT || '').toLowerCase() !== 'waku') {
-      // In HTTP mode, disable Waku analytics
-      return null;
-    }
-    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-    node = await createLightNode({} as any);
-    if (!node) return null;
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.Relay]);
-    return node;
-  } catch (err) {
-    errorLog('Failed to start Waku node', err);
-    node = null;
-    return null;
-  }
-}
-
 export async function publish(
   contentTopic: string,
   type: string,

--- a/src/services/eventLog.ts
+++ b/src/services/eventLog.ts
@@ -1,11 +1,10 @@
 // @ts-nocheck
 import { errorLog } from '@/utils/logger';
-import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import { uuid } from '../utils/uuid';
 import { OrderStatus } from '../types';
-import config from '@/config';
 import { canonicalJson } from '@/utils/serialization';
+import { ensureRelayNode } from '@/services/wakuNode';
 
 export type OrderEventType =
   | 'order.created'
@@ -26,26 +25,7 @@ export interface OrderEvent {
 }
 
 const ORDER_TOPIC = '/blue-ocean/orders/1';
-let node: LightNode | null = null;
-
-async function ensureNode(): Promise<LightNode | null> {
-  if (node) return node;
-  try {
-    if ((config.EXPO_PUBLIC_TRANSPORT || '').toLowerCase() !== 'waku') {
-      return null;
-    }
-    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-    node = await createLightNode({});
-    if (!node) return null;
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.Relay]);
-    return node;
-  } catch (err) {
-    errorLog('Failed to start Waku node', err);
-    node = null;
-    return null;
-  }
-}
+const ensureNode = ensureRelayNode;
 
 export async function logOrderEvent(
   event: Omit<OrderEvent, 'id'>,

--- a/src/services/nearSettings.ts
+++ b/src/services/nearSettings.ts
@@ -2,7 +2,6 @@ import { debugLog, errorLog } from '@/utils/logger';
 import { assertNearChain } from './chain';
 import { getValue, setValue, listValues } from './nearKvStore';
 import config from '@/config';
-import type { LightNode } from '@waku/sdk';
 import { getClient } from '@/utils/transport';
 import type { SettingsWriteEvent } from '../types/waku';
 import { settingsWriteEventSchema, wakuMessageSchema } from '../schemas/waku';
@@ -12,11 +11,13 @@ import { canonicalJson } from '@/utils/serialization';
 import { makeSignedWakuMessage } from '@/utils/wakuSigning';
 import type { AdminScope } from '@/types';
 import { ALL_ADMIN_SCOPES } from '@/types';
+import { ensureRelayNode } from '@/services/wakuNode';
 
 assertNearChain();
 
 const ADDRESS = 'settings';
 const SETTINGS_TOPIC = '/blue-ocean/settings/1';
+const ensureNode = ensureRelayNode;
 
 async function assertAdmin(actor: string): Promise<void> {
   if (!actor) {
@@ -54,27 +55,6 @@ export interface NearSettings {
 
 export async function getSetting(key: string): Promise<string | null> {
   return await getValue(ADDRESS, key);
-}
-
-let node: LightNode | null = null;
-
-async function ensureNode(): Promise<LightNode | null> {
-  if (node) return node;
-  try {
-    if ((config.EXPO_PUBLIC_TRANSPORT || '').toLowerCase() !== 'waku') {
-      return null;
-    }
-    const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
-    node = await createLightNode({} as any);
-    if (!node) return null;
-    await node.start();
-    await waitForRemotePeer(node, [Protocols.Relay]);
-    return node;
-  } catch (err) {
-    errorLog('Failed to start Waku node', err);
-    node = null;
-    return null;
-  }
 }
 
 async function emit(event: SettingsWriteEvent) {

--- a/src/services/wakuNode.ts
+++ b/src/services/wakuNode.ts
@@ -1,0 +1,67 @@
+import { errorLog } from '@/utils/logger';
+import { getClient } from '@/utils/transport';
+import config from '@/config';
+import type { LightNode } from '@waku/sdk';
+
+type WakuModule = typeof import('@waku/sdk');
+type ProtocolMap = WakuModule['Protocols'];
+type ProtocolValue = ProtocolMap[keyof ProtocolMap];
+type ProtocolSelection = ProtocolValue | ProtocolValue[] | null | undefined;
+type ProtocolSelector = (protocols: ProtocolMap) => ProtocolSelection;
+
+function isWakuTransportEnabled(): boolean {
+  return (config.EXPO_PUBLIC_TRANSPORT || '').toLowerCase() === 'waku';
+}
+
+function toProtocolArray(
+  protocols: ProtocolMap,
+  selectProtocols?: ProtocolSelector,
+): ProtocolValue[] {
+  const selection = selectProtocols?.(protocols);
+  const array = Array.isArray(selection)
+    ? selection
+    : selection
+      ? [selection]
+      : [protocols.Relay];
+  return array.filter((value): value is ProtocolValue => Boolean(value));
+}
+
+async function startLightNode(
+  selectProtocols?: ProtocolSelector,
+): Promise<LightNode | null> {
+  const { createLightNode, waitForRemotePeer, Protocols } = await getClient();
+  const node = await createLightNode({} as any);
+  if (!node) return null;
+  await node.start();
+  const requiredProtocols = toProtocolArray(Protocols, selectProtocols);
+  await waitForRemotePeer(node, requiredProtocols);
+  return node;
+}
+
+export interface EnsureNodeOptions {
+  selectProtocols?: ProtocolSelector;
+  enabled?: () => boolean;
+}
+
+export function createEnsureNode({
+  selectProtocols,
+  enabled,
+}: EnsureNodeOptions = {}): () => Promise<LightNode | null> {
+  let node: LightNode | null = null;
+  const isEnabled = enabled ?? isWakuTransportEnabled;
+  return async () => {
+    if (!isEnabled()) return null;
+    if (node) return node;
+    try {
+      const started = await startLightNode(selectProtocols);
+      node = started;
+      return started;
+    } catch (err) {
+      errorLog('Failed to start Waku node', err);
+      node = null;
+      return null;
+    }
+  };
+}
+
+export const ensureRelayNode = createEnsureNode();


### PR DESCRIPTION
## Summary
- add a shared `createEnsureNode` helper to centralize bootstrapping Waku light nodes
- update event bus, event log, and near settings services to reuse the helper and drop duplicated startup logic

## Testing
- yarn lint src/services/eventBus.ts src/services/eventLog.ts src/services/nearSettings.ts src/services/wakuNode.ts *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68d3b513c230832690bcba7a46e7614e