### PR TITLE
refactor: centralize json cloning helper

### DIFF
--- a/src/agents/cart-agent.ts
+++ b/src/agents/cart-agent.ts
@@ -8,6 +8,7 @@ import {
 } from '@/features/cart/services/nearCart';
 import ensureNearWallet from '../utils/ensureNearWallet';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import { jsonClone } from '@/utils/jsonClone';
 
 assertNearChain();
 
@@ -40,7 +41,7 @@ class CartAgent {
    */
   async selectCartItem(id: string): Promise<CartItem | null> {
     const item = await getCartItem(id);
-    return item ? JSON.parse(JSON.stringify(item)) : null;
+    return item ? jsonClone(item) : null;
   }
 
   /**
@@ -48,7 +49,7 @@ class CartAgent {
    */
   async getCartItems(): Promise<CartItem[]> {
     const list = await listCartItems();
-    return list.map((c) => JSON.parse(JSON.stringify(c)));
+    return list.map((c) => jsonClone(c));
   }
 }
 

--- a/src/agents/categories-agent.ts
+++ b/src/agents/categories-agent.ts
@@ -8,6 +8,7 @@ import {
 } from '@/features/products/services/nearCategories';
 import ensureNearWallet from '@/utils/ensureNearWallet';
 import { normalizeMessage } from '../lib/normalizeMessage';
+import { jsonClone } from '@/utils/jsonClone';
 
 assertNearChain();
 
@@ -40,7 +41,7 @@ class CategoriesAgent {
    */
   async selectCategory(storeId: string, id: string): Promise<Category | null> {
     const cat = await getCategory(storeId, id);
-    return cat ? JSON.parse(JSON.stringify(cat)) : null;
+    return cat ? jsonClone(cat) : null;
   }
 
   /**
@@ -48,7 +49,7 @@ class CategoriesAgent {
    */
   async getCategories(storeId: string): Promise<Category[]> {
     const list = await listCategories(storeId);
-    return list.map((c) => JSON.parse(JSON.stringify(c)));
+    return list.map((c) => jsonClone(c));
   }
 }
 

--- a/src/agents/products-agent.ts
+++ b/src/agents/products-agent.ts
@@ -1,5 +1,6 @@
 import type { Product } from '@/types';
 import { canonicalJson } from '@/utils/serialization';
+import { jsonClone } from '@/utils/jsonClone';
 import { verifyBeforeWrite } from '../utils/verifyMessageSignature';
 import { productUpdatedSchema } from '../schemas/waku/product.updated';
 import { errorLog } from '@/utils/logger';
@@ -274,13 +275,13 @@ class ProductsAgent {
   async selectProduct(id: string): Promise<Product | null> {
     await this.ensureCache();
     const cached = this.cache.get(id);
-    if (cached) return JSON.parse(JSON.stringify(cached));
+    if (cached) return jsonClone(cached);
     const nearProducts = await loadNearProducts();
     const prod = await nearProducts.getProduct('default', id);
     if (prod) {
       this.cache.set(id, prod);
       this.summaries.set(id, { rating: prod.rating, reviews: prod.reviews });
-      return JSON.parse(JSON.stringify(prod));
+      return jsonClone(prod);
     }
     return null;
   }
@@ -290,9 +291,7 @@ class ProductsAgent {
    */
   async getProducts(): Promise<Product[]> {
     await this.ensureCache();
-    return Array.from(this.cache.values()).map((p) =>
-      JSON.parse(JSON.stringify(p)),
-    );
+    return Array.from(this.cache.values()).map((p) => jsonClone(p));
   }
 
   /**

--- a/src/billing/MeteredBillingService.ts
+++ b/src/billing/MeteredBillingService.ts
@@ -7,6 +7,7 @@ import { canonicalJson } from '@/utils/serialization';
 import ensureNearWallet from '@/utils/ensureNearWallet';
 import { uuid } from '@/utils/uuid';
 import { errorLog } from '@/utils/logger';
+import { jsonClone } from '@/utils/jsonClone';
 import type {
   BillingPayment,
   BillingSummary,
@@ -53,7 +54,7 @@ function pseudonymizeWallet(address: string, tenantId: string): string {
 function sanitizeMetadata(metadata?: Record<string, unknown>): Record<string, unknown> | undefined {
   if (!metadata) return undefined;
   try {
-    return JSON.parse(JSON.stringify(metadata));
+    return jsonClone(metadata);
   } catch {
     return undefined;
   }

--- a/src/ui/ThemeProvider.tsx
+++ b/src/ui/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import { errorLog } from '@/utils/logger';
+import { jsonClone } from '@/utils/jsonClone';
 import React, {
   createContext,
   useState,
@@ -210,7 +211,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       // Attempt to clone the translation object; if the JSON is malformed this
       // will throw and be caught below.
       const raw = language === 'en' ? enTranslations : heTranslations;
-      const parsed = JSON.parse(JSON.stringify(raw));
+      const parsed = jsonClone(raw);
 
       setTranslationsState(parsed);
       setGlobalTranslations(parsed);
@@ -222,7 +223,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
       // Any IO or JSON parse errors default the app back to English so the UI
       // remains usable.
       errorLog(error);
-      const fallback = JSON.parse(JSON.stringify(enTranslations));
+      const fallback = jsonClone(enTranslations);
       setTranslationsState(fallback);
       setGlobalTranslations(fallback);
       setIsRTL(false);

--- a/src/utils/jsonClone.ts
+++ b/src/utils/jsonClone.ts
@@ -1,0 +1,12 @@
+/**
+ * Creates a deep clone of JSON-serializable data structures using the same
+ * `JSON.parse(JSON.stringify(value))` approach used throughout the project.
+ *
+ * Centralising the logic keeps behaviour identical while avoiding repeated
+ * inline cloning snippets across agents and services.
+ */
+export function jsonClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export default jsonClone;


### PR DESCRIPTION
## Summary
- add a shared `jsonClone` utility that encapsulates the existing JSON-based deep clone pattern
- update agents, billing, and language logic to reuse the helper, trimming repeated cloning code

## Testing
- yarn lint --max-warnings=0 *(fails: missing @typescript-eslint/parser in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d46131e3948326b9ab1a651eae0a9a