### PR TITLE
Document npm install attempt

### DIFF
--- a/docs/maintenance/dependency-maintenance.md
+++ b/docs/maintenance/dependency-maintenance.md
@@ -1,0 +1,16 @@
+# Dependency Maintenance Log
+
+This log captures the most recent cleanup and install attempt for the monorepo.
+
+## 2025-09-27 Cleanup
+- Searched for build artifacts (`.expo`, `dist`, `expo-export`) and cache directories (`.turbo`, `**/.cache`), but none were present in the repository.
+- Verified that no `node_modules` directories were checked in or left over from previous installs.
+
+## 2025-09-27 Install Attempt
+- Ran `npm install` to align with the updated package manager choice.
+- Installation failed because npm does not support the `workspace:*` protocol used by the monorepo. The resolver emitted an `EUNSUPPORTEDPROTOCOL` error before it could even reach the missing `@blue-ocean/sdk-near` dependency.
+
+## Recommended Follow-Up
+1. Ensure the `@blue-ocean/sdk-near` package is available (publish to the registry or add it as a local workspace).
+2. Re-run `npm install` once the workspace dependencies are refactored to be compatible with npm or replaced with published versions.
+3. Confirm that any newly generated lockfile (`package-lock.json`) is committed after a successful install.


### PR DESCRIPTION
## Summary
- update the dependency maintenance log to reflect switching the install command to npm
- note the npm workspace protocol limitation that blocks installation
- adjust follow-up guidance to reference package-lock.json instead of yarn.lock

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d760eee4a48326963db5a9cba3181f