### PR TITLE
refactor: share labeled form input component

### DIFF
--- a/src/components/form/LabeledInput.tsx
+++ b/src/components/form/LabeledInput.tsx
@@ -1,0 +1,77 @@
+import React, { forwardRef } from 'react';
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextInput,
+  TextInputProps,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+import { useTheme } from '@/ui/ThemeProvider';
+
+type Props = TextInputProps & {
+  label: string;
+  containerStyle?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+};
+
+const LabeledInput = forwardRef<TextInput, Props>(function LabeledInput(
+  { label, containerStyle, labelStyle, style, multiline, placeholderTextColor, textAlign, ...inputProps },
+  ref,
+) {
+  const { colors } = useTheme();
+
+  const resolvedPlaceholderColor = placeholderTextColor ?? colors.text.tertiary;
+  const resolvedTextAlign = textAlign ?? 'right';
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <Text style={[styles.label, { color: colors.text.primary }, labelStyle]}>{label}</Text>
+      <TextInput
+        ref={ref}
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.border.primary,
+            color: colors.text.primary,
+          },
+          multiline && styles.textArea,
+          style,
+        ]}
+        placeholderTextColor={resolvedPlaceholderColor}
+        textAlign={resolvedTextAlign}
+        multiline={multiline}
+        {...inputProps}
+      />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+    textAlign: 'right',
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  textArea: {
+    height: 80,
+    textAlignVertical: 'top',
+  },
+});
+
+export default LabeledInput;

--- a/src/features/cart/components/CartModal.tsx
+++ b/src/features/cart/components/CartModal.tsx
@@ -10,7 +10,6 @@ import {
   Modal,
   TouchableOpacity,
   ScrollView,
-  TextInput,
   KeyboardAvoidingView,
   Platform,
   Linking,
@@ -64,6 +63,7 @@ import { useLaunchGate } from '@/features/launchGate';
 import { useAppRouter } from '@/hooks';
 import InfoModal from '@/components/InfoModal';
 import ConfirmationModal from '@/components/ConfirmationModal';
+import LabeledInput from '@/components/form/LabeledInput';
 import {
   getCheckoutRequestScopes,
   getSession,
@@ -226,6 +226,12 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
     postalCode: '',
     notes: '',
   });
+  const updateShippingAddress = useCallback(
+    <K extends keyof ShippingAddress>(key: K, value: ShippingAddress[K]) => {
+      setShippingAddress((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
   const [loading, setLoading] = useState(false);
   const [orderPlaced, setOrderPlaced] = useState(false);
   const [orderIds, setOrderIds] = useState<string[]>([]);
@@ -786,140 +792,55 @@ export default function CartModal({ visible, onClose }: CartModalProps) {
           </Text>
         </View>
 
-        <View style={styles.formGroup}>
-          <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-            {t('cart.fullName')}
-          </Text>
-          <TextInput
-            style={[
-              styles.formInput,
-              {
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary,
-                color: colors.text.primary,
-              },
-            ]}
-            value={shippingAddress.name}
-            onChangeText={(text) => setShippingAddress({ ...shippingAddress, name: text })}
-            placeholder={t('cart.fullNamePlaceholder')}
-            textAlign="right"
-            placeholderTextColor={colors.text.tertiary}
-          />
-        </View>
+        <LabeledInput
+          label={t('cart.fullName')}
+          value={shippingAddress.name}
+          onChangeText={(text) => updateShippingAddress('name', text)}
+          placeholder={t('cart.fullNamePlaceholder')}
+        />
 
-        <View style={styles.formGroup}>
-          <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-            {t('cart.phone')}
-          </Text>
-          <TextInput
-            style={[
-              styles.formInput,
-              {
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary,
-                color: colors.text.primary,
-              },
-            ]}
-            value={shippingAddress.phone}
-            onChangeText={(text) => setShippingAddress({ ...shippingAddress, phone: text })}
-            placeholder={t('cart.phonePlaceholder')}
-            keyboardType="phone-pad"
-            textAlign="right"
-            placeholderTextColor={colors.text.tertiary}
-          />
-        </View>
+        <LabeledInput
+          label={t('cart.phone')}
+          value={shippingAddress.phone}
+          onChangeText={(text) => updateShippingAddress('phone', text)}
+          placeholder={t('cart.phonePlaceholder')}
+          keyboardType="phone-pad"
+        />
 
-        <View style={styles.formGroup}>
-          <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-            {t('cart.streetAddress')}
-          </Text>
-          <TextInput
-            style={[
-              styles.formInput,
-              {
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary,
-                color: colors.text.primary,
-              },
-            ]}
-            value={shippingAddress.street}
-            onChangeText={(text) => setShippingAddress({ ...shippingAddress, street: text })}
-            placeholder={t('cart.streetAddressPlaceholder')}
-            textAlign="right"
-            placeholderTextColor={colors.text.tertiary}
-          />
-        </View>
+        <LabeledInput
+          label={t('cart.streetAddress')}
+          value={shippingAddress.street}
+          onChangeText={(text) => updateShippingAddress('street', text)}
+          placeholder={t('cart.streetAddressPlaceholder')}
+        />
 
         <View style={styles.formRow}>
-          <View style={styles.formGroupHalf}>
-            <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-              {t('cart.city')}
-            </Text>
-            <TextInput
-              style={[
-                styles.formInput,
-                {
-                  backgroundColor: colors.surface.primary,
-                  borderColor: colors.border.primary,
-                  color: colors.text.primary,
-                },
-              ]}
-              value={shippingAddress.city}
-              onChangeText={(text) => setShippingAddress({ ...shippingAddress, city: text })}
-              placeholder={t('cart.cityPlaceholder')}
-              textAlign="right"
-              placeholderTextColor={colors.text.tertiary}
-            />
-          </View>
+          <LabeledInput
+            label={t('cart.city')}
+            value={shippingAddress.city}
+            onChangeText={(text) => updateShippingAddress('city', text)}
+            placeholder={t('cart.cityPlaceholder')}
+            containerStyle={styles.formGroupHalf}
+          />
 
-          <View style={styles.formGroupHalf}>
-            <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-              {t('cart.postalCode')}
-            </Text>
-            <TextInput
-              style={[
-                styles.formInput,
-                {
-                  backgroundColor: colors.surface.primary,
-                  borderColor: colors.border.primary,
-                  color: colors.text.primary,
-                },
-              ]}
-              value={shippingAddress.postalCode}
-              onChangeText={(text) =>
-                setShippingAddress({ ...shippingAddress, postalCode: text })
-              }
-              placeholder={t('cart.postalCodePlaceholder')}
-              keyboardType="numeric"
-              textAlign="right"
-              placeholderTextColor={colors.text.tertiary}
-            />
-          </View>
-        </View>
-
-        <View style={styles.formGroup}>
-          <Text style={[styles.formLabel, { color: colors.text.primary }]}>
-            {t('cart.notes')}
-          </Text>
-          <TextInput
-            style={[
-              styles.formInput,
-              styles.textArea,
-              {
-                backgroundColor: colors.surface.primary,
-                borderColor: colors.border.primary,
-                color: colors.text.primary,
-              },
-            ]}
-            value={shippingAddress.notes}
-            onChangeText={(text) => setShippingAddress({ ...shippingAddress, notes: text })}
-            placeholder={t('cart.notesPlaceholder')}
-            multiline
-            numberOfLines={3}
-            textAlign="right"
-            placeholderTextColor={colors.text.tertiary}
+          <LabeledInput
+            label={t('cart.postalCode')}
+            value={shippingAddress.postalCode}
+            onChangeText={(text) => updateShippingAddress('postalCode', text)}
+            placeholder={t('cart.postalCodePlaceholder')}
+            keyboardType="numeric"
+            containerStyle={styles.formGroupHalf}
           />
         </View>
+
+        <LabeledInput
+          label={t('cart.notes')}
+          value={shippingAddress.notes}
+          onChangeText={(text) => updateShippingAddress('notes', text)}
+          placeholder={t('cart.notesPlaceholder')}
+          multiline
+          numberOfLines={3}
+        />
 
         <View
           style={[
@@ -1728,18 +1649,8 @@ const styles = StyleSheet.create({
   checkoutForm: { flex: 1, padding: 16 },
   checkoutHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 24, justifyContent: 'center' },
   checkoutTitle: { fontSize: 18, fontWeight: 'bold', marginLeft: 8 },
-  formGroup: { marginBottom: 16 },
   formRow: { flexDirection: 'row', gap: 12 },
   formGroupHalf: { flex: 1 },
-  formLabel: { fontSize: 14, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
-  formInput: {
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    fontSize: 16,
-  },
-  textArea: { height: 80, textAlignVertical: 'top' },
   orderSummary: { borderRadius: 12, padding: 16, marginVertical: 24, borderWidth: 1 },
   summaryTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 12, textAlign: 'right' },
   summaryItem: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },

--- a/src/features/products/components/PricingTierFormModal.tsx
+++ b/src/features/products/components/PricingTierFormModal.tsx
@@ -1,5 +1,5 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Modal,
   View,
@@ -7,15 +7,15 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  TextInput,
   SafeAreaView,
 } from 'react-native';
 import { X, Save, Trash2 } from 'lucide-react-native';
-import { PricingTier } from '@/types';
+import { PricingTier, PricingTierRule } from '@/types';
 import { useTheme } from '@/ui/ThemeProvider';
 import DatabaseService from '@/services/database';
 import InfoModal from '@/components/InfoModal';
 import { Spinner } from '@/ui/primitives';
+import LabeledInput from '@/components/form/LabeledInput';
 
 interface PricingTierFormModalProps {
   visible: boolean;
@@ -24,6 +24,15 @@ interface PricingTierFormModalProps {
   onSaved?: (tier: PricingTier, isNew: boolean) => void;
   onDeleted?: (id: string) => void;
 }
+
+const createEmptyRule = (): PricingTierRule => ({
+  id: '',
+  tierId: '',
+  minQty: 1,
+  maxQty: 1,
+  pricePerBaseUnit: undefined,
+  discountPct: undefined,
+});
 
 export default function PricingTierFormModal({
   visible,
@@ -38,9 +47,7 @@ export default function PricingTierFormModal({
     id: '',
     name: '',
     description: '',
-    rules: [
-      { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any,
-    ],
+    rules: [createEmptyRule()],
   });
   const [loading, setLoading] = useState(false);
   const [infoModal, setInfoModal] = useState({
@@ -49,6 +56,32 @@ export default function PricingTierFormModal({
     message: '',
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
+  const updateFormData = useCallback(
+    <K extends keyof PricingTier>(key: K, value: Partial<PricingTier>[K]) => {
+      setFormData((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+  const updateRuleField = useCallback(
+    <K extends keyof PricingTierRule>(index: number, key: K, value: PricingTierRule[K]) => {
+      setFormData((prev) => {
+        const rules = [...(prev.rules || [])];
+        if (!rules[index]) {
+          return prev;
+        }
+        rules[index] = { ...rules[index], [key]: value };
+        return { ...prev, rules };
+      });
+    },
+    [],
+  );
+  const removeRule = useCallback((index: number) => {
+    setFormData((prev) => {
+      const rules = [...(prev.rules || [])];
+      rules.splice(index, 1);
+      return { ...prev, rules };
+    });
+  }, []);
 
   useEffect(() => {
     if (visible) {
@@ -60,9 +93,7 @@ export default function PricingTierFormModal({
           id: '',
           name: '',
           description: '',
-          rules: [
-            { minQty: 1, maxQty: 1, pricePerBaseUnit: undefined, discountPct: undefined } as any,
-          ],
+          rules: [createEmptyRule()],
         });
       }
     }
@@ -161,160 +192,99 @@ export default function PricingTierFormModal({
           </View>
 
           <ScrollView style={styles.modalContent}>
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מזהה מדרג *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={formData.id}
-                onChangeText={text => setFormData({ ...formData, id: text })}
-                placeholder="הכנס מזהה מדרג (באנגלית, לדוגמה: bulk_discount)"
-                textAlign="right"
-                editable={!editingTier}
-              />
-            </View>
+            <LabeledInput
+              label="מזהה מדרג *"
+              value={formData.id ?? ''}
+              onChangeText={(text) => updateFormData('id', text)}
+              placeholder="הכנס מזהה מדרג (באנגלית, לדוגמה: bulk_discount)"
+              editable={!editingTier}
+              labelStyle={styles.fieldLabel}
+            />
 
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>שם המדרג *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={formData.name}
-                onChangeText={text => setFormData({ ...formData, name: text })}
-                placeholder="הכנס שם מדרג (לדוגמה: הנחת כמות)"
-                textAlign="right"
-              />
-            </View>
+            <LabeledInput
+              label="שם המדרג *"
+              value={formData.name ?? ''}
+              onChangeText={(text) => updateFormData('name', text)}
+              placeholder="הכנס שם מדרג (לדוגמה: הנחת כמות)"
+              labelStyle={styles.fieldLabel}
+            />
 
             {formData.rules?.map((rule, idx) => (
               <View key={idx} style={styles.formRow}>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מינימום</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
-                    value={rule.minQty.toString()}
-                    onChangeText={text => {
-                      const updated = [...(formData.rules || [])];
-                      updated[idx].minQty = parseInt(text) || 1;
-                      setFormData({ ...formData, rules: updated });
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מקסימום</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
-                    value={rule.maxQty.toString()}
-                    onChangeText={text => {
-                      const updated = [...(formData.rules || [])];
-                      updated[idx].maxQty = parseInt(text) || 0;
-                      setFormData({ ...formData, rules: updated });
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר ליחידה</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
-                    value={rule.pricePerBaseUnit?.toString() || ''}
-                    onChangeText={text => {
-                      const updated = [...(formData.rules || [])];
-                      updated[idx].pricePerBaseUnit = text ? parseFloat(text) : undefined;
-                      setFormData({ ...formData, rules: updated });
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <View style={styles.formGroupHalf}>
-                  <Text style={[styles.formLabel, { color: colors.text.primary }]}>הנחה %</Text>
-                  <TextInput
-                    style={[styles.formInput, {
-                      borderColor: colors.border.primary,
-                      backgroundColor: colors.surface.primary,
-                      color: colors.text.primary,
-                    }]}
-                    value={rule.discountPct?.toString() || ''}
-                    onChangeText={text => {
-                      const updated = [...(formData.rules || [])];
-                      updated[idx].discountPct = text ? parseFloat(text) : undefined;
-                      setFormData({ ...formData, rules: updated });
-                    }}
-                    keyboardType="numeric"
-                    textAlign="right"
-                  />
-                </View>
-                <TouchableOpacity
-                  onPress={() => {
-                    const updated = [...(formData.rules || [])];
-                    updated.splice(idx, 1);
-                    setFormData({ ...formData, rules: updated });
-                  }}
-                >
+                <LabeledInput
+                  label="מינימום"
+                  value={rule.minQty.toString()}
+                  onChangeText={(text) =>
+                    updateRuleField(idx, 'minQty', Number.parseInt(text, 10) || 1)
+                  }
+                  keyboardType="numeric"
+                  containerStyle={styles.formGroupHalf}
+                  labelStyle={styles.fieldLabel}
+                />
+                <LabeledInput
+                  label="מקסימום"
+                  value={rule.maxQty.toString()}
+                  onChangeText={(text) =>
+                    updateRuleField(idx, 'maxQty', Number.parseInt(text, 10) || 0)
+                  }
+                  keyboardType="numeric"
+                  containerStyle={styles.formGroupHalf}
+                  labelStyle={styles.fieldLabel}
+                />
+                <LabeledInput
+                  label="מחיר ליחידה"
+                  value={rule.pricePerBaseUnit?.toString() || ''}
+                  onChangeText={(text) =>
+                    updateRuleField(
+                      idx,
+                      'pricePerBaseUnit',
+                      text ? Number.parseFloat(text) : undefined,
+                    )
+                  }
+                  keyboardType="numeric"
+                  containerStyle={styles.formGroupHalf}
+                  labelStyle={styles.fieldLabel}
+                />
+                <LabeledInput
+                  label="הנחה %"
+                  value={rule.discountPct?.toString() || ''}
+                  onChangeText={(text) =>
+                    updateRuleField(
+                      idx,
+                      'discountPct',
+                      text ? Number.parseFloat(text) : undefined,
+                    )
+                  }
+                  keyboardType="numeric"
+                  containerStyle={styles.formGroupHalf}
+                  labelStyle={styles.fieldLabel}
+                />
+                <TouchableOpacity onPress={() => removeRule(idx)}>
                   <Trash2 size={20} color={colors.status.error} />
                 </TouchableOpacity>
               </View>
             ))}
             <TouchableOpacity
               onPress={() =>
-                setFormData({
-                  ...formData,
-                  rules: [
-                    ...(formData.rules || []),
-                    {
-                      id: '',
-                      tierId: '',
-                      minQty: 1,
-                      maxQty: 1,
-                      pricePerBaseUnit: undefined,
-                      discountPct: undefined,
-                    },
-                  ],
-                })
+                setFormData((prev) => ({
+                  ...prev,
+                  rules: [...(prev.rules || []), createEmptyRule()],
+                }))
               }
               style={styles.addRuleButton}
             >
               <Text style={[styles.addRuleText, { color: colors.gold }]}>הוסף כלל</Text>
             </TouchableOpacity>
 
-            <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תיאור *</Text>
-              <TextInput
-                style={[styles.formInput, styles.textArea, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={formData.description}
-                onChangeText={text => setFormData({ ...formData, description: text })}
-                placeholder="הכנס תיאור מדרג (לדוגמה: מחיר מיוחד של 8₪ ליחידה בקנייה של 5 פריטים ומעלה)"
-                multiline
-                numberOfLines={4}
-                textAlign="right"
-              />
-            </View>
+            <LabeledInput
+              label="תיאור *"
+              value={formData.description ?? ''}
+              onChangeText={(text) => updateFormData('description', text)}
+              placeholder="הכנס תיאור מדרג (לדוגמה: מחיר מיוחד של 8₪ ליחידה בקנייה של 5 פריטים ומעלה)"
+              multiline
+              numberOfLines={4}
+              labelStyle={styles.fieldLabel}
+            />
 
             <View style={styles.modalActions}>
               <TouchableOpacity
@@ -370,12 +340,9 @@ const styles = StyleSheet.create({
   },
   modalTitle: { fontSize: 18, fontWeight: 'bold' },
   modalContent: { padding: 16 },
-  formGroup: { marginBottom: 20 },
   formRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20, gap: 12 },
   formGroupHalf: { flex: 1 },
-  formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
-  formInput: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
-  textArea: { height: 100, textAlignVertical: 'top' },
+  fieldLabel: { fontSize: 16, fontWeight: '600', textAlign: 'right' },
   addRuleButton: { marginBottom: 10 },
   addRuleText: { fontWeight: '600' },
   modalActions: { gap: 16, marginTop: 20, marginBottom: 40 },

--- a/src/features/products/components/ProductFormModal.tsx
+++ b/src/features/products/components/ProductFormModal.tsx
@@ -1,5 +1,5 @@
 import { errorLog } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Modal,
   View,
@@ -39,6 +39,7 @@ import SubcategoryPicker from './SubcategoryPicker';
 import { useCategories } from '@/hooks';
 import { useAppRouter } from '@/hooks';
 import { Spinner } from '@/ui/primitives';
+import LabeledInput from '@/components/form/LabeledInput';
 
 interface ProductFormModalProps {
   visible: boolean;
@@ -89,6 +90,12 @@ export default function ProductFormModal({
     type: 'info' as 'success' | 'error' | 'info' | 'warning',
   });
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
+  const updateProduct = useCallback(
+    <K extends keyof Product>(key: K, value: Partial<Product>[K]) => {
+      setEditingProduct((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
 
   useEffect(() => {
     if (visible) {
@@ -133,19 +140,19 @@ export default function ProductFormModal({
   };
 
   const selectCategory = (id: string) => {
-    setEditingProduct({ ...editingProduct, category: id, subcategory: '' });
+    setEditingProduct((prev) => ({ ...prev, category: id, subcategory: '' }));
     const category = categories.find(c => c.id === id);
     setAvailableSubcategories(category?.subcategories || []);
     setShowCategorySelector(false);
   };
 
   const selectSubcategory = (id: string) => {
-    setEditingProduct({ ...editingProduct, subcategory: id });
+    setEditingProduct((prev) => ({ ...prev, subcategory: id }));
     setShowSubcategorySelector(false);
   };
 
   const selectPricingTier = (id: string) => {
-    setEditingProduct({ ...editingProduct, pricingTier: id });
+    setEditingProduct((prev) => ({ ...prev, pricingTier: id }));
     setShowPricingTierSelector(false);
   };
 
@@ -315,20 +322,12 @@ export default function ProductFormModal({
 
           <ScrollView style={styles.modalContent}>
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תמונות (CID או URL, שורה לכל פריט)</Text>
-              <TextInput
-                multiline
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                  height: 80,
-                  textAlignVertical: 'top'
-                }]}
+              <LabeledInput
+                label="תמונות (CID או URL, שורה לכל פריט)"
                 value={imageUrls}
                 onChangeText={(text) => {
                   setImageUrls(text);
-                  const first = text.split('\n').map(s => s.trim()).find(Boolean) || null;
+                  const first = text.split('\n').map((s) => s.trim()).find(Boolean) || null;
                   if (first && pinata.isCidOrUrl(first)) {
                     setImagePreview(first);
                   } else {
@@ -337,7 +336,9 @@ export default function ProductFormModal({
                   setImageError(null);
                 }}
                 placeholder="ipfs://..."
-                textAlign="right"
+                multiline
+                numberOfLines={4}
+                labelStyle={styles.formLabel}
               />
               {imagePreview ? (
                 <Image source={{ uri: toHttpUrl(imagePreview) }} style={styles.mediaPreview} />
@@ -350,20 +351,12 @@ export default function ProductFormModal({
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>סרטונים (CID או URL, שורה לכל פריט)</Text>
-              <TextInput
-                multiline
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                  height: 80,
-                  textAlignVertical: 'top'
-                }]}
+              <LabeledInput
+                label="סרטונים (CID או URL, שורה לכל פריט)"
                 value={videoUrls}
                 onChangeText={(text) => {
                   setVideoUrls(text);
-                  const first = text.split('\n').map(s => s.trim()).find(Boolean) || null;
+                  const first = text.split('\n').map((s) => s.trim()).find(Boolean) || null;
                   if (first && pinata.isCidOrUrl(first)) {
                     setVideoPreview(first);
                   } else {
@@ -372,7 +365,9 @@ export default function ProductFormModal({
                   setVideoError(null);
                 }}
                 placeholder="ipfs://..."
-                textAlign="right"
+                multiline
+                numberOfLines={4}
+                labelStyle={styles.formLabel}
               />
               {videoPreview ? (
                 Platform.OS === 'web' ? (
@@ -420,33 +415,23 @@ export default function ProductFormModal({
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>שם המוצר *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.name}
-                onChangeText={text => setEditingProduct({ ...editingProduct, name: text })}
+              <LabeledInput
+                label="שם המוצר *"
+                value={editingProduct.name ?? ''}
+                onChangeText={(text) => updateProduct('name', text)}
                 placeholder="הכנס שם מוצר"
-                textAlign="right"
+                labelStyle={styles.formLabel}
               />
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מחיר *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.price?.toString()}
-                onChangeText={text => setEditingProduct({ ...editingProduct, price: parseFloat(text) || 0 })}
+              <LabeledInput
+                label="מחיר *"
+                value={editingProduct.price != null ? editingProduct.price.toString() : ''}
+                onChangeText={(text) => updateProduct('price', Number.parseFloat(text) || 0)}
                 placeholder="הכנס מחיר"
                 keyboardType="numeric"
-                textAlign="right"
+                labelStyle={styles.formLabel}
               />
             </View>
 
@@ -470,19 +455,14 @@ export default function ProductFormModal({
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תיאור *</Text>
-              <TextInput
-                style={[styles.formInput, styles.textArea, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.description}
-                onChangeText={text => setEditingProduct({ ...editingProduct, description: text })}
+              <LabeledInput
+                label="תיאור *"
+                value={editingProduct.description ?? ''}
+                onChangeText={(text) => updateProduct('description', text)}
                 placeholder="הכנס תיאור מוצר"
                 multiline
                 numberOfLines={4}
-                textAlign="right"
+                labelStyle={styles.formLabel}
               />
             </View>
 
@@ -589,36 +569,26 @@ export default function ProductFormModal({
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>מלאי *</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.stock?.toString()}
-                onChangeText={text => setEditingProduct({ ...editingProduct, stock: parseInt(text) || 0 })}
+              <LabeledInput
+                label="מלאי *"
+                value={editingProduct.stock != null ? editingProduct.stock.toString() : ''}
+                onChangeText={(text) => updateProduct('stock', Number.parseInt(text, 10) || 0)}
                 placeholder="הכנס כמות במלאי"
                 keyboardType="numeric"
-                textAlign="right"
+                labelStyle={styles.formLabel}
               />
             </View>
 
             <View style={styles.formGroup}>
-              <Text style={[styles.formLabel, { color: colors.text.primary }]}>תגיות (אופציונלי)</Text>
-              <TextInput
-                style={[styles.formInput, {
-                  borderColor: colors.border.primary,
-                  backgroundColor: colors.surface.primary,
-                  color: colors.text.primary,
-                }]}
-                value={editingProduct.badges?.join(', ')}
-                onChangeText={text => {
-                  const badges = text.split(',').map(b => b.trim()).filter(b => b);
-                  setEditingProduct({ ...editingProduct, badges });
+              <LabeledInput
+                label="תגיות (אופציונלי)"
+                value={editingProduct.badges?.join(', ') ?? ''}
+                onChangeText={(text) => {
+                  const badges = text.split(',').map((b) => b.trim()).filter((b) => b);
+                  updateProduct('badges', badges);
                 }}
                 placeholder="הכנס תגיות מופרדות בפסיקים (למשל: חדש, מבצע, מומלץ)"
-                textAlign="right"
+                labelStyle={styles.formLabel}
               />
             </View>
 
@@ -796,8 +766,6 @@ const styles = StyleSheet.create({
   modalContent: { padding: 16 },
   formGroup: { marginBottom: 20 },
   formLabel: { fontSize: 16, fontWeight: '600', marginBottom: 8, textAlign: 'right' },
-  formInput: { borderWidth: 1, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, fontSize: 16 },
-  textArea: { height: 100, textAlignVertical: 'top' },
   modalActions: { gap: 16, marginTop: 20, marginBottom: 40 },
   saveButton: { borderRadius: 12, paddingVertical: 16, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' },
   saveButtonText: { fontSize: 16, fontWeight: '600', marginLeft: 8 },


### PR DESCRIPTION
## Summary
- add a reusable `LabeledInput` form control that centralizes theming, layout, and multiline handling
- refactor the cart checkout, pricing tier, and product modals to rely on the shared control and functional state helpers
- remove the duplicated styling and inline state spread patterns that the new component replaces

## Testing
- yarn typecheck *(fails: missing Expo/TypeScript base config and type definition packages in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ba329d54832686f4263b33685945