### PR TITLE
refactor: centralize wallet guard creation

### DIFF
--- a/src/agents/cart-agent.ts
+++ b/src/agents/cart-agent.ts
@@ -6,7 +6,7 @@ import {
   listCartItems,
   removeCartItem,
 } from '@/features/cart/services/nearCart';
-import ensureNearWallet from '../utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { jsonClone } from '@/utils/jsonClone';
 
@@ -15,9 +15,9 @@ assertNearChain();
 // TODO:TODO-112 Extend CartAgent to support multi-store contexts without clobbering per-tenant line items.
 // TODO:REC-212 Move wallet prompt handling into a shared UX utility for consistent localization and messaging.
 class CartAgent {
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to manage your cart.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage your cart.',
+  );
 
   async add(item: CartItem): Promise<void> {
     await this.ensureWallet();

--- a/src/agents/categories-agent.ts
+++ b/src/agents/categories-agent.ts
@@ -6,7 +6,7 @@ import {
   listCategories,
   removeCategory,
 } from '@/features/products/services/nearCategories';
-import ensureNearWallet from '@/utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { jsonClone } from '@/utils/jsonClone';
 
@@ -15,9 +15,9 @@ assertNearChain();
 // TODO:TODO-113 Expand CategoriesAgent to coordinate cross-channel taxonomy sync when stores sell in multiple marketplaces.
 // TODO:REC-213 Share wallet guard copy through localization dictionaries to keep admin prompts consistent.
 class CategoriesAgent {
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to manage categories.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage categories.',
+  );
 
   async add(storeId: string, item: Category): Promise<void> {
     await this.ensureWallet();

--- a/src/agents/moderation-agent.ts
+++ b/src/agents/moderation-agent.ts
@@ -2,7 +2,7 @@ import { uuid } from '@/utils/uuid';
 import { Report } from '@/types';
 import { assertNearChain } from '@/services/chain';
 import { addReport, listReports, removeReport } from '@/features/reviews/services/nearReports';
-import ensureNearWallet from '@/utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
@@ -10,12 +10,9 @@ assertNearChain();
 // TODO:TODO-116 Add rate limiting and abuse heuristics to ModerationAgent to prevent automated spam reports.
 // TODO:REC-216 Feed moderation events into analytics topics so trust & safety dashboards stay up to date.
 class ModerationAgent {
-  private async ensureWallet() {
-    const { address, publicKey } = await ensureNearWallet(
-      'Please connect your NEAR wallet to report items.',
-    );
-    return { address, publicKey };
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to report items.',
+  );
 
   async reportProduct(productId: string, reason: string): Promise<void> {
     const { address } = await this.ensureWallet();

--- a/src/agents/notifications-agent.ts
+++ b/src/agents/notifications-agent.ts
@@ -16,7 +16,7 @@ import { normalizeMessage } from '../lib/normalizeMessage';
 
 assertNearChain();
 import { publish, isWakuDisabled } from '@/services/waku';
-import ensureNearWallet from '../utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { errorLog } from '../utils/logger';
 import { buildTopic } from '../utils/wakuTopics';
 import {
@@ -64,9 +64,9 @@ class NotificationsAgent {
     onDrained(() => this.resume('waku'));
   }
 
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to send notifications.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to send notifications.',
+  );
 
   async add(item: Notification, storeId = '1'): Promise<void> {
     if (!isNotificationsPipelineEnabled(item.userId)) return;

--- a/src/agents/orders-agent.ts
+++ b/src/agents/orders-agent.ts
@@ -34,7 +34,7 @@ assertNearChain();
 import { encryptShippingInfo } from '../utils/shippingCrypto';
 import { sha256 } from '@noble/hashes/sha256';
 import { logOrderEvent } from '@/services/eventLog';
-import ensureNearWallet from '../utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import eventBus from '@/services/eventBus';
 import { errorLog, warnLog } from '../utils/logger';
 import type { LightNode } from '@waku/sdk';
@@ -179,9 +179,9 @@ class OrdersAgent {
     });
   }
 
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to manage orders.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage orders.',
+  );
 
   private async ensureAuthorized(order: Order) {
     await this.ensureWallet();

--- a/src/agents/review-agent.ts
+++ b/src/agents/review-agent.ts
@@ -4,7 +4,7 @@ import { addReview, getReviews } from '@/features/reviews/services/nearReviews';
 import ordersAgent from './orders-agent';
 import { selectProduct } from './products-agent';
 import storesAgent from './stores-agent';
-import ensureNearWallet from '../utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import AgentError from '@/types/AgentError';
 
@@ -17,9 +17,9 @@ const TOPIC = '/blue-ocean/reviews/1';
 class ReviewAgent {
   private subscribers: Set<(r: Review) => void> = new Set();
 
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to manage reviews.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage reviews.',
+  );
 
   async add(review: Review): Promise<void> {
     await this.ensureWallet();

--- a/src/agents/settings-agent.ts
+++ b/src/agents/settings-agent.ts
@@ -11,7 +11,7 @@ import {
   setAdminPublicKeys as storeAdminPublicKeys,
   subscribeToSettingsWrites,
 } from '@/services/nearSettings';
-import ensureNearWallet from '../utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import { normalizeMessage } from '../lib/normalizeMessage';
 import { canonicalJson } from '@/utils/serialization';
 import type { AdminScope } from '@/types';
@@ -67,9 +67,9 @@ class SettingsAgent {
     });
   }
 
-  private async ensureWallet() {
-    await ensureNearWallet('Please connect your NEAR wallet to manage settings.');
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage settings.',
+  );
 
   async set(key: string, value: string): Promise<void> {
     await this.ensureWallet();

--- a/src/agents/users-agent.ts
+++ b/src/agents/users-agent.ts
@@ -7,7 +7,7 @@ import { assertNearChain } from '@/services/chain';
 import { getUser, setUser, listUsers, removeUser } from '@/features/auth/services/nearUsers';
 import { getPublicKeyHex } from '@/services/localIdentity';
 import SettingsAgent from './settings-agent';
-import ensureNearWallet from '@/utils/ensureNearWallet';
+import { createWalletGuard } from '@/utils/createWalletGuard';
 import validateNearAddress from '@/utils/validateNearAddress';
 import { verifyMessageSignature } from '@/utils/verifyMessageSignature';
 import type { WakuMessage } from '@/types/waku';
@@ -38,12 +38,9 @@ export type UsersAgentMessage =
 // TODO:TODO-109 Add audit-trail friendly storage of KYC transitions to meet regional compliance requirements.
 // TODO:REC-209 Evaluate using capability tokens instead of wallet prompts for privileged user mutations.
 class UsersAgent {
-  private async ensureWallet() {
-    const { address, publicKey } = await ensureNearWallet(
-      'Please connect your NEAR wallet to manage users.',
-    );
-    return { address, publicKey };
-  }
+  private ensureWallet = createWalletGuard(
+    'Please connect your NEAR wallet to manage users.',
+  );
 
   async add(user: User): Promise<void> {
     const normalized = normalizeMessage<User>('User', user);

--- a/src/utils/createWalletGuard.ts
+++ b/src/utils/createWalletGuard.ts
@@ -1,0 +1,9 @@
+import ensureNearWallet from './ensureNearWallet';
+
+type WalletSession = Awaited<ReturnType<typeof ensureNearWallet>>;
+
+export function createWalletGuard(message: string): () => Promise<WalletSession> {
+  return () => ensureNearWallet(message);
+}
+
+export type { WalletSession };


### PR DESCRIPTION
## Summary
- add a reusable `createWalletGuard` helper to wrap `ensureNearWallet` prompts once
- switch wallet-gated agents to use the shared guard, eliminating duplicated wrapper methods

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser in container)*
- npm run typecheck *(fails: missing Expo/React typings in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d46f717c1c832695dde3e65dcdb563