### PR TITLE
Refactor polyfill setup to reduce duplication

### DIFF
--- a/polyfills.native.ts
+++ b/polyfills.native.ts
@@ -1,7 +1,12 @@
-import { debugLog } from './utils/logger';
 import 'react-native-url-polyfill/auto';
-import { sha512 } from '@noble/hashes/sha512';
-import { etc as edUtils } from '@noble/ed25519';
+
+import {
+  ensureEd25519SyncHash,
+  ensureNodeLikeGlobals,
+  ensureTslibDefault,
+  type GlobalLike,
+} from './polyfills/shared';
+import { debugLog } from './utils/logger';
 
 try {
   // MUST be require() on native
@@ -12,25 +17,12 @@ try {
   debugLog('❌ Native polyfills load failed:', err);
 }
 
-// Noble needs sync sha512
-if (!edUtils.sha512Sync) edUtils.sha512Sync = sha512;
+ensureEd25519SyncHash();
+ensureNodeLikeGlobals(globalThis as unknown as GlobalLike);
 
-// Node-ish globals
-if (typeof global.Buffer === 'undefined') {
-  // require, not import
-  global.Buffer = require('buffer').Buffer;
-}
-if (typeof global.process === 'undefined') {
-  global.process = require('process');
-}
-
-// Ensure tslib has a default export for libs that expect it
-try {
-  const tslib = require('tslib/modules/index.js');
-  if (tslib && !('default' in tslib)) {
-    // @ts-ignore
-    tslib.default = tslib;
-  }
-} catch (err) {
-  debugLog('❌ tslib polyfill failed (native):', err);
-}
+ensureTslibDefault('tslib/modules/index.js', {
+  onError: (err) => debugLog('❌ tslib polyfill failed (native):', err),
+});
+ensureTslibDefault('tslib', {
+  onError: (err) => debugLog('❌ tslib polyfill failed (native):', err),
+});

--- a/polyfills.web.ts
+++ b/polyfills.web.ts
@@ -1,4 +1,11 @@
+import {
+  ensureEd25519SyncHash,
+  ensureNodeLikeGlobals,
+  ensureTslibDefault,
+  type GlobalLike,
+} from './polyfills/shared';
 import { debugLog } from './utils/logger';
+
 // Ensure Expo Modules web shims are loaded so globalThis.expo is defined
 try {
   // Side-effect import to setup globalThis.expo (SharedObject, etc.)
@@ -6,28 +13,20 @@ try {
 } catch {}
 // Minimal fallback if the shim didn't set it for some reason
 try {
-  const g: any = globalThis as any;
+  const g = globalThis as GlobalLike & { expo?: Record<string, unknown> };
   if (!g.expo) g.expo = {};
   if (!g.expo.SharedObject) {
     g.expo.SharedObject = class {};
   }
 } catch {}
-import { sha512 } from '@noble/hashes/sha512';
-import { etc as edUtils } from '@noble/ed25519';
 
 // On web, URL is natively supported; skip react-native-url-polyfill.
 // On web, browser already has crypto.subtle. Do NOT import expo-standard-web-crypto here.
-// Noble needs sync sha512
-if (!edUtils.sha512Sync) edUtils.sha512Sync = sha512;
+ensureEd25519SyncHash();
 
 // Optional: only add Buffer/process if you need them on web
 try {
-  if (typeof (globalThis as any).Buffer === 'undefined') {
-    (globalThis as any).Buffer = require('buffer').Buffer;
-  }
-  if (typeof (globalThis as any).process === 'undefined') {
-    (globalThis as any).process = require('process');
-  }
+  ensureNodeLikeGlobals(globalThis as unknown as GlobalLike);
   // Some compiled libs (e.g., expo-router build output) may be transformed
   // with the classic JSX runtime and expect a global React identifier.
   // Ensure React is available as a global on web to avoid ReferenceError.
@@ -49,13 +48,5 @@ try {
 }
 
 // Keep the tslib shim to be safe on web too
-try {
-  // Prefer the standard entry; webpack alias maps modules/index.js to a CJS shim
-  const tslib = require('tslib');
-  if (tslib && !('default' in tslib)) {
-    // @ts-ignore
-    tslib.default = tslib;
-  }
-} catch {
-  // Quietly ignore; modern builds usually don't require this
-}
+ensureTslibDefault('tslib');
+ensureTslibDefault('tslib/modules/index.js');

--- a/polyfills/shared.ts
+++ b/polyfills/shared.ts
@@ -1,0 +1,50 @@
+/*
+ * Shared helpers for runtime polyfills.
+ * These utilities keep the platform-specific entry points lean while
+ * guaranteeing consistent behaviour across web and native targets.
+ */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import { sha512 } from '@noble/hashes/sha512';
+import { etc as edUtils } from '@noble/ed25519';
+
+export type GlobalLike = Record<string, unknown>;
+
+export const ensureEd25519SyncHash = (): void => {
+  if (!edUtils.sha512Sync) {
+    edUtils.sha512Sync = sha512;
+  }
+};
+
+export const ensureNodeLikeGlobals = (target: GlobalLike): void => {
+  if (typeof target.Buffer === 'undefined') {
+    target.Buffer = require('buffer').Buffer;
+  }
+
+  if (typeof target.process === 'undefined') {
+    target.process = require('process');
+  }
+};
+
+type EnsureTslibOptions = {
+  onError?: (error: unknown) => void;
+};
+
+export const ensureTslibDefault = (
+  moduleId: string,
+  { onError }: EnsureTslibOptions = {},
+): boolean => {
+  try {
+    const tslib = require(moduleId);
+
+    if (tslib && !('default' in tslib)) {
+      (tslib as Record<string, unknown>).default = tslib;
+    }
+
+    return true;
+  } catch (error) {
+    onError?.(error);
+    return false;
+  }
+};
+

--- a/tslib-polyfill.js
+++ b/tslib-polyfill.js
@@ -1,4 +1,0 @@
-const tslib = require('tslib/tslib.js');
-// Ensure tslib has a default export for environments expecting it.
-module.exports = tslib;
-module.exports.default = tslib;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,6 @@ module.exports = async function (env, argv) {
       'node_modules/react-native-url-polyfill'
     ),
     tslib: require.resolve('tslib'),
-    'tslib/modules/index.js': path.resolve(__dirname, 'tslib-polyfill.js'),
   };
 
   if (!config.module.rules.some((r) => String(r.test) === '/\\.mjs$/')) {


### PR DESCRIPTION
## Summary
- add a shared helper module for common polyfill steps across platforms
- simplify the native and web polyfill entrypoints to reuse the shared helpers and keep behaviour intact
- drop the bespoke tslib shim and rely on runtime helpers, trimming the webpack alias accordingly

## Testing
- ⚠️ `yarn typecheck` *(fails: missing optional @types dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d46542beb48326961559e4830c8716