### PR TITLE
Refactor KYC file cleanup utilities

### DIFF
--- a/src/services/kycUpload.ts
+++ b/src/services/kycUpload.ts
@@ -3,23 +3,12 @@ import { sha256 } from '@noble/hashes/sha256';
 import { canonicalJson } from '@/utils/serialization';
 import { deriveSharedKey, deriveChatSalt, aesEncrypt } from '@/utils/encryption';
 import { cleanupTrackedKycCapturedPaths } from '@/utils/kycTemp';
+import { deleteFile, deleteIfTemporary, readFileAsBuffer, writeTempFile } from '@/utils/fileAccess';
 import { getEd25519KeyPair } from './localIdentity';
 import { sign } from '@noble/ed25519';
 import { randomBytes } from '@noble/hashes/utils';
 import type { KycArtifact, KycArtifactType } from '@/types';
 import PinataService from './pinata';
-import * as FileSystem from 'expo-file-system';
-
-type ExpoFsExtras = {
-  EncodingType?: {
-    Base64?: string;
-    UTF8?: string;
-  };
-  cacheDirectory?: string;
-  temporaryDirectory?: string;
-};
-
-const expoFs = FileSystem as typeof FileSystem & ExpoFsExtras;
 
 export interface KycUploadFile {
   uri: string;
@@ -45,93 +34,6 @@ export interface EncryptedKycBundle {
 }
 
 const INFO_LABEL = 'kyc.v2';
-
-function toFilePath(uri: string): string {
-  return uri.startsWith('file://') ? uri.replace('file://', '') : uri;
-}
-
-async function readBinary(uri: string): Promise<Buffer> {
-  if (typeof FileSystem.readAsStringAsync === 'function') {
-    const base64Encoding = expoFs.EncodingType?.Base64 ?? 'base64';
-    const base64 = await FileSystem.readAsStringAsync(uri, {
-      encoding: base64Encoding as any,
-    });
-    return Buffer.from(base64, 'base64');
-  }
-  const fs = await import('fs/promises');
-  const data = await fs.readFile(toFilePath(uri));
-  return Buffer.from(data);
-}
-
-function randomSuffix(): string {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-    return crypto.randomUUID();
-  }
-  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
-
-async function writeTemp(contents: string): Promise<string> {
-  if (
-    typeof FileSystem.writeAsStringAsync === 'function' &&
-    typeof expoFs.cacheDirectory === 'string'
-  ) {
-    const path = `${expoFs.cacheDirectory}kyc-${randomSuffix()}.json`;
-    const utf8Encoding = expoFs.EncodingType?.UTF8 ?? 'utf8';
-    await FileSystem.writeAsStringAsync(path, contents, {
-      encoding: utf8Encoding as any,
-    });
-    return path;
-  }
-  const fs = await import('fs/promises');
-  const os = await import('os');
-  const path = await import('path');
-  const filePath = path.join(os.tmpdir(), `kyc-${randomSuffix()}.json`);
-  await fs.writeFile(filePath, contents, 'utf8');
-  return filePath;
-}
-
-async function removeFile(uri: string): Promise<void> {
-  if (!uri) return;
-  if (typeof FileSystem.deleteAsync === 'function') {
-    try {
-      await FileSystem.deleteAsync(uri, { idempotent: true });
-      return;
-    } catch {}
-  }
-  try {
-    const fs = await import('fs/promises');
-    await fs.unlink(toFilePath(uri));
-  } catch {}
-}
-
-async function cleanupSource(uri: string): Promise<void> {
-  if (!uri) return;
-  if (
-    typeof FileSystem.deleteAsync === 'function' &&
-    (typeof expoFs.cacheDirectory === 'string' ||
-      typeof expoFs.temporaryDirectory === 'string')
-  ) {
-    const { cacheDirectory, temporaryDirectory } = expoFs;
-    if (
-      (cacheDirectory && uri.startsWith(cacheDirectory)) ||
-      (temporaryDirectory && uri.startsWith(temporaryDirectory))
-    ) {
-      try {
-        await FileSystem.deleteAsync(uri, { idempotent: true });
-      } catch {}
-    }
-    return;
-  }
-  try {
-    const os = await import('os');
-    const tmpDir = os.tmpdir();
-    const path = toFilePath(uri);
-    if (path.startsWith(tmpDir)) {
-      const fs = await import('fs/promises');
-      await fs.unlink(path);
-    }
-  } catch {}
-}
 
 function ensureIpfs(uri: string, fallback: string): string {
   if (!uri) return fallback;
@@ -173,7 +75,7 @@ export async function encryptForTenant(
   for (const file of files) {
     const name = file.name || 'document';
     const type = file.type || 'application/octet-stream';
-    const buffer = await readBinary(file.uri);
+    const buffer = await readFileAsBuffer(file.uri);
     const bytes = buffer instanceof Uint8Array ? new Uint8Array(buffer) : Uint8Array.from(buffer);
     const hash = Buffer.from(sha256(bytes)).toString('hex');
     const base64 = Buffer.from(bytes).toString('base64');
@@ -226,16 +128,16 @@ export async function encryptForTenant(
   const cipher = await aesEncrypt(canonicalJson(payload), key);
   const encryptedBody = canonicalJson({ version: 1, cipher });
 
-  const tempPath = await writeTemp(encryptedBody);
+  const tempPath = await writeTempFile(encryptedBody, { prefix: 'kyc', extension: 'json' });
   let uploaded: string | null = null;
   try {
     const pinata = PinataService.getInstance();
     uploaded = await pinata.uploadFile(tempPath, `kyc-${Date.now()}.json`);
 
     await cleanupTrackedKycCapturedPaths(enriched.map(({ sourceUri }) => sourceUri));
-    await Promise.all(enriched.map(({ sourceUri }) => cleanupSource(sourceUri)));
+    await Promise.all(enriched.map(({ sourceUri }) => deleteIfTemporary(sourceUri)));
   } finally {
-    await removeFile(tempPath);
+    await deleteFile(tempPath, { allowContentScheme: true });
   }
 
   const encryptedBodyBytes = Buffer.from(encryptedBody);

--- a/src/utils/fileAccess.ts
+++ b/src/utils/fileAccess.ts
@@ -1,0 +1,156 @@
+import { Buffer } from 'buffer';
+import * as FileSystem from 'expo-file-system';
+
+const FILE_SCHEME = 'file://';
+const CONTENT_SCHEME = 'content://';
+
+type ExpoFsExtras = {
+  EncodingType?: {
+    Base64?: string;
+    UTF8?: string;
+  };
+  cacheDirectory?: string;
+  temporaryDirectory?: string;
+};
+
+const expoFs = FileSystem as typeof FileSystem & ExpoFsExtras;
+
+function normalizeFileUri(uri: string): string {
+  if (!uri) return uri;
+  if (uri.startsWith(FILE_SCHEME) || uri.startsWith(CONTENT_SCHEME)) {
+    return uri;
+  }
+  return `${FILE_SCHEME}${uri}`;
+}
+
+export function stripFileScheme(uri: string): string {
+  return uri.startsWith(FILE_SCHEME) ? uri.slice(FILE_SCHEME.length) : uri;
+}
+
+async function tryExpoDelete(uri: string): Promise<boolean> {
+  if (typeof FileSystem.deleteAsync !== 'function') {
+    return false;
+  }
+
+  try {
+    await FileSystem.deleteAsync(uri, { idempotent: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function deleteFile(
+  uri: string,
+  { allowContentScheme = false }: { allowContentScheme?: boolean } = {},
+): Promise<void> {
+  if (!uri) return;
+
+  const expoUri = normalizeFileUri(uri);
+  if (await tryExpoDelete(expoUri)) {
+    return;
+  }
+
+  if (!allowContentScheme && expoUri.startsWith(CONTENT_SCHEME)) {
+    return;
+  }
+
+  try {
+    const fs = await import('fs/promises');
+    await fs.unlink(stripFileScheme(expoUri));
+  } catch {}
+}
+
+export async function readFileAsBuffer(uri: string): Promise<Buffer> {
+  const expoUri = normalizeFileUri(uri);
+
+  if (typeof FileSystem.readAsStringAsync === 'function') {
+    const encoding = (expoFs.EncodingType?.Base64 ?? 'base64') as never;
+    const base64 = await FileSystem.readAsStringAsync(expoUri, { encoding });
+    return Buffer.from(base64, 'base64');
+  }
+
+  const fs = await import('fs/promises');
+  const data = await fs.readFile(stripFileScheme(expoUri));
+  return Buffer.isBuffer(data) ? data : Buffer.from(data);
+}
+
+function randomSuffix(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function toTempFileName(prefix: string, extension: string): string {
+  const cleanExtension = extension.startsWith('.') ? extension : `.${extension}`;
+  return `${prefix}-${randomSuffix()}${cleanExtension}`;
+}
+
+export async function writeTempFile(
+  contents: string,
+  { prefix = 'tmp', extension = 'tmp' }: { prefix?: string; extension?: string } = {},
+): Promise<string> {
+  const fileName = toTempFileName(prefix, extension);
+
+  if (typeof FileSystem.writeAsStringAsync === 'function' && typeof expoFs.cacheDirectory === 'string') {
+    const encoding = (expoFs.EncodingType?.UTF8 ?? 'utf8') as never;
+    const path = `${expoFs.cacheDirectory}${fileName}`;
+    await FileSystem.writeAsStringAsync(path, contents, { encoding });
+    return path;
+  }
+
+  const fs = await import('fs/promises');
+  const os = await import('os');
+  const pathModule = await import('path');
+  const filePath = pathModule.join(os.tmpdir(), fileName);
+  await fs.writeFile(filePath, contents, 'utf8');
+  return filePath;
+}
+
+function expoTempDirectories(): string[] {
+  const dirs: string[] = [];
+  if (typeof expoFs.cacheDirectory === 'string') {
+    dirs.push(expoFs.cacheDirectory);
+  }
+  if (typeof expoFs.temporaryDirectory === 'string') {
+    dirs.push(expoFs.temporaryDirectory);
+  }
+  return dirs;
+}
+
+function isExpoTemporaryUri(uri: string, dirs: string[] = expoTempDirectories()): boolean {
+  if (!uri) return false;
+  return dirs.some((dir) => uri.startsWith(dir));
+}
+
+export async function deleteIfTemporary(uri: string): Promise<void> {
+  if (!uri) return;
+
+  const expoDirs = expoTempDirectories();
+  if (typeof FileSystem.deleteAsync === 'function' && expoDirs.length) {
+    if (isExpoTemporaryUri(uri, expoDirs)) {
+      await deleteFile(uri, { allowContentScheme: true });
+    }
+    return;
+  }
+
+  try {
+    const os = await import('os');
+    const tmpDir = os.tmpdir();
+    const path = stripFileScheme(uri);
+    if (!path.startsWith(tmpDir)) {
+      return;
+    }
+    const fs = await import('fs/promises');
+    await fs.unlink(path);
+  } catch {}
+}
+
+export default {
+  deleteFile,
+  deleteIfTemporary,
+  readFileAsBuffer,
+  stripFileScheme,
+  writeTempFile,
+};

--- a/src/utils/kycTemp.ts
+++ b/src/utils/kycTemp.ts
@@ -1,41 +1,10 @@
-import * as FileSystem from 'expo-file-system';
+import { deleteFile } from '@/utils/fileAccess';
 
 const trackedPaths = new Set<string>();
 
 function isTrackableUri(uri: string): boolean {
   if (!uri) return false;
   return uri.startsWith('file://') || uri.startsWith('/') || uri.startsWith('content://');
-}
-
-function toExpoUri(uri: string): string {
-  if (uri.startsWith('file://') || uri.startsWith('content://')) {
-    return uri;
-  }
-  return `file://${uri}`;
-}
-
-function toFsPath(uri: string): string {
-  return uri.startsWith('file://') ? uri.slice('file://'.length) : uri;
-}
-
-async function deleteUri(uri: string): Promise<void> {
-  const expoUri = toExpoUri(uri);
-
-  if (typeof FileSystem.deleteAsync === 'function') {
-    try {
-      await FileSystem.deleteAsync(expoUri, { idempotent: true });
-      return;
-    } catch {}
-  }
-
-  if (uri.startsWith('content://')) {
-    return;
-  }
-
-  try {
-    const fs = await import('fs/promises');
-    await fs.unlink(toFsPath(uri));
-  } catch {}
 }
 
 export function trackKycCapturedPath(uri?: string | null): void {
@@ -70,7 +39,7 @@ export async function cleanupTrackedKycCapturedPaths(
 
   await Promise.all(
     [...targets].map(async (uri) => {
-      await deleteUri(uri);
+      await deleteFile(uri);
       trackedPaths.delete(uri);
     }),
   );


### PR DESCRIPTION
## Summary
- extract cross-platform helpers for reading, writing, and removing temporary files used by KYC flows
- update the KYC upload service to rely on the shared helpers and simplify local cleanup logic
- reuse the shared deletion helper inside the tracked KYC capture cleanup utility to avoid duplicated file handling code

## Testing
- npx jest --runTestsByPath tests/kycUpload.test.ts *(fails: jest binary not available without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a53d64188326acc8bb756d0ae4a2