### PR TITLE
Simplify app bootstrap and composition

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,21 +17,11 @@ import {
 } from '@/hooks/adminSubscription';
 
 const USE_ROUTER = isRouterEnabled();
+const FALLBACK_STYLE = { flex: 1, alignItems: 'center', justifyContent: 'center' };
 
-function RouterApp() {
-  return <ExpoRoot context={ctx} />;
-}
-
-function FallbackScreen() {
+export default function App() {
   const { t } = useLanguage();
-  return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>{t('app.routerDisabled')}</Text>
-    </View>
-  );
-}
 
-function MainApp() {
   useEffect(() => {
     void initSessionTokens();
 
@@ -55,19 +45,21 @@ function MainApp() {
     };
   }, []);
 
+  const screen = USE_ROUTER ? (
+    <ExpoRoot context={ctx} />
+  ) : (
+    <View style={FALLBACK_STYLE}>
+      <Text>{t('app.routerDisabled')}</Text>
+    </View>
+  );
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <React.Suspense fallback={<Spinner />}>
-          <AppProviders>
-            {USE_ROUTER ? <RouterApp /> : <FallbackScreen />}
-          </AppProviders>
+          <AppProviders>{screen}</AppProviders>
         </React.Suspense>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );
-}
-
-export default function App() {
-  return <MainApp />;
 }

--- a/index.ts
+++ b/index.ts
@@ -9,42 +9,28 @@ const GLOBAL_STYLE_RULES = `
   body { background: #0b0b0b; }
 `;
 
-function injectGlobalStyles() {
-  const style = document.createElement('style');
-  style.innerHTML = GLOBAL_STYLE_RULES;
-  document.head.appendChild(style);
-}
+if (typeof document !== 'undefined') {
+  try {
+    const style = document.createElement('style');
+    style.textContent = GLOBAL_STYLE_RULES;
+    document.head.appendChild(style);
 
-function ensureRootContainer(): HTMLElement {
-  const rootElement =
-    document.getElementById('root') ?? document.getElementById('app-root');
-  if (rootElement instanceof HTMLElement) {
-    return rootElement;
+    const existingRoot =
+      document.getElementById('root') ?? document.getElementById('app-root');
+    const root =
+      existingRoot instanceof HTMLElement
+        ? existingRoot
+        : document.body.appendChild(
+            Object.assign(document.createElement('div'), { id: 'root' }),
+          );
+
+    AppRegistry.registerComponent('main', () => App);
+    AppRegistry.runApplication('main', {
+      rootTag: root,
+      initialProps: {},
+      hydrate: false,
+    } as any);
+  } catch (err) {
+    console.error('Failed to start app', err);
   }
-
-  const root = document.createElement('div');
-  root.id = 'root';
-  document.body.appendChild(root);
-  return root;
-}
-
-function bootstrap() {
-  if (typeof document === 'undefined') {
-    return;
-  }
-
-  injectGlobalStyles();
-  const root = ensureRootContainer();
-  AppRegistry.registerComponent('main', () => App);
-  AppRegistry.runApplication('main', {
-    rootTag: root,
-    initialProps: {},
-    hydrate: false,
-  } as any);
-}
-
-try {
-  bootstrap();
-} catch (err) {
-  console.error('Failed to start app', err);
 }


### PR DESCRIPTION
## Summary
- collapse the App component into a single tree while keeping providers and effects intact
- streamline the web bootstrap path by inlining style injection and root container setup

## Testing
- yarn lint *(fails: missing @typescript-eslint/parser in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45a3fa19c8326a33d600da3e2b7db